### PR TITLE
docs: record Local File History in README, TODO, CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Local file history.** Editora now silently snapshots local files over time — on save, auto-save, and
+  before an external-change reload — so you can recover earlier versions independently of any VCS. Browse them
+  in a new **File History** tool window (`M-g l` or the palette **File History: Show**): each revision shows
+  its date/time, reason, and size, with the latest tagged **Current**. Double-click a revision for a read-only
+  diff against the current file, or restore one (an undoable whole-file replace). Snapshots are deduped by
+  content, stored gzip-compressed and content-addressed under `<configDir>/history/`, and pruned by
+  configurable limits (max revisions/file, max age, max size per project — Settings → Application → Local
+  History). On by default; local-only (no SFTP) and off in Simple UI mode.
 - **Emacs fill commands.** Re-wrap paragraphs to a fill column: **Fill Paragraph** (`M-q`) reflows the
   paragraph at the caret, **Fill Region** reflows every paragraph in the selection, and **Set Fill Column**
   (`C-x f`) sets the target width (default 70, also in Settings → Editor). Filling preserves the paragraph's

--- a/README.md
+++ b/README.md
@@ -190,6 +190,12 @@ Emacs-style keymap or a fuzzy command palette.
   intra-line highlights, prev/next-change navigation, apply-a-hunk / apply-all (undoable), live refresh,
   and patch export. Diff against `HEAD` (`C-x v =`), another commit, or any other file; a separate
   merge-conflict resolver accepts ours / theirs / both per conflict.
+- **Local file history** — IntelliJ-style snapshots of local files, taken on save, auto-save, and before an
+  external-change reload, independent of any VCS. A **File History** tool window (`M-g l`) lists each revision
+  (date/time, reason, size; the latest tagged *Current*); double-click for a read-only diff against the
+  current file, or restore one (an undoable whole-file replace). Snapshots are deduped by content and stored
+  gzip-compressed under `<configDir>/history/`, pruned by configurable limits (revisions/file, age,
+  size/project). On by default; local-only; off in Simple UI mode.
 - **HTTP client** _(Beta)_ — open a `.http`/`.rest` file and click the green ▶ next to a request to run it with
   Editora's **built-in** HTTP client; the response (status, headers, pretty-printed JSON body, timing/
   size) shows in an HTTP Client tool window (`M-0`). Supports `{{variable}}`/`@var` substitution,
@@ -219,9 +225,9 @@ Emacs-style keymap or a fuzzy command palette.
   *who* published — not a sandbox. See [`docs/plugins.md`](docs/plugins.md),
   [`examples/example-plugin/`](examples/example-plugin/), and
   [`examples/editora-plugins-registry/`](examples/editora-plugins-registry/).
-- **Tool windows** — IntelliJ-style dockable panels (Project, Commit, Structure, File Information,
-  Bookmarks, Personal Notes, Problems, Search Results, Run, Debug, HTTP Client) — plus any contributed by a
-  plugin.
+- **Tool windows** — IntelliJ-style dockable panels (Project, Commit, Git Log, File History, Structure, File
+  Information, Bookmarks, Personal Notes, Problems, Search Results, Run, Debug, HTTP Client) — plus any
+  contributed by a plugin.
 - **Settings** — a category sidebar (Appearance, Editor, Tool Windows, Spell Check, Application, …) with a
   search box, a live font/theme preview, and Reset to Defaults. Changes apply instantly.
 - **Multi-language interface** — run Editora in **English, Italian, Spanish, French, Portuguese, or

--- a/TODO.md
+++ b/TODO.md
@@ -135,7 +135,11 @@ A backlog of planned features and improvements. Unordered within each section.
 - [x] Git support — native CLI (branch/status, gutter change bars, commit workflow, fetch/pull/push)
 - [x] Diff viewer + merge-conflict UI — side-by-side / unified diff (vs HEAD / commit / another file),
       word-level highlights, apply-hunk / apply-all, patch export, merge-conflict resolver
-- [ ] Local History support
+- [x] Local file history — IntelliJ-style snapshots on save / auto-save / before an external reload; a
+      **File History** tool window (`M-g l`) lists revisions (date/time, reason, size; latest tagged
+      *Current*), double-click for a read-only diff vs current, restore = undoable whole-file replace.
+      Gzip'd content-addressed blobs + a per-project index under `<configDir>/history/`, deduped, with
+      configurable retention (revisions/file, age, size/project). On by default; local-only; off in Simple UI
 - [x] Detect external file changes — prompt to reload when a file changes on disk (focus-regain / tab switch)
 - [ ] Auto-reload modified files
 - [x] Remote file editing support — SSH/SFTP: browse/open/edit/save remote files; saved connections


### PR DESCRIPTION
Follow-up to #22 — documents the **Local File History** feature in the project docs:

- **README** — a new *Local file history* feature bullet, and *Git Log* + *File History* added to the Tool windows list.
- **TODO.md** — the *Local History support* roadmap item flipped from planned to shipped, with a description.
- **CHANGELOG.md** — a `[Unreleased] → Added` entry.

Docs only; no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)