### PR TITLE
Windows MSI/Linux DEB: add Start Menu + shortcut + dir chooser

### DIFF
--- a/scripts/aot_build.java
+++ b/scripts/aot_build.java
@@ -136,6 +136,18 @@ public class aot_build {
             cmd.add("--icon");
             cmd.add(icon);
         }
+        // Without these, a Windows MSI installs to Program Files but creates NO Start Menu entry,
+        // NO desktop shortcut, and NO install wizard — so it looks like "nothing installed". Add a
+        // real wizard (dir chooser) + a Start Menu group + a desktop shortcut. Linux .deb/.rpm
+        // likewise need --linux-shortcut for an application-menu entry. macOS DMG needs nothing
+        // (drag-to-Applications).
+        String t = type.toUpperCase(Locale.ROOT);
+        if (t.equals("MSI") || t.equals("EXE")) {
+            cmd.addAll(List.of("--win-menu", "--win-menu-group", appName,
+                    "--win-shortcut", "--win-dir-chooser"));
+        } else if (t.equals("DEB") || t.equals("RPM")) {
+            cmd.add("--linux-shortcut");
+        }
         System.out.println("[aot] wrapping installer: " + String.join(" ", cmd));
         Process p = new ProcessBuilder(cmd).inheritIO().start();
         int code = p.waitFor();


### PR DESCRIPTION
## Problem
The installer-wrap step passed no platform shortcut options, so a **Windows MSI installed to `C:\Program Files\Editora\` with no Start Menu entry, no desktop shortcut, and no install wizard** — it ran but looked like nothing installed. (Linux `.deb` had the same gap; macOS DMG is fine via drag-to-Applications.)

## Fix
Per-OS options in `aot_build.java`'s installer wrap:
- **Windows MSI/EXE:** `--win-menu --win-menu-group Editora --win-shortcut --win-dir-chooser` — real install wizard with a directory chooser, a Start Menu folder, and a desktop shortcut.
- **Linux DEB/RPM:** `--linux-shortcut` — application-menu entry.
- **macOS DMG:** unchanged.

## Testing
Can't be verified from macOS (MSI generation needs WiX on Windows; install test needs a Windows machine). The change is standard jpackage usage; verify by re-running the release and installing the new MSI/DEB.

🤖 Generated with [Claude Code](https://claude.com/claude-code)