### PR TITLE
refactor: remove redundant project combo from the Project tool window

### DIFF
--- a/src/main/java/com/editora/ui/MainController.java
+++ b/src/main/java/com/editora/ui/MainController.java
@@ -1461,8 +1461,7 @@ public class MainController {
     }
 
     private void refreshProjectPanelList() {
-        // The combo shows THIS window's project as selected (each window is one project).
-        projectPanel.setProjects(projects.list(), projectKey);
+        // The toolbar combo shows THIS window's project as selected (each window is one project).
         if (toolbarProjectCombo != null) {
             toolbarProjectCombo.setProjects(projects.list(), projectKey);
         }
@@ -1808,9 +1807,8 @@ public class MainController {
 
     private void setupToolWindows() {
         toolWindows = new ToolWindowManager(workspace, tabPane, config, keymap);
-        projectPanel = new ProjectPanel(this::openPath, this::switchToProject, this::closeProject,
-                this::deleteProject, this::onProjectFileRenamed, this::onProjectFileDeleted,
-                this::isPathModified);
+        projectPanel = new ProjectPanel(this::openPath, this::onProjectFileRenamed,
+                this::onProjectFileDeleted, this::isPathModified);
         projectPanel.setPrompt(this::promptText); // in-scene rename prompt
         projectPanel.setOnNewFromTemplate(this::newFromTemplate); // folder "New From Template…"
         projectToolWindow = new ToolWindow("project", tr("toolwindow.project"), ToolWindow.Side.RIGHT,

--- a/src/main/java/com/editora/ui/ProjectPanel.java
+++ b/src/main/java/com/editora/ui/ProjectPanel.java
@@ -19,38 +19,34 @@ import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import java.util.stream.Stream;
 
-import com.editora.config.Project;
-
 import javafx.application.Platform;
 import javafx.animation.PauseTransition;
 import javafx.collections.ObservableList;
 import javafx.geometry.Pos;
 import javafx.scene.control.Alert;
-import javafx.scene.control.Button;
 import javafx.scene.control.ButtonType;
 import javafx.scene.control.ContextMenu;
 import javafx.scene.control.Label;
 import javafx.scene.control.MenuItem;
 import javafx.scene.control.TextField;
-import javafx.scene.control.Tooltip;
 import javafx.scene.control.TreeCell;
 import javafx.scene.control.TreeItem;
 import javafx.scene.control.TreeView;
 import javafx.scene.input.KeyCode;
 import javafx.scene.input.KeyEvent;
 import javafx.scene.input.MouseButton;
-import javafx.scene.layout.HBox;
 import javafx.scene.layout.Priority;
 import javafx.scene.layout.StackPane;
 import javafx.scene.layout.VBox;
 import javafx.util.Duration;
 
 /**
- * The Project tool window: a project switcher (combobox incl. "No Project", + close button) and a
- * filter box over a lazy file tree rooted at the active project's folder. Typing in the filter runs a
- * bounded, debounced project-wide name search (dot-dirs skipped, capped) and shows matches as a flat
- * list; clearing it restores the lazy tree. Emacs-style keyboard nav (C-n/C-p, C-f/C-b, Enter) like
- * the Structure panel; Enter/double-click opens a file; a right-click menu renames/deletes files.
+ * The Project tool window: a filter box over a lazy file tree rooted at the active project's folder.
+ * Typing in the filter runs a bounded, debounced project-wide name search (dot-dirs skipped, capped)
+ * and shows matches as a flat list; clearing it restores the lazy tree. Emacs-style keyboard nav
+ * (C-n/C-p, C-f/C-b, Enter) like the Structure panel; Enter/double-click opens a file; a right-click
+ * menu renames/deletes files. (Project switch/close/delete live on the toolbar project combo and the
+ * {@code project.*} palette commands — each window is one project, named in the window title.)
  */
 public class ProjectPanel extends VBox implements ToolWindowContent {
 
@@ -59,9 +55,6 @@ public class ProjectPanel extends VBox implements ToolWindowContent {
     private static final int MAX_DEPTH = 25;
 
     private final Consumer<Path> onOpenFile;
-    private final Consumer<Project> onSwitchProject;
-    private final Runnable onCloseProject;
-    private final Runnable onDeleteProject;
     private final BiConsumer<Path, Path> onFileRenamed;
     private final Consumer<Path> onFileDeleted;
     private final java.util.function.Predicate<Path> isModified;
@@ -71,9 +64,6 @@ public class ProjectPanel extends VBox implements ToolWindowContent {
     /** In-scene single-line prompt (injected by MainController) used to rename a file/folder. */
     private OverlayInput.Prompt prompt;
 
-    private ProjectCombo projectCombo;
-    private final Button closeButton = new Button();
-    private final Button deleteButton = new Button();
     private final TextField filterField = new TextField();
     private final TreeView<Path> tree = new TreeView<>();
     private final StackPane placeholderPane;
@@ -91,14 +81,10 @@ public class ProjectPanel extends VBox implements ToolWindowContent {
     private boolean filtering;
     private boolean loading;
 
-    public ProjectPanel(Consumer<Path> onOpenFile, Consumer<Project> onSwitchProject,
-                        Runnable onCloseProject, Runnable onDeleteProject,
+    public ProjectPanel(Consumer<Path> onOpenFile,
                         BiConsumer<Path, Path> onFileRenamed, Consumer<Path> onFileDeleted,
                         java.util.function.Predicate<Path> isModified) {
         this.onOpenFile = onOpenFile;
-        this.onSwitchProject = onSwitchProject;
-        this.onCloseProject = onCloseProject;
-        this.onDeleteProject = onDeleteProject;
         this.onFileRenamed = onFileRenamed;
         this.onFileDeleted = onFileDeleted;
         this.isModified = isModified;
@@ -106,7 +92,6 @@ public class ProjectPanel extends VBox implements ToolWindowContent {
         getProperties().put("editora.ownsKeys", Boolean.TRUE);
         setSpacing(4);
 
-        buildHeader();
         buildFilter();
 
         tree.setShowRoot(true);
@@ -129,29 +114,6 @@ public class ProjectPanel extends VBox implements ToolWindowContent {
         setRoot(null);
     }
 
-    private void buildHeader() {
-        // Every combo selection is a switch — including "No Project" (id "" = return to the global
-        // session without closing any project); the caller (switchToProject) handles the sentinel.
-        projectCombo = new ProjectCombo(onSwitchProject);
-        projectCombo.setMaxWidth(Double.MAX_VALUE);
-        HBox.setHgrow(projectCombo, Priority.ALWAYS);
-
-        closeButton.setGraphic(Icons.closeSmall());
-        closeButton.getStyleClass().addAll("button-icon", "flat");
-        closeButton.setTooltip(new Tooltip(tr("project.closeTip")));
-        closeButton.setOnAction(e -> onCloseProject.run());
-
-        deleteButton.setGraphic(Icons.trash());
-        deleteButton.getStyleClass().addAll("button-icon", "flat");
-        deleteButton.setTooltip(new Tooltip(tr("project.deleteTip")));
-        deleteButton.setOnAction(e -> onDeleteProject.run());
-
-        HBox header = new HBox(4, projectCombo, deleteButton, closeButton);
-        header.getStyleClass().add("project-header");
-        header.setAlignment(Pos.CENTER_LEFT);
-        getChildren().add(header);
-    }
-
     private void buildFilter() {
         filterField.setPromptText(tr("project.filterPrompt"));
         filterField.getStyleClass().add("project-filter");
@@ -161,14 +123,6 @@ public class ProjectPanel extends VBox implements ToolWindowContent {
             }
         });
         filterDebounce.setOnFinished(e -> rebuildBody());
-    }
-
-    /** Populates the project switcher; {@code activeId} selects the current project (or "" for none). */
-    public void setProjects(List<Project> all, String activeId) {
-        projectCombo.setProjects(all, activeId);
-        boolean noActive = activeId == null || activeId.isEmpty();
-        closeButton.setDisable(noActive);
-        deleteButton.setDisable(noActive);
     }
 
     /** Re-renders the visible tree cells so each file's modified marker/color reflects current state. */
@@ -252,7 +206,7 @@ public class ProjectPanel extends VBox implements ToolWindowContent {
     private void rebuildBody() {
         long gen = searchGen.incrementAndGet(); // invalidate any in-flight search
         if (root == null || !Files.isDirectory(root)) {
-            getChildren().setAll(header(), placeholderPane);
+            getChildren().setAll(placeholderPane);
             return;
         }
         String q = filterField.getText().trim();
@@ -283,11 +237,7 @@ public class ProjectPanel extends VBox implements ToolWindowContent {
                 });
             });
         }
-        getChildren().setAll(header(), filterField, tree);
-    }
-
-    private HBox header() {
-        return (HBox) getChildren().get(0);
+        getChildren().setAll(filterField, tree);
     }
 
     /** Bounded project-wide filename search: dot-dirs skipped, capped on entries visited and matches. */

--- a/src/main/resources/com/editora/i18n/messages.properties
+++ b/src/main/resources/com/editora/i18n/messages.properties
@@ -665,8 +665,6 @@ bookmarks.deleteFileBody=Remove all bookmarks in "{0}"?
 
 # ---- Project panel ----
 project.placeholder=No project open
-project.closeTip=Close project (keeps it in your list)
-project.deleteTip=Delete project (remove from list; files on disk are kept)
 project.filterPrompt=Search files…
 project.renameTitle=Rename
 project.renameContent=New name:

--- a/src/main/resources/com/editora/i18n/messages_de.properties
+++ b/src/main/resources/com/editora/i18n/messages_de.properties
@@ -661,8 +661,6 @@ bookmarks.deleteFileBody=Alle Lesezeichen in „{0}“ entfernen?
 
 # ---- Project panel ----
 project.placeholder=Kein Projekt geöffnet
-project.closeTip=Projekt schließen (bleibt in deiner Liste)
-project.deleteTip=Projekt löschen (aus der Liste entfernen; Dateien auf der Festplatte bleiben erhalten)
 project.filterPrompt=Dateien suchen…
 project.renameTitle=Umbenennen
 project.renameContent=Neuer Name:

--- a/src/main/resources/com/editora/i18n/messages_es.properties
+++ b/src/main/resources/com/editora/i18n/messages_es.properties
@@ -661,8 +661,6 @@ bookmarks.deleteFileBody=¿Quitar todos los marcadores de «{0}»?
 
 # ---- Project panel ----
 project.placeholder=Ningún proyecto abierto
-project.closeTip=Cerrar proyecto (se mantiene en tu lista)
-project.deleteTip=Eliminar proyecto (quitar de la lista; los archivos en disco se conservan)
 project.filterPrompt=Buscar archivos…
 project.renameTitle=Renombrar
 project.renameContent=Nuevo nombre:

--- a/src/main/resources/com/editora/i18n/messages_fr.properties
+++ b/src/main/resources/com/editora/i18n/messages_fr.properties
@@ -661,8 +661,6 @@ bookmarks.deleteFileBody=Supprimer tous les signets dans « {0} » ?
 
 # ---- Project panel ----
 project.placeholder=Aucun projet ouvert
-project.closeTip=Fermer le projet (le conserve dans votre liste)
-project.deleteTip=Supprimer le projet (retirer de la liste ; les fichiers sur le disque sont conservés)
 project.filterPrompt=Rechercher des fichiers…
 project.renameTitle=Renommer
 project.renameContent=Nouveau nom :

--- a/src/main/resources/com/editora/i18n/messages_it.properties
+++ b/src/main/resources/com/editora/i18n/messages_it.properties
@@ -661,8 +661,6 @@ bookmarks.deleteFileBody=Rimuovere tutti i segnalibri in «{0}»?
 
 # ---- Project panel ----
 project.placeholder=Nessun progetto aperto
-project.closeTip=Chiudi il progetto (resta nell'elenco)
-project.deleteTip=Elimina il progetto (rimuovi dall'elenco; i file su disco vengono mantenuti)
 project.filterPrompt=Cerca file…
 project.renameTitle=Rinomina
 project.renameContent=Nuovo nome:

--- a/src/main/resources/com/editora/i18n/messages_pt.properties
+++ b/src/main/resources/com/editora/i18n/messages_pt.properties
@@ -661,8 +661,6 @@ bookmarks.deleteFileBody=Remover todos os marcadores em «{0}»?
 
 # ---- Project panel ----
 project.placeholder=Nenhum projeto aberto
-project.closeTip=Fechar projeto (mantém na sua lista)
-project.deleteTip=Excluir projeto (remover da lista; os arquivos no disco são mantidos)
 project.filterPrompt=Pesquisar arquivos…
 project.renameTitle=Renomear
 project.renameContent=Novo nome:


### PR DESCRIPTION
## What

Removes the Project tool window's header row — the project-switcher **ComboBox** plus the **🗑 delete** and **✕ close** buttons. The panel now goes straight from the **Project** title to the **Search files…** filter field.

## Why redundant

- Each project opens in **its own window** with the project name in the title (multi-window model).
- The **toolbar** already carries a project combo (switch + per-item delete).
- Switch / close / delete remain reachable via the `project.switch` / `project.close` / `project.delete` **palette commands**.

## Changes

- **ProjectPanel** — drop `buildHeader()`/`header()`/`setProjects()`, the `projectCombo` + close/delete buttons, the now-dead `onSwitch`/`onClose`/`onDelete` callbacks, and 4 unused imports; `rebuildBody()` no longer prepends the header.
- **MainController** — trim the `ProjectPanel` constructor call; drop the panel's `setProjects` from `refreshProjectPanelList()` (the toolbar combo still updates).
- **i18n** — remove the orphaned `project.closeTip`/`project.deleteTip` keys from all 6 catalogs (parity preserved).

## Verification

Full `./mvnw test` green (incl. `MessagesTest` six-locale parity). Net perf positive — one fewer ComboBox + 2 Buttons per Project tool window, one less `setProjects` call per refresh.

🤖 Generated with [Claude Code](https://claude.com/claude-code)