### PR TITLE
Make the Find in Files toolbar icon toggle the panel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **The Find in Files toolbar icon now toggles the panel** — one click opens it (focusing the query field),
+  another click closes it (matching `C-s`'s in-file find and the `M-6` tool-window toggle). `C-S-f` toggles
+  too, since it shares the command.
+
 ### Fixed
 
 - **Find/Replace highlights now stay in sync when you edit the buffer.** With the find bar open, editing the

--- a/src/main/java/com/editora/ui/MainController.java
+++ b/src/main/java/com/editora/ui/MainController.java
@@ -2245,9 +2245,14 @@ public class MainController {
         });
     }
 
-    /** Opens (or focuses) the Find-in-Files tool window and focuses its query field. */
+    /** Toggles the Find-in-Files tool window: opens it (focusing its query field) when closed, closes it
+     *  when already open — so the toolbar icon (and {@code C-S-f}) acts as an open/close toggle. */
     private void openSearchInFiles() {
-        toolWindows.open(searchToolWindow, true);
+        if (toolWindows.isOpen(searchToolWindow)) {
+            toolWindows.close(searchToolWindow);
+        } else {
+            toolWindows.open(searchToolWindow, true);
+        }
     }
 
     /** Starts AceJump on the active buffer: type a character, then a label, to jump the caret. */


### PR DESCRIPTION
## Summary

The Find in Files toolbar icon now **toggles** its panel — one click opens it (focusing the query field), another click closes it.

`openSearchInFiles()` — the single handler the icon's `search.inFiles` command, the `C-S-f` shortcut, and the FXML handler all route to — now closes the search tool window when it's already open instead of always re-opening it:

```java
if (toolWindows.isOpen(searchToolWindow)) toolWindows.close(searchToolWindow);
else                                       toolWindows.open(searchToolWindow, true);
```

This matches the in-file find (`C-s`) and the `M-6` tool-window toggle, which already toggle. `C-S-f` toggles too, since it shares the command.

## Verification

- `./mvnw verify` → BUILD SUCCESS, 686 tests, spotless clean, jlink links. Clean startup smoke.

One-method change; no i18n / schema / test impact (the search logic is unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)