### PR TITLE
fix: stop JSVG SVG-in-SVG warning from leaking back at runtime

### DIFF
--- a/src/main/java/com/editora/editor/PreviewImageLoader.java
+++ b/src/main/java/com/editora/editor/PreviewImageLoader.java
@@ -47,10 +47,19 @@ final class PreviewImageLoader {
     /** SVGs render at this device scale for crispness, then display at their logical size. */
     private static final double RASTER_SCALE = 2.0;
 
+    /**
+     * Strong reference to JSVG's logger. Badges often embed a logo as a nested SVG {@code <image>}, which
+     * JSVG can't decode-in-decode; it logs a WARNING (with a stack trace) per occurrence. The badge itself
+     * still renders, so we quiet that noise to SEVERE. The field must be {@code static final} (not a bare
+     * {@code Logger.getLogger(...)} call): {@code java.util.logging} holds only a <em>weak</em> reference to
+     * a logger, so without a strong ref of our own the logger is eventually GC'd, the SEVERE level is lost,
+     * and the warning leaks back through at the inherited level. (Mirrors {@code App.TM4E_LOG}/{@code LSP4J_LOG}.)
+     */
+    private static final java.util.logging.Logger JSVG_LOG =
+            java.util.logging.Logger.getLogger("com.github.weisj.jsvg");
+
     static {
-        // Badges often embed a logo as a nested SVG <image>, which JSVG can't decode-in-decode; it logs a
-        // WARNING (with a stack trace) per occurrence. The badge itself still renders, so quiet that noise.
-        java.util.logging.Logger.getLogger("com.github.weisj.jsvg").setLevel(java.util.logging.Level.SEVERE);
+        JSVG_LOG.setLevel(java.util.logging.Level.SEVERE);
     }
 
     /** Cap on cached decoded images. Each holds a GPU texture, so the cache is bounded (LRU) instead


### PR DESCRIPTION
## Problem

A `java.io.IOException: Unsupported Mime type image/svg+xml` warning (with a full stack trace) repeatedly appeared during normal use. It's JSVG's *benign* complaint when a Markdown preview badge embeds a nested SVG-in-SVG (e.g. shields.io badges with an embedded logo glyph — the badge still renders fine).

That warning was *supposed* to be silenced: `PreviewImageLoader`'s static block set JSVG's logger level to `SEVERE`. But it called `Logger.getLogger(...)` without keeping a reference. `java.util.logging` holds loggers only **weakly**, so the unreferenced logger was eventually GC'd, the `SEVERE` level lost, and the logger reverted to inheriting the root level (INFO) — letting the warning leak back through.

## Fix

Hold a strong `static final Logger JSVG_LOG` field so the level sticks for the JVM's lifetime — mirroring the existing `App.TM4E_LOG` / `App.LSP4J_LOG` pattern.

## Performance

Zero cost on every hot path (typing/scrolling/highlighting/rendering). One extra retained `Logger` reference; if anything it slightly reduces overhead by suppressing the per-occurrence stack-trace formatting that was leaking through.

🤖 Generated with [Claude Code](https://claude.com/claude-code)