### PR TITLE
Stop spell-checking commands, URLs, paths, and identifiers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Spell check no longer flags commands, URLs, paths, and identifiers.** Tokens like `./mvnw`,
+  `javafx:run`, `https://github.com/…`, `path/to/file.txt`, `snake_case`, and `a@b.com` were getting red
+  squiggles — in Markdown prose, in fenced ` ``` ` code blocks, and in comments/strings of Java/Python/Shell
+  and other code files. The checker now recognizes a flagged word that's part of a URL, path, e-mail, or
+  dotted/underscored/colon-joined token and leaves it alone (ordinary words, including hyphenated ones like
+  `well-known`, are still checked). In Markdown it additionally skips whole fenced code blocks and link
+  targets. The check runs only for the few already-flagged words, so it doesn't affect scroll performance.
+
 - **Language servers and debug adapters no longer pile up as orphaned processes.** Previously the external
   servers Editora spawns (e.g. `jdtls`) were only killed when a window was closed through the app — so
   force-quitting, a crash, an OS quit, or a `kill` left them running, where they accumulate and hold their

--- a/src/main/java/com/editora/editor/EditorBuffer.java
+++ b/src/main/java/com/editora/editor/EditorBuffer.java
@@ -756,6 +756,7 @@ public class EditorBuffer implements TabContent {
         spellChecker = new SpellChecker(spellLanguage, spellUserWords);
         spellOverlay.setChecker(spellChecker);
         spellOverlay.setProseMode(isProse());
+        spellOverlay.setMarkdown(isMarkdown()); // skip fenced ``` code blocks from spell check
         AnchorPane.setTopAnchor(lintOverlay, 0d);
         AnchorPane.setBottomAnchor(lintOverlay, 0d);
         AnchorPane.setLeftAnchor(lintOverlay, 0d);
@@ -1026,8 +1027,8 @@ public class EditorBuffer implements TabContent {
         for (int[] span : SpellChecker.wordSpans(line)) {
             if (col >= span[0] && col <= span[1]) {
                 int absStart = area.getAbsolutePosition(paragraph, span[0]);
-                if (!spellEligible(absStart)) {
-                    return null;
+                if (!spellEligible(absStart) || SpellChecker.partOfStructuredToken(line, span[0], span[1])) {
+                    return null; // not eligible, or part of a URL/path/identifier — not a misspelling
                 }
                 String word = line.substring(span[0], span[1]);
                 return spellChecker.isMisspelled(word)
@@ -1041,7 +1042,9 @@ public class EditorBuffer implements TabContent {
     /** Mirror of {@link SpellCheckOverlay}'s eligibility: which words are checked in this buffer. */
     private boolean spellEligible(int abs) {
         java.util.Collection<String> style = area.getStyleOfChar(abs);
-        return isProse() ? !style.contains("code") : style.contains("comment") || style.contains("string");
+        return isProse()
+                ? !style.contains("code") && !style.contains("link")
+                : style.contains("comment") || style.contains("string");
     }
 
     private void addToDictionary(String word) {

--- a/src/main/java/com/editora/editor/SpellCheckOverlay.java
+++ b/src/main/java/com/editora/editor/SpellCheckOverlay.java
@@ -1,5 +1,7 @@
 package com.editora.editor;
 
+import java.time.Duration;
+import java.util.BitSet;
 import java.util.Collection;
 import java.util.List;
 
@@ -31,8 +33,14 @@ final class SpellCheckOverlay extends Region {
     private final Canvas canvas = new Canvas(1, 1);
     private SpellChecker checker;
     private boolean proseMode;
+    private boolean markdown;
     private boolean active;
     private boolean redrawPending;
+
+    /** Lines (0-based) inside a Markdown fenced ``` code block — never spell-checked. Their content is
+     *  the embedded language (or unstyled), so the per-char "code" style class can't catch them; this
+     *  whole-line skip does. Recomputed off the debounced edit pulse, not per scroll. */
+    private BitSet codeLines = new BitSet();
 
     // Both wordSpans(line) and isMisspelled(word) are otherwise recomputed for every visible word on
     // every scroll/resize pulse, even though the text hasn't changed — and isMisspelled is a Hunspell
@@ -59,8 +67,51 @@ final class SpellCheckOverlay extends Region {
         getChildren().add(canvas);
         area.viewportDirtyEvents().subscribe(ignore -> scheduleRedraw());
         area.multiPlainChanges().subscribe(ignore -> scheduleRedraw());
+        // Recompute fenced-code line ranges off the debounced edit pulse (O(lines), not per keystroke);
+        // only while active, so an inactive overlay (e.g. a large file with spell check off) does no work.
+        area.multiPlainChanges().successionEnds(Duration.ofMillis(300)).subscribe(ignore -> {
+            if (active) {
+                recomputeCodeLines();
+            }
+        });
         area.estimatedScrollXProperty().addListener((o, a, b) -> scheduleRedraw());
         area.estimatedScrollYProperty().addListener((o, a, b) -> scheduleRedraw());
+    }
+
+    /** Whether this is a Markdown buffer (enables fenced-code-block skipping). */
+    void setMarkdown(boolean markdown) {
+        this.markdown = markdown;
+        recomputeCodeLines();
+        scheduleRedraw();
+    }
+
+    private void recomputeCodeLines() {
+        codeLines = markdown ? fencedCodeLines(area.getText()) : new BitSet();
+    }
+
+    /** 0-based line indices inside Markdown fenced code blocks (the ``` delimiter lines included). Pure. */
+    static BitSet fencedCodeLines(String text) {
+        BitSet code = new BitSet();
+        if (text == null || text.isEmpty()) {
+            return code;
+        }
+        String[] lines = text.split("\n", -1);
+        int fenceStart = -1;
+        for (int i = 0; i < lines.length; i++) {
+            String trimmed = lines[i].trim();
+            if (trimmed.startsWith("```") || trimmed.startsWith("~~~")) {
+                if (fenceStart < 0) {
+                    fenceStart = i;
+                } else {
+                    code.set(fenceStart, i + 1); // mark the whole fence, delimiters included
+                    fenceStart = -1;
+                }
+            }
+        }
+        if (fenceStart >= 0) {
+            code.set(fenceStart, lines.length); // an unterminated fence runs to EOF (as editors render it)
+        }
+        return code;
     }
 
     void setChecker(SpellChecker checker) {
@@ -82,6 +133,7 @@ final class SpellCheckOverlay extends Region {
         this.active = active;
         setVisible(active);
         if (active) {
+            recomputeCodeLines(); // pick up the current text (it may have changed while inactive)
             scheduleRedraw();
         } else {
             clear();
@@ -143,8 +195,8 @@ final class SpellCheckOverlay extends Region {
             g.setStroke(SQUIGGLE);
             g.setLineWidth(1.0);
             for (int p = first; p <= last; p++) {
-                if (area.isFolded(p)) {
-                    continue;
+                if (area.isFolded(p) || (markdown && codeLines.get(p))) {
+                    continue; // skip folded lines and Markdown fenced code blocks
                 }
                 drawParagraph(g, p, w, h);
             }
@@ -171,6 +223,11 @@ final class SpellCheckOverlay extends Region {
             if (!spellCache.computeIfAbsent(line.substring(start, end), checker::isMisspelled)) {
                 continue;
             }
+            // Don't flag a "misspelled" run that is actually part of a URL, path, command, or
+            // dotted/underscored identifier (checked only for the few flagged words, off the hot path).
+            if (SpellChecker.partOfStructuredToken(line, start, end)) {
+                continue;
+            }
             int abs = parBase + start;
             if (!eligible(abs)) {
                 continue; // eligibility is style-dependent (inline/fenced code) → evaluated fresh
@@ -191,7 +248,8 @@ final class SpellCheckOverlay extends Region {
     private boolean eligible(int abs) {
         Collection<String> style = area.getStyleOfChar(abs);
         if (proseMode) {
-            return !style.contains("code"); // skip Markdown inline/fenced code; check prose
+            // Skip Markdown inline `code` and links/URLs; check the rest (prose, headings, bold/italic).
+            return !style.contains("code") && !style.contains("link");
         }
         return style.contains("comment") || style.contains("string"); // code: only comments/strings
     }

--- a/src/main/java/com/editora/editor/SpellChecker.java
+++ b/src/main/java/com/editora/editor/SpellChecker.java
@@ -104,6 +104,49 @@ public final class SpellChecker {
         return allUpper; // ALL-CAPS acronym (e.g. HTTP, NASA)
     }
 
+    /** Wrapping punctuation trimmed from a whitespace token's ends before judging it (quotes, brackets,
+     *  sentence punctuation, Markdown emphasis). Notably excludes {@code / \\ @ _ = ~} and {@code -}: those
+     *  are part of the token's structure (or intra-word), not edge decoration. */
+    private static final String EDGE = "\"'`()[]{}<>,;:.!?*#|…‘’“”";
+
+    /**
+     * Whether the letter run {@code [start, end)} is part of a URL, file path, e-mail, or
+     * dotted/underscored/colon-joined identifier rather than a standalone prose word — i.e. spell check
+     * should leave it alone. Looks at the whole whitespace-bounded token around the run: after trimming
+     * wrapping punctuation, if it contains anything other than letters, {@code -}, or {@code '} (a slash,
+     * colon, {@code @}, underscore, internal dot, digit, …) the run is structural. Pure / unit-tested.
+     *
+     * <p>So {@code ./mvnw}, {@code mvnw.cmd}, {@code javafx:run}, {@code https://x/y}, {@code a@b.com},
+     * {@code snake_case}, {@code file.txt} are skipped, while {@code well-known}, {@code don't},
+     * {@code sentence.} (trailing period trimmed) and ordinary words are still checked.
+     */
+    public static boolean partOfStructuredToken(String line, int start, int end) {
+        if (line == null || start < 0 || end > line.length() || start >= end) {
+            return false;
+        }
+        int ts = start;
+        int te = end;
+        while (ts > 0 && !Character.isWhitespace(line.charAt(ts - 1))) {
+            ts--;
+        }
+        while (te < line.length() && !Character.isWhitespace(line.charAt(te))) {
+            te++;
+        }
+        while (ts < te && EDGE.indexOf(line.charAt(ts)) >= 0) {
+            ts++;
+        }
+        while (te > ts && EDGE.indexOf(line.charAt(te - 1)) >= 0) {
+            te--;
+        }
+        for (int k = ts; k < te; k++) {
+            char c = line.charAt(k);
+            if (!Character.isLetter(c) && c != '-' && c != '\'') {
+                return true;
+            }
+        }
+        return false;
+    }
+
     /**
      * Splits a line into checkable word spans ({@code [start, end)} offsets) — maximal runs of letters
      * with intra-word apostrophes (so {@code don't} stays one word), trimming leading/trailing

--- a/src/test/java/com/editora/editor/SpellCheckOverlayTest.java
+++ b/src/test/java/com/editora/editor/SpellCheckOverlayTest.java
@@ -1,0 +1,63 @@
+package com.editora.editor;
+
+import java.util.BitSet;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class SpellCheckOverlayTest {
+
+    private static BitSet fences(String text) {
+        return SpellCheckOverlay.fencedCodeLines(text);
+    }
+
+    @Test
+    void marksLinesInsideABacktickFence() {
+        // line: 0 prose, 1 ```, 2 code, 3 code, 4 ```, 5 prose
+        BitSet f = fences("prose\n```bash\n./mvnw javafx:run\nmvn test\n```\nmore prose\n");
+        assertFalse(f.get(0));
+        assertTrue(f.get(1)); // opening fence
+        assertTrue(f.get(2));
+        assertTrue(f.get(3));
+        assertTrue(f.get(4)); // closing fence
+        assertFalse(f.get(5));
+    }
+
+    @Test
+    void handlesTildeFencesAndIndentation() {
+        BitSet f = fences("text\n  ~~~\n  code here\n  ~~~\ntext\n");
+        assertFalse(f.get(0));
+        assertTrue(f.get(1));
+        assertTrue(f.get(2));
+        assertTrue(f.get(3));
+        assertFalse(f.get(4));
+    }
+
+    @Test
+    void unterminatedFenceRunsToEnd() {
+        BitSet f = fences("intro\n```\ncode\nmore code\n");
+        assertFalse(f.get(0));
+        assertTrue(f.get(1));
+        assertTrue(f.get(2));
+        assertTrue(f.get(3));
+    }
+
+    @Test
+    void multipleFencesAndProseBetween() {
+        BitSet f = fences("a\n```\nx\n```\nb\n```\ny\n```\nc\n");
+        assertFalse(f.get(0)); // a
+        assertTrue(f.get(2)); // x
+        assertFalse(f.get(4)); // b
+        assertTrue(f.get(6)); // y
+        assertFalse(f.get(8)); // c
+    }
+
+    @Test
+    void noFencesOrEmpty() {
+        assertTrue(fences("just\nplain\nprose\n").isEmpty());
+        assertTrue(fences("").isEmpty());
+        assertTrue(fences(null).isEmpty());
+    }
+}

--- a/src/test/java/com/editora/editor/SpellCheckerTest.java
+++ b/src/test/java/com/editora/editor/SpellCheckerTest.java
@@ -42,6 +42,51 @@ class SpellCheckerTest {
                 SpellChecker.wordSpans(q).stream().map(s -> word(q, s)).toList());
     }
 
+    /** Is the first letter run of {@code token} part of a structured (URL/path/identifier) token? */
+    private static boolean structural(String token) {
+        List<int[]> spans = SpellChecker.wordSpans(token);
+        return !spans.isEmpty() && SpellChecker.partOfStructuredToken(token, spans.get(0)[0], spans.get(0)[1]);
+    }
+
+    @Test
+    void structuredTokensAreSkipped() {
+        assertTrue(structural("./mvnw")); // command / path
+        assertTrue(structural("mvnw.cmd")); // dotted
+        assertTrue(structural("javafx:run")); // colon-joined
+        assertTrue(structural("https://github.com/adriandeleon/Editora")); // URL
+        assertTrue(structural("user@example.com")); // e-mail
+        assertTrue(structural("snake_case_name")); // underscore
+        assertTrue(structural("path/to/file.txt")); // path
+        assertTrue(structural("target/Editora-1.0.jar")); // path + version
+    }
+
+    @Test
+    void plainWordsAreNotSkipped() {
+        assertFalse(structural("hello"));
+        assertFalse(structural("well-known")); // hyphenated word
+        assertFalse(structural("state-of-the-art"));
+        assertFalse(structural("don't")); // apostrophe
+        assertFalse(structural("sentence.")); // trailing period trimmed
+        assertFalse(structural("(word),")); // wrapping punctuation trimmed
+        assertFalse(structural("\"quoted\"")); // quotes trimmed
+        assertFalse(structural("word"));
+    }
+
+    @Test
+    void structuredCheckIsContextAwareWithinALine() {
+        String line = "see https://example.com or the mvnw script";
+        for (int[] s : SpellChecker.wordSpans(line)) {
+            String w = word(line, s);
+            boolean st = SpellChecker.partOfStructuredToken(line, s[0], s[1]);
+            if (w.equals("https") || w.equals("example") || w.equals("com")) {
+                assertTrue(st, w + " should be structural (part of the URL)");
+            }
+            if (w.equals("see") || w.equals("or") || w.equals("the") || w.equals("mvnw") || w.equals("script")) {
+                assertFalse(st, w + " should be a plain word");
+            }
+        }
+    }
+
     @Test
     void skipsIdentifiersAcronymsNumbersAndShortWords() {
         assertTrue(SpellChecker.skip("a")); // too short


### PR DESCRIPTION
## Summary

Fixes false spell-check squiggles on non-prose tokens — in Markdown prose, in fenced ` ``` ` code blocks, and in the comments/strings of Java/Python/Shell and other code files. The word-splitter only sees bare letter runs (`https`, `mvnw`, `com`), losing the surrounding structure that marks them as part of a URL/path/identifier.

## Fix

- **`SpellChecker.partOfStructuredToken(line, start, end)`** (pure, unit-tested): for a word that would otherwise be flagged, it inspects the whitespace-delimited token around it; after trimming wrapping punctuation, if the token contains URL/path/identifier structure (`/ \ : @ _ =`, an internal `.`, …) the word is left alone. Ordinary words — hyphenated (`well-known`), contractions (`don't`), trailing-period (`sentence.`) — are still checked. Wired into both the squiggle overlay and the right-click path, so it applies to **every** buffer. Runs only for the few already-flagged words, so scroll performance is unaffected.
- **Markdown extras:** skip whole fenced ` ``` ` code blocks (a `BitSet` of fence lines recomputed off the debounced edit pulse) and the `link` style — so bare command words and URL link targets aren't checked either.

Now skipped: `./mvnw`, `javafx:run`, `https://github.com/…`, `user@example.com`, `path/to/file.txt`, `target/Editora-1.0.jar`, `snake_case`, `a=b`.

## Verification

- `SpellCheckerTest` (8) + `SpellCheckOverlayTest` (5) ✅ — structured tokens skipped, plain/hyphenated words still checked, context-aware within a line.
- `./mvnw verify` (tests + spotless + jlink) ✅

## Known limitation

A **bare** command word with no separators in a code comment (e.g. `mvn` alone) is still checkable — only the whole-line fence skip handles those (Markdown only). Suppressing those would need a command dictionary; the structural rule catches everything with URL/path/identifier shape, which is the bulk of it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)