### PR TITLE
Make spell-check overlay redraw cheaper while scrolling prose

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   faster in the gutter (measured A/B in one process). Line numbers, folding, and all gutter markers are
   unchanged.
 
+- **Cheaper spell-check overlay redraw while scrolling prose.** The red-squiggle overlay re-runs each scroll
+  pulse over the visible words. It now checks the (cached) spelling verdict *before* the per-word syntax-style
+  lookup, so that lookup runs only for the few misspelled words instead of every visible word, and it hoists
+  the per-word offset query out of the loop. Redrawing a ~375-line Markdown file was ~16–22% faster (measured
+  A/B in one process); squiggle placement is unchanged.
+
 ### Changed
 
 - **The Find in Files toolbar icon now toggles the panel** — one click opens it (focusing the query field),

--- a/src/main/java/com/editora/editor/SpellCheckOverlay.java
+++ b/src/main/java/com/editora/editor/SpellCheckOverlay.java
@@ -158,20 +158,25 @@ final class SpellCheckOverlay extends Region {
         if (line.isEmpty()) {
             return;
         }
+        // Absolute offset is the paragraph's base offset plus the column — hoist the base query out of the
+        // per-word loop (it was called up to twice per word). getParagraph(p,0) is the paragraph's first char.
+        int parBase = area.getAbsolutePosition(paragraph, 0);
         for (int[] span : spanCache.computeIfAbsent(line, SpellChecker::wordSpans)) {
             int start = span[0];
             int end = span[1];
-            int abs = area.getAbsolutePosition(paragraph, start);
-            if (!eligible(abs)) {
-                continue; // eligibility is style-dependent → always evaluated fresh (never cached)
-            }
-            // Cache the Hunspell verdict per word (cleared on dictionary/ignore changes). Checked only
-            // after eligibility, so ineligible code tokens still never reach the dictionary, as before.
+            // Spell verdict first (cached per word) — so the per-word style lookup (eligible(), an area
+            // query) runs only for the few misspelled words on screen, not every visible word. Reordering
+            // is safe: eligibility still gates drawing, and a misspelled code token is still skipped; the
+            // only difference is its (harmless) cache entry. This is the per-scroll-pulse hot path on prose.
             if (!spellCache.computeIfAbsent(line.substring(start, end), checker::isMisspelled)) {
                 continue;
             }
-            Bounds b = toLocal(area.getCharacterBoundsOnScreen(abs, area.getAbsolutePosition(paragraph, end))
-                    .orElse(null));
+            int abs = parBase + start;
+            if (!eligible(abs)) {
+                continue; // eligibility is style-dependent (inline/fenced code) → evaluated fresh
+            }
+            Bounds b =
+                    toLocal(area.getCharacterBoundsOnScreen(abs, parBase + end).orElse(null));
             if (b == null) {
                 continue;
             }


### PR DESCRIPTION
## Summary

Reduces the second scroll-jank contributor (after the gutter) on prose-heavy files. The red-squiggle spell overlay re-runs each scroll pulse over the visible words; two changes cut its per-pulse work:

1. **Check the cached spelling verdict *before* the per-word `getStyleOfChar` eligibility** — so that style lookup (an area query) runs only for the few misspelled words on screen instead of *every* visible word. Logically equivalent: eligibility still gates drawing, and a misspelled code token is still skipped (only difference is its harmless cache entry).
2. **Hoist the per-word `getAbsolutePosition` out of the loop** — query the paragraph's base offset once; word offsets are arithmetic.

Squiggle placement and behavior are unchanged.

## Measurement

A/B in one process (both paths behind a temp flag, 400 synchronous redraws each at a misspelling-heavy viewport on README.md, identical load):

- old 857 ms → new 669 ms (**22% faster**)
- old 827 ms → new 693 ms (**16% faster**)

→ **~16–22% faster spell-overlay redraw per pulse.** Benchmark scaffolding removed; the change is a single clean edit to `SpellCheckOverlay.java`.

## Verification

- `./mvnw verify` (tests + spotless + jlink) ✅
- The A/B bench exercised the optimized redraw ~900× drawing squiggles without error.

Together with #27 (gutter, ~12–21%), this addresses both scroll-cost contributors identified for prose files, with spell-check left on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)