### PR TITLE
Theme the autocomplete completion popup

### DIFF
--- a/src/main/java/com/editora/editor/CompletionPopup.java
+++ b/src/main/java/com/editora/editor/CompletionPopup.java
@@ -53,6 +53,13 @@ public final class CompletionPopup {
         });
         VBox box = new VBox(list);
         box.getStyleClass().add("completion-popup");
+        // A Popup has its own scene that does NOT inherit the editor scene's stylesheets, so without this
+        // app.css (and its `.completion-*` rules + AtlantaFX `-color-*` vars) never apply and the list
+        // falls back to bare default colors. Attach it to the content subtree (the note-tooltip idiom).
+        java.net.URL css = CompletionPopup.class.getResource("/com/editora/styles/app.css");
+        if (css != null) {
+            box.getStylesheets().add(css.toExternalForm());
+        }
         popup.getContent().add(box);
         popup.setAutoHide(true);
         popup.setAutoFix(true);


### PR DESCRIPTION
## Summary

The autocomplete dropdown is a `javafx.stage.Popup`, whose scene doesn't inherit the editor scene's stylesheets — so `app.css` and all its `.completion-*` rules (border, drop shadow, rounded corners, themed text/selection, accent-colored detail + snippet labels) never applied. The popup rendered with bare defaults. This attaches `app.css` to the popup content subtree (the same idiom the Markdown/note tooltips use for their popup scenes); AtlantaFX is the global user-agent stylesheet, so the `-color-*` variables resolve and the popup now tracks the app theme.

Before → after (rendered with the app's exact AtlantaFX + `app.css` setup):
- Before: faint/empty selection, no border or shadow, square corners.
- After: accent-blue selected row + white text, rounded border + drop shadow, accent-colored detail.

## Verification

- `./mvnw verify` → BUILD SUCCESS, 669 tests, spotless clean, jlink links.
- Clean startup smoke; before/after rendered via a headless snapshot harness.

Negligible perf cost — one stylesheet attached once at popup construction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)