### PR TITLE
Multi-window projects: open each project in its own window

### DIFF
--- a/src/main/java/com/editora/App.java
+++ b/src/main/java/com/editora/App.java
@@ -4,21 +4,15 @@ import java.io.IOException;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-import com.editora.command.CommandRegistry;
-import com.editora.command.KeyDispatcher;
 import com.editora.command.KeymapManager;
 import com.editora.config.ConfigManager;
 import com.editora.config.Settings;
-import com.editora.config.WorkspaceState;
+import com.editora.config.SharedConfig;
 import com.editora.ui.MainController;
 
 import com.editora.ui.Themes;
 
 import javafx.application.Application;
-import javafx.fxml.FXMLLoader;
-import javafx.scene.Scene;
-import javafx.scene.layout.BorderPane;
-import javafx.stage.Screen;
 import javafx.stage.Stage;
 
 public class App extends Application {
@@ -44,17 +38,27 @@ public class App extends Application {
     public void start(Stage stage) throws IOException {
         com.editora.ui.Fonts.load(); // register bundled fonts before any UI/CSS uses them
 
+        // On macOS the JavaFX/AppKit (FX application) thread's context classloader can be null, which
+        // breaks loading FXML-referenced classes (and other lazy class loads) when building windows at
+        // runtime — the single-window app loaded its FXML once at startup and never hit this, but
+        // multi-window builds a window per project. Pin a real classloader as the FXMLLoader default and
+        // as this thread's context classloader so every runtime window build (and lazy load) resolves.
+        javafx.fxml.FXMLLoader.setDefaultClassLoader(App.class.getClassLoader());
+        Thread.currentThread().setContextClassLoader(App.class.getClassLoader());
+
         // Config dir precedence: --config-dir CLI arg > EDITORA_CONFIG_DIR env var > default
-        // (~/.editora, or ~/.editora-dev with --dev so a dev instance can't disturb production).
+        // (~/.editora, or ~/.editora-dev with --dev so a dev instance can't disturb production). The
+        // bootstrap ConfigManager loads the shared config once; per-window ConfigManagers reuse it.
         var rawArgs = getParameters().getRaw();
         String cliConfigDir = configDirArg(rawArgs);
-        ConfigManager config = cliConfigDir != null
+        ConfigManager bootstrap = cliConfigDir != null
                 ? new ConfigManager(java.nio.file.Path.of(cliConfigDir))
                 : new ConfigManager(devFlag(rawArgs));
-        Settings settings = config.load();
+        Settings settings = bootstrap.load();
+        SharedConfig shared = bootstrap.shared();
         // Mirror captured logs to a session file in the config dir so a packaged build's log survives a
         // crash and can be attached to a bug report (the in-memory capture was installed in main()).
-        com.editora.ui.DebugLog.attachFile(config.getConfigDir());
+        com.editora.ui.DebugLog.attachFile(shared.getConfigDir());
 
         // Localize the UI: pick the language (explicit setting, else system, else English) and load the
         // message catalog before any UI text is created. A change takes effect on the next launch.
@@ -69,62 +73,23 @@ public class App extends Application {
 
         Application.setUserAgentStylesheet(Themes.stylesheetFor(settings.getTheme()));
 
-        CommandRegistry registry = new CommandRegistry();
         KeymapManager keymap = new KeymapManager();
         keymap.loadNamed(settings.getKeymap());
         keymap.applyOverrides(settings.getKeybindings());
 
-        FXMLLoader loader = new FXMLLoader(App.class.getResource("ui/main.fxml"));
-        BorderPane root = loader.load();
-        MainController controller = loader.getController();
-        controller.init(stage, config, registry, keymap);
-        controller.setHostServices(getHostServices()); // for the Welcome page's home-page link
-
-        // Wrap the UI in a StackPane so a floating overlay (the Zen-mode exit button) can sit on top.
-        javafx.scene.layout.StackPane sceneRoot = new javafx.scene.layout.StackPane(root);
         // Experiment: on macOS, render the UI chrome in the native system font (San Francisco) instead of
-        // AtlantaFX's Inter — across every window (main, dialogs, the Settings window, and popups like the
-        // command palette / context menus / tooltips). See installMacSystemFont.
+        // AtlantaFX's Inter — across every window. A listener on the live window list covers windows
+        // opened later (so each project window picks it up). See installMacSystemFont.
         if (isMac()) {
             installMacSystemFont();
         }
-        controller.installZenOverlay(sceneRoot);
-        Scene scene = new Scene(sceneRoot, 1000, 700);
-        // Pre-fill with the theme background so the first frame isn't JavaFX's default light gray
-        // (which otherwise flashes before the CSS is applied — most visible with a dark theme). The
-        // root and editor are transparent until CSS paints them, so this fill shows through. (Scene
-        // fill isn't a CSS property, so it doesn't interfere with later theme switches.)
-        scene.setFill(Themes.backgroundFor(settings.getTheme()));
-        scene.getStylesheets().addAll(
-                App.class.getResource("styles/app.css").toExternalForm(),
-                App.class.getResource("styles/syntax.css").toExternalForm());
 
-        KeyDispatcher keyDispatcher = new KeyDispatcher(registry, keymap, controller::setStatus);
-        keyDispatcher.install(scene);
-        controller.setKeyDispatcher(keyDispatcher);
-
-        // Ctrl + mouse wheel zooms (and is consumed so the editor/preview doesn't also scroll): the
-        // Markdown preview when the pointer is over it, otherwise the editor text.
-        scene.addEventFilter(javafx.scene.input.ScrollEvent.SCROLL, e -> {
-            if (e.isControlDown() && e.getDeltaY() != 0) {
-                controller.zoomFromWheel(e);
-                e.consume();
-            }
-        });
-
-        stage.setScene(scene);
-        stage.setTitle("Editora");
-        loadAppIcons(stage);
-        controller.applyEditorTheme(settings.getEditorTheme());
-        restoreWindowBounds(stage, config.getWorkspaceState());
-        stage.show();
-
-        // Startup CLI actions: open a project (if enabled), restore the session, open any FILE(s)
-        // (jumping to LINE:COLUMN), and enter Zen — all on top of the restored session.
-        var raw = getParameters().getRaw();
-        String project = projectArg(raw);
-        controller.startup(project == null ? null : java.nio.file.Path.of(project),
-                fileTargets(raw), zenFlag(raw), newFileArg(raw), simpleFlag(raw));
+        // WindowManager builds each window (reusing the primary stage for the first) and, with projects
+        // enabled, restores every window that was open at last quit. CLI targets go to the first window.
+        com.editora.ui.WindowManager windows =
+                new com.editora.ui.WindowManager(shared, keymap, getHostServices());
+        windows.launch(stage, projectArg(rawArgs), fileTargets(rawArgs), zenFlag(rawArgs),
+                newFileArg(rawArgs), simpleFlag(rawArgs));
     }
 
     /** True when running on macOS (used to opt the UI chrome into the native system font). */
@@ -207,39 +172,6 @@ public class App extends Application {
             }
         }
         return null;
-    }
-
-    /**
-     * Restores the main window's size, position, and maximized state from the last session. Bounds
-     * are only applied when they were saved (non-zero size) and still land on a connected screen, so
-     * a disconnected monitor or first launch falls back to the scene's default size and OS centering.
-     */
-    private void restoreWindowBounds(Stage stage, WorkspaceState state) {
-        double w = state.getWindowWidth();
-        double h = state.getWindowHeight();
-        if (w > 0 && h > 0) {
-            double x = state.getWindowX();
-            double y = state.getWindowY();
-            if (!Screen.getScreensForRectangle(x, y, w, h).isEmpty()) {
-                stage.setX(x);
-                stage.setY(y);
-            }
-            stage.setWidth(w);
-            stage.setHeight(h);
-        }
-        if (state.isWindowMaximized()) {
-            stage.setMaximized(true);
-        }
-    }
-
-    /** Adds the app icon (multiple sizes) so it shows in the title bar, dock, and taskbar. */
-    private void loadAppIcons(Stage stage) {
-        for (int size : new int[]{16, 32, 48, 128, 256, 512}) {
-            var in = App.class.getResourceAsStream("/com/editora/icons/icon-" + size + ".png");
-            if (in != null) {
-                stage.getIcons().add(new javafx.scene.image.Image(in));
-            }
-        }
     }
 
     public static void main(String[] args) {

--- a/src/main/java/com/editora/config/ConfigManager.java
+++ b/src/main/java/com/editora/config/ConfigManager.java
@@ -4,27 +4,27 @@ import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Stream;
 
-import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
-import com.fasterxml.jackson.databind.node.ObjectNode;
-import com.fasterxml.jackson.dataformat.toml.TomlMapper;
 
 import com.editora.config.migration.ConfigMigrations;
 import com.editora.config.migration.ConfigSchema;
 
 /**
- * Loads and saves the user config in the config directory: the {@code EDITORA_CONFIG_DIR} environment
- * variable when set, otherwise {@code ~/.editora/} ({@code user.home} maps to the user profile on
- * macOS, Linux, and Windows). Preferences ({@link Settings}) are stored as TOML in
- * {@code settings.toml}; session state ({@link WorkspaceState}: fold regions, tool-window layout) is
- * stored as JSON in {@code workspace-state.json}. Missing or malformed files fall back to defaults.
+ * The <em>per-window</em> view of the configuration. Each window owns its own session state
+ * ({@link WorkspaceState} + the {@code workspace-state.json} or {@code projects/<id>.json} file it lives
+ * in) but shares all global config — preferences, bookmarks, notes, breakpoints, connections, the
+ * spell dictionary, and the projects index — through a {@link SharedConfig} held <strong>by
+ * reference</strong>. So every window sees the same {@link Settings} object and the same stores, and a
+ * {@link #save()} from one window writes settings without clobbering another window's copy.
+ *
+ * <p>The config directory is the {@code EDITORA_CONFIG_DIR} environment variable when set, otherwise
+ * {@code ~/.editora/} ({@code ~/.editora-dev/} in {@code --dev}). Preferences are TOML in
+ * {@code settings.toml}; session state is JSON in the window's state file. Missing/malformed files fall
+ * back to defaults. In single-window/test use a {@code ConfigManager} owns its own {@link SharedConfig}.
  */
 public class ConfigManager {
 
@@ -40,74 +40,168 @@ public class ConfigManager {
     static final String DICTIONARY_FILE_NAME = "dictionary.txt";
     static final String PROJECTS_DIR_NAME = "projects";
 
-    /** TOML for preferences. */
-    private final TomlMapper toml = new TomlMapper();
-    /** Pretty JSON for session/state data. */
+    /** Pretty JSON for this window's session-state file. */
     private final ObjectMapper json = new ObjectMapper().enable(SerializationFeature.INDENT_OUTPUT);
 
-    private final Path configDir;
-    /** Whether this instance was started in dev mode ({@code --dev}); surfaced in the UI (toolbar badge). */
-    private final boolean dev;
-    private Settings settings = new Settings();
+    /** The shared, app-wide config (preferences + cross-project stores), shared by reference. */
+    private final SharedConfig shared;
     private WorkspaceState workspaceState = new WorkspaceState();
-    /** Global bookmarks (all files/projects), stored in {@code bookmarks.json} — see {@link BookmarkStore}. */
-    private BookmarkStore bookmarkStore = new BookmarkStore();
-    /** Personal Notes (all files/projects), stored in {@code notes.json} — see {@link NoteStore}. */
-    private NoteStore noteStore = new NoteStore();
-    /** Breakpoints (all files/projects), stored in {@code breakpoints.json} — see {@link BreakpointStore}. */
-    private BreakpointStore breakpointStore = new BreakpointStore();
-    /** Saved SFTP connections (metadata only, no secrets), stored in {@code connections.json}. */
-    private ConnectionStore connectionStore = new ConnectionStore();
-    /** User-added spell-check words (one per line in {@code dictionary.txt}); lower-cased, shared globally. */
-    private final java.util.Set<String> userDictionary = new java.util.LinkedHashSet<>();
     /** The session-state file currently in use — the default, or a project's state file. */
     private Path workspaceStateFile;
 
     public ConfigManager() {
-        this(defaultConfigDir(), false);
+        this(new SharedConfig(defaultConfigDir(), false));
     }
 
     /** Uses the default config dir, or {@code ~/.editora-dev} when {@code dev} (the {@code --dev} flag). */
     public ConfigManager(boolean dev) {
-        this(defaultConfigDir(dev), dev);
+        this(new SharedConfig(defaultConfigDir(dev), dev));
     }
 
     public ConfigManager(Path configDir) {
-        this(configDir, false);
+        this(new SharedConfig(configDir, false));
     }
 
-    private ConfigManager(Path configDir, boolean dev) {
-        this.configDir = configDir;
-        this.dev = dev;
-        this.workspaceStateFile = configDir.resolve(WORKSPACE_FILE_NAME);
+    /** A window over {@code shared}, pointed at the default {@code workspace-state.json} (no project). */
+    public ConfigManager(SharedConfig shared) {
+        this(shared, shared.getConfigDir().resolve(WORKSPACE_FILE_NAME));
     }
 
-    /** True when started in dev mode ({@code --dev}); the UI shows a "dev mode" badge in this case. */
+    /** A window over {@code shared}, pointed at a specific session-state file (e.g. a project's). */
+    public ConfigManager(SharedConfig shared, Path stateFile) {
+        this.shared = shared;
+        this.workspaceStateFile = stateFile;
+    }
+
+    /** The shared, app-wide config backing this (and every other) window. */
+    public SharedConfig shared() {
+        return shared;
+    }
+
+    /** The shared projects index (one source of truth across all windows). */
+    public ProjectManager projects() {
+        return shared.projects();
+    }
+
+    // --- shared config: plain delegation ---
+
     public boolean isDev() {
-        return dev;
+        return shared.isDev();
     }
 
     public Path getConfigDir() {
-        return configDir;
+        return shared.getConfigDir();
     }
 
-    /**
-     * Zips the active config directory into a timestamped {@code .zip} in the user's home directory
-     * and returns the created file (e.g. {@code ~/editora-config-2026-06-04_153012.zip}). Backs up
-     * whichever config dir is in use ({@code ~/.editora}, {@code ~/.editora-dev}, or a
-     * {@code --config-dir} override).
-     *
-     * @throws IOException if the home directory can't be written or a config file can't be read
-     */
     public Path exportConfig() throws IOException {
-        Path home = Path.of(System.getProperty("user.home"));
-        return ConfigExporter.export(configDir, home, com.editora.AppInfo.VERSION,
-                System.getProperty("user.name"), java.time.LocalDateTime.now());
+        return shared.exportConfig();
+    }
+
+    public Settings getSettings() {
+        return shared.getSettings();
     }
 
     public Path getSettingsFile() {
-        return configDir.resolve(SETTINGS_FILE_NAME);
+        return shared.getSettingsFile();
     }
+
+    public Path getBookmarksFile() {
+        return shared.getBookmarksFile();
+    }
+
+    public Path getNotesFile() {
+        return shared.getNotesFile();
+    }
+
+    public Path getBreakpointsFile() {
+        return shared.getBreakpointsFile();
+    }
+
+    public Path getConnectionsFile() {
+        return shared.getConnectionsFile();
+    }
+
+    public Path getUserDictionaryFile() {
+        return shared.getUserDictionaryFile();
+    }
+
+    public List<com.editora.vfs.RemoteConnection> getConnections() {
+        return shared.getConnections();
+    }
+
+    public void putConnection(com.editora.vfs.RemoteConnection conn) {
+        shared.putConnection(conn);
+    }
+
+    public void removeConnection(String id) {
+        shared.removeConnection(id);
+    }
+
+    public void saveConnections() {
+        shared.saveConnections();
+    }
+
+    public java.util.Set<String> getUserDictionary() {
+        return shared.getUserDictionary();
+    }
+
+    public void addUserWord(String word) {
+        shared.addUserWord(word);
+    }
+
+    /**
+     * Personal Notes (canonical file path -> notes) for <em>this window's</em> project — bucket chosen by
+     * the current session file, exactly like {@link #getBookmarks()}. Persist changes with {@link #saveNotes()}.
+     */
+    public Map<String, List<PersonalNote>> getNotes() {
+        return shared.notesBucket(currentBookmarkKey());
+    }
+
+    public void saveNotes() {
+        shared.saveNotes();
+    }
+
+    /** Removes a project's entire notes bucket (called when the project is deleted) and persists. */
+    public void deleteNotesForProject(String projectKey) {
+        shared.deleteNotesForProject(projectKey);
+    }
+
+    /**
+     * The bookmark map (absolute file path -> bookmarks) for <em>this window's</em> project — the bucket is
+     * chosen by the current session file, so switching the session file ({@link #setWorkspaceStateFile} /
+     * {@link #useDefaultWorkspaceStateFile}) swaps which bookmarks are visible. Persist with {@link #saveBookmarks()}.
+     */
+    public Map<String, List<Bookmark>> getBookmarks() {
+        return shared.bookmarksBucket(currentBookmarkKey());
+    }
+
+    public void saveBookmarks() {
+        shared.saveBookmarks();
+    }
+
+    /** Removes a project's entire bookmark bucket (called when the project is deleted) and persists. */
+    public void deleteBookmarksForProject(String projectKey) {
+        shared.deleteBookmarksForProject(projectKey);
+    }
+
+    /**
+     * The breakpoint map (absolute file path -> breakpoints) for <em>this window's</em> project — bucket
+     * chosen by the current session file, exactly like {@link #getBookmarks()}. Persist with {@link #saveBreakpoints()}.
+     */
+    public Map<String, List<Breakpoint>> getBreakpoints() {
+        return shared.breakpointsBucket(currentBookmarkKey());
+    }
+
+    public void saveBreakpoints() {
+        shared.saveBreakpoints();
+    }
+
+    /** Removes a project's entire breakpoint bucket (called when the project is deleted) and persists. */
+    public void deleteBreakpointsForProject(String projectKey) {
+        shared.deleteBreakpointsForProject(projectKey);
+    }
+
+    // --- per-window session state ---
 
     public Path getWorkspaceStateFile() {
         return workspaceStateFile;
@@ -125,109 +219,17 @@ public class ConfigManager {
 
     /** Points the session back at the default {@code workspace-state.json} (no project) and reloads it. */
     public void useDefaultWorkspaceStateFile() {
-        setWorkspaceStateFile(configDir.resolve(WORKSPACE_FILE_NAME));
-    }
-
-    public Settings getSettings() {
-        return settings;
+        setWorkspaceStateFile(getConfigDir().resolve(WORKSPACE_FILE_NAME));
     }
 
     public WorkspaceState getWorkspaceState() {
         return workspaceState;
     }
 
-    public Path getBookmarksFile() {
-        return configDir.resolve(BOOKMARKS_FILE_NAME);
-    }
-
-    public Path getNotesFile() {
-        return configDir.resolve(NOTES_FILE_NAME);
-    }
-
-    public Path getBreakpointsFile() {
-        return configDir.resolve(BREAKPOINTS_FILE_NAME);
-    }
-
-    public Path getConnectionsFile() {
-        return configDir.resolve(CONNECTIONS_FILE_NAME);
-    }
-
-    /** The saved SFTP connections (metadata only), most-recent first. */
-    public List<com.editora.vfs.RemoteConnection> getConnections() {
-        return connectionStore.connections;
-    }
-
-    /** Saves (or refreshes) a connection and persists {@code connections.json}. */
-    public void putConnection(com.editora.vfs.RemoteConnection conn) {
-        connectionStore.put(conn);
-        saveConnections();
-    }
-
-    public void removeConnection(String id) {
-        connectionStore.remove(id);
-        saveConnections();
-    }
-
-    public void saveConnections() {
-        try {
-            json.writeValue(getConnectionsFile().toFile(), connectionStore);
-        } catch (IOException e) {
-            throw new UncheckedIOException("Failed to write connections to " + getConnectionsFile(), e);
-        }
-    }
-
     /**
-     * Personal Notes (canonical file path -> notes) for the <em>active</em> project — bucket chosen by the
-     * current session file, exactly like {@link #getBookmarks()}. Persist changes with {@link #saveNotes()}.
-     */
-    public Map<String, List<PersonalNote>> getNotes() {
-        return noteStore.bucket(currentBookmarkKey());
-    }
-
-    /** Removes a project's entire notes bucket (called when the project is deleted) and persists. */
-    public void deleteNotesForProject(String projectKey) {
-        if (noteStore.getByProject().remove(projectKey == null ? "" : projectKey) != null) {
-            saveNotes();
-        }
-    }
-
-    /**
-     * The bookmark map (absolute file path -> bookmarks) for the <em>active</em> project — the bucket is
-     * chosen by the current session file, so switching projects (via {@link #setWorkspaceStateFile} /
-     * {@link #useDefaultWorkspaceStateFile}) automatically swaps which bookmarks are visible. Persist
-     * changes with {@link #saveBookmarks()}.
-     */
-    public Map<String, List<Bookmark>> getBookmarks() {
-        return bookmarkStore.bucket(currentBookmarkKey());
-    }
-
-    /** Removes a project's entire bookmark bucket (called when the project is deleted) and persists. */
-    public void deleteBookmarksForProject(String projectKey) {
-        if (bookmarkStore.getByProject().remove(projectKey == null ? "" : projectKey) != null) {
-            saveBookmarks();
-        }
-    }
-
-    /**
-     * The breakpoint map (absolute file path -> breakpoints) for the <em>active</em> project — bucket
-     * chosen by the current session file, exactly like {@link #getBookmarks()}. Persist changes with
-     * {@link #saveBreakpoints()}.
-     */
-    public Map<String, List<Breakpoint>> getBreakpoints() {
-        return breakpointStore.bucket(currentBookmarkKey());
-    }
-
-    /** Removes a project's entire breakpoint bucket (called when the project is deleted) and persists. */
-    public void deleteBreakpointsForProject(String projectKey) {
-        if (breakpointStore.getByProject().remove(projectKey == null ? "" : projectKey) != null) {
-            saveBreakpoints();
-        }
-    }
-
-    /**
-     * The project key for the active session: {@code ""} for the default {@code workspace-state.json}
-     * (no project), otherwise the project id (the {@code projects/<id>.json} base name). Bookmarks are
-     * bucketed by this key in {@code bookmarks.json}.
+     * The project key for this window's session: {@code ""} for the default {@code workspace-state.json}
+     * (no project), otherwise the project id (the {@code projects/<id>.json} base name). The bucketed
+     * stores are keyed by this.
      */
     private String currentBookmarkKey() {
         Path name = workspaceStateFile.getFileName();
@@ -241,187 +243,23 @@ public class ConfigManager {
         return file.endsWith(".json") ? file.substring(0, file.length() - ".json".length()) : file;
     }
 
-    /** Reads all config files, merging stored values onto defaults. Falls back to defaults on any error. */
+    /** Reads all config (shared + this window's session), merging stored values onto defaults. */
     public Settings load() {
-        settings = ConfigMigrations.readVersioned(getSettingsFile(), toml, new Settings(), ConfigSchema.SETTINGS);
+        shared.load();
         workspaceState = ConfigMigrations.readVersioned(
-                getWorkspaceStateFile(), json, new WorkspaceState(), ConfigSchema.WORKSPACE);
-        loadBookmarks();
-        loadBreakpoints();
-        loadNotes();
-        loadConnections();
-        loadUserDictionary();
-        return settings;
+                workspaceStateFile, json, new WorkspaceState(), ConfigSchema.WORKSPACE);
+        return shared.getSettings();
     }
 
-    /** The user's added spell-check words (lower-cased). Mutated in place; persisted by {@link #addUserWord}. */
-    public java.util.Set<String> getUserDictionary() {
-        return userDictionary;
-    }
-
-    public Path getUserDictionaryFile() {
-        return configDir.resolve(DICTIONARY_FILE_NAME);
-    }
-
-    /** Adds a word to the user dictionary (lower-cased) and appends it to {@code dictionary.txt}. */
-    public void addUserWord(String word) {
-        if (word == null || word.isBlank()) {
-            return;
-        }
-        String w = word.strip().toLowerCase(java.util.Locale.ROOT);
-        if (!userDictionary.add(w)) {
-            return; // already present
-        }
-        try {
-            Files.createDirectories(configDir);
-            Files.writeString(getUserDictionaryFile(), w + System.lineSeparator(),
-                    java.nio.file.StandardOpenOption.CREATE, java.nio.file.StandardOpenOption.APPEND);
-        } catch (IOException e) {
-            // non-fatal: the word still applies for this session, just isn't persisted
-        }
-    }
-
-    private void loadUserDictionary() {
-        userDictionary.clear();
-        Path file = getUserDictionaryFile();
-        if (!Files.isReadable(file)) {
-            return;
-        }
-        try {
-            for (String line : Files.readAllLines(file)) {
-                String w = line.strip().toLowerCase(java.util.Locale.ROOT);
-                if (!w.isEmpty()) {
-                    userDictionary.add(w);
-                }
-            }
-        } catch (IOException ignored) {
-            // missing/unreadable dictionary just means no user words
-        }
-    }
-
-    /**
-     * Loads {@code bookmarks.json}. On first run (no {@code bookmarks.json} yet) it migrates any bookmarks
-     * previously stored inside {@code workspace-state.json} (→ the {@code ""} / no-project bucket) and
-     * each per-project {@code projects/<id>.json} session file (→ that project's bucket), strips them from
-     * those files, and writes {@code bookmarks.json} so the migration runs only once.
-     */
-    private void loadBookmarks() {
-        if (Files.exists(getBookmarksFile())) {
-            bookmarkStore = ConfigMigrations.readVersioned(
-                    getBookmarksFile(), json, new BookmarkStore(), ConfigSchema.BOOKMARKS);
-            return;
-        }
-        bookmarkStore = new BookmarkStore();
-        migrateLegacyBookmarks();
-        saveBookmarks(); // create bookmarks.json so migration is one-time (even if empty)
-    }
-
-    /** Loads {@code breakpoints.json} (a fresh, empty store if it doesn't exist yet — no legacy migration). */
-    private void loadConnections() {
-        if (Files.exists(getConnectionsFile())) {
-            connectionStore = ConfigMigrations.readVersioned(
-                    getConnectionsFile(), json, new ConnectionStore(), ConfigSchema.CONNECTIONS);
-        } else {
-            connectionStore = new ConnectionStore();
-        }
-    }
-
-    private void loadBreakpoints() {
-        if (Files.exists(getBreakpointsFile())) {
-            breakpointStore = ConfigMigrations.readVersioned(
-                    getBreakpointsFile(), json, new BreakpointStore(), ConfigSchema.BREAKPOINTS);
-        } else {
-            breakpointStore = new BreakpointStore();
-        }
-    }
-
-    /** Migrates bookmarks out of the legacy session files into their per-project buckets, stripping each. */
-    private void migrateLegacyBookmarks() {
-        extractAndStripBookmarks(configDir.resolve(WORKSPACE_FILE_NAME), ""); // no-project bucket
-        Path projectsDir = configDir.resolve(PROJECTS_DIR_NAME);
-        if (Files.isDirectory(projectsDir)) {
-            try (Stream<Path> s = Files.list(projectsDir)) {
-                s.filter(p -> p.getFileName().toString().endsWith(".json")).sorted().forEach(f -> {
-                    String fn = f.getFileName().toString();
-                    extractAndStripBookmarks(f, fn.substring(0, fn.length() - ".json".length()));
-                });
-            } catch (IOException ignored) {
-                // best-effort migration; a missing/unreadable projects dir just means nothing to migrate
-            }
-        }
-    }
-
-    /** Pulls the {@code bookmarks} node out of a legacy session file into {@code projectKey}'s bucket and rewrites it without that node. */
-    private void extractAndStripBookmarks(Path file, String projectKey) {
-        if (!Files.isReadable(file)) {
-            return;
-        }
-        try {
-            JsonNode root = json.readTree(Files.readString(file));
-            if (!(root instanceof ObjectNode obj)) {
-                return;
-            }
-            if (!obj.has("bookmarks")) {
-                return;
-            }
-            JsonNode bm = obj.get("bookmarks");
-            if (bm != null && bm.isObject() && !bm.isEmpty()) {
-                Map<String, List<Bookmark>> legacy =
-                        json.convertValue(bm, new TypeReference<LinkedHashMap<String, List<Bookmark>>>() { });
-                Map<String, List<Bookmark>> into = bookmarkStore.bucket(projectKey);
-                legacy.forEach(into::putIfAbsent);
-            }
-            obj.remove("bookmarks"); // drop the legacy node (even when empty) so it stops lingering
-            json.writeValue(file.toFile(), obj);
-        } catch (IOException | IllegalArgumentException e) {
-            // a malformed legacy file simply contributes no bookmarks
-        }
-    }
-
+    /** Writes the shared preferences ({@code settings.toml}) and this window's session-state file. */
     public void save() {
+        shared.saveSettings();
         try {
-            Files.createDirectories(configDir);
-            toml.writeValue(getSettingsFile().toFile(), settings);
             // The workspace-state file may live in a sub-dir (a project's state file).
             Files.createDirectories(workspaceStateFile.getParent());
             json.writeValue(workspaceStateFile.toFile(), workspaceState);
         } catch (IOException e) {
-            throw new UncheckedIOException("Failed to write config to " + configDir, e);
-        }
-    }
-
-    /** Writes the global bookmarks to {@code bookmarks.json}. Bookmarks are saved independently of {@link #save()}. */
-    public void saveBookmarks() {
-        try {
-            Files.createDirectories(configDir);
-            json.writeValue(getBookmarksFile().toFile(), bookmarkStore);
-        } catch (IOException e) {
-            throw new UncheckedIOException("Failed to write bookmarks to " + getBookmarksFile(), e);
-        }
-    }
-
-    /** Writes the breakpoints to {@code breakpoints.json}, independently of {@link #save()}. */
-    public void saveBreakpoints() {
-        try {
-            Files.createDirectories(configDir);
-            json.writeValue(getBreakpointsFile().toFile(), breakpointStore);
-        } catch (IOException e) {
-            throw new UncheckedIOException("Failed to write breakpoints to " + getBreakpointsFile(), e);
-        }
-    }
-
-    /** Loads {@code notes.json} (versioned, per-project buckets). Missing/malformed ⇒ an empty store. */
-    private void loadNotes() {
-        noteStore = ConfigMigrations.readVersioned(getNotesFile(), json, new NoteStore(), ConfigSchema.NOTES);
-    }
-
-    /** Writes the global Personal Notes to {@code notes.json}, independently of {@link #save()}. */
-    public void saveNotes() {
-        try {
-            Files.createDirectories(configDir);
-            json.writeValue(getNotesFile().toFile(), noteStore);
-        } catch (IOException e) {
-            throw new UncheckedIOException("Failed to write notes to " + getNotesFile(), e);
+            throw new UncheckedIOException("Failed to write session state to " + workspaceStateFile, e);
         }
     }
 

--- a/src/main/java/com/editora/config/ProjectManager.java
+++ b/src/main/java/com/editora/config/ProjectManager.java
@@ -26,14 +26,17 @@ public class ProjectManager {
     static final String INDEX_FILE_NAME = "projects.json";
     static final String PROJECTS_DIR = "projects";
 
-    /** The serialized index: the known projects and which one is active ("" = none). */
+    /** The serialized index: the known projects, the last-focused one, and the open-window set. */
     @JsonIgnoreProperties(ignoreUnknown = true)
     public static class Index {
-        /** Current on-disk schema version of {@code projects.json}. */
-        public static final int SCHEMA_VERSION = 1;
+        /** Current on-disk schema version of {@code projects.json}. v1→v2 added {@code openProjectIds}. */
+        public static final int SCHEMA_VERSION = 2;
         private int schemaVersion = SCHEMA_VERSION;
         private List<Project> projects = new ArrayList<>();
+        /** The last-focused project ("" = the no-project/global window). Drives focus on restore. */
         private String activeProjectId = "";
+        /** Project ids whose windows were open at last quit ("" = the global window). Empty ⇒ open global. */
+        private List<String> openProjectIds = new ArrayList<>();
 
         public int getSchemaVersion() {
             return schemaVersion;
@@ -57,6 +60,14 @@ public class ProjectManager {
 
         public void setActiveProjectId(String activeProjectId) {
             this.activeProjectId = activeProjectId == null ? "" : activeProjectId;
+        }
+
+        public List<String> getOpenProjectIds() {
+            return openProjectIds;
+        }
+
+        public void setOpenProjectIds(List<String> openProjectIds) {
+            this.openProjectIds = openProjectIds == null ? new ArrayList<>() : openProjectIds;
         }
     }
 
@@ -100,6 +111,29 @@ public class ProjectManager {
         index.setActiveProjectId(projectId == null ? "" : projectId);
     }
 
+    /** The project keys whose windows were open ({@code ""} = the global window). Callers persist via {@link #save()}. */
+    public List<String> openProjectIds() {
+        return List.copyOf(index.getOpenProjectIds());
+    }
+
+    /** Records that a window for {@code projectKey} ({@code ""} = global) is open. Callers persist via {@link #save()}. */
+    public void markOpen(String projectKey) {
+        String key = projectKey == null ? "" : projectKey;
+        if (!index.getOpenProjectIds().contains(key)) {
+            index.getOpenProjectIds().add(key);
+        }
+    }
+
+    /** Records that the window for {@code projectKey} ({@code ""} = global) has closed. Callers persist via {@link #save()}. */
+    public void markClosed(String projectKey) {
+        index.getOpenProjectIds().remove(projectKey == null ? "" : projectKey);
+    }
+
+    /** True if a window for {@code projectKey} ({@code ""} = global) is recorded as open. */
+    public boolean isOpen(String projectKey) {
+        return index.getOpenProjectIds().contains(projectKey == null ? "" : projectKey);
+    }
+
     /**
      * Removes the project from the index and deletes its per-project session-state file. The project's
      * folder and its files on disk are left untouched. Clears the active project if it was the one
@@ -113,6 +147,7 @@ public class ProjectManager {
         if (projectId.equals(index.getActiveProjectId())) {
             index.setActiveProjectId("");
         }
+        index.getOpenProjectIds().remove(projectId); // a deleted project can't have an open window
         try {
             Files.deleteIfExists(configDir.resolve(PROJECTS_DIR).resolve(projectId + ".json"));
         } catch (IOException ignored) {

--- a/src/main/java/com/editora/config/SharedConfig.java
+++ b/src/main/java/com/editora/config/SharedConfig.java
@@ -1,0 +1,356 @@
+package com.editora.config;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Stream;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.fasterxml.jackson.dataformat.toml.TomlMapper;
+
+import com.editora.config.migration.ConfigMigrations;
+import com.editora.config.migration.ConfigSchema;
+
+/**
+ * The <em>shared</em>, app-wide half of the configuration: preferences ({@link Settings}) plus the
+ * cross-project stores (bookmarks, notes, breakpoints, SFTP connections, the user spell dictionary)
+ * and the {@link ProjectManager} index. A single instance is created once at startup and shared
+ * <strong>by reference</strong> across every open window's {@link ConfigManager}, so a save from any
+ * window can never clobber another window's in-memory copy. Per-window <em>session</em> state
+ * ({@link WorkspaceState} + its file) lives in {@link ConfigManager}, not here.
+ *
+ * <p>The bucketed stores ({@code bookmarks.json}, {@code notes.json}, {@code breakpoints.json}) are
+ * keyed by a project key ({@code ""} = the no-project/global session, else the project id); the key is
+ * supplied by the caller (a {@link ConfigManager} derives it from its session file).
+ */
+public class SharedConfig {
+
+    /** TOML for preferences. */
+    private final TomlMapper toml = new TomlMapper();
+    /** Pretty JSON for the bucketed stores. */
+    private final ObjectMapper json = new ObjectMapper().enable(SerializationFeature.INDENT_OUTPUT);
+
+    private final Path configDir;
+    /** Whether this instance was started in dev mode ({@code --dev}); surfaced in the UI (toolbar badge). */
+    private final boolean dev;
+    private Settings settings = new Settings();
+    /** Global bookmarks (all files/projects), stored in {@code bookmarks.json} — see {@link BookmarkStore}. */
+    private BookmarkStore bookmarkStore = new BookmarkStore();
+    /** Personal Notes (all files/projects), stored in {@code notes.json} — see {@link NoteStore}. */
+    private NoteStore noteStore = new NoteStore();
+    /** Breakpoints (all files/projects), stored in {@code breakpoints.json} — see {@link BreakpointStore}. */
+    private BreakpointStore breakpointStore = new BreakpointStore();
+    /** Saved SFTP connections (metadata only, no secrets), stored in {@code connections.json}. */
+    private ConnectionStore connectionStore = new ConnectionStore();
+    /** User-added spell-check words (one per line in {@code dictionary.txt}); lower-cased, shared globally. */
+    private final java.util.Set<String> userDictionary = new java.util.LinkedHashSet<>();
+    /** The shared projects index ({@code projects.json}) — one source of truth across all windows. */
+    private final ProjectManager projects;
+
+    public SharedConfig(Path configDir, boolean dev) {
+        this.configDir = configDir;
+        this.dev = dev;
+        this.projects = new ProjectManager(configDir);
+    }
+
+    /** True when started in dev mode ({@code --dev}); the UI shows a "dev mode" badge in this case. */
+    public boolean isDev() {
+        return dev;
+    }
+
+    public Path getConfigDir() {
+        return configDir;
+    }
+
+    /** The shared projects index, one instance for the whole app. */
+    public ProjectManager projects() {
+        return projects;
+    }
+
+    /** The JSON mapper used for the bucketed stores (reused by {@link ConfigManager} for session state). */
+    ObjectMapper json() {
+        return json;
+    }
+
+    /** Reads all shared config files, merging stored values onto defaults. Falls back to defaults on error. */
+    public void load() {
+        settings = ConfigMigrations.readVersioned(getSettingsFile(), toml, new Settings(), ConfigSchema.SETTINGS);
+        loadBookmarks();
+        loadBreakpoints();
+        loadNotes();
+        loadConnections();
+        loadUserDictionary();
+    }
+
+    public Settings getSettings() {
+        return settings;
+    }
+
+    /** Writes preferences to {@code settings.toml}. Called by every window's {@link ConfigManager#save()}. */
+    public void saveSettings() {
+        try {
+            Files.createDirectories(configDir);
+            toml.writeValue(getSettingsFile().toFile(), settings);
+        } catch (IOException e) {
+            throw new UncheckedIOException("Failed to write settings to " + getSettingsFile(), e);
+        }
+    }
+
+    /**
+     * Zips the active config directory into a timestamped {@code .zip} in the user's home directory
+     * and returns the created file. Backs up whichever config dir is in use.
+     */
+    public Path exportConfig() throws IOException {
+        Path home = Path.of(System.getProperty("user.home"));
+        return ConfigExporter.export(configDir, home, com.editora.AppInfo.VERSION,
+                System.getProperty("user.name"), java.time.LocalDateTime.now());
+    }
+
+    // --- file locations ---
+
+    public Path getSettingsFile() {
+        return configDir.resolve(ConfigManager.SETTINGS_FILE_NAME);
+    }
+
+    public Path getBookmarksFile() {
+        return configDir.resolve(ConfigManager.BOOKMARKS_FILE_NAME);
+    }
+
+    public Path getNotesFile() {
+        return configDir.resolve(ConfigManager.NOTES_FILE_NAME);
+    }
+
+    public Path getBreakpointsFile() {
+        return configDir.resolve(ConfigManager.BREAKPOINTS_FILE_NAME);
+    }
+
+    public Path getConnectionsFile() {
+        return configDir.resolve(ConfigManager.CONNECTIONS_FILE_NAME);
+    }
+
+    public Path getUserDictionaryFile() {
+        return configDir.resolve(ConfigManager.DICTIONARY_FILE_NAME);
+    }
+
+    // --- SFTP connections ---
+
+    public List<com.editora.vfs.RemoteConnection> getConnections() {
+        return connectionStore.connections;
+    }
+
+    public void putConnection(com.editora.vfs.RemoteConnection conn) {
+        connectionStore.put(conn);
+        saveConnections();
+    }
+
+    public void removeConnection(String id) {
+        connectionStore.remove(id);
+        saveConnections();
+    }
+
+    public void saveConnections() {
+        try {
+            json.writeValue(getConnectionsFile().toFile(), connectionStore);
+        } catch (IOException e) {
+            throw new UncheckedIOException("Failed to write connections to " + getConnectionsFile(), e);
+        }
+    }
+
+    // --- bucketed stores (keyed by project key) ---
+
+    public Map<String, List<PersonalNote>> notesBucket(String key) {
+        return noteStore.bucket(key);
+    }
+
+    public void deleteNotesForProject(String projectKey) {
+        if (noteStore.getByProject().remove(projectKey == null ? "" : projectKey) != null) {
+            saveNotes();
+        }
+    }
+
+    public Map<String, List<Bookmark>> bookmarksBucket(String key) {
+        return bookmarkStore.bucket(key);
+    }
+
+    public void deleteBookmarksForProject(String projectKey) {
+        if (bookmarkStore.getByProject().remove(projectKey == null ? "" : projectKey) != null) {
+            saveBookmarks();
+        }
+    }
+
+    public Map<String, List<Breakpoint>> breakpointsBucket(String key) {
+        return breakpointStore.bucket(key);
+    }
+
+    public void deleteBreakpointsForProject(String projectKey) {
+        if (breakpointStore.getByProject().remove(projectKey == null ? "" : projectKey) != null) {
+            saveBreakpoints();
+        }
+    }
+
+    // --- user dictionary ---
+
+    /** The user's added spell-check words (lower-cased). Mutated in place; persisted by {@link #addUserWord}. */
+    public java.util.Set<String> getUserDictionary() {
+        return userDictionary;
+    }
+
+    /** Adds a word to the user dictionary (lower-cased) and appends it to {@code dictionary.txt}. */
+    public void addUserWord(String word) {
+        if (word == null || word.isBlank()) {
+            return;
+        }
+        String w = word.strip().toLowerCase(java.util.Locale.ROOT);
+        if (!userDictionary.add(w)) {
+            return; // already present
+        }
+        try {
+            Files.createDirectories(configDir);
+            Files.writeString(getUserDictionaryFile(), w + System.lineSeparator(),
+                    java.nio.file.StandardOpenOption.CREATE, java.nio.file.StandardOpenOption.APPEND);
+        } catch (IOException e) {
+            // non-fatal: the word still applies for this session, just isn't persisted
+        }
+    }
+
+    private void loadUserDictionary() {
+        userDictionary.clear();
+        Path file = getUserDictionaryFile();
+        if (!Files.isReadable(file)) {
+            return;
+        }
+        try {
+            for (String line : Files.readAllLines(file)) {
+                String w = line.strip().toLowerCase(java.util.Locale.ROOT);
+                if (!w.isEmpty()) {
+                    userDictionary.add(w);
+                }
+            }
+        } catch (IOException ignored) {
+            // missing/unreadable dictionary just means no user words
+        }
+    }
+
+    // --- loading + saving the bucketed stores ---
+
+    /**
+     * Loads {@code bookmarks.json}. On first run (no {@code bookmarks.json} yet) it migrates any bookmarks
+     * previously stored inside {@code workspace-state.json} (→ the {@code ""} / no-project bucket) and
+     * each per-project {@code projects/<id>.json} session file (→ that project's bucket), strips them from
+     * those files, and writes {@code bookmarks.json} so the migration runs only once.
+     */
+    private void loadBookmarks() {
+        if (Files.exists(getBookmarksFile())) {
+            bookmarkStore = ConfigMigrations.readVersioned(
+                    getBookmarksFile(), json, new BookmarkStore(), ConfigSchema.BOOKMARKS);
+            return;
+        }
+        bookmarkStore = new BookmarkStore();
+        migrateLegacyBookmarks();
+        saveBookmarks(); // create bookmarks.json so migration is one-time (even if empty)
+    }
+
+    private void loadConnections() {
+        if (Files.exists(getConnectionsFile())) {
+            connectionStore = ConfigMigrations.readVersioned(
+                    getConnectionsFile(), json, new ConnectionStore(), ConfigSchema.CONNECTIONS);
+        } else {
+            connectionStore = new ConnectionStore();
+        }
+    }
+
+    private void loadBreakpoints() {
+        if (Files.exists(getBreakpointsFile())) {
+            breakpointStore = ConfigMigrations.readVersioned(
+                    getBreakpointsFile(), json, new BreakpointStore(), ConfigSchema.BREAKPOINTS);
+        } else {
+            breakpointStore = new BreakpointStore();
+        }
+    }
+
+    /** Migrates bookmarks out of the legacy session files into their per-project buckets, stripping each. */
+    private void migrateLegacyBookmarks() {
+        extractAndStripBookmarks(configDir.resolve(ConfigManager.WORKSPACE_FILE_NAME), ""); // no-project bucket
+        Path projectsDir = configDir.resolve(ConfigManager.PROJECTS_DIR_NAME);
+        if (Files.isDirectory(projectsDir)) {
+            try (Stream<Path> s = Files.list(projectsDir)) {
+                s.filter(p -> p.getFileName().toString().endsWith(".json")).sorted().forEach(f -> {
+                    String fn = f.getFileName().toString();
+                    extractAndStripBookmarks(f, fn.substring(0, fn.length() - ".json".length()));
+                });
+            } catch (IOException ignored) {
+                // best-effort migration; a missing/unreadable projects dir just means nothing to migrate
+            }
+        }
+    }
+
+    /** Pulls the {@code bookmarks} node out of a legacy session file into {@code projectKey}'s bucket and rewrites it without that node. */
+    private void extractAndStripBookmarks(Path file, String projectKey) {
+        if (!Files.isReadable(file)) {
+            return;
+        }
+        try {
+            JsonNode root = json.readTree(Files.readString(file));
+            if (!(root instanceof ObjectNode obj)) {
+                return;
+            }
+            if (!obj.has("bookmarks")) {
+                return;
+            }
+            JsonNode bm = obj.get("bookmarks");
+            if (bm != null && bm.isObject() && !bm.isEmpty()) {
+                Map<String, List<Bookmark>> legacy =
+                        json.convertValue(bm, new TypeReference<LinkedHashMap<String, List<Bookmark>>>() { });
+                Map<String, List<Bookmark>> into = bookmarkStore.bucket(projectKey);
+                legacy.forEach(into::putIfAbsent);
+            }
+            obj.remove("bookmarks"); // drop the legacy node (even when empty) so it stops lingering
+            json.writeValue(file.toFile(), obj);
+        } catch (IOException | IllegalArgumentException e) {
+            // a malformed legacy file simply contributes no bookmarks
+        }
+    }
+
+    /** Writes the global bookmarks to {@code bookmarks.json}, independently of a session save. */
+    public void saveBookmarks() {
+        try {
+            Files.createDirectories(configDir);
+            json.writeValue(getBookmarksFile().toFile(), bookmarkStore);
+        } catch (IOException e) {
+            throw new UncheckedIOException("Failed to write bookmarks to " + getBookmarksFile(), e);
+        }
+    }
+
+    /** Writes the breakpoints to {@code breakpoints.json}, independently of a session save. */
+    public void saveBreakpoints() {
+        try {
+            Files.createDirectories(configDir);
+            json.writeValue(getBreakpointsFile().toFile(), breakpointStore);
+        } catch (IOException e) {
+            throw new UncheckedIOException("Failed to write breakpoints to " + getBreakpointsFile(), e);
+        }
+    }
+
+    /** Loads {@code notes.json} (versioned, per-project buckets). Missing/malformed ⇒ an empty store. */
+    private void loadNotes() {
+        noteStore = ConfigMigrations.readVersioned(getNotesFile(), json, new NoteStore(), ConfigSchema.NOTES);
+    }
+
+    /** Writes the global Personal Notes to {@code notes.json}, independently of a session save. */
+    public void saveNotes() {
+        try {
+            Files.createDirectories(configDir);
+            json.writeValue(getNotesFile().toFile(), noteStore);
+        } catch (IOException e) {
+            throw new UncheckedIOException("Failed to write notes to " + getNotesFile(), e);
+        }
+    }
+}

--- a/src/main/java/com/editora/config/migration/ConfigMigrations.java
+++ b/src/main/java/com/editora/config/migration/ConfigMigrations.java
@@ -6,6 +6,7 @@ import java.nio.file.Path;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 
@@ -129,6 +130,25 @@ public final class ConfigMigrations {
     static JsonNode wrapRecentFilesArray(JsonNode input) {
         ObjectNode o = JsonNodeFactory.instance.objectNode();
         o.set("files", input != null && input.isArray() ? input : JsonNodeFactory.instance.arrayNode());
+        return o;
+    }
+
+    /**
+     * v1 → v2 for {@code projects.json}: seed the new {@code openProjectIds} (the open-window set) from the
+     * single {@code activeProjectId} that pre-multi-window installs tracked, so the previously-active
+     * project reopens as its own window on first launch. No active project ⇒ an empty set (the global
+     * window opens by default).
+     */
+    static JsonNode seedOpenProjectIds(JsonNode input) {
+        if (!(input instanceof ObjectNode o) || o.has("openProjectIds")) {
+            return input;
+        }
+        ArrayNode ids = JsonNodeFactory.instance.arrayNode();
+        JsonNode active = o.get("activeProjectId");
+        if (active != null && active.isTextual() && !active.asText().isEmpty()) {
+            ids.add(active.asText());
+        }
+        o.set("openProjectIds", ids);
         return o;
     }
 }

--- a/src/main/java/com/editora/config/migration/ConfigSchema.java
+++ b/src/main/java/com/editora/config/migration/ConfigSchema.java
@@ -56,7 +56,8 @@ public enum ConfigSchema {
     WORKSPACE(WorkspaceState.SCHEMA_VERSION, 1, Map.of()),
     BOOKMARKS(BookmarkStore.SCHEMA_VERSION, 1, Map.of()),
     BREAKPOINTS(BreakpointStore.SCHEMA_VERSION, 1, Map.of()),
-    PROJECTS(ProjectManager.Index.SCHEMA_VERSION, 1, Map.of()),
+    // v1 → v2 added openProjectIds (the multi-window open-set), seeded from the old activeProjectId.
+    PROJECTS(ProjectManager.Index.SCHEMA_VERSION, 1, Map.of(1, ConfigMigrations::seedOpenProjectIds)),
     /** Legacy {@code recent-files.json} was a bare JSON array (v0); v1 wraps it in an object. */
     RECENT(RecentFiles.SCHEMA_VERSION, 1, Map.of(0, ConfigMigrations::wrapRecentFilesArray)),
     NOTES(NoteStore.SCHEMA_VERSION, 1, Map.of()),

--- a/src/main/java/com/editora/mermaid/MermaidService.java
+++ b/src/main/java/com/editora/mermaid/MermaidService.java
@@ -90,4 +90,9 @@ public final class MermaidService {
             }
         });
     }
+
+    /** Stops the background render/validate thread (called when the owning window closes). */
+    public void shutdown() {
+        exec.shutdownNow();
+    }
 }

--- a/src/main/java/com/editora/pdf/PdfExportService.java
+++ b/src/main/java/com/editora/pdf/PdfExportService.java
@@ -75,4 +75,9 @@ public final class PdfExportService {
             Platform.runLater(() -> onResult.accept(r));
         });
     }
+
+    /** Stops the background export thread (called when the owning window closes). */
+    public void shutdown() {
+        exec.shutdownNow();
+    }
 }

--- a/src/main/java/com/editora/print/PrintService.java
+++ b/src/main/java/com/editora/print/PrintService.java
@@ -151,4 +151,9 @@ public final class PrintService {
     private static String message(Exception e) {
         return e.getMessage() == null ? e.toString() : e.getMessage();
     }
+
+    /** Stops the background prepare thread (called when the owning window closes). */
+    public void shutdown() {
+        exec.shutdownNow();
+    }
 }

--- a/src/main/java/com/editora/search/SearchService.java
+++ b/src/main/java/com/editora/search/SearchService.java
@@ -146,4 +146,9 @@ public final class SearchService {
             return null;
         }
     }
+
+    /** Stops the background search thread (called when the owning window closes). */
+    public void shutdown() {
+        exec.shutdownNow();
+    }
 }

--- a/src/main/java/com/editora/ui/MainController.java
+++ b/src/main/java/com/editora/ui/MainController.java
@@ -173,6 +173,12 @@ public class MainController {
     private FileFinder folderFinder;
     private ProjectPanel projectPanel;
     private ProjectManager projects;
+    /** The multi-window coordinator (null in single-window/test use); set right after {@link #init}. */
+    private WindowManager windowManager;
+    /** This window's project ({@code null} = the no-project/global window). */
+    private Project windowProject;
+    /** This window's project key ({@code ""} = global), kept in sync with {@link #windowProject}. */
+    private String projectKey = "";
     private QuickOpen<Project> projectPicker;
     private ProjectCombo toolbarProjectCombo;
     private Label projectToolbarLabel;
@@ -302,8 +308,23 @@ public class MainController {
     public void init(Stage stage, ConfigManager config, CommandRegistry registry, KeymapManager keymap) {
         this.stage = stage;
         stage.setOnCloseRequest(e -> {
-            if (!confirmQuit() || !confirmCloseAllBuffers()) {
+            // Save/prompt this window's dirty buffers + persist its session; cancel the close if the
+            // user backs out. (No separate "Quit?" prompt — each window closes independently now.)
+            if (!confirmCloseAllBuffers()) {
                 e.consume();
+                return;
+            }
+            // Defensive: a disposal hiccup must never block the close (or it would look like the window
+            // can't be closed). Let JavaFX close this stage normally afterwards; the app keeps running
+            // while other windows remain (implicitExit quits only when the last window closes).
+            try {
+                disposeWindow();
+            } catch (RuntimeException | Error t) {
+                java.util.logging.Logger.getLogger(MainController.class.getName())
+                        .log(java.util.logging.Level.WARNING, "disposeWindow failed on close", t);
+            }
+            if (windowManager != null) {
+                windowManager.onWindowClosed(this);
             }
         });
         // Detect files changed by another program: re-check open files whenever the window regains focus.
@@ -350,7 +371,7 @@ public class MainController {
         bottomBox.getChildren().setAll(breadcrumb, statusBar);
         setupToolWindows();
         this.settingsWindow = new SettingsWindow(config, toolWindows, gitService, mermaidService,
-                lspManager, dapManager, this::applyViewSettingsToAllBuffers, this::setZenMode,
+                lspManager, dapManager, this::onSettingsApplied, this::setZenMode,
                 this::openPath, this::exportConfig, this::showDebugLog);
         debugLogWindow.setSessionFile(DebugLog.sessionFile(config.getConfigDir()));
         this.switcher = new Switcher(
@@ -612,6 +633,76 @@ public class MainController {
     }
 
     /**
+     * Binds this window to the multi-window coordinator and records which project it edits ({@code null}
+     * = the no-project/global window). Called by {@link WindowManager} right after {@link #init} and
+     * before {@link #startup}, so the project panel root, title, and combo reflect <em>this</em> window's
+     * project (not the globally last-focused one).
+     */
+    public void setWindowContext(WindowManager windowManager, Project project) {
+        this.windowManager = windowManager;
+        this.windowProject = project;
+        this.projectKey = project == null ? "" : project.id();
+        projectPanel.setRoot(project == null ? null : Path.of(project.root()));
+        refreshProjectPanelList();
+        updateWindowTitle();
+        // When a project window is freshly opened, show the Projects tool window so the file tree is
+        // right there (called only on a new window build, never when focusing an already-open project).
+        if (project != null && projectsEnabled() && projectToolWindow != null) {
+            toolWindows.open(projectToolWindow, false);
+        }
+    }
+
+    /** Re-applies preferences + the editor theme to this window after a Settings change in any window. */
+    public void reapplyAfterSharedSettingsChange(Settings settings) {
+        applyViewSettingsToAllBuffers(settings);
+    }
+
+    /**
+     * A Settings change was applied in this window. Re-apply it to every open window (the {@link Settings}
+     * object is shared by reference, so other windows already see the new values — they just need to
+     * restyle). Falls back to this window only when multi-window isn't wired.
+     */
+    private void onSettingsApplied(Settings settings) {
+        if (windowManager != null) {
+            windowManager.broadcastSettingsApplied(); // re-applies to every window, including this one
+        } else {
+            applyViewSettingsToAllBuffers(settings);
+        }
+    }
+
+    /**
+     * Closes this window's session programmatically (the "Close Project" command): prompts to save dirty
+     * buffers, persists the session, and releases the window's resources. Returns {@code false} if the
+     * user cancelled (the window stays open). The caller ({@link WindowManager}) closes the stage.
+     */
+    public boolean closeWindowProgrammatically() {
+        if (!confirmCloseAllBuffers()) {
+            return false;
+        }
+        disposeWindow();
+        return true;
+    }
+
+    /** Releases this window's resources on close: language servers, debug session, and worker threads. */
+    private void disposeWindow() {
+        for (Tab tab : tabPane.getTabs()) {
+            EditorBuffer buffer = bufferOf(tab);
+            if (buffer != null) {
+                buffer.dispose();
+            }
+        }
+        lspManager.shutdownAll(); // don't orphan this window's external language servers
+        dapManager.stop();        // end any debug session
+        gitService.shutdown();
+        searchService.shutdown();
+        mermaidService.shutdown();
+        pdfService.shutdown();
+        printService.shutdown();
+        runService.stop();
+        autoSaveExecutor.shutdownNow();
+    }
+
+    /**
      * Wires the key dispatcher's first-look hook so that <b>M-g</b>, while a tool window is focused,
      * closes that window and returns focus to the editor (instead of starting the go-to prefix).
      */
@@ -780,7 +871,8 @@ public class MainController {
 
     /** Loads the projects index and, if a project is active, points the session at it before restore. */
     private void setupProjects() {
-        projects = new ProjectManager(config.getConfigDir());
+        // The projects index is shared across all windows (one source of truth), so use the shared one.
+        projects = config.projects();
         projectPicker = new QuickOpen<>("Switch Project", "Type to filter projects…",
                 this::projectsWithNoProject,
                 Project::name,
@@ -789,12 +881,8 @@ public class MainController {
         // Keyboard "Open Project Folder" — mirrors the file finder, but picks a directory.
         folderFinder = new FileFinder(this::finderStartDir, this::openProjectRoot,
                 true, "Open Project Folder");
-        Project active = projects.active();
-        if (active != null) {
-            // Restore this project's session (openInitialBuffer + toolWindows.restore run after init).
-            config.setWorkspaceStateFile(projects.stateFile(active));
-            projectPanel.setRoot(Path.of(active.root()));
-        }
+        // Which project this window edits (and its session file) is set by WindowManager via
+        // setWindowContext(); the global window just keeps the default workspace-state.json.
         refreshProjectPanelList();
         updateWindowTitle();
     }
@@ -817,11 +905,10 @@ public class MainController {
     }
 
     private void refreshProjectPanelList() {
-        Project active = projects.active();
-        String activeId = active == null ? "" : active.id();
-        projectPanel.setProjects(projects.list(), activeId);
+        // The combo shows THIS window's project as selected (each window is one project).
+        projectPanel.setProjects(projects.list(), projectKey);
         if (toolbarProjectCombo != null) {
-            toolbarProjectCombo.setProjects(projects.list(), activeId);
+            toolbarProjectCombo.setProjects(projects.list(), projectKey);
         }
     }
 
@@ -840,20 +927,9 @@ public class MainController {
     /** Shows/hides all project UI per the "Enable projects" setting: toolbar icon + combo, tool window. */
     private void applyProjectSupport() {
         boolean on = projectsEnabled();
-        // Turning projects off while one is active: return to the global session first (saving the
-        // project's session) so the editor isn't stranded in a now-hidden project. If the user cancels
-        // the unsaved-changes prompt, abort the disable and re-check the box. The projectSupportApplied
-        // guard limits this to the runtime on→off toggle (it's false during the initial apply).
-        if (!on && projectSupportApplied && projects != null && projects.active() != null) {
-            if (!switchToProject(ProjectCombo.NO_PROJECT)) {
-                config.getSettings().setProjectSupport(true);
-                requestSave();
-                if (settingsWindow != null) {
-                    settingsWindow.syncProjectsCheck();
-                }
-                return; // leave the project UI in place
-            }
-        }
+        // Turning projects off just hides the project chrome — each window keeps editing its open files
+        // (windows no longer share one session that could be "stranded"). On the next launch with projects
+        // off, WindowManager opens a single global window.
         // The project toolbar group is also hidden by Simple UI mode (it stays a project even though the
         // selector is hidden); kept here so this later pass doesn't re-show it over applySimpleMode.
         boolean showProjectGroup = on && !simpleModeActive();
@@ -876,74 +952,55 @@ public class MainController {
     }
 
     /**
-     * Switches the editor to {@code p}'s session (saving the current one first). An empty id is the
-     * "No Project" sentinel — it returns to the default global session without closing any project.
+     * Opens (or focuses) {@code p}'s window. Each project lives in its own window now, so this no longer
+     * swaps the current window's session in place — it brings up that project's window, leaving this one
+     * as-is. The "No Project" sentinel (empty id) opens/focuses the global window.
      */
     private boolean switchToProject(Project p) {
         if (p == null) {
             return false;
         }
-        boolean toNoProject = p.id().isEmpty();
-        Project active = projects.active();
-        if (toNoProject ? active == null : p.equals(active)) {
-            return true; // already there (e.g. re-selected in the combo)
+        if (windowManager == null) {
+            return false; // multi-window not wired (shouldn't happen in the running app)
         }
-        if (!confirmCloseAllBuffers()) {
-            refreshProjectPanelList(); // cancelled — snap the combo back to the actual active project
-            return false;
+        if (p.id().equals(projectKey)) {
+            return true; // already this window (e.g. the combo re-selected the current project)
         }
-        exitZenIfActive();
-        if (toNoProject) {
-            projects.setActive("");
-            projects.save();
-            config.useDefaultWorkspaceStateFile();
-            activateSession(null);
-            setStatus(tr("status.noProject"));
-        } else {
-            projects.setActive(p.id());
-            projects.save();
-            config.setWorkspaceStateFile(projects.stateFile(p));
-            activateSession(Path.of(p.root()));
-            setStatus(tr("status.project", p.name()));
-        }
+        windowManager.openOrFocus(p.id().isEmpty() ? null : p);
+        // This window didn't change; snap its combo back to its own project.
+        refreshProjectPanelList();
         return true;
     }
 
-    /** Closes the active project (with confirmation), returning to the default global session. */
+    /** Closes this project window (with confirmation via the save prompts). */
     private void closeProject() {
-        Project active = projects.active();
-        if (active == null) {
+        if (windowProject == null) {
             setStatus(tr("status.noProjectOpen"));
             return;
         }
         Alert confirm = new Alert(Alert.AlertType.CONFIRMATION,
-                tr("dialog.closeProject.body", active.name()), ButtonType.OK, ButtonType.CANCEL);
+                tr("dialog.closeProject.body", windowProject.name()), ButtonType.OK, ButtonType.CANCEL);
         confirm.initOwner(stage);
         confirm.setTitle(tr("dialog.closeProject.title"));
         confirm.setHeaderText(null);
         if (confirm.showAndWait().orElse(ButtonType.CANCEL) != ButtonType.OK) {
             return;
         }
-        if (!confirmCloseAllBuffers()) {
-            return;
+        if (windowManager != null) {
+            windowManager.requestClose(this); // persists + closes this window
         }
-        exitZenIfActive();
-        projects.setActive("");
-        projects.save();
-        config.useDefaultWorkspaceStateFile();
-        activateSession(null);
-        setStatus(tr("status.projectClosed"));
     }
 
-    /** Deletes the active project (with confirmation). */
+    /** Deletes this window's project (with confirmation). */
     private void deleteProject() {
-        deleteProject(projects.active());
+        deleteProject(windowProject);
     }
 
     /**
-     * Deletes a specific project from the managed list (with confirmation). Only the project entry + its
-     * saved session are removed — the folder and its files on disk are left untouched. If it's the
-     * active project, the global session is restored; otherwise the current session is untouched.
+     * Deletes a project from the shared list (with confirmation). Only the project entry, its saved
+     * session, and its bookmark/note/breakpoint buckets are removed — the folder and its files on disk are
+     * left untouched. If the project has an open window, it is closed first (saving its dirty buffers); a
+     * cancelled save prompt aborts the deletion.
      */
     private void deleteProject(Project p) {
         if (p == null || p.id().isEmpty()) {
@@ -959,85 +1016,22 @@ public class MainController {
         if (confirm.showAndWait().orElse(ButtonType.CANCEL) != ButtonType.OK) {
             return;
         }
-        if (p.equals(projects.active())) {
-            // Deleting the open project: save/close its buffers and fall back to the global session.
-            if (!confirmCloseAllBuffers()) {
-                return;
-            }
-            exitZenIfActive();
-            projects.delete(p.id()); // also clears the active id
-            projects.save();
-            config.deleteBookmarksForProject(p.id()); // the project's bookmarks go with it
-            config.deleteNotesForProject(p.id()); // ...and its personal notes
-            config.useDefaultWorkspaceStateFile();
-            activateSession(null); // restores the global session + refreshes the combos/panel
-        } else {
-            // Deleting a project we're not in: just drop it from the list; the session is unaffected.
-            projects.delete(p.id());
-            projects.save();
-            config.deleteBookmarksForProject(p.id()); // the project's bookmarks go with it
-            config.deleteNotesForProject(p.id()); // ...and its personal notes
-            refreshProjectPanelList();
+        // Close the project's window first (persisting its session + saving dirty buffers); a cancelled
+        // save prompt leaves everything intact. No-op when the project has no open window.
+        if (windowManager != null && !windowManager.closeWindowForKey(p.id())) {
+            return;
         }
+        projects.delete(p.id()); // drops it from the index + open set + deletes its state file
+        projects.save();
+        config.deleteBookmarksForProject(p.id()); // the project's bookmarks go with it
+        config.deleteNotesForProject(p.id());     // ...its personal notes
+        config.deleteBreakpointsForProject(p.id()); // ...and its breakpoints
+        refreshProjectPanelList();
         setStatus(tr("status.deletedProject", p.name()));
     }
 
-    /**
-     * Leaves Zen before a session switch, restoring the real view settings. The snapshot needed to
-     * restore them lives in the *current* session's {@link WorkspaceState}; once the workspace-state
-     * file is swapped that snapshot is orphaned, so exiting Zen first prevents a permanently mangled
-     * UI (all chrome off with no way back).
-     */
-    private void exitZenIfActive() {
-        if (config.getWorkspaceState().isZenMode()) {
-            setZenMode(false);
-        }
-    }
-
-    /** Replaces the editor + tool-window state with the freshly-loaded session (after the file swap). */
-    private void activateSession(Path root) {
-        // Switching from the Project tool window's own combo shouldn't close the panel the user is in,
-        // even if the target session didn't have it open — keep it open across the switch if it was.
-        boolean keepProjectPanelOpen = toolWindows.isOpen(projectToolWindow);
-        // A live session switch lands in normal (non-Zen) view. Zen is transient and its restore
-        // snapshot belongs to the previous session, so drop any persisted Zen flag on the incoming
-        // session to keep it consistent with the chrome already restored by exitZenIfActive().
-        WorkspaceState incoming = config.getWorkspaceState();
-        if (incoming.isZenMode()) {
-            incoming.setZenMode(false);
-            incoming.getPreZenView().clear();
-            incoming.getPreZenToolWindows().clear();
-        }
-        tabPane.getTabs().clear(); // the tabs listener clears mru/pinned for removed tabs
-        mru.clear();
-        pinned.clear();
-        openInitialBuffer();
-        toolWindows.closeAllOpen();
-        toolWindows.restore();
-        toolWindows.setZenStripesHidden(false);
-        applyChromeVisibility();
-        projectPanel.setRoot(root);
-        refreshProjectPanelList();
-        if (bookmarksPanel != null) {
-            bookmarksPanel.refresh(); // the swapped session has its own bookmarks
-        }
-        if (notesPanel != null) {
-            notesPanel.refresh(); // the swapped session has its own notes
-        }
-        if (debugPanel != null) {
-            debugPanel.setWatches(config.getWorkspaceState().getDebugWatches()); // per-session watches
-        }
-        gitService.invalidateCaches(); // a different project may be a different repo
-        refreshGit();
-        if (keepProjectPanelOpen && projectsEnabled() && !toolWindows.isOpen(projectToolWindow)) {
-            toolWindows.open(projectToolWindow, false); // keep-open across a session swap; don't grab focus
-        }
-        updateWindowTitle();
-    }
-
     private void updateWindowTitle() {
-        Project active = projects == null ? null : projects.active();
-        stage.setTitle(active == null ? "Editora" : "Editora — " + active.name());
+        stage.setTitle(windowProject == null ? "Editora" : "Editora — " + windowProject.name());
     }
 
     /** Syncs editor/session state after the Project tree renames a file on disk (old → target). */

--- a/src/main/java/com/editora/ui/WindowManager.java
+++ b/src/main/java/com/editora/ui/WindowManager.java
@@ -1,0 +1,386 @@
+package com.editora.ui;
+
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+
+import com.editora.command.CommandRegistry;
+import com.editora.command.KeyDispatcher;
+import com.editora.command.KeymapManager;
+import com.editora.config.ConfigManager;
+import com.editora.config.Project;
+import com.editora.config.ProjectManager;
+import com.editora.config.Settings;
+import com.editora.config.SharedConfig;
+import com.editora.config.WorkspaceState;
+
+import javafx.application.HostServices;
+import javafx.fxml.FXMLLoader;
+import javafx.scene.Scene;
+import javafx.scene.layout.BorderPane;
+import javafx.scene.layout.StackPane;
+import javafx.stage.Screen;
+import javafx.stage.Stage;
+
+/**
+ * Owns the set of top-level editor windows and the shared config behind them. In single-window terms
+ * this replaces the per-window construction that used to live inline in {@code App.start}.
+ *
+ * <p>Multi-window behaviour is gated on the <em>Projects</em> feature: with projects disabled (the
+ * default) the app opens exactly one global window, just like before. With projects enabled, each
+ * project gets its own window — {@link #openOrFocus(Project)} focuses an already-open project window or
+ * builds a new one — the no-project "global" session is itself a window, and the set of open windows is
+ * restored on the next launch (persisted in {@code projects.json} as {@code openProjectIds}).
+ */
+public class WindowManager {
+
+    private final SharedConfig shared;
+    private final KeymapManager keymap;   // shared, read-only across windows
+    private final HostServices hostServices;
+    private final List<Holder> windows = new ArrayList<>();
+    /** The JavaFX primary stage, reused for the first window built (then null — others get a new Stage). */
+    private Stage primaryStage;
+
+    /** A live window: its project key ({@code ""} = the global session), its stage and controller. */
+    private record Holder(String key, Stage stage, MainController controller) { }
+
+    public WindowManager(SharedConfig shared, KeymapManager keymap, HostServices hostServices) {
+        this.shared = shared;
+        this.keymap = keymap;
+        this.hostServices = hostServices;
+    }
+
+    private ProjectManager projects() {
+        return shared.projects();
+    }
+
+    // --- startup ---
+
+    /**
+     * Opens the initial window(s) at launch. With projects disabled, opens one global window (carrying any
+     * CLI targets). With projects enabled, restores every window that was open at last quit (plus a CLI
+     * {@code --project}), routing the CLI targets to the primary window.
+     */
+    public void launch(Stage primaryStage, String projectArg, List<MainController.OpenTarget> targets,
+                       boolean zen, String newFile, boolean simple) {
+        this.primaryStage = primaryStage; // reused for the first window built
+        Settings settings = shared.getSettings();
+        if (!settings.isProjectSupport()) {
+            buildWindow("", null, null, targets, zen, newFile, simple);
+            return;
+        }
+        ProjectManager pm = projects();
+        LinkedHashSet<String> toOpen = new LinkedHashSet<>(pm.openProjectIds());
+        Project cli = null;
+        if (projectArg != null) {
+            Path root = Path.of(projectArg).toAbsolutePath().normalize();
+            String name = root.getFileName() == null ? root.toString() : root.getFileName().toString();
+            cli = pm.createOrGet(name, root);
+            pm.save();
+            toOpen.add(cli.id());
+        }
+        if (toOpen.isEmpty()) {
+            toOpen.add(""); // nothing remembered ⇒ open the global window
+        }
+        String primary = cli != null ? cli.id()
+                : toOpen.contains("") ? ""
+                : (pm.active() != null && toOpen.contains(pm.active().id())) ? pm.active().id()
+                : toOpen.iterator().next();
+
+        for (String key : toOpen) {
+            Project project = key.isEmpty() ? null : findProject(key);
+            if (!key.isEmpty() && project == null) {
+                continue; // a stale id (project deleted out from under the open set)
+            }
+            boolean isPrimary = key.equals(primary);
+            buildWindow(key, project, project == null ? null : pm.stateFile(project),
+                    isPrimary ? targets : List.of(), isPrimary && zen,
+                    isPrimary ? newFile : null, isPrimary && simple);
+            pm.markOpen(key);
+        }
+        pm.save();
+        focusKey(primary);
+    }
+
+    // --- open / focus ---
+
+    /** Opens (or focuses) the global, no-project window. */
+    public Stage openOrFocusGlobal() {
+        Holder existing = findHolder("");
+        if (existing != null) {
+            focus(existing.stage);
+            setActiveAndSave("");
+            return existing.stage;
+        }
+        Stage stage = buildWindow("", null, null, List.of(), false, null, false);
+        projects().markOpen("");
+        setActiveAndSave("");
+        return stage;
+    }
+
+    /** Opens (or focuses) {@code project}'s window. A null/empty-id project routes to the global window. */
+    public Stage openOrFocus(Project project) {
+        if (project == null || project.id().isEmpty()) {
+            return openOrFocusGlobal();
+        }
+        Holder existing = findHolder(project.id());
+        if (existing != null) {
+            focus(existing.stage);
+            setActiveAndSave(project.id());
+            return existing.stage;
+        }
+        Stage stage = buildWindow(project.id(), project, projects().stateFile(project),
+                List.of(), false, null, false);
+        projects().markOpen(project.id());
+        setActiveAndSave(project.id());
+        return stage;
+    }
+
+    private void setActiveAndSave(String key) {
+        projects().setActive(key);
+        projects().save();
+    }
+
+    // --- lifecycle ---
+
+    /**
+     * Called from a window's close handler after its session has been persisted. Drops the window from the
+     * live set; if other windows remain (the user closed one of several), forgets it from the restore set.
+     * When the last window closes (a quit), the restore set is left intact so the app reopens it.
+     */
+    public void onWindowClosed(MainController controller) {
+        Holder holder = null;
+        for (Holder h : windows) {
+            if (h.controller == controller) {
+                holder = h;
+                break;
+            }
+        }
+        if (holder == null) {
+            return;
+        }
+        windows.remove(holder);
+        if (!windows.isEmpty()) {
+            projects().markClosed(holder.key);
+            projects().save();
+        }
+    }
+
+    /**
+     * Programmatically closes {@code controller}'s window (the "Close Project" command). Returns
+     * {@code true} if it closed (or wasn't tracked), {@code false} if the user cancelled the save prompt.
+     */
+    public boolean requestClose(MainController controller) {
+        for (Holder h : windows) {
+            if (h.controller == controller) {
+                if (!controller.closeWindowProgrammatically()) {
+                    return false; // user cancelled
+                }
+                onWindowClosed(controller);
+                h.stage.close();
+                return true;
+            }
+        }
+        return true;
+    }
+
+    /**
+     * Closes the window for {@code projectKey} if one is open (used before deleting a project). Returns
+     * {@code true} if there was no open window or it closed; {@code false} if the user cancelled.
+     */
+    public boolean closeWindowForKey(String projectKey) {
+        Holder h = findHolder(projectKey == null ? "" : projectKey);
+        return h == null || requestClose(h.controller);
+    }
+
+    /** Re-applies view settings + the editor theme to every open window (after a Settings change). */
+    public void broadcastSettingsApplied() {
+        Settings settings = shared.getSettings();
+        for (Holder h : new ArrayList<>(windows)) {
+            h.controller.reapplyAfterSharedSettingsChange(settings);
+        }
+    }
+
+    // --- window construction (extracted from App.start) ---
+
+    private Stage buildWindow(String key, Project project, Path stateFile,
+                              List<MainController.OpenTarget> targets, boolean zen, String newFile,
+                              boolean simple) {
+        try {
+            Stage stage = primaryStage != null ? primaryStage : new Stage();
+            primaryStage = null; // only the first window reuses the JavaFX primary stage
+            CommandRegistry registry = new CommandRegistry();
+            ConfigManager config = project == null
+                    ? new ConfigManager(shared)
+                    : new ConfigManager(shared, stateFile);
+            config.setWorkspaceStateFile(config.getWorkspaceStateFile()); // load this window's session
+
+            FXMLLoader loader = new FXMLLoader(WindowManager.class.getResource("main.fxml"));
+            // Set the classloader explicitly: FXMLLoader otherwise falls back to the FX thread's context
+            // classloader, which is non-null at launch but can become null later — so building a window at
+            // runtime (every project window past the first) would fail with a null-classloader NPE.
+            loader.setClassLoader(WindowManager.class.getClassLoader());
+            BorderPane root = loader.load();
+            MainController controller = loader.getController();
+            controller.init(stage, config, registry, keymap);
+            controller.setHostServices(hostServices);
+            controller.setWindowContext(this, project);
+
+            StackPane sceneRoot = new StackPane(root);
+            controller.installZenOverlay(sceneRoot);
+            Scene scene = new Scene(sceneRoot, 1000, 700);
+            Settings settings = shared.getSettings();
+            scene.setFill(Themes.backgroundFor(settings.getTheme()));
+            scene.getStylesheets().addAll(
+                    WindowManager.class.getResource("/com/editora/styles/app.css").toExternalForm(),
+                    WindowManager.class.getResource("/com/editora/styles/syntax.css").toExternalForm());
+
+            KeyDispatcher keyDispatcher = new KeyDispatcher(registry, keymap, controller::setStatus);
+            keyDispatcher.install(scene);
+            controller.setKeyDispatcher(keyDispatcher);
+
+            scene.addEventFilter(javafx.scene.input.ScrollEvent.SCROLL, e -> {
+                if (e.isControlDown() && e.getDeltaY() != 0) {
+                    controller.zoomFromWheel(e);
+                    e.consume();
+                }
+            });
+
+            boolean secondary = !windows.isEmpty(); // another window is already open
+            stage.setScene(scene);
+            stage.setTitle("Editora");
+            loadAppIcons(stage);
+            controller.applyEditorTheme(settings.getEditorTheme());
+            restoreWindowBounds(stage, config.getWorkspaceState());
+            // Don't bury a secondary window full-screen on top of an existing one: drop maximized so it
+            // falls back to normal (cascadable) bounds. (Projects carried identical saved bounds — incl.
+            // maximized — from the single-window era, so otherwise every project window stacks exactly.)
+            if (secondary && stage.isMaximized()) {
+                stage.setMaximized(false);
+            }
+            stage.show();
+            // Offset a new window so it doesn't land exactly on top of an existing one, then bring it
+            // to the front so it's clearly a separate window rather than an in-place swap.
+            cascadeIfOverlapping(stage);
+            focus(stage);
+
+            windows.add(new Holder(key, stage, controller));
+            controller.startup(null, targets, zen, newFile, simple);
+            return stage;
+        } catch (java.io.IOException e) {
+            throw new java.io.UncheckedIOException("Failed to build a window for project '" + key + "'", e);
+        }
+    }
+
+    // --- helpers ---
+
+    /**
+     * Nudges {@code stage} down-right by a cascade step while its top-left would land on an already-open
+     * window, so a newly-opened project window is visibly separate instead of stacking exactly on top.
+     * Runs after {@code show()} so the bounds are realized. No-op for the first window / a maximized one.
+     */
+    private void cascadeIfOverlapping(Stage stage) {
+        if (windows.isEmpty() || stage.isMaximized()) {
+            return;
+        }
+        final double step = 32;
+        double x = stage.getX();
+        double y = stage.getY();
+        if (Double.isNaN(x) || Double.isNaN(y)) {
+            return;
+        }
+        int guard = 0;
+        while (guard++ < 25 && overlapsExisting(stage, x, y, step)) {
+            x += step;
+            y += step;
+        }
+        javafx.geometry.Rectangle2D vis = visualBoundsFor(x, y);
+        if (x + stage.getWidth() > vis.getMaxX() || y + stage.getHeight() > vis.getMaxY()) {
+            x = vis.getMinX() + step; // cascaded off-screen — wrap back near the top-left
+            y = vis.getMinY() + step;
+        }
+        stage.setX(x);
+        stage.setY(y);
+    }
+
+    private boolean overlapsExisting(Stage stage, double x, double y, double step) {
+        for (Holder h : windows) {
+            if (h.stage == stage || !h.stage.isShowing()) {
+                continue;
+            }
+            if (Math.abs(h.stage.getX() - x) < step && Math.abs(h.stage.getY() - y) < step) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static javafx.geometry.Rectangle2D visualBoundsFor(double x, double y) {
+        var screens = Screen.getScreensForRectangle(x, y, 1, 1);
+        Screen screen = screens.isEmpty() ? Screen.getPrimary() : screens.get(0);
+        return screen.getVisualBounds();
+    }
+
+    private Project findProject(String id) {
+        for (Project p : projects().list()) {
+            if (p.id().equals(id)) {
+                return p;
+            }
+        }
+        return null;
+    }
+
+    private Holder findHolder(String key) {
+        for (Holder h : windows) {
+            if (h.key.equals(key)) {
+                return h;
+            }
+        }
+        return null;
+    }
+
+    private void focusKey(String key) {
+        Holder h = findHolder(key);
+        if (h != null) {
+            focus(h.stage);
+        }
+    }
+
+    private static void focus(Stage stage) {
+        if (stage.isIconified()) {
+            stage.setIconified(false);
+        }
+        stage.toFront();
+        stage.requestFocus();
+    }
+
+    /** Restores a window's size/position/maximized state from its session (see {@code App} original). */
+    private static void restoreWindowBounds(Stage stage, WorkspaceState state) {
+        double w = state.getWindowWidth();
+        double h = state.getWindowHeight();
+        if (w > 0 && h > 0) {
+            double x = state.getWindowX();
+            double y = state.getWindowY();
+            if (!Screen.getScreensForRectangle(x, y, w, h).isEmpty()) {
+                stage.setX(x);
+                stage.setY(y);
+            }
+            stage.setWidth(w);
+            stage.setHeight(h);
+        }
+        if (state.isWindowMaximized()) {
+            stage.setMaximized(true);
+        }
+    }
+
+    /** Adds the app icon (multiple sizes) so it shows in the title bar, dock, and taskbar. */
+    private static void loadAppIcons(Stage stage) {
+        for (int size : new int[]{16, 32, 48, 128, 256, 512}) {
+            var in = WindowManager.class.getResourceAsStream("/com/editora/icons/icon-" + size + ".png");
+            if (in != null) {
+                stage.getIcons().add(new javafx.scene.image.Image(in));
+            }
+        }
+    }
+}

--- a/src/test/java/com/editora/config/ProjectManagerTest.java
+++ b/src/test/java/com/editora/config/ProjectManagerTest.java
@@ -4,8 +4,11 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
+import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.List;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -76,5 +79,40 @@ class ProjectManagerTest {
         ProjectManager reloaded = new ProjectManager(dir);
         assertEquals(1, reloaded.list().size());
         assertNull(reloaded.active());
+    }
+
+    @Test
+    void openWindowSetTracksAndPersists(@TempDir Path dir) {
+        ProjectManager pm = new ProjectManager(dir);
+        Project a = pm.createOrGet("A", dir.resolve("a"));
+        pm.markOpen("");        // the global window
+        pm.markOpen(a.id());    // a project window
+        pm.markOpen(a.id());    // idempotent
+        assertEquals(List.of("", a.id()), pm.openProjectIds());
+        assertTrue(pm.isOpen(a.id()));
+        pm.save();
+
+        ProjectManager reloaded = new ProjectManager(dir);
+        assertEquals(List.of("", a.id()), reloaded.openProjectIds());
+
+        reloaded.markClosed("");
+        assertEquals(List.of(a.id()), reloaded.openProjectIds());
+        // Deleting a project also drops it from the open set.
+        reloaded.delete(a.id());
+        assertFalse(reloaded.isOpen(a.id()));
+        assertTrue(reloaded.openProjectIds().isEmpty());
+    }
+
+    @Test
+    void migratesV1ActiveProjectIntoOpenSet(@TempDir Path dir) throws Exception {
+        // A pre-multi-window (v1) projects.json: a single activeProjectId, no openProjectIds.
+        Files.writeString(dir.resolve("projects.json"), """
+                {"schemaVersion":1,"activeProjectId":"myrepo-1a2b3c",
+                 "projects":[{"id":"myrepo-1a2b3c","name":"MyRepo","root":"/tmp/myrepo"}]}""");
+        ProjectManager pm = new ProjectManager(dir);
+        // The active project is seeded into the open-window set so it reopens as its own window.
+        assertEquals(List.of("myrepo-1a2b3c"), pm.openProjectIds());
+        assertNotNull(pm.active());
+        assertEquals("myrepo-1a2b3c", pm.active().id());
     }
 }


### PR DESCRIPTION
## Summary
Projects now open in their **own top-level window** instead of swapping the session in place. The no-project "global" session is itself a window; opening a project builds (or focuses) its window; the set of open windows is restored on the next launch. **Multi-window only activates when Projects are enabled** — with the default (off) the app stays single-window with zero behavior change.

## Config
- **`SharedConfig`** (new) holds the app-wide config (settings, bookmarks, notes, breakpoints, connections, dictionary, projects index), shared *by reference* across all windows so saves can't clobber each other.
- **`ConfigManager`** became a thin per-window delegator owning only the session (`WorkspaceState` + its file). All existing call sites unchanged; backward-compatible constructors keep single-window/tests working.
- **`ProjectManager.Index`** gains `openProjectIds` (the open-window set) + `markOpen/markClosed/isOpen`; **schema 1→2** migration seeds it from the old `activeProjectId` so the previously-active project reopens as a window.

## UI
- **`WindowManager`** (new) owns window construction (extracted from `App.start`), open/focus, restore-all on launch, per-window close/dispose, and broadcasting Settings changes to every window. Cascades a new window so it doesn't stack exactly on an existing one (projects carried identical bounds from the single-window era) and brings it to the front.
- **`MainController`**: `setWindowContext` wires the window's project (and auto-opens the Projects tool window); `switchToProject` opens/focuses a window; `closeProject` closes this window; `deleteProject` closes the project's window first; the close handler disposes the window's services and no longer shows a per-window "Quit?" prompt; settings changes broadcast to all windows. Removed the dead in-place-swap path.
- **`App.start`** bootstraps `SharedConfig` + delegates to `WindowManager`, and pins a classloader (`FXMLLoader` default + FX-thread context classloader): on macOS the AppKit thread's context classloader can be null, which broke building windows at runtime (null-classloader NPE in `FXMLLoader`) and any lazy class load on that thread.
- `SearchService`/`MermaidService`/`PdfExportService`/`PrintService` gained `shutdown()` so closing a window releases their threads.

## Testing
- `mvn test` — all 599 tests pass (incl. the new schema-1→2 migration + open-window-set tests, and `MessagesTest` key parity).
- Interactively verified (`--dev`): open → new window, focus existing, restore-all on launch, close one window without quitting the app, auto-open Projects tool window.

## Known limitation
The open-window restore set uses a "remain" rule, so a Cmd-Q that closes several windows in sequence may reopen only the last. A fully-correct fix needs an OS quit hook JavaFX doesn't cleanly expose.

🤖 Generated with [Claude Code](https://claude.com/claude-code)