### PR TITLE
Make line-number gutter scroll cheaper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Performance
+
+- **Smoother scrolling in files with many lines.** The line-number gutter set each row's number via a
+  per-row reactive binding that subscribed/unsubscribed as cells recycled during a scroll — measurable churn
+  on the hot path. The number is now set directly from the live line count, and re-pads only when the count
+  crosses a power of 10 (rare). A layout-forced scroll sweep over a ~375-line Markdown file was ~12–21%
+  faster in the gutter (measured A/B in one process). Line numbers, folding, and all gutter markers are
+  unchanged.
+
 ### Changed
 
 - **The Find in Files toolbar icon now toggles the panel** — one click opens it (focusing the query field),

--- a/src/main/java/com/editora/editor/FoldManager.java
+++ b/src/main/java/com/editora/editor/FoldManager.java
@@ -32,8 +32,6 @@ import com.editora.editor.FoldRegions.Region;
 import org.fxmisc.richtext.CharacterHit;
 import org.fxmisc.richtext.CodeArea;
 import org.fxmisc.richtext.model.TwoDimensional.Bias;
-import org.reactfx.collection.LiveList;
-import org.reactfx.value.Val;
 
 /**
  * Computes foldable regions for a {@link CodeArea}, drives folding/unfolding, and supplies the gutter
@@ -112,6 +110,9 @@ public final class FoldManager {
     private IntFunction<String> changeClass = i -> null;
     /** Hunk text (unified diff) for a line's change bar hover tooltip, or {@code null} for none. */
     private IntFunction<String> changeTooltip = i -> null;
+
+    /** Digit width the gutter line numbers were last padded to; re-pad visible rows when it changes. */
+    private int lastLineDigits = 1;
 
     /** Shared hover preview of a collapsed line's hidden content; reused across all lines. */
     private final Tooltip linePreview = new Tooltip();
@@ -229,7 +230,29 @@ public final class FoldManager {
                 area.recreateParagraphGraphic(line);
             }
         }
+        // The line-number gutter pads to the digit width of the line count (see formatLineNo). Since the
+        // line number is now set directly (no live binding), re-pad the visible rows when that width
+        // changes — i.e. the count crossed a power of 10. Runs only on this debounced recompute, not per
+        // keystroke; offscreen rows get the right width when they're next built.
+        int d = digits(total);
+        if (d != lastLineDigits) {
+            lastLineDigits = d;
+            repadVisibleLineNumbers(total);
+        }
         onRegionsChanged.run();
+    }
+
+    /** Recreates the visible rows' gutter graphics so their line numbers re-pad to a new digit width. */
+    private void repadVisibleLineNumbers(int total) {
+        try {
+            int first = Math.max(0, area.firstVisibleParToAllParIndex());
+            int last = Math.min(total - 1, area.lastVisibleParToAllParIndex());
+            for (int i = first; i <= last; i++) {
+                area.recreateParagraphGraphic(i);
+            }
+        } catch (RuntimeException ignored) {
+            // viewport mid-layout — the next build picks up the new width anyway
+        }
     }
 
     /** Wires the bookmark gutter marker: a predicate for which lines are bookmarked + a click handler. */
@@ -516,11 +539,11 @@ public final class FoldManager {
      * that begin a foldable region. Clicking the chevron toggles that region.
      */
     public IntFunction<Node> gutterFactory(boolean showLineNumbers) {
-        Val<Integer> nParagraphs = LiveList.sizeOf(area.getParagraphs());
-        return idx -> buildGutter(idx, showLineNumbers, nParagraphs);
+        lastLineDigits = digits(area.getParagraphs().size());
+        return idx -> buildGutter(idx, showLineNumbers);
     }
 
-    private Node buildGutter(int idx, boolean showLineNumbers, Val<Integer> nParagraphs) {
+    private Node buildGutter(int idx, boolean showLineNumbers) {
         HBox box = new HBox();
         box.getStyleClass().add("fold-gutter");
         box.setAlignment(Pos.CENTER_RIGHT);
@@ -626,8 +649,12 @@ public final class FoldManager {
             Label lineNo = new Label();
             lineNo.getStyleClass().add("lineno");
             lineNo.setAlignment(Pos.CENTER_RIGHT);
-            Val<String> formatted = nParagraphs.map(n -> formatLineNo(idx + 1, n));
-            lineNo.textProperty().bind(formatted.conditionOnShowing(lineNo));
+            // Set the text directly from the live (O(1)) paragraph count rather than a per-row reactive
+            // binding — the binding's subscribe/unsubscribe churn as cells recycle was a measurable cost
+            // on every scroll (a layout-forced scroll sweep over README.md was ~12-21% faster without it).
+            // Padding re-pads via repadVisibleLineNumbers() only when the digit width of the line count
+            // actually changes (a power-of-10 crossing — rare), not per row.
+            lineNo.setText(formatLineNo(idx + 1, area.getParagraphs().size()));
             box.getChildren().add(lineNo);
         }
 
@@ -741,7 +768,11 @@ public final class FoldManager {
     }
 
     private static String formatLineNo(int line, int total) {
-        int digits = (int) Math.floor(Math.log10(Math.max(1, total))) + 1;
-        return String.format("%1$" + digits + "s", line);
+        return String.format("%1$" + digits(total) + "s", line);
+    }
+
+    /** Number of decimal digits needed for {@code total} (>= 1). */
+    private static int digits(int total) {
+        return (int) Math.floor(Math.log10(Math.max(1, total))) + 1;
     }
 }


### PR DESCRIPTION
## Summary

Reduces scroll jank in files with many lines. The line-number gutter set each row's number through a **per-row ReactFX binding** (`nParagraphs.map(...).conditionOnShowing(lineNo)`) that subscribed/unsubscribed every time RichTextFX recycled a cell during a scroll — real churn on the hot path, and the dominant per-row gutter cost (confirmed: scrolling is faster in Simple UI, which nulls the gutter factory; the minimap re-blit and the format bar are cheap/inactive by comparison).

## Fix

Set the line number **directly from the live O(1) line count**, and re-pad visible rows only when the count's digit width changes (a power-of-10 crossing — rare), via the already-debounced `recompute`. No per-row reactive subscriptions. Line numbers, folding, and every gutter marker (bookmark/note/run/git/breakpoint) are unchanged.

## Measurement

A construction-time microbenchmark was useless here — machine load swamped the signal, and it can't capture the scene-attached subscription cost. So I measured **A/B in one process** (both code paths behind a temp flag, real layout-forced scroll sweep over README.md, back-to-back under identical load):

- binding 1257 ms → direct **995 ms (21% faster)**
- binding 1177 ms → direct **1040 ms (12% faster)**

→ **~12–21% off the gutter's actual scroll cost.** All benchmark scaffolding was removed; the change is a single clean edit to `FoldManager.java`.

## Verification

- `./mvnw verify` (tests + spotless + jlink) ✅
- Dev smoke: opened a 317-line Markdown file (folds + 3-digit line numbers), 0 exceptions; the A/B sweep exercised the optimized gutter through 8× full-document layout passes without error.

## Scope

Deliberately left the per-row clip `Rectangle` and the slot `StackPane`s alone — removing the clip risked a folded-row "smear" regression and its measurement was noise. Larger gutter wins (fewer nodes per row) are a riskier rewrite of a central component, left for a separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)