### PR TITLE
fix: close Markdown preview context menu on an outside click

### DIFF
--- a/src/main/java/com/editora/editor/EditorBuffer.java
+++ b/src/main/java/com/editora/editor/EditorBuffer.java
@@ -1652,7 +1652,15 @@ public class EditorBuffer implements TabContent {
             // Keyboard scrolling in the preview: Space / PageDown page down, Backspace / PageUp page up
             // (C-v / M-v go through nav.pageDown/Up → pagePreview). Focus it on click so the keys land.
             previewPane.setFocusTraversable(true);
-            previewPane.addEventFilter(javafx.scene.input.MouseEvent.MOUSE_PRESSED, e -> previewPane.requestFocus());
+            previewPane.addEventFilter(javafx.scene.input.MouseEvent.MOUSE_PRESSED, e -> {
+                // A press in the preview dismisses an open preview context menu. The ScrollPane consumes
+                // the press before the popup's auto-hide can fire (same as the editor menu — see
+                // installContextMenu), so close it explicitly; the click still falls through to focus.
+                if (previewContextMenu != null && previewContextMenu.isShowing()) {
+                    previewContextMenu.hide();
+                }
+                previewPane.requestFocus();
+            });
             // Right-click menu: Select All / Copy (rendered plain text) + Export to PDF / Print.
             previewPane.setOnContextMenuRequested(e -> {
                 showPreviewContextMenu(e.getScreenX(), e.getScreenY());


### PR DESCRIPTION
## Problem

The Markdown preview's right-click menu (Select All / Copy / Export PDF / Print) only closed with **Esc** or **C-g** — clicking elsewhere left it open.

## Cause

The menu is a JavaFX `ContextMenu` (auto-hide on by default), but the preview `ScrollPane` consumes the mouse press before the popup's auto-hide can fire. This is the exact situation the **editor's** own context menu already documents and works around in `installContextMenu` (it hides explicitly on `MOUSE_PRESSED`); the preview pane never did.

## Fix

Hide the preview context menu explicitly inside the preview pane's existing `MOUSE_PRESSED` filter, then fall through to the focus request (unchanged). A click anywhere in the preview now dismisses the menu, matching the editor and standard platform behavior. Clicks outside the preview were already handled by the popup's normal auto-hide.

## Verification

`./mvnw verify` green — full test suite **and** `spotless:check`. Zero hot-path cost (one `isShowing()` check on an actual mouse press; nothing on typing/scroll/render).

🤖 Generated with [Claude Code](https://claude.com/claude-code)