### PR TITLE
Acknowledge LSP workspace/diagnostic/refresh request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Silenced a spurious LSP "Internal error" log.** Language servers that support pull diagnostics
+  (the HTML/CSS/JSON servers) send a `workspace/diagnostic/refresh` request; the client didn't implement it,
+  so lsp4j logged a SEVERE `UnsupportedOperationException` each time (visible in the debug log / dev console).
+  The client now acknowledges the request. Diagnostics were never actually affected — they already refresh on
+  each edit, on save, and when a server reports ready.
+
 - **Find/Replace highlights now stay in sync when you edit the buffer.** With the find bar open, editing the
   text left the match highlights painted at their old offsets (no longer aligned with the searched text).
   The bar now re-runs the search on each (debounced) edit and re-highlights at the new positions — without

--- a/src/main/java/com/editora/lsp/LanguageServerSession.java
+++ b/src/main/java/com/editora/lsp/LanguageServerSession.java
@@ -435,6 +435,20 @@ final class LanguageServerSession implements LanguageClient {
     }
 
     /**
+     * Acknowledges {@code workspace/diagnostic/refresh}. Servers that support pull diagnostics
+     * (vscode-html/css/json) send this request to ask the client to re-request diagnostics for its
+     * open documents. lsp4j's default {@link LanguageClient#refreshDiagnostics()} throws
+     * {@code UnsupportedOperationException}, which lsp4j then logs as a SEVERE "Internal error";
+     * overriding it to complete normally silences that noise. We don't force an immediate re-pull
+     * here — {@code LspManager.pullDiagnostics} already runs on every (debounced) edit, on save, and
+     * when the server first reports ready — so the hint is effectively honored on the next pulse.
+     */
+    @Override
+    public CompletableFuture<Void> refreshDiagnostics() {
+        return CompletableFuture.completedFuture(null);
+    }
+
+    /**
      * Answers {@code workspace/configuration} so servers that read settings this way pick up our defaults
      * — notably **Pyright**, which only offers auto-import completions when
      * {@code python.analysis.autoImportCompletions} is on (its own default is off). We enable it however


### PR DESCRIPTION
## Summary

Silences a spurious **SEVERE `Internal error: null` / `UnsupportedOperationException`** that lsp4j logged whenever a pull-diagnostics-capable language server (the HTML / CSS / JSON servers) sent a `workspace/diagnostic/refresh` request.

`LanguageServerSession implements LanguageClient` but didn't override `refreshDiagnostics()`, so lsp4j's default impl (which throws `UnsupportedOperationException`) ran and got logged as an internal error. **Diagnostics themselves were never affected** — it was pure log noise (visible in the debug log / dev console).

## Fix

One override in `LanguageServerSession`:

```java
@Override
public CompletableFuture<Void> refreshDiagnostics() {
    return CompletableFuture.completedFuture(null);
}
```

We don't force an immediate re-pull — `LspManager.pullDiagnostics` already runs on every debounced edit, on save, and when a server reports ready — so the refresh hint is effectively honored on the next pulse.

## Verification

- `./mvnw verify` (tests + spotless + jlink) ✅
- `javap` confirms lsp4j's interface declares `default CompletableFuture<Void> refreshDiagnostics()` (the throwing default at `LanguageClient.java:251`, the exact line in the original stack trace); our `@Override` returns a completed future, so that line is no longer reachable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)