### PR TITLE
Expand HTTP Client toward IntelliJ parity (chaining, multipart, dynamic vars, richer viewer)

### DIFF
--- a/src/main/java/com/editora/http/CapturedResponses.java
+++ b/src/main/java/com/editora/http/CapturedResponses.java
@@ -1,0 +1,66 @@
+package com.editora.http;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * The in-memory, per-run session that backs request chaining: each named request's {@link HttpResult} is
+ * captured after it runs, so a later request in the same run can reference it with
+ * {@code {{name.response.body.$.path}}}, {@code {{name.response.body.*}}}, {@code {{name.response.headers.H}}}
+ * or {@code {{name.response.status}}}. Holds no data across runs and persists nothing. An unknown reference
+ * resolves to {@code ""} (the unknown-variable contract). Pure, so it is unit-tested.
+ */
+public final class CapturedResponses {
+
+    private static final String MARKER = ".response.";
+
+    private final Map<String, HttpResult> byName = new LinkedHashMap<>();
+
+    /** Records a completed request's result under its name (no-op for a blank name / null result). */
+    public void put(String name, HttpResult result) {
+        if (name != null && !name.isBlank() && result != null) {
+            byName.put(name, result);
+        }
+    }
+
+    /** True for a {@code name.response.<…>} reference (so {@link HttpVars} routes it here). */
+    public static boolean isResponseRef(String reference) {
+        return reference != null && reference.contains(MARKER);
+    }
+
+    /** Resolves a {@code name.response.<…>} reference against the captured responses, or {@code ""}. */
+    public String resolve(String reference) {
+        if (reference == null) {
+            return "";
+        }
+        int marker = reference.indexOf(MARKER);
+        if (marker < 0) {
+            return "";
+        }
+        HttpResult r = byName.get(reference.substring(0, marker));
+        if (r == null) {
+            return "";
+        }
+        String rest = reference.substring(marker + MARKER.length());
+        if (rest.equals("body") || rest.startsWith("body.")) {
+            String path = rest.equals("body") ? "" : rest.substring("body.".length());
+            return JsonPath.eval(r.body() == null ? "" : r.body(), path);
+        }
+        if (rest.startsWith("headers.")) {
+            return headerValue(r, rest.substring("headers.".length()));
+        }
+        if (rest.equals("status")) {
+            return String.valueOf(r.status());
+        }
+        return "";
+    }
+
+    private static String headerValue(HttpResult r, String name) {
+        for (String[] h : r.headers()) {
+            if (h[0].equalsIgnoreCase(name)) {
+                return h[1];
+            }
+        }
+        return "";
+    }
+}

--- a/src/main/java/com/editora/http/CurlExport.java
+++ b/src/main/java/com/editora/http/CurlExport.java
@@ -1,0 +1,39 @@
+package com.editora.http;
+
+import java.util.List;
+
+/**
+ * Renders a (resolved) request as a {@code curl} command for the response viewer's "Copy as cURL" action.
+ * Single-quotes every value (POSIX-escaping embedded quotes), drops an explicit {@code -X GET}. Pure, so it
+ * is unit-tested.
+ */
+public final class CurlExport {
+
+    private CurlExport() {}
+
+    public static String toCurl(String method, String url, List<String[]> headers, String body) {
+        StringBuilder sb = new StringBuilder("curl");
+        if (method != null && !method.isEmpty() && !method.equalsIgnoreCase("GET")) {
+            sb.append(" -X ").append(method);
+        }
+        sb.append(" '").append(url == null ? "" : url).append('\'');
+        if (headers != null) {
+            for (String[] h : headers) {
+                sb.append(" \\\n  -H '")
+                        .append(h[0])
+                        .append(": ")
+                        .append(escape(h[1]))
+                        .append('\'');
+            }
+        }
+        if (body != null && !body.isBlank()) {
+            sb.append(" \\\n  --data '").append(escape(body)).append('\'');
+        }
+        return sb.toString();
+    }
+
+    /** POSIX single-quote escaping: {@code '} → {@code '\''}. */
+    private static String escape(String s) {
+        return s.replace("'", "'\\''");
+    }
+}

--- a/src/main/java/com/editora/http/CurlImport.java
+++ b/src/main/java/com/editora/http/CurlImport.java
@@ -1,0 +1,156 @@
+package com.editora.http;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Converts a {@code curl …} command line into a {@code .http} request block. Tokenizes the command
+ * (single/double quotes, {@code \}-newline continuations), maps the common flags ({@code -X}/{@code --request},
+ * {@code -H}/{@code --header}, {@code -d}/{@code --data*}, {@code -u}/{@code --user}, {@code -A},
+ * {@code -b}, {@code --url}), and infers {@code POST} + a form Content-Type when a data flag is present and
+ * no method/Content-Type was given. Pure, so it is unit-tested.
+ */
+public final class CurlImport {
+
+    private CurlImport() {}
+
+    /** Builds a {@code METHOD url} + headers + body request block from a {@code curl} command. */
+    public static String toHttpRequest(String curl) {
+        List<String> tokens = tokenize(curl);
+        String method = null;
+        String url = null;
+        List<String[]> headers = new ArrayList<>();
+        String data = null;
+        for (int i = 0; i < tokens.size(); i++) {
+            String t = tokens.get(i);
+            switch (t) {
+                case "curl" -> {}
+                case "-X", "--request" -> {
+                    if (i + 1 < tokens.size()) {
+                        method = tokens.get(++i);
+                    }
+                }
+                case "-H", "--header" -> {
+                    if (i + 1 < tokens.size()) {
+                        headers.add(splitHeader(tokens.get(++i)));
+                    }
+                }
+                case "-d", "--data", "--data-raw", "--data-binary", "--data-ascii" -> {
+                    if (i + 1 < tokens.size()) {
+                        String d = tokens.get(++i);
+                        data = data == null ? d : data + "&" + d;
+                    }
+                }
+                case "-u", "--user" -> {
+                    if (i + 1 < tokens.size()) {
+                        headers.add(userHeader(tokens.get(++i)));
+                    }
+                }
+                case "-A", "--user-agent" -> {
+                    if (i + 1 < tokens.size()) {
+                        headers.add(new String[] {"User-Agent", tokens.get(++i)});
+                    }
+                }
+                case "-b", "--cookie" -> {
+                    if (i + 1 < tokens.size()) {
+                        headers.add(new String[] {"Cookie", tokens.get(++i)});
+                    }
+                }
+                case "--url" -> {
+                    if (i + 1 < tokens.size()) {
+                        url = tokens.get(++i);
+                    }
+                }
+                default -> {
+                    if (!t.startsWith("-") && url == null) {
+                        url = t;
+                    }
+                    // other flags (e.g. -L, -k, -s) are ignored — best effort
+                }
+            }
+        }
+        if (method == null) {
+            method = data != null ? "POST" : "GET";
+        }
+        StringBuilder sb = new StringBuilder();
+        sb.append(method).append(' ').append(url == null ? "" : url).append('\n');
+        boolean hasContentType = headers.stream().anyMatch(h -> h[0].equalsIgnoreCase("Content-Type"));
+        if (data != null && !hasContentType) {
+            headers.add(new String[] {"Content-Type", "application/x-www-form-urlencoded"});
+        }
+        for (String[] h : headers) {
+            sb.append(h[0]).append(": ").append(h[1]).append('\n');
+        }
+        if (data != null) {
+            sb.append('\n').append(data).append('\n');
+        }
+        return sb.toString();
+    }
+
+    private static String[] splitHeader(String h) {
+        int colon = h.indexOf(':');
+        return colon > 0
+                ? new String[] {
+                    h.substring(0, colon).strip(), h.substring(colon + 1).strip()
+                }
+                : new String[] {h.strip(), ""};
+    }
+
+    private static String[] userHeader(String userPass) {
+        int colon = userPass.indexOf(':');
+        String user = colon >= 0 ? userPass.substring(0, colon) : userPass;
+        String pass = colon >= 0 ? userPass.substring(colon + 1) : "";
+        return new String[] {"Authorization", HttpAuth.basic(user, pass)};
+    }
+
+    /** Splits a curl command into tokens, honoring quotes and {@code \}-newline continuations. */
+    static List<String> tokenize(String s) {
+        List<String> out = new ArrayList<>();
+        if (s == null) {
+            return out;
+        }
+        StringBuilder cur = new StringBuilder();
+        boolean inTok = false;
+        int i = 0;
+        int n = s.length();
+        while (i < n) {
+            char c = s.charAt(i);
+            if (c == '\\' && i + 1 < n && (s.charAt(i + 1) == '\n' || s.charAt(i + 1) == '\r')) {
+                i += 2; // line continuation
+                continue;
+            }
+            if (c == '\'' || c == '"') {
+                inTok = true;
+                char q = c;
+                i++;
+                while (i < n && s.charAt(i) != q) {
+                    if (q == '"' && s.charAt(i) == '\\' && i + 1 < n) {
+                        cur.append(s.charAt(i + 1));
+                        i += 2;
+                    } else {
+                        cur.append(s.charAt(i));
+                        i++;
+                    }
+                }
+                i++; // closing quote
+                continue;
+            }
+            if (Character.isWhitespace(c)) {
+                if (inTok) {
+                    out.add(cur.toString());
+                    cur.setLength(0);
+                    inTok = false;
+                }
+                i++;
+                continue;
+            }
+            inTok = true;
+            cur.append(c);
+            i++;
+        }
+        if (inTok) {
+            out.add(cur.toString());
+        }
+        return out;
+    }
+}

--- a/src/main/java/com/editora/http/DotEnv.java
+++ b/src/main/java/com/editora/http/DotEnv.java
@@ -1,0 +1,46 @@
+package com.editora.http;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * Pure parser for a {@code .env} file: {@code KEY=VALUE} lines, optional surrounding quotes, {@code #}
+ * comments and blank lines skipped, an optional leading {@code export }. Backs the {@code {{$dotenv.NAME}}}
+ * dynamic variable. Takes the file content as a string, so it is unit-tested.
+ */
+public final class DotEnv {
+
+    private DotEnv() {}
+
+    /** Parses {@code content} into {@code KEY → VALUE}, in declaration order. */
+    public static Map<String, String> parse(String content) {
+        Map<String, String> out = new LinkedHashMap<>();
+        if (content == null || content.isBlank()) {
+            return out;
+        }
+        for (String raw : content.split("\n", -1)) {
+            String line = raw.strip();
+            if (line.isEmpty() || line.startsWith("#")) {
+                continue;
+            }
+            if (line.startsWith("export ")) {
+                line = line.substring("export ".length()).strip();
+            }
+            int eq = line.indexOf('=');
+            if (eq <= 0) {
+                continue;
+            }
+            out.put(
+                    line.substring(0, eq).strip(),
+                    unquote(line.substring(eq + 1).strip()));
+        }
+        return out;
+    }
+
+    private static String unquote(String v) {
+        if (v.length() >= 2 && ((v.startsWith("\"") && v.endsWith("\"")) || (v.startsWith("'") && v.endsWith("'")))) {
+            return v.substring(1, v.length() - 1);
+        }
+        return v;
+    }
+}

--- a/src/main/java/com/editora/http/DynamicVars.java
+++ b/src/main/java/com/editora/http/DynamicVars.java
@@ -1,0 +1,191 @@
+package com.editora.http;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
+import java.util.Locale;
+import java.util.UUID;
+import java.util.concurrent.ThreadLocalRandom;
+
+/**
+ * Expands {@code {{$…}}} dynamic variables to mirror the IntelliJ HTTP Client family: UUIDs, timestamps,
+ * the {@code $random.*} generators, formatted {@code $datetime}/{@code $localDatetime}, and the
+ * {@code $processEnv.NAME}/{@code $dotenv.NAME} lookups (the latter reads a {@code .env} beside the request
+ * file). Given a fixed clock the deterministic cases are unit-tested; the random cases are tested by bound
+ * and charset, the uuid by shape.
+ */
+public final class DynamicVars {
+
+    private static final String LETTERS = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ";
+    private static final String ALNUM = LETTERS + "0123456789";
+    private static final String HEX = "0123456789abcdef";
+
+    private DynamicVars() {}
+
+    /** True for a dynamic-variable name (begins with {@code $}). */
+    public static boolean isDynamic(String name) {
+        return name != null && name.startsWith("$");
+    }
+
+    /**
+     * Expands a dynamic variable {@code name} (without the surrounding braces), using {@code now} as the
+     * clock and {@code dir} (the request file's directory, may be {@code null}) for {@code $dotenv}. Unknown
+     * names yield {@code ""}.
+     */
+    public static String value(String name, LocalDateTime now, Path dir) {
+        if (name == null) {
+            return "";
+        }
+        String n = name.trim();
+        String head = n;
+        String args = "";
+        int paren = n.indexOf('(');
+        if (paren >= 0 && n.endsWith(")")) {
+            head = n.substring(0, paren).trim();
+            args = n.substring(paren + 1, n.length() - 1).trim();
+        }
+        switch (head) {
+            case "$uuid", "$random.uuid", "$guid":
+                return UUID.randomUUID().toString();
+            case "$timestamp":
+                return String.valueOf(now.toEpochSecond(ZoneOffset.UTC));
+            case "$isoTimestamp":
+                return now.atOffset(ZoneOffset.UTC).format(DateTimeFormatter.ISO_INSTANT);
+            case "$randomInt":
+                return String.valueOf(randInt(args, 0, 1000));
+            case "$random.integer":
+                return String.valueOf(randInt(args, 0, 1000));
+            case "$random.float":
+                return randFloat(args);
+            case "$random.alphabetic":
+                return randString(intArg(args, 16), LETTERS);
+            case "$random.alphanumeric":
+                return randString(intArg(args, 16), ALNUM);
+            case "$random.hexadecimal":
+                return randString(intArg(args, 16), HEX);
+            case "$random.email":
+                return randString(8, LETTERS).toLowerCase(Locale.ROOT) + "@example.com";
+            default:
+                break;
+        }
+        if (n.startsWith("$localDatetime")) {
+            return datetime(n.substring("$localDatetime".length()), now, true);
+        }
+        if (n.startsWith("$datetime")) {
+            return datetime(n.substring("$datetime".length()), now, false);
+        }
+        if (n.startsWith("$processEnv")) {
+            String v = System.getenv(key(n.substring("$processEnv".length())));
+            return v == null ? "" : v;
+        }
+        if (n.startsWith("$dotenv")) {
+            return dotenv(key(n.substring("$dotenv".length())), dir);
+        }
+        return "";
+    }
+
+    private static String datetime(String suffix, LocalDateTime now, boolean local) {
+        String fmt = stripQuotes(suffix.trim());
+        try {
+            if (fmt.isEmpty() || fmt.equalsIgnoreCase("iso8601")) {
+                return local
+                        ? now.atZone(ZoneId.systemDefault()).format(DateTimeFormatter.ISO_OFFSET_DATE_TIME)
+                        : now.atOffset(ZoneOffset.UTC).format(DateTimeFormatter.ISO_INSTANT);
+            }
+            DateTimeFormatter f = fmt.equalsIgnoreCase("rfc1123")
+                    ? DateTimeFormatter.RFC_1123_DATE_TIME
+                    : DateTimeFormatter.ofPattern(fmt, Locale.ROOT);
+            return local
+                    ? now.atZone(ZoneId.systemDefault()).format(f)
+                    : now.atOffset(ZoneOffset.UTC).format(f);
+        } catch (Exception e) {
+            return "";
+        }
+    }
+
+    private static String dotenv(String key, Path dir) {
+        if (key.isEmpty() || dir == null) {
+            return "";
+        }
+        try {
+            Path env = dir.resolve(".env");
+            return Files.exists(env) ? DotEnv.parse(Files.readString(env)).getOrDefault(key, "") : "";
+        } catch (Exception e) {
+            return "";
+        }
+    }
+
+    private static int randInt(String args, int defLo, int defHi) {
+        int lo = defLo;
+        int hi = defHi;
+        String[] parts = args.isEmpty() ? new String[0] : args.split(",");
+        if (parts.length >= 1 && !parts[0].isBlank()) {
+            lo = parseInt(parts[0].trim(), defLo);
+        }
+        if (parts.length >= 2 && !parts[1].isBlank()) {
+            hi = parseInt(parts[1].trim(), defHi);
+        }
+        return hi > lo ? ThreadLocalRandom.current().nextInt(lo, hi) : lo;
+    }
+
+    private static String randFloat(String args) {
+        double lo = 0;
+        double hi = 1;
+        String[] parts = args.isEmpty() ? new String[0] : args.split(",");
+        if (parts.length >= 1 && !parts[0].isBlank()) {
+            lo = parseDouble(parts[0].trim(), 0);
+        }
+        if (parts.length >= 2 && !parts[1].isBlank()) {
+            hi = parseDouble(parts[1].trim(), 1);
+        }
+        double v = hi > lo ? ThreadLocalRandom.current().nextDouble(lo, hi) : lo;
+        return String.valueOf(v);
+    }
+
+    private static String randString(int len, String charset) {
+        int n = Math.max(0, len);
+        StringBuilder sb = new StringBuilder(n);
+        for (int i = 0; i < n; i++) {
+            sb.append(charset.charAt(ThreadLocalRandom.current().nextInt(charset.length())));
+        }
+        return sb.toString();
+    }
+
+    private static int intArg(String args, int def) {
+        return args.isBlank() ? def : parseInt(args.trim(), def);
+    }
+
+    private static String key(String suffix) {
+        String s = suffix.trim();
+        if (s.startsWith(".")) {
+            s = s.substring(1);
+        }
+        return s.trim();
+    }
+
+    private static int parseInt(String s, int def) {
+        try {
+            return Integer.parseInt(s);
+        } catch (NumberFormatException e) {
+            return def;
+        }
+    }
+
+    private static double parseDouble(String s, double def) {
+        try {
+            return Double.parseDouble(s);
+        } catch (NumberFormatException e) {
+            return def;
+        }
+    }
+
+    private static String stripQuotes(String s) {
+        if (s.length() >= 2 && ((s.startsWith("\"") && s.endsWith("\"")) || (s.startsWith("'") && s.endsWith("'")))) {
+            return s.substring(1, s.length() - 1);
+        }
+        return s;
+    }
+}

--- a/src/main/java/com/editora/http/HttpAuth.java
+++ b/src/main/java/com/editora/http/HttpAuth.java
@@ -1,0 +1,44 @@
+package com.editora.http;
+
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.List;
+
+/**
+ * Basic-auth convenience: builds a {@code Basic <base64>} header and rewrites the IntelliJ-style
+ * {@code Authorization: Basic user pass} two-token form (which the JDK client would otherwise send
+ * verbatim) into a proper base64 header just before sending. Pure, so it is unit-tested.
+ */
+public final class HttpAuth {
+
+    private HttpAuth() {}
+
+    /** {@code "Basic " + base64(user:pass)}. */
+    public static String basic(String user, String pass) {
+        String token = Base64.getEncoder().encodeToString((user + ":" + pass).getBytes(StandardCharsets.UTF_8));
+        return "Basic " + token;
+    }
+
+    /** Returns {@code headers} with any {@code Authorization: Basic user pass} value base64-encoded. */
+    public static List<String[]> normalizeHeaders(List<String[]> headers) {
+        List<String[]> out = new ArrayList<>();
+        for (String[] h : headers) {
+            if (h[0].equalsIgnoreCase("Authorization")) {
+                out.add(new String[] {h[0], normalizeBasic(h[1].strip())});
+            } else {
+                out.add(h);
+            }
+        }
+        return out;
+    }
+
+    private static String normalizeBasic(String value) {
+        if (!value.regionMatches(true, 0, "Basic ", 0, 6)) {
+            return value;
+        }
+        String[] parts = value.substring(6).strip().split("\\s+");
+        // Two whitespace-separated tokens = the user/pass shorthand; a single token is already base64.
+        return parts.length == 2 ? basic(parts[0], parts[1]) : value;
+    }
+}

--- a/src/main/java/com/editora/http/HttpClientService.java
+++ b/src/main/java/com/editora/http/HttpClientService.java
@@ -1,10 +1,14 @@
 package com.editora.http;
 
+import java.net.CookieManager;
 import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
+import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.time.Duration;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
@@ -13,14 +17,18 @@ import java.util.Map;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.function.Consumer;
+import java.util.function.Function;
 
 import javafx.application.Platform;
 
 /**
  * UI-facing façade for running {@code .http} requests with the <b>built-in JDK {@code HttpClient}</b>
- * (no external CLI): work runs on one daemon executor and results post back on the JavaFX thread. The
- * caller supplies a parsed request ({@link HttpFile.Parsed}) and the resolved variable map; this resolves
- * {@code {{vars}}} (via {@link HttpVars}), executes, and returns an {@link HttpResult}.
+ * (no external CLI): work runs on one daemon executor and results post back on the JavaFX thread. A run
+ * gets a fresh {@link CookieManager} (a per-run cookie jar) and a {@link CapturedResponses} session, so a
+ * later request can reference an earlier one's response ({@code {{name.response.body.$.x}}}). Per-request
+ * directives ({@code @no-redirect}/{@code @no-cookie-jar}/{@code @timeout}), external bodies, multipart, and
+ * the {@code >>}/{@code >>!} response-redirect operators are honored here. Each call returns an
+ * {@link HttpExchange} carrying the fully resolved request alongside its {@link HttpResult}.
  */
 public final class HttpClientService {
 
@@ -32,64 +40,183 @@ public final class HttpClientService {
         t.setDaemon(true);
         return t;
     });
-    private final HttpClient client = HttpClient.newBuilder()
-            .connectTimeout(CONNECT_TIMEOUT)
-            .followRedirects(HttpClient.Redirect.NORMAL)
-            .build();
 
-    /** Runs a single request off-thread, posting its {@link HttpResult} on the FX thread. */
-    public void run(HttpFile.Parsed request, Map<String, String> vars, Consumer<HttpResult> onResult) {
+    /** Runs a single request off-thread (its own cookie jar, no prior context), posting on the FX thread. */
+    public void run(HttpFile.Parsed request, Map<String, String> vars, Path baseDir, Consumer<HttpExchange> onResult) {
         exec.submit(() -> {
-            HttpResult r = execute(request, vars);
-            Platform.runLater(() -> onResult.accept(r));
+            CookieManager cookies = new CookieManager();
+            HttpExchange ex = execute(request, vars, baseDir, new CapturedResponses(), cookies);
+            Platform.runLater(() -> onResult.accept(ex));
         });
     }
 
-    /** Runs {@code requests} sequentially off-thread, posting all results together on the FX thread. */
-    public void runAll(List<HttpFile.Parsed> requests, Map<String, String> vars, Consumer<List<HttpResult>> onResult) {
+    /** Runs {@code requests} sequentially off-thread, sharing one cookie jar + captured-response session so
+     *  later requests can reference earlier responses; posts all exchanges together on the FX thread. */
+    public void runAll(
+            List<HttpFile.Parsed> requests,
+            Map<String, String> vars,
+            Path baseDir,
+            Consumer<List<HttpExchange>> onResult) {
         exec.submit(() -> {
-            List<HttpResult> results = new ArrayList<>();
+            CookieManager cookies = new CookieManager();
+            CapturedResponses captured = new CapturedResponses();
+            List<HttpExchange> out = new ArrayList<>();
             for (HttpFile.Parsed req : requests) {
-                results.add(execute(req, vars));
+                HttpExchange ex = execute(req, vars, baseDir, captured, cookies);
+                captured.put(req.name(), ex.result());
+                out.add(ex);
             }
-            Platform.runLater(() -> onResult.accept(results));
+            Platform.runLater(() -> onResult.accept(out));
         });
     }
 
-    private HttpResult execute(HttpFile.Parsed request, Map<String, String> vars) {
+    private HttpExchange execute(
+            HttpFile.Parsed request,
+            Map<String, String> vars,
+            Path baseDir,
+            CapturedResponses captured,
+            CookieManager cookies) {
         LocalDateTime now = LocalDateTime.now();
-        String url = HttpVars.substitute(request.url(), vars, now).trim();
+        Function<String, String> sub = s -> HttpVars.substitute(s, vars, now, captured, baseDir);
+        String url = sub.apply(request.url()).trim();
+        String method = request.method().isEmpty() ? "GET" : request.method();
+
+        List<String[]> headers = new ArrayList<>();
+        for (String[] h : request.headers()) {
+            headers.add(new String[] {h[0], sub.apply(h[1])});
+        }
+        headers = HttpAuth.normalizeHeaders(headers);
+        String contentType = headerValue(headers, "Content-Type");
+
+        BodyContent bc = resolveBody(request, baseDir, sub, contentType, headers);
+        String label = method + " " + url;
         try {
-            String body = HttpVars.substitute(request.body(), vars, now);
-            HttpRequest.Builder b = HttpRequest.newBuilder(URI.create(url)).timeout(REQUEST_TIMEOUT);
-            for (String[] h : request.headers()) {
+            HttpClient client = clientFor(request.directives(), cookies);
+            Duration timeout = request.directives().timeoutSeconds() > 0
+                    ? Duration.ofSeconds(request.directives().timeoutSeconds())
+                    : REQUEST_TIMEOUT;
+            HttpRequest.Builder b = HttpRequest.newBuilder(URI.create(url)).timeout(timeout);
+            for (String[] h : headers) {
                 try {
-                    b.header(h[0], HttpVars.substitute(h[1], vars, now));
+                    b.header(h[0], h[1]);
                 } catch (IllegalArgumentException ignore) {
                     // a header the JDK client forbids setting (Host, Content-Length, …) — skip it
                 }
             }
-            HttpRequest.BodyPublisher publisher = body == null || body.isBlank()
-                    ? HttpRequest.BodyPublishers.noBody()
-                    : HttpRequest.BodyPublishers.ofString(body);
-            b.method(request.method().isEmpty() ? "GET" : request.method(), publisher);
+            b.method(method, bc.publisher());
 
             long t0 = System.nanoTime();
             HttpResponse<String> resp = client.send(b.build(), HttpResponse.BodyHandlers.ofString());
             long ms = (System.nanoTime() - t0) / 1_000_000;
 
-            List<String[]> headers = new ArrayList<>();
+            List<String[]> respHeaders = new ArrayList<>();
             resp.headers().map().forEach((k, values) -> {
                 for (String v : values) {
-                    headers.add(new String[] {k, v});
+                    respHeaders.add(new String[] {k, v});
                 }
             });
-            String contentType = resp.headers().firstValue("content-type").orElse("");
+            String respType = resp.headers().firstValue("content-type").orElse("");
             long size = resp.body() == null ? 0 : resp.body().getBytes(StandardCharsets.UTF_8).length;
-            return new HttpResult(resp.statusCode(), headers, resp.body(), contentType, ms, size, null);
+            HttpResult result = new HttpResult(resp.statusCode(), respHeaders, resp.body(), respType, ms, size, null);
+            writeRedirects(request, baseDir, result);
+            return new HttpExchange(label, method, url, headers, bc.display(), result);
         } catch (Exception e) {
-            return new HttpResult(0, List.of(), "", "", 0, 0, errorMessage(url, e));
+            HttpResult err = new HttpResult(0, List.of(), "", "", 0, 0, errorMessage(url, e));
+            return new HttpExchange(label, method, url, headers, bc.display(), err);
         }
+    }
+
+    /** The request body publisher + a display string (for the cURL/history view). */
+    private record BodyContent(HttpRequest.BodyPublisher publisher, String display) {}
+
+    private static BodyContent resolveBody(
+            HttpFile.Parsed request,
+            Path baseDir,
+            Function<String, String> sub,
+            String contentType,
+            List<String[]> headers) {
+        // multipart/form-data: assemble the parts (inline parts substituted, < ./file parts slurped).
+        if (Multipart.isMultipart(contentType)) {
+            String boundary = Multipart.boundaryOf(contentType);
+            if (boundary.isEmpty()) {
+                boundary = "EditoraBoundary" + Long.toHexString(System.nanoTime());
+                setHeader(headers, "Content-Type", contentType + "; boundary=" + boundary);
+            }
+            byte[] bytes = Multipart.build(Multipart.parse(request.body(), boundary), boundary, baseDir, sub);
+            return new BodyContent(
+                    HttpRequest.BodyPublishers.ofByteArray(bytes), "(multipart/form-data, " + bytes.length + " bytes)");
+        }
+        // external body: < ./file (raw) or <@ ./file (substituted), optional encoding.
+        if (request.bodyRef() != null && baseDir != null) {
+            try {
+                HttpFile.BodyRef ref = request.bodyRef();
+                Charset cs = ref.encoding() == null ? StandardCharsets.UTF_8 : Charset.forName(ref.encoding());
+                String content = new String(Files.readAllBytes(baseDir.resolve(ref.path())), cs);
+                if (ref.substitute()) {
+                    content = sub.apply(content);
+                }
+                return new BodyContent(HttpRequest.BodyPublishers.ofString(content), content);
+            } catch (Exception e) {
+                return new BodyContent(
+                        HttpRequest.BodyPublishers.noBody(),
+                        "(missing body file: " + request.bodyRef().path() + ")");
+            }
+        }
+        String body = sub.apply(request.body());
+        if (body == null || body.isBlank()) {
+            return new BodyContent(HttpRequest.BodyPublishers.noBody(), "");
+        }
+        return new BodyContent(HttpRequest.BodyPublishers.ofString(body), body);
+    }
+
+    private static HttpClient clientFor(HttpFile.Directives directives, CookieManager cookies) {
+        HttpClient.Builder b = HttpClient.newBuilder()
+                .connectTimeout(CONNECT_TIMEOUT)
+                .followRedirects(directives.noRedirect() ? HttpClient.Redirect.NEVER : HttpClient.Redirect.NORMAL);
+        if (!directives.noCookieJar()) {
+            b.cookieHandler(cookies);
+        }
+        return b.build();
+    }
+
+    /** Writes the response body to each {@code >>}/{@code >>!} target (force overwrites; plain skips existing). */
+    private static void writeRedirects(HttpFile.Parsed request, Path baseDir, HttpResult result) {
+        if (baseDir == null || result.failed()) {
+            return;
+        }
+        for (HttpFile.Redirect r : request.redirects()) {
+            try {
+                Path target = baseDir.resolve(r.path());
+                if (!r.force() && Files.exists(target)) {
+                    continue;
+                }
+                if (target.getParent() != null) {
+                    Files.createDirectories(target.getParent());
+                }
+                Files.writeString(target, result.body() == null ? "" : result.body());
+            } catch (Exception ignore) {
+                // best-effort: a failed redirect write never aborts the response
+            }
+        }
+    }
+
+    private static String headerValue(List<String[]> headers, String name) {
+        for (String[] h : headers) {
+            if (h[0].equalsIgnoreCase(name)) {
+                return h[1];
+            }
+        }
+        return "";
+    }
+
+    private static void setHeader(List<String[]> headers, String name, String value) {
+        for (String[] h : headers) {
+            if (h[0].equalsIgnoreCase(name)) {
+                h[1] = value;
+                return;
+            }
+        }
+        headers.add(new String[] {name, value});
     }
 
     private static String errorMessage(String url, Exception e) {

--- a/src/main/java/com/editora/http/HttpExchange.java
+++ b/src/main/java/com/editora/http/HttpExchange.java
@@ -1,0 +1,12 @@
+package com.editora.http;
+
+import java.util.List;
+
+/**
+ * One executed request/response pair: the {@code label} (method + URL) and the fully <b>resolved</b> request
+ * ({@code method}/{@code url}/{@code headers}/{@code requestBody}, with {@code {{vars}}} already substituted)
+ * alongside its {@link HttpResult}. Produced by {@link HttpClientService} so the response viewer can show a
+ * history entry, render the body by content type, and build a "Copy as cURL" command from resolved values.
+ */
+public record HttpExchange(
+        String label, String method, String url, List<String[]> headers, String requestBody, HttpResult result) {}

--- a/src/main/java/com/editora/http/HttpFile.java
+++ b/src/main/java/com/editora/http/HttpFile.java
@@ -2,6 +2,7 @@ package com.editora.http;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 import java.util.Set;
 
 /**
@@ -10,9 +11,11 @@ import java.util.Set;
  * each request is a method+URL line, optional headers, a blank line, and an optional body. Lines starting
  * with {@code #}/{@code //} are comments and {@code @name = value} lines are variable declarations.
  *
- * <p>Used to draw a gutter ▶ on each request's start line and to <b>extract</b> a single request (plus the
- * file's {@code @variable} preamble) into a temp file that {@code ijhttp} can run on its own — since
- * {@code ijhttp} only executes whole files.
+ * <p>Beyond the basics it recognizes the IntelliJ extensions used by the executor: an external body
+ * reference ({@code < ./file} raw, {@code <@ ./file} substituted), response-redirect operators
+ * ({@code >> file} / {@code >>! file} force), and per-request comment directives ({@code # @no-redirect},
+ * {@code # @no-cookie-jar}, {@code # @no-log}, {@code # @timeout N}, {@code # @name x}). Response-handler
+ * scripts ({@code > {% … %}}) are still recognized only to end the body — they are not executed.
  */
 public final class HttpFile {
 
@@ -21,14 +24,28 @@ public final class HttpFile {
 
     private HttpFile() {}
 
+    /** Per-request comment directives; {@code timeoutSeconds == 0} means "use the default". */
+    public record Directives(boolean noRedirect, boolean noCookieJar, boolean noLog, int timeoutSeconds) {
+        public static final Directives NONE = new Directives(false, false, false, 0);
+    }
+
+    /** An external request body: the {@code path} (relative to the request file), whether to substitute
+     *  {@code {{vars}}} in it ({@code <@} vs {@code <}), and an optional {@code encoding}. */
+    public record BodyRef(String path, boolean substitute, String encoding) {}
+
+    /** A response-redirect operator: write the response body to {@code path}; {@code force} ({@code >>!})
+     *  overwrites an existing file, plain {@code >>} skips it. */
+    public record Redirect(String path, boolean force) {}
+
     /**
      * One request: its 0-based {@code startLine} (the method/URL line — where the ▶ goes) through
      * {@code endLine} (the last non-blank line of its section), the {@code method} (defaulting to
      * {@code GET} when omitted), the raw {@code url} (may contain {@code {{vars}}}), an optional
-     * {@code name} (from a {@code ### name} separator or a {@code # @name x} comment), and the raw
-     * {@code block} text (the request, from start to end line).
+     * {@code name} (from a {@code ### name} separator or a {@code # @name x} comment), the per-request
+     * {@code directives}, and the raw {@code block} text (the request, from start to end line).
      */
-    public record Request(int startLine, int endLine, String method, String url, String name, String block) {}
+    public record Request(
+            int startLine, int endLine, String method, String url, String name, Directives directives, String block) {}
 
     /** Parses {@code text} into its requests, in document order. */
     public static List<Request> parse(String text) {
@@ -74,7 +91,8 @@ public final class HttpFile {
                     last--;
                 }
                 String[] mu = methodUrl(lines[reqLine]);
-                out.add(new Request(reqLine, last, mu[0], mu[1], name, join(lines, reqLine, last)));
+                Directives directives = directivesOf(lines, i, sectionEnd);
+                out.add(new Request(reqLine, last, mu[0], mu[1], name, directives, join(lines, reqLine, last)));
             }
             i = sectionEnd;
         }
@@ -93,11 +111,25 @@ public final class HttpFile {
         return -1;
     }
 
-    /** A single request broken into its parts for the built-in executor. {@code headers} is a list of
-     *  {@code [name, value]}; {@code url}/{@code value}s/{@code body} may still contain {@code {{vars}}}. */
-    public record Parsed(String method, String url, List<String[]> headers, String body) {}
+    /**
+     * A single request broken into its parts for the built-in executor. {@code headers} is a list of
+     * {@code [name, value]}; {@code url}/{@code value}s/{@code body} may still contain {@code {{vars}}}. The
+     * {@code name}/{@code directives} are carried from the {@link Request} (only via {@link #parseRequest(Request)});
+     * {@code bodyRef} is non-null for an external body; {@code redirects} holds any {@code >>}/{@code >>!} targets.
+     */
+    public record Parsed(
+            String method,
+            String url,
+            List<String[]> headers,
+            String body,
+            String name,
+            BodyRef bodyRef,
+            List<Redirect> redirects,
+            Directives directives) {}
 
-    /** Parses one request {@code block} (from {@link Request#block()}) into method/URL/headers/body. */
+    /** Parses one request {@code block} (from {@link Request#block()}) into method/URL/headers/body, plus an
+     *  external-body reference + redirect operators. The {@code name}/{@code directives} default; use
+     *  {@link #parseRequest(Request)} to carry those from the enclosing request. */
     public static Parsed parseRequest(String block) {
         String[] lines = (block == null ? "" : block).split("\n", -1);
         int i = 0;
@@ -110,7 +142,7 @@ public final class HttpFile {
             }
         }
         if (i >= lines.length) {
-            return new Parsed("GET", "", List.of(), "");
+            return new Parsed("GET", "", List.of(), "", null, null, List.of(), Directives.NONE);
         }
         String[] mu = methodUrl(lines[i]);
         StringBuilder url = new StringBuilder(mu[1]);
@@ -136,18 +168,46 @@ public final class HttpFile {
         while (i < lines.length && lines[i].strip().isEmpty()) {
             i++; // skip the blank line between headers and body
         }
+        // An external-body reference (< ./file raw, <@ ./file substituted) replaces an inline body.
+        BodyRef bodyRef = null;
+        if (i < lines.length) {
+            String t = lines[i].stripLeading();
+            if (t.startsWith("<@") || (t.startsWith("<") && !t.startsWith("<>"))) {
+                bodyRef = parseBodyRef(t);
+                i++;
+            }
+        }
         StringBuilder body = new StringBuilder();
+        List<Redirect> redirects = new ArrayList<>();
+        boolean bodyDone = false;
         for (; i < lines.length; i++) {
             String t = lines[i].stripLeading();
+            if (t.startsWith(">>")) {
+                bodyDone = true; // a response-redirect operator (>> file / >>! file)
+                redirects.add(parseRedirect(t));
+                continue;
+            }
             if (t.startsWith(">") || t.startsWith("<>")) {
-                break; // a response-handler / redirect line ends the body (not executed in v1)
+                bodyDone = true; // a response-handler / response-ref line ends the body (not executed)
+                continue;
+            }
+            if (bodyDone) {
+                continue; // trailing handler-script content after the body is ignored
             }
             if (body.length() > 0) {
                 body.append('\n');
             }
             body.append(lines[i]);
         }
-        return new Parsed(mu[0], url.toString(), headers, body.toString().strip());
+        return new Parsed(
+                mu[0], url.toString(), headers, body.toString().strip(), null, bodyRef, redirects, Directives.NONE);
+    }
+
+    /** Like {@link #parseRequest(String)} but carries the request's {@code name} + {@code directives}. */
+    public static Parsed parseRequest(Request req) {
+        Parsed p = parseRequest(req.block());
+        return new Parsed(
+                p.method(), p.url(), p.headers(), p.body(), req.name(), p.bodyRef(), p.redirects(), req.directives());
     }
 
     /** Every {@code @name = value} declaration as {@code [name, rawValue]} pairs, in order. */
@@ -232,6 +292,63 @@ public final class HttpFile {
             return rest.isEmpty() ? null : rest;
         }
         return null;
+    }
+
+    /** Scans a section's comment lines {@code [from, to)} for the per-request directives. */
+    static Directives directivesOf(String[] lines, int from, int to) {
+        boolean noRedirect = false;
+        boolean noCookieJar = false;
+        boolean noLog = false;
+        int timeout = 0;
+        for (int k = from; k < to; k++) {
+            String s = lines[k].strip();
+            if (!isComment(s)) {
+                continue;
+            }
+            String c = (s.startsWith("//") ? s.substring(2) : s.substring(1)).strip();
+            if (!c.startsWith("@")) {
+                continue;
+            }
+            String tok = c.substring(1);
+            String low = tok.toLowerCase(Locale.ROOT);
+            if (low.startsWith("no-redirect")) {
+                noRedirect = true;
+            } else if (low.startsWith("no-cookie-jar")) {
+                noCookieJar = true;
+            } else if (low.startsWith("no-log")) {
+                noLog = true;
+            } else if (low.startsWith("timeout")) {
+                timeout = parseInt(tok.substring("timeout".length()).strip());
+            }
+        }
+        return new Directives(noRedirect, noCookieJar, noLog, timeout);
+    }
+
+    private static BodyRef parseBodyRef(String line) {
+        boolean substitute = line.startsWith("<@");
+        String rest = line.substring(substitute ? 2 : 1).strip();
+        String encoding = null;
+        if (substitute && !rest.startsWith(".") && !rest.startsWith("/")) {
+            int sp = rest.indexOf(' ');
+            if (sp > 0) {
+                encoding = rest.substring(0, sp);
+                rest = rest.substring(sp + 1).strip();
+            }
+        }
+        return new BodyRef(rest, substitute, encoding);
+    }
+
+    private static Redirect parseRedirect(String line) {
+        boolean force = line.startsWith(">>!");
+        return new Redirect(line.substring(force ? 3 : 2).strip(), force);
+    }
+
+    private static int parseInt(String s) {
+        try {
+            return Integer.parseInt(s.strip());
+        } catch (NumberFormatException e) {
+            return 0;
+        }
     }
 
     private static boolean isVarDecl(String stripped) {

--- a/src/main/java/com/editora/http/HttpResponseFormat.java
+++ b/src/main/java/com/editora/http/HttpResponseFormat.java
@@ -33,7 +33,7 @@ public final class HttpResponseFormat {
     }
 
     /** Pretty-prints a JSON body (by content type); other bodies are returned unchanged. */
-    static String prettyBody(String body, String contentType) {
+    public static String prettyBody(String body, String contentType) {
         if (body == null) {
             return "";
         }

--- a/src/main/java/com/editora/http/HttpVars.java
+++ b/src/main/java/com/editora/http/HttpVars.java
@@ -1,22 +1,19 @@
 package com.editora.http;
 
+import java.nio.file.Path;
 import java.time.LocalDateTime;
-import java.time.ZoneOffset;
-import java.time.format.DateTimeFormatter;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.UUID;
-import java.util.concurrent.ThreadLocalRandom;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 /**
- * Resolves {@code {{variable}}} references in a {@code .http} request (replacing what {@code ijhttp} used
- * to do): named variables come from the environment file + the file's {@code @name = value} declarations;
- * {@code {{$uuid}}}/{@code {{$timestamp}}}/{@code {{$randomInt}}}/{@code {{$isoTimestamp}}} are dynamic
- * built-ins. Pure given a fixed clock (the dynamic uuid/random aside), so the resolution + timestamp logic
- * is unit-tested.
+ * Resolves {@code {{variable}}} references in a {@code .http} request: named variables come from the
+ * environment file + the file's {@code @name = value} declarations; {@code {{$…}}} are dynamic built-ins
+ * (see {@link DynamicVars}); and {@code {{request.response.…}}} references pull from earlier responses in the
+ * same run (see {@link CapturedResponses}). Pure given a fixed clock (the dynamic/random aside), so the
+ * resolution + timestamp logic is unit-tested.
  */
 public final class HttpVars {
 
@@ -24,49 +21,59 @@ public final class HttpVars {
 
     private HttpVars() {}
 
+    /** {@link #resolve(Map, List, LocalDateTime, Path)} with no file directory (no {@code $dotenv}). */
+    public static Map<String, String> resolve(Map<String, String> envVars, List<String[]> fileVars, LocalDateTime now) {
+        return resolve(envVars, fileVars, now, null);
+    }
+
     /**
      * Builds the effective variable map: the environment variables, then the file's {@code @var}
      * declarations layered on top (each resolved against the accumulating map, so a later {@code @var}
-     * may reference an earlier one or an env var).
+     * may reference an earlier one, an env var, or a dynamic built-in).
      */
-    public static Map<String, String> resolve(Map<String, String> envVars, List<String[]> fileVars, LocalDateTime now) {
+    public static Map<String, String> resolve(
+            Map<String, String> envVars, List<String[]> fileVars, LocalDateTime now, Path dir) {
         Map<String, String> map = new LinkedHashMap<>(envVars == null ? Map.of() : envVars);
         if (fileVars != null) {
             for (String[] pair : fileVars) {
-                map.put(pair[0], substitute(pair[1], map, now));
+                map.put(pair[0], substitute(pair[1], map, now, null, dir));
             }
         }
         return map;
     }
 
-    /** Replaces every {@code {{name}}} in {@code text} with its value (built-ins resolved; unknown → ""). */
+    /** {@link #substitute(String, Map, LocalDateTime, CapturedResponses, Path)} with no chaining/dir context. */
     public static String substitute(String text, Map<String, String> vars, LocalDateTime now) {
+        return substitute(text, vars, now, null, null);
+    }
+
+    /**
+     * Replaces every {@code {{name}}} in {@code text}: dynamic {@code $…} built-ins (resolved with {@code now}
+     * and {@code dir}), {@code request.response.…} references (resolved against {@code captured} when given),
+     * else the variable map. Unknown references → {@code ""}.
+     */
+    public static String substitute(
+            String text, Map<String, String> vars, LocalDateTime now, CapturedResponses captured, Path dir) {
         if (text == null || text.isEmpty()) {
             return text == null ? "" : text;
         }
         Matcher m = VAR.matcher(text);
         StringBuilder sb = new StringBuilder();
         while (m.find()) {
-            m.appendReplacement(sb, Matcher.quoteReplacement(value(m.group(1), vars, now)));
+            m.appendReplacement(sb, Matcher.quoteReplacement(value(m.group(1), vars, now, captured, dir)));
         }
         m.appendTail(sb);
         return sb.toString();
     }
 
-    private static String value(String name, Map<String, String> vars, LocalDateTime now) {
-        if (name.startsWith("$")) {
-            return builtin(name, now);
+    private static String value(
+            String name, Map<String, String> vars, LocalDateTime now, CapturedResponses captured, Path dir) {
+        if (DynamicVars.isDynamic(name)) {
+            return DynamicVars.value(name, now, dir);
+        }
+        if (captured != null && CapturedResponses.isResponseRef(name)) {
+            return captured.resolve(name);
         }
         return vars == null ? "" : vars.getOrDefault(name, "");
-    }
-
-    private static String builtin(String name, LocalDateTime now) {
-        return switch (name) {
-            case "$uuid", "$random.uuid" -> UUID.randomUUID().toString();
-            case "$timestamp" -> String.valueOf(now.toEpochSecond(ZoneOffset.UTC));
-            case "$isoTimestamp" -> now.atOffset(ZoneOffset.UTC).format(DateTimeFormatter.ISO_INSTANT);
-            case "$randomInt" -> String.valueOf(ThreadLocalRandom.current().nextInt(0, 1000));
-            default -> "";
-        };
     }
 }

--- a/src/main/java/com/editora/http/JsonPath.java
+++ b/src/main/java/com/editora/http/JsonPath.java
@@ -1,0 +1,110 @@
+package com.editora.http;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+/**
+ * A tiny JSONPath <b>subset</b> evaluator (Jackson-backed) used to pull values out of a captured response
+ * body for request chaining ({@code {{request.response.body.$.a.b}}}). Supports a leading {@code $}, dotted
+ * fields ({@code .field}), bracketed fields ({@code ["a.b"]}/{@code ['a.b']}), array indices ({@code [0]}),
+ * and {@code *} (the whole node). Any miss yields {@code ""} — it never throws, mirroring the unknown-variable
+ * contract of {@link HttpVars}. Pure, so it is unit-tested.
+ */
+public final class JsonPath {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    private JsonPath() {}
+
+    /** The value at {@code path} in {@code json} as text (objects/arrays serialized), or {@code ""}. */
+    public static String eval(String json, String path) {
+        if (json == null || json.isBlank()) {
+            return "";
+        }
+        try {
+            JsonNode node = node(MAPPER.readTree(json), path);
+            if (node == null || node.isMissingNode() || node.isNull()) {
+                return "";
+            }
+            return node.isValueNode() ? node.asText() : node.toString();
+        } catch (Exception e) {
+            return "";
+        }
+    }
+
+    /** Walks {@code path} from {@code root}; {@code null} on any miss. */
+    static JsonNode node(JsonNode root, String path) {
+        JsonNode cur = root;
+        for (String tok : tokenize(path)) {
+            if (cur == null) {
+                return null;
+            }
+            if (tok.equals("$") || tok.equals("*")) {
+                continue; // root / whole-node passthrough
+            }
+            if (isIndex(tok)) {
+                int idx = Integer.parseInt(tok);
+                cur = cur.isArray() && idx >= 0 && idx < cur.size() ? cur.get(idx) : null;
+            } else {
+                cur = cur.isObject() ? cur.get(tok) : null;
+            }
+        }
+        return cur;
+    }
+
+    /** Splits a path like {@code $.a.b[2]["c.d"]} into its field/index tokens. */
+    static List<String> tokenize(String path) {
+        List<String> out = new ArrayList<>();
+        if (path == null) {
+            return out;
+        }
+        String p = path.strip();
+        int i = 0;
+        int n = p.length();
+        while (i < n) {
+            char c = p.charAt(i);
+            if (c == '$') {
+                out.add("$");
+                i++;
+            } else if (c == '.') {
+                i++; // the field name follows
+            } else if (c == '[') {
+                int end = p.indexOf(']', i);
+                if (end < 0) {
+                    break;
+                }
+                out.add(stripQuotes(p.substring(i + 1, end).strip()));
+                i = end + 1;
+            } else {
+                int start = i;
+                while (i < n && p.charAt(i) != '.' && p.charAt(i) != '[') {
+                    i++;
+                }
+                out.add(p.substring(start, i));
+            }
+        }
+        return out;
+    }
+
+    private static boolean isIndex(String tok) {
+        if (tok.isEmpty()) {
+            return false;
+        }
+        for (int i = 0; i < tok.length(); i++) {
+            if (!Character.isDigit(tok.charAt(i))) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private static String stripQuotes(String s) {
+        if (s.length() >= 2 && ((s.startsWith("\"") && s.endsWith("\"")) || (s.startsWith("'") && s.endsWith("'")))) {
+            return s.substring(1, s.length() - 1);
+        }
+        return s;
+    }
+}

--- a/src/main/java/com/editora/http/Multipart.java
+++ b/src/main/java/com/editora/http/Multipart.java
@@ -1,0 +1,146 @@
+package com.editora.http;
+
+import java.io.ByteArrayOutputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+
+/**
+ * Pure {@code multipart/form-data} body builder for a request authored in a {@code .http} file. The body is
+ * split on {@code --boundary} lines into {@link Part}s, each with its own headers and either inline content
+ * or a {@code < ./file} reference; {@link #build} assembles the wire bytes (CRLF framing), substituting
+ * {@code {{vars}}} in inline parts and slurping file parts from the request file's directory. The split is
+ * unit-tested; {@link #build} is verified on its byte output.
+ */
+public final class Multipart {
+
+    /** One multipart section: its {@code headers}, the {@code inlineBody} (when authored inline), or a
+     *  {@code filePath} (relative to the request file) to slurp instead. */
+    public record Part(Map<String, String> headers, String inlineBody, String filePath) {}
+
+    private Multipart() {}
+
+    /** True for a multipart content type (so the executor builds the body via {@link #build}). */
+    public static boolean isMultipart(String contentType) {
+        return contentType != null && contentType.toLowerCase().contains("multipart/");
+    }
+
+    /** Extracts the {@code boundary=…} token from a multipart Content-Type, or {@code ""} if absent. */
+    public static String boundaryOf(String contentType) {
+        if (contentType == null) {
+            return "";
+        }
+        int b = contentType.toLowerCase().indexOf("boundary=");
+        if (b < 0) {
+            return "";
+        }
+        String v = contentType.substring(b + "boundary=".length()).trim();
+        int semi = v.indexOf(';');
+        if (semi >= 0) {
+            v = v.substring(0, semi).trim();
+        }
+        if (v.length() >= 2 && v.startsWith("\"") && v.endsWith("\"")) {
+            v = v.substring(1, v.length() - 1);
+        }
+        return v;
+    }
+
+    /** Splits a multipart {@code body} on {@code --boundary} lines into its parts. */
+    public static List<Part> parse(String body, String boundary) {
+        List<Part> parts = new ArrayList<>();
+        if (body == null || boundary == null || boundary.isBlank()) {
+            return parts;
+        }
+        String delim = "--" + boundary;
+        List<String> current = null;
+        for (String line : body.split("\n", -1)) {
+            String t = line.strip();
+            if (t.equals(delim) || t.equals(delim + "--")) {
+                if (current != null) {
+                    parts.add(toPart(current));
+                }
+                current = t.endsWith("--") ? null : new ArrayList<>();
+            } else if (current != null) {
+                current.add(line);
+            }
+        }
+        if (current != null) {
+            parts.add(toPart(current)); // an unterminated final part
+        }
+        return parts;
+    }
+
+    private static Part toPart(List<String> lines) {
+        Map<String, String> headers = new LinkedHashMap<>();
+        int i = 0;
+        while (i < lines.size() && lines.get(i).strip().isEmpty()) {
+            i++;
+        }
+        for (; i < lines.size(); i++) {
+            String line = lines.get(i);
+            if (line.strip().isEmpty()) {
+                i++;
+                break;
+            }
+            int colon = line.indexOf(':');
+            if (colon > 0) {
+                headers.put(
+                        line.substring(0, colon).strip(),
+                        line.substring(colon + 1).strip());
+            }
+        }
+        StringBuilder content = new StringBuilder();
+        String filePath = null;
+        for (; i < lines.size(); i++) {
+            String t = lines.get(i).stripLeading();
+            if (filePath == null && content.length() == 0 && t.startsWith("<") && !t.startsWith("<>")) {
+                String ref = t.substring(1).strip();
+                if (ref.startsWith("@")) {
+                    ref = ref.substring(1).strip();
+                }
+                filePath = ref;
+                continue;
+            }
+            if (content.length() > 0) {
+                content.append('\n');
+            }
+            content.append(lines.get(i));
+        }
+        return new Part(headers, filePath == null ? content.toString() : "", filePath);
+    }
+
+    /** Assembles the multipart wire bytes; inline parts pass through {@code subst} and file parts are read
+     *  from {@code baseDir}. Best-effort — a missing file leaves its part empty rather than throwing. */
+    public static byte[] build(List<Part> parts, String boundary, Path baseDir, Function<String, String> subst) {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        String delim = "--" + boundary;
+        for (Part p : parts) {
+            write(out, delim + "\r\n");
+            for (Map.Entry<String, String> h : p.headers().entrySet()) {
+                write(out, h.getKey() + ": " + h.getValue() + "\r\n");
+            }
+            write(out, "\r\n");
+            if (p.filePath() != null) {
+                try {
+                    out.writeBytes(baseDir != null ? Files.readAllBytes(baseDir.resolve(p.filePath())) : new byte[0]);
+                } catch (Exception ignore) {
+                    // a missing file part — leave it empty
+                }
+            } else {
+                write(out, subst == null ? p.inlineBody() : subst.apply(p.inlineBody()));
+            }
+            write(out, "\r\n");
+        }
+        write(out, delim + "--\r\n");
+        return out.toByteArray();
+    }
+
+    private static void write(ByteArrayOutputStream out, String s) {
+        out.writeBytes(s.getBytes(StandardCharsets.UTF_8));
+    }
+}

--- a/src/main/java/com/editora/ui/HttpClientPanel.java
+++ b/src/main/java/com/editora/ui/HttpClientPanel.java
@@ -5,10 +5,12 @@ import java.util.List;
 import java.util.function.Consumer;
 
 import javafx.geometry.Insets;
+import javafx.geometry.Orientation;
 import javafx.geometry.Pos;
 import javafx.scene.control.Button;
 import javafx.scene.control.ComboBox;
 import javafx.scene.control.Label;
+import javafx.scene.control.SplitPane;
 import javafx.scene.control.TextArea;
 import javafx.scene.layout.HBox;
 import javafx.scene.layout.Priority;
@@ -16,29 +18,59 @@ import javafx.scene.layout.Region;
 import javafx.scene.layout.VBox;
 import javafx.util.StringConverter;
 
+import com.editora.editor.GrammarRegistry;
+import com.editora.editor.TextMateHighlighter;
+import com.editora.http.HttpExchange;
+import com.editora.http.HttpResponseFormat;
+import com.editora.http.HttpResult;
+import org.eclipse.tm4e.core.grammar.IGrammar;
+import org.fxmisc.flowless.VirtualizedScrollPane;
+import org.fxmisc.richtext.CodeArea;
+
 import static com.editora.i18n.Messages.tr;
 
 /**
- * The "HTTP Client" tool window: shows the {@code ijhttp} response report for a run request, with an
- * environment picker (for {@code {{var}}} resolution), Save response, and Clear. A
- * {@link ToolWindowContent} modeled on {@link RunPanel}; the controller drives it via
- * {@code started}/{@code showResult} on the FX thread.
+ * The "HTTP Client" tool window: a request/response viewer modeled on {@link RunPanel}. Shows the selected
+ * {@link HttpExchange}'s status + response headers in one pane and its body — syntax-highlighted by content
+ * type (JSON/XML/HTML, reusing the editor's TextMate grammars) — in a read-only {@link CodeArea} below. A
+ * history picker keeps the last runs, plus actions for "Copy as cURL", "Open in editor tab", Save, and
+ * Clear, and an environment picker for {@code {{var}}} resolution. The controller drives it via
+ * {@code started}/{@code showExchanges} on the FX thread.
  */
 public final class HttpClientPanel extends VBox implements ToolWindowContent {
 
-    private static final int MAX_CHARS = 400_000;
+    private static final int MAX_HISTORY = 20;
+    private static final int MAX_BODY_CHARS = 400_000;
 
     private final Label status = new Label();
     private final ComboBox<String> envCombo = new ComboBox<>();
-    private final TextArea output = new TextArea();
+    private final ComboBox<HttpExchange> historyCombo = new ComboBox<>();
+    private final TextArea headersArea = new TextArea();
+    private final CodeArea bodyArea = new CodeArea();
+    private final Button copyCurlButton = new Button();
+    private final Button openTabButton = new Button();
     private final Button saveButton = new Button();
     private final Button clearButton = new Button();
+
+    private final List<HttpExchange> history = new ArrayList<>();
+    private final Consumer<HttpExchange> onCopyAsCurl;
+    private final Consumer<HttpExchange> onOpenInTab;
+
     /** Receives the chosen environment name ({@code ""} = none) so the controller can persist it. */
     private Consumer<String> onEnvironmentChanged;
 
     private boolean updatingEnv;
+    private boolean updatingHistory;
+    private String fontStyle;
 
-    public HttpClientPanel(Runnable onSaveResponse) {
+    public HttpClientPanel(
+            Runnable onSaveResponse,
+            Consumer<HttpExchange> onCopyAsCurl,
+            Consumer<HttpExchange> onOpenInTab,
+            String fontFamily,
+            int fontSize) {
+        this.onCopyAsCurl = onCopyAsCurl;
+        this.onOpenInTab = onOpenInTab;
         getStyleClass().add("http-panel");
         getProperties().put("editora.ownsKeys", Boolean.TRUE);
         setSpacing(6);
@@ -64,6 +96,30 @@ public final class HttpClientPanel extends VBox implements ToolWindowContent {
             }
         });
 
+        historyCombo.getStyleClass().add("http-history");
+        historyCombo.setConverter(new StringConverter<>() {
+            @Override
+            public String toString(HttpExchange ex) {
+                return ex == null ? "" : historyLabel(ex);
+            }
+
+            @Override
+            public HttpExchange fromString(String s) {
+                return null;
+            }
+        });
+        historyCombo.valueProperty().addListener((o, a, b) -> {
+            if (!updatingHistory && b != null) {
+                showExchange(b);
+            }
+        });
+
+        copyCurlButton.setText(tr("httppanel.copyAsCurl"));
+        copyCurlButton.setDisable(true);
+        copyCurlButton.setOnAction(e -> withSelected(onCopyAsCurl));
+        openTabButton.setText(tr("httppanel.openInTab"));
+        openTabButton.setDisable(true);
+        openTabButton.setOnAction(e -> withSelected(onOpenInTab));
         saveButton.setText(tr("httppanel.save"));
         saveButton.setDisable(true);
         saveButton.setOnAction(e -> {
@@ -72,21 +128,39 @@ public final class HttpClientPanel extends VBox implements ToolWindowContent {
             }
         });
         clearButton.setText(tr("httppanel.clear"));
-        clearButton.setOnAction(e -> {
-            output.clear();
-            saveButton.setDisable(true);
-        });
+        clearButton.setOnAction(e -> clear());
 
-        Label envLabel = new Label(tr("httppanel.environment"));
-        HBox header = new HBox(8, status, spacer(), envLabel, envCombo, clearButton, saveButton);
+        HBox header = new HBox(8, status, spacer(), copyCurlButton, openTabButton, clearButton, saveButton);
         header.setAlignment(Pos.CENTER_LEFT);
 
-        output.setEditable(false);
-        output.setWrapText(false);
-        output.getStyleClass().add("http-output");
+        HBox controls = new HBox(
+                8,
+                new Label(tr("httppanel.history")),
+                historyCombo,
+                spacer(),
+                new Label(tr("httppanel.environment")),
+                envCombo);
+        controls.setAlignment(Pos.CENTER_LEFT);
 
-        VBox.setVgrow(output, Priority.ALWAYS);
-        getChildren().addAll(header, output);
+        headersArea.setEditable(false);
+        headersArea.setWrapText(true);
+        headersArea.getStyleClass().add("http-headers");
+        headersArea.setPrefRowCount(5);
+
+        bodyArea.getStyleClass().addAll("editor-area", "http-body");
+        bodyArea.setEditable(false);
+        bodyArea.setFocusTraversable(true);
+        bodyArea.setShowCaret(org.fxmisc.richtext.Caret.CaretVisibility.OFF);
+        bodyArea.setWrapText(false);
+        setEditorFont(fontFamily, fontSize);
+
+        SplitPane split = new SplitPane(headersArea, new VirtualizedScrollPane<>(bodyArea));
+        split.setOrientation(Orientation.VERTICAL);
+        split.setDividerPositions(0.28);
+        SplitPane.setResizableWithParent(headersArea, false);
+
+        VBox.setVgrow(split, Priority.ALWAYS);
+        getChildren().addAll(header, controls, split);
         idle();
     }
 
@@ -96,29 +170,158 @@ public final class HttpClientPanel extends VBox implements ToolWindowContent {
         return r;
     }
 
+    /** Updates the body editor font (called on a settings/font change). */
+    public void setEditorFont(String fontFamily, int fontSize) {
+        fontStyle = "-fx-font-family: \"" + fontFamily + "\"; -fx-font-size: " + fontSize + "px;";
+        bodyArea.setStyle(fontStyle);
+        headersArea.setStyle(fontStyle);
+    }
+
     /** No request run yet / cleared. */
     public void idle() {
         status.setText(tr("httppanel.idle"));
     }
 
-    /** A request started: clears the console and shows a running note for {@code label} (method + URL). */
+    /** A request started: shows a running note for {@code label} (method + URL). */
     public void started(String label) {
-        output.clear();
-        saveButton.setDisable(true);
         status.setText(tr("httppanel.running", label));
     }
 
-    /** Shows the finished response report and the exit status; enables Save when there is output. */
-    public void showResult(String text, int exit) {
-        String t = text == null ? "" : text;
-        if (t.length() > MAX_CHARS) {
-            t = t.substring(t.length() - MAX_CHARS);
+    /** Adds the finished exchanges to the history (newest first) and shows the first. */
+    public void showExchanges(List<HttpExchange> exchanges) {
+        if (exchanges == null || exchanges.isEmpty()) {
+            return;
         }
-        output.setText(t);
-        output.positionCaret(0);
-        output.setScrollTop(0);
-        saveButton.setDisable(output.getLength() == 0);
-        status.setText(exit == 0 ? tr("httppanel.done") : tr("httppanel.failed", exit));
+        for (int i = exchanges.size() - 1; i >= 0; i--) {
+            history.add(0, exchanges.get(i));
+        }
+        while (history.size() > MAX_HISTORY) {
+            history.remove(history.size() - 1);
+        }
+        updatingHistory = true;
+        historyCombo.getItems().setAll(history);
+        updatingHistory = false;
+        HttpExchange first = exchanges.get(0);
+        historyCombo.setValue(first);
+        showExchange(first);
+        boolean allOk = exchanges.stream().allMatch(ex -> ex.result().ok());
+        status.setText(allOk ? tr("httppanel.done") : tr("httppanel.failed", exchanges.size()));
+    }
+
+    private void showExchange(HttpExchange ex) {
+        HttpResult r = ex.result();
+        StringBuilder head = new StringBuilder();
+        if (r.failed()) {
+            head.append("⚠  ").append(r.error());
+        } else {
+            head.append("HTTP ").append(r.status()).append('\n');
+            for (String[] h : r.headers()) {
+                head.append(h[0]).append(": ").append(h[1]).append('\n');
+            }
+            head.append('\n')
+                    .append(r.status())
+                    .append("  ·  ")
+                    .append(r.elapsedMs())
+                    .append(" ms  ·  ")
+                    .append(humanSize(r.sizeBytes()));
+        }
+        headersArea.setText(head.toString());
+        headersArea.positionCaret(0);
+
+        String body = r.failed() ? "" : HttpResponseFormat.prettyBody(r.body(), r.contentType());
+        if (body.length() > MAX_BODY_CHARS) {
+            body = body.substring(0, MAX_BODY_CHARS);
+        }
+        bodyArea.replaceText(body);
+        bodyArea.setStyle(fontStyle);
+        applyHighlight(body, r.contentType());
+        bodyArea.moveTo(0);
+        bodyArea.scrollToPixel(0, 0);
+
+        boolean has = !r.failed();
+        copyCurlButton.setDisable(false);
+        openTabButton.setDisable(!has);
+        saveButton.setDisable(false);
+    }
+
+    private void applyHighlight(String body, String contentType) {
+        if (body.isEmpty()) {
+            return; // RichTextFX rejects zero-length spans
+        }
+        IGrammar grammar = grammarFor(contentType);
+        if (grammar == null) {
+            return;
+        }
+        try {
+            bodyArea.setStyleSpans(0, TextMateHighlighter.compute(body, grammar));
+        } catch (RuntimeException ignored) {
+            // unknown/oversized — leave it unstyled
+        }
+    }
+
+    private static IGrammar grammarFor(String contentType) {
+        String ext = extFor(contentType);
+        if (ext == null) {
+            return null;
+        }
+        try {
+            return GrammarRegistry.shared().forFileName("response." + ext);
+        } catch (RuntimeException e) {
+            return null;
+        }
+    }
+
+    private static String extFor(String contentType) {
+        if (contentType == null) {
+            return null;
+        }
+        String ct = contentType.toLowerCase();
+        if (ct.contains("json")) {
+            return "json";
+        }
+        if (ct.contains("html")) {
+            return "html";
+        }
+        if (ct.contains("xml")) {
+            return "xml";
+        }
+        return null;
+    }
+
+    private static String humanSize(long bytes) {
+        if (bytes < 1024) {
+            return bytes + " B";
+        }
+        double kb = bytes / 1024.0;
+        return kb < 1024
+                ? String.format(java.util.Locale.ROOT, "%.1f KB", kb)
+                : String.format(java.util.Locale.ROOT, "%.1f MB", kb / 1024);
+    }
+
+    private static String historyLabel(HttpExchange ex) {
+        String state = ex.result().failed() ? "⚠" : String.valueOf(ex.result().status());
+        return state + "  " + ex.label();
+    }
+
+    private void withSelected(Consumer<HttpExchange> action) {
+        HttpExchange ex = historyCombo.getValue();
+        if (ex != null && action != null) {
+            action.accept(ex);
+        }
+    }
+
+    private void clear() {
+        history.clear();
+        updatingHistory = true;
+        historyCombo.getItems().clear();
+        historyCombo.setValue(null);
+        updatingHistory = false;
+        headersArea.clear();
+        bodyArea.clear();
+        copyCurlButton.setDisable(true);
+        openTabButton.setDisable(true);
+        saveButton.setDisable(true);
+        idle();
     }
 
     /** Populates the environment picker; {@code active} ({@code ""} = none) is selected. */
@@ -145,13 +348,19 @@ public final class HttpClientPanel extends VBox implements ToolWindowContent {
         this.onEnvironmentChanged = onEnvironmentChanged;
     }
 
-    /** The current response text (for Save response). */
+    /** The selected exchange (for Copy as cURL / Open in tab), or {@code null}. */
+    public HttpExchange getSelectedExchange() {
+        return historyCombo.getValue();
+    }
+
+    /** The current response as a full text report (for Save response). */
     public String getResponseText() {
-        return output.getText();
+        HttpExchange ex = historyCombo.getValue();
+        return ex == null ? "" : HttpResponseFormat.render(ex.result());
     }
 
     @Override
     public void focusFirstItem() {
-        output.requestFocus();
+        bodyArea.requestFocus();
     }
 }

--- a/src/main/java/com/editora/ui/MainController.java
+++ b/src/main/java/com/editora/ui/MainController.java
@@ -2220,7 +2220,13 @@ public class MainController {
         });
         debugToolWindow = new ToolWindow(
                 "debug", tr("toolwindow.debug"), ToolWindow.Side.BOTTOM, Icons::debug, debugPanel, "tool.debug");
-        httpPanel = new HttpClientPanel(this::saveHttpResponse);
+        httpPanel = new HttpClientPanel(
+                this::saveHttpResponse,
+                this::copyHttpAsCurl,
+                this::openHttpResponseInTab,
+                config.getSettings().getFontFamily(),
+                Math.max(1, (int) Math.round(config.getSettings().getFontSize()
+                        * config.getSettings().getFontZoom())));
         httpPanel.setOnEnvironmentChanged(env -> {
             config.getWorkspaceState().setHttpEnvironment(env);
             config.save();
@@ -2642,6 +2648,8 @@ public class MainController {
                 b.setHttpEnabled(on);
             }
         }
+        Settings s = config.getSettings();
+        httpPanel.setEditorFont(s.getFontFamily(), Math.max(1, (int) Math.round(s.getFontSize() * s.getFontZoom())));
         updateRunButton(); // re-gate the HTTP tool window on the active buffer
     }
 
@@ -2673,10 +2681,11 @@ public class MainController {
         }
         com.editora.http.HttpFile.Request req =
                 com.editora.http.HttpFile.parse(text).get(index);
-        com.editora.http.HttpFile.Parsed parsed = com.editora.http.HttpFile.parseRequest(req.block());
+        com.editora.http.HttpFile.Parsed parsed = com.editora.http.HttpFile.parseRequest(req);
         String label = parsed.method() + " " + parsed.url();
         startHttpRun(label);
-        httpService.run(parsed, httpVariables(buffer, text), r -> finishHttpRun(label, r));
+        java.nio.file.Path baseDir = buffer.getPath().toAbsolutePath().getParent();
+        httpService.run(parsed, httpVariables(buffer, text), baseDir, ex -> finishHttpRun(label, ex));
     }
 
     /** Runs every request in the active {@code .http} file sequentially (palette command). */
@@ -2696,7 +2705,7 @@ public class MainController {
         }
         String text = b.getContent();
         java.util.List<com.editora.http.HttpFile.Parsed> reqs = com.editora.http.HttpFile.parse(text).stream()
-                .map(r -> com.editora.http.HttpFile.parseRequest(r.block()))
+                .map(r -> com.editora.http.HttpFile.parseRequest(r))
                 .toList();
         if (reqs.isEmpty()) {
             setStatus(tr("status.http.noRequest"));
@@ -2704,18 +2713,11 @@ public class MainController {
         }
         String label = b.getPath().getFileName().toString();
         startHttpRun(label);
-        httpService.runAll(reqs, httpVariables(b, text), results -> {
-            StringBuilder sb = new StringBuilder();
-            boolean allOk = true;
-            for (int i = 0; i < results.size(); i++) {
-                if (i > 0) {
-                    sb.append("\n\n").append("─".repeat(40)).append("\n\n");
-                }
-                sb.append(com.editora.http.HttpResponseFormat.render(results.get(i)));
-                allOk &= results.get(i).ok();
-            }
-            httpPanel.showResult(sb.toString(), allOk ? 0 : 1);
-            setStatus(allOk ? tr("status.http.done", label) : tr("status.http.failed", reqs.size()));
+        java.nio.file.Path baseDir = b.getPath().toAbsolutePath().getParent();
+        httpService.runAll(reqs, httpVariables(b, text), baseDir, exchanges -> {
+            httpPanel.showExchanges(exchanges);
+            boolean allOk = exchanges.stream().allMatch(ex -> ex.result().ok());
+            setStatus(allOk ? tr("status.http.done", label) : tr("status.http.failed", exchanges.size()));
         });
     }
 
@@ -2725,9 +2727,89 @@ public class MainController {
         setStatus(tr("status.http.running", label));
     }
 
-    private void finishHttpRun(String label, com.editora.http.HttpResult r) {
-        httpPanel.showResult(com.editora.http.HttpResponseFormat.render(r), r.ok() ? 0 : 1);
+    private void finishHttpRun(String label, com.editora.http.HttpExchange ex) {
+        httpPanel.showExchanges(java.util.List.of(ex));
+        com.editora.http.HttpResult r = ex.result();
         setStatus(r.failed() || !r.ok() ? tr("status.http.failed", r.status()) : tr("status.http.done", label));
+    }
+
+    /** Copies {@code ex}'s (resolved) request as a {@code curl} command to the clipboard. */
+    private void copyHttpAsCurl(com.editora.http.HttpExchange ex) {
+        String curl = com.editora.http.CurlExport.toCurl(ex.method(), ex.url(), ex.headers(), ex.requestBody());
+        javafx.scene.input.ClipboardContent cc = new javafx.scene.input.ClipboardContent();
+        cc.putString(curl);
+        javafx.scene.input.Clipboard.getSystemClipboard().setContent(cc);
+        setStatus(tr("status.http.curlCopied"));
+    }
+
+    /** Opens {@code ex}'s response body in a new (untitled) editor tab, highlighted by content type. */
+    private void openHttpResponseInTab(com.editora.http.HttpExchange ex) {
+        com.editora.http.HttpResult r = ex.result();
+        if (r.failed()) {
+            setStatus(tr("status.http.noResponse"));
+            return;
+        }
+        EditorBuffer buffer = new EditorBuffer();
+        buffer.setDisplayName("response" + responseExt(r.contentType()));
+        addBuffer(buffer, true);
+        buffer.setContent(com.editora.http.HttpResponseFormat.prettyBody(r.body(), r.contentType()));
+    }
+
+    private static String responseExt(String contentType) {
+        String ct = contentType == null ? "" : contentType.toLowerCase(java.util.Locale.ROOT);
+        if (ct.contains("json")) {
+            return ".json";
+        }
+        if (ct.contains("html")) {
+            return ".html";
+        }
+        if (ct.contains("xml")) {
+            return ".xml";
+        }
+        return ".txt";
+    }
+
+    /** Copies the response viewer's selected request as a {@code curl} command (palette command). */
+    private void copyActiveHttpAsCurl() {
+        com.editora.http.HttpExchange ex = httpPanel.getSelectedExchange();
+        if (ex == null) {
+            setStatus(tr("status.http.noResponse"));
+            return;
+        }
+        copyHttpAsCurl(ex);
+    }
+
+    /** Opens the response viewer's selected response in a new editor tab (palette command). */
+    private void openActiveHttpResponseInTab() {
+        com.editora.http.HttpExchange ex = httpPanel.getSelectedExchange();
+        if (ex == null) {
+            setStatus(tr("status.http.noResponse"));
+            return;
+        }
+        openHttpResponseInTab(ex);
+    }
+
+    /** Converts a {@code curl} command on the clipboard into a request block, appending it to the active
+     *  {@code .http} buffer (or a new one). */
+    private void importCurlFromClipboard() {
+        String clip = javafx.scene.input.Clipboard.getSystemClipboard().getString();
+        if (clip == null || clip.isBlank() || !clip.contains("curl")) {
+            setStatus(tr("status.http.notCurl"));
+            return;
+        }
+        String request = com.editora.http.CurlImport.toHttpRequest(clip.strip());
+        EditorBuffer b = activeBuffer();
+        if (b != null && b.isHttpFile() && b.isEditable()) {
+            String snippet = (b.getArea().getLength() == 0 ? "" : "\n") + "###\n" + request + "\n";
+            b.getArea().insertText(b.getArea().getLength(), snippet);
+            b.getArea().moveTo(b.getArea().getLength());
+        } else {
+            EditorBuffer nb = new EditorBuffer();
+            nb.setDisplayName("requests.http");
+            addBuffer(nb, true);
+            nb.setContent(request);
+        }
+        setStatus(tr("status.http.curlImported"));
     }
 
     /** The resolved variable map for a {@code .http} buffer: the selected environment's vars (public +
@@ -10171,6 +10253,9 @@ public class MainController {
         registry.register(Command.of("http.runFile", () -> ifHttp(this::runHttpFile)));
         registry.register(
                 Command.of("http.selectEnvironment", () -> ifHttp(() -> toolWindows.open(httpToolWindow, true))));
+        registry.register(Command.of("http.importCurl", () -> ifHttp(this::importCurlFromClipboard)));
+        registry.register(Command.of("http.copyAsCurl", () -> ifHttp(this::copyActiveHttpAsCurl)));
+        registry.register(Command.of("http.openResponseInTab", () -> ifHttp(this::openActiveHttpResponseInTab)));
         registry.register(Command.of("tool.http", () -> ifHttp(() -> toolWindows.toggle(httpToolWindow))));
         // Debugging (DAP). Gated by the "Enable Java debugging" setting (default off).
         registry.register(Command.of("debug.start", () -> ifDebug(this::debugStart)));

--- a/src/main/resources/com/editora/i18n/messages.properties
+++ b/src/main/resources/com/editora/i18n/messages.properties
@@ -1658,3 +1658,17 @@ settings.history.maxPerFile=Max revisions / file
 settings.history.maxAgeDays=Max age (days)
 settings.history.maxTotalMb=Max size / project (MB)
 settings.history.note=History snapshots are kept per project under the config folder; identical consecutive saves are skipped.
+
+# HTTP Client (parity additions)
+command.http.importCurl=HTTP: Import cURL from Clipboard
+command.http.importCurl.desc=Convert a curl command on the clipboard into a .http request.
+command.http.copyAsCurl=HTTP: Copy Response Request as cURL
+command.http.copyAsCurl.desc=Copy the selected response's request as a curl command.
+command.http.openResponseInTab=HTTP: Open Response in Editor Tab
+command.http.openResponseInTab.desc=Open the selected response body in a new editor tab.
+httppanel.history=History:
+httppanel.copyAsCurl=Copy as cURL
+httppanel.openInTab=Open in tab
+status.http.curlImported=Imported cURL command as a request
+status.http.curlCopied=Copied request as a curl command
+status.http.notCurl=No curl command on the clipboard

--- a/src/main/resources/com/editora/i18n/messages_de.properties
+++ b/src/main/resources/com/editora/i18n/messages_de.properties
@@ -1650,3 +1650,17 @@ settings.history.maxPerFile=Max. Versionen / Datei
 settings.history.maxAgeDays=Max. Alter (Tage)
 settings.history.maxTotalMb=Max. Größe / Projekt (MB)
 settings.history.note=Verlaufs-Schnappschüsse werden pro Projekt im Konfigurationsordner gespeichert; identische aufeinanderfolgende Speicherungen werden übersprungen.
+
+# HTTP Client (parity additions)
+command.http.importCurl=HTTP: cURL aus Zwischenablage importieren
+command.http.importCurl.desc=Wandelt einen curl-Befehl aus der Zwischenablage in eine .http-Anfrage um.
+command.http.copyAsCurl=HTTP: Antwort-Anfrage als cURL kopieren
+command.http.copyAsCurl.desc=Kopiert die Anfrage der ausgewählten Antwort als curl-Befehl.
+command.http.openResponseInTab=HTTP: Antwort in Editor-Tab öffnen
+command.http.openResponseInTab.desc=Öffnet den Antworttext der ausgewählten Antwort in einem neuen Editor-Tab.
+httppanel.history=Verlauf:
+httppanel.copyAsCurl=Als cURL kopieren
+httppanel.openInTab=In Tab öffnen
+status.http.curlImported=cURL-Befehl als Anfrage importiert
+status.http.curlCopied=Anfrage als curl-Befehl kopiert
+status.http.notCurl=Kein curl-Befehl in der Zwischenablage

--- a/src/main/resources/com/editora/i18n/messages_es.properties
+++ b/src/main/resources/com/editora/i18n/messages_es.properties
@@ -1650,3 +1650,17 @@ settings.history.maxPerFile=Máx. revisiones / archivo
 settings.history.maxAgeDays=Antigüedad máx. (días)
 settings.history.maxTotalMb=Tamaño máx. / proyecto (MB)
 settings.history.note=Las instantáneas del historial se guardan por proyecto en la carpeta de configuración; se omiten los guardados consecutivos idénticos.
+
+# HTTP Client (parity additions)
+command.http.importCurl=HTTP: Importar cURL del portapapeles
+command.http.importCurl.desc=Convierte un comando curl del portapapeles en una solicitud .http.
+command.http.copyAsCurl=HTTP: Copiar la solicitud de la respuesta como cURL
+command.http.copyAsCurl.desc=Copia la solicitud de la respuesta seleccionada como un comando curl.
+command.http.openResponseInTab=HTTP: Abrir la respuesta en una pestaña
+command.http.openResponseInTab.desc=Abre el cuerpo de la respuesta seleccionada en una nueva pestaña del editor.
+httppanel.history=Historial:
+httppanel.copyAsCurl=Copiar como cURL
+httppanel.openInTab=Abrir en pestaña
+status.http.curlImported=Comando cURL importado como solicitud
+status.http.curlCopied=Solicitud copiada como comando curl
+status.http.notCurl=No hay ningún comando curl en el portapapeles

--- a/src/main/resources/com/editora/i18n/messages_fr.properties
+++ b/src/main/resources/com/editora/i18n/messages_fr.properties
@@ -1650,3 +1650,17 @@ settings.history.maxPerFile=Révisions max / fichier
 settings.history.maxAgeDays=Âge max (jours)
 settings.history.maxTotalMb=Taille max / projet (Mo)
 settings.history.note=Les instantanés d'historique sont conservés par projet dans le dossier de configuration ; les enregistrements consécutifs identiques sont ignorés.
+
+# HTTP Client (parity additions)
+command.http.importCurl=HTTP : Importer cURL depuis le presse-papiers
+command.http.importCurl.desc=Convertit une commande curl du presse-papiers en requête .http.
+command.http.copyAsCurl=HTTP : Copier la requête de la réponse en cURL
+command.http.copyAsCurl.desc=Copie la requête de la réponse sélectionnée sous forme de commande curl.
+command.http.openResponseInTab=HTTP : Ouvrir la réponse dans un onglet
+command.http.openResponseInTab.desc=Ouvre le corps de la réponse sélectionnée dans un nouvel onglet de l'éditeur.
+httppanel.history=Historique :
+httppanel.copyAsCurl=Copier en cURL
+httppanel.openInTab=Ouvrir dans un onglet
+status.http.curlImported=Commande cURL importée comme requête
+status.http.curlCopied=Requête copiée comme commande curl
+status.http.notCurl=Aucune commande curl dans le presse-papiers

--- a/src/main/resources/com/editora/i18n/messages_it.properties
+++ b/src/main/resources/com/editora/i18n/messages_it.properties
@@ -1650,3 +1650,17 @@ settings.history.maxPerFile=Max revisioni / file
 settings.history.maxAgeDays=Età massima (giorni)
 settings.history.maxTotalMb=Dimensione max / progetto (MB)
 settings.history.note=Le istantanee della cronologia sono conservate per progetto nella cartella di configurazione; i salvataggi consecutivi identici vengono ignorati.
+
+# HTTP Client (parity additions)
+command.http.importCurl=HTTP: Importa cURL dagli appunti
+command.http.importCurl.desc=Converte un comando curl negli appunti in una richiesta .http.
+command.http.copyAsCurl=HTTP: Copia la richiesta della risposta come cURL
+command.http.copyAsCurl.desc=Copia la richiesta della risposta selezionata come comando curl.
+command.http.openResponseInTab=HTTP: Apri la risposta in una scheda
+command.http.openResponseInTab.desc=Apre il corpo della risposta selezionata in una nuova scheda dell'editor.
+httppanel.history=Cronologia:
+httppanel.copyAsCurl=Copia come cURL
+httppanel.openInTab=Apri in scheda
+status.http.curlImported=Comando cURL importato come richiesta
+status.http.curlCopied=Richiesta copiata come comando curl
+status.http.notCurl=Nessun comando curl negli appunti

--- a/src/main/resources/com/editora/i18n/messages_pt.properties
+++ b/src/main/resources/com/editora/i18n/messages_pt.properties
@@ -1650,3 +1650,17 @@ settings.history.maxPerFile=Máx. revisões / ficheiro
 settings.history.maxAgeDays=Idade máx. (dias)
 settings.history.maxTotalMb=Tamanho máx. / projeto (MB)
 settings.history.note=Os instantâneos do histórico são guardados por projeto na pasta de configuração; gravações consecutivas idênticas são ignoradas.
+
+# HTTP Client (parity additions)
+command.http.importCurl=HTTP: Importar cURL da área de transferência
+command.http.importCurl.desc=Converte um comando curl da área de transferência em uma requisição .http.
+command.http.copyAsCurl=HTTP: Copiar a requisição da resposta como cURL
+command.http.copyAsCurl.desc=Copia a requisição da resposta selecionada como um comando curl.
+command.http.openResponseInTab=HTTP: Abrir a resposta em uma aba
+command.http.openResponseInTab.desc=Abre o corpo da resposta selecionada em uma nova aba do editor.
+httppanel.history=Histórico:
+httppanel.copyAsCurl=Copiar como cURL
+httppanel.openInTab=Abrir em aba
+status.http.curlImported=Comando cURL importado como requisição
+status.http.curlCopied=Requisição copiada como comando curl
+status.http.notCurl=Nenhum comando curl na área de transferência

--- a/src/test/java/com/editora/http/CapturedResponsesTest.java
+++ b/src/test/java/com/editora/http/CapturedResponsesTest.java
@@ -1,0 +1,66 @@
+package com.editora.http;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/** Unit tests for the per-run captured-response session backing request chaining. */
+class CapturedResponsesTest {
+
+    private static HttpResult result() {
+        return new HttpResult(
+                201,
+                List.of(new String[] {"Content-Type", "application/json"}, new String[] {"X-Trace", "t-1"}),
+                "{ \"token\": \"abc\", \"id\": 7 }",
+                "application/json",
+                12,
+                25,
+                null);
+    }
+
+    @Test
+    void resolvesBodyPathHeaderAndStatus() {
+        CapturedResponses cr = new CapturedResponses();
+        cr.put("login", result());
+        assertEquals("abc", cr.resolve("login.response.body.$.token"));
+        assertEquals("7", cr.resolve("login.response.body.id"));
+        assertEquals("t-1", cr.resolve("login.response.headers.X-Trace"));
+        assertEquals("201", cr.resolve("login.response.status"));
+    }
+
+    @Test
+    void headerLookupIsCaseInsensitive() {
+        CapturedResponses cr = new CapturedResponses();
+        cr.put("login", result());
+        assertEquals("application/json", cr.resolve("login.response.headers.content-type"));
+    }
+
+    @Test
+    void bodyStarReturnsRawBody() {
+        CapturedResponses cr = new CapturedResponses();
+        cr.put("login", result());
+        assertEquals(
+                "{ \"token\": \"abc\", \"id\": 7 }".replaceAll("\\s+", ""),
+                cr.resolve("login.response.body.*").replaceAll("\\s+", ""));
+    }
+
+    @Test
+    void unknownRequestOrRefIsEmpty() {
+        CapturedResponses cr = new CapturedResponses();
+        cr.put("login", result());
+        assertEquals("", cr.resolve("other.response.body.$.token"));
+        assertEquals("", cr.resolve("login.response.body.$.missing"));
+        assertEquals("", cr.resolve("not a ref"));
+    }
+
+    @Test
+    void isResponseRefDetectsTheMarker() {
+        assertTrue(CapturedResponses.isResponseRef("login.response.body.$.x"));
+        assertFalse(CapturedResponses.isResponseRef("host"));
+        assertFalse(CapturedResponses.isResponseRef(null));
+    }
+}

--- a/src/test/java/com/editora/http/CurlExportTest.java
+++ b/src/test/java/com/editora/http/CurlExportTest.java
@@ -1,0 +1,37 @@
+package com.editora.http;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/** Unit tests for the "Copy as cURL" export. */
+class CurlExportTest {
+
+    @Test
+    void getOmitsMethodFlag() {
+        String curl = CurlExport.toCurl("GET", "https://api.test/x", List.of(), null);
+        assertTrue(curl.startsWith("curl 'https://api.test/x'"), curl);
+        assertFalse(curl.contains("-X"), curl);
+    }
+
+    @Test
+    void postIncludesMethodHeadersAndBody() {
+        String curl = CurlExport.toCurl(
+                "POST",
+                "https://api.test/x",
+                List.<String[]>of(new String[] {"Content-Type", "application/json"}),
+                "{\"k\":\"v\"}");
+        assertTrue(curl.contains("-X POST"), curl);
+        assertTrue(curl.contains("-H 'Content-Type: application/json'"), curl);
+        assertTrue(curl.contains("--data '{\"k\":\"v\"}'"), curl);
+    }
+
+    @Test
+    void singleQuotesAreEscaped() {
+        String curl = CurlExport.toCurl("POST", "https://api.test/x", List.of(), "it's");
+        assertTrue(curl.contains("it'\\''s"), curl);
+    }
+}

--- a/src/test/java/com/editora/http/CurlImportTest.java
+++ b/src/test/java/com/editora/http/CurlImportTest.java
@@ -1,0 +1,47 @@
+package com.editora.http;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/** Unit tests for the curl → .http import. */
+class CurlImportTest {
+
+    @Test
+    void getWithHeaders() {
+        String http = CurlImport.toHttpRequest("curl 'https://api.test/x' -H 'Accept: application/json'");
+        assertTrue(http.startsWith("GET https://api.test/x\n"), http);
+        assertTrue(http.contains("Accept: application/json"), http);
+    }
+
+    @Test
+    void dataInfersPostAndContentType() {
+        String http = CurlImport.toHttpRequest("curl https://api.test/x -d 'a=1&b=2'");
+        assertTrue(http.startsWith("POST https://api.test/x\n"), http);
+        assertTrue(http.contains("Content-Type: application/x-www-form-urlencoded"), http);
+        assertTrue(http.contains("\na=1&b=2"), http);
+    }
+
+    @Test
+    void explicitMethodAndQuotedJsonBody() {
+        String http = CurlImport.toHttpRequest(
+                "curl -X PUT https://api.test/x -H 'Content-Type: application/json' -d '{\"k\": \"v\"}'");
+        assertTrue(http.startsWith("PUT https://api.test/x\n"), http);
+        assertTrue(http.contains("{\"k\": \"v\"}"), http);
+        // an explicit Content-Type is not overwritten
+        assertTrue(http.indexOf("Content-Type") == http.lastIndexOf("Content-Type"), http);
+    }
+
+    @Test
+    void userBecomesBasicAuth() {
+        String http = CurlImport.toHttpRequest("curl https://api.test/x -u user:pass");
+        assertTrue(http.contains("Authorization: Basic dXNlcjpwYXNz"), http);
+    }
+
+    @Test
+    void lineContinuationsAreJoined() {
+        String http = CurlImport.toHttpRequest("curl https://api.test/x \\\n  -H 'X-A: 1' \\\n  -H 'X-B: 2'");
+        assertTrue(http.contains("X-A: 1"), http);
+        assertTrue(http.contains("X-B: 2"), http);
+    }
+}

--- a/src/test/java/com/editora/http/DotEnvTest.java
+++ b/src/test/java/com/editora/http/DotEnvTest.java
@@ -1,0 +1,36 @@
+package com.editora.http;
+
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/** Unit tests for the {@code .env} reader. */
+class DotEnvTest {
+
+    @Test
+    void parsesKeyValuePairsStrippingQuotesCommentsAndExport() {
+        Map<String, String> env = DotEnv.parse("""
+                # a comment
+                SECRET=plain
+                QUOTED="with spaces"
+                SINGLE='single'
+                export EXPORTED=yes
+
+                EQUALS=a=b=c
+                """);
+        assertEquals("plain", env.get("SECRET"));
+        assertEquals("with spaces", env.get("QUOTED"));
+        assertEquals("single", env.get("SINGLE"));
+        assertEquals("yes", env.get("EXPORTED"));
+        assertEquals("a=b=c", env.get("EQUALS"));
+    }
+
+    @Test
+    void blankOrNullYieldsEmpty() {
+        assertTrue(DotEnv.parse("").isEmpty());
+        assertTrue(DotEnv.parse(null).isEmpty());
+    }
+}

--- a/src/test/java/com/editora/http/DynamicVarsTest.java
+++ b/src/test/java/com/editora/http/DynamicVarsTest.java
@@ -1,0 +1,68 @@
+package com.editora.http;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/** Unit tests for the dynamic-variable family. */
+class DynamicVarsTest {
+
+    private static final LocalDateTime CLOCK = LocalDateTime.of(2026, 6, 10, 9, 30, 0);
+
+    @Test
+    void timestampAndIsoUseTheClock() {
+        assertEquals(String.valueOf(CLOCK.toEpochSecond(ZoneOffset.UTC)), DynamicVars.value("$timestamp", CLOCK, null));
+        assertEquals("2026-06-10T09:30:00Z", DynamicVars.value("$isoTimestamp", CLOCK, null));
+    }
+
+    @Test
+    void uuidIsAUuid() {
+        String s = DynamicVars.value("$uuid", CLOCK, null);
+        assertEquals(36, s.length());
+        assertTrue(s.matches("[0-9a-f-]{36}"));
+    }
+
+    @Test
+    void datetimeFormatsWithAPattern() {
+        assertEquals("2026-06-10", DynamicVars.value("$datetime \"yyyy-MM-dd\"", CLOCK, null));
+    }
+
+    @Test
+    void randomIntegerHonorsBounds() {
+        for (int i = 0; i < 200; i++) {
+            int v = Integer.parseInt(DynamicVars.value("$random.integer(5,10)", CLOCK, null));
+            assertTrue(v >= 5 && v < 10, "out of range: " + v);
+        }
+    }
+
+    @Test
+    void randomStringsHaveTheRightLengthAndCharset() {
+        assertEquals(
+                12, DynamicVars.value("$random.alphabetic(12)", CLOCK, null).length());
+        assertTrue(DynamicVars.value("$random.alphabetic(12)", CLOCK, null).matches("[A-Za-z]{12}"));
+        assertTrue(DynamicVars.value("$random.alphanumeric(8)", CLOCK, null).matches("[A-Za-z0-9]{8}"));
+        assertTrue(DynamicVars.value("$random.hexadecimal(16)", CLOCK, null).matches("[0-9a-f]{16}"));
+        assertTrue(DynamicVars.value("$random.email", CLOCK, null).matches("[a-z]+@example\\.com"));
+    }
+
+    @Test
+    void dotenvReadsTheSiblingFile(@TempDir Path dir) throws IOException {
+        Files.writeString(dir.resolve(".env"), "SECRET=s3cr3t\n");
+        assertEquals("s3cr3t", DynamicVars.value("$dotenv.SECRET", CLOCK, dir));
+        assertEquals("", DynamicVars.value("$dotenv.MISSING", CLOCK, dir));
+        assertEquals("", DynamicVars.value("$dotenv.SECRET", CLOCK, null));
+    }
+
+    @Test
+    void unknownIsEmpty() {
+        assertEquals("", DynamicVars.value("$nope", CLOCK, null));
+    }
+}

--- a/src/test/java/com/editora/http/HttpAuthTest.java
+++ b/src/test/java/com/editora/http/HttpAuthTest.java
@@ -1,0 +1,35 @@
+package com.editora.http;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/** Unit tests for the Basic-auth convenience. */
+class HttpAuthTest {
+
+    @Test
+    void basicEncodesUserAndPass() {
+        // base64("user:pass") = dXNlcjpwYXNz
+        assertEquals("Basic dXNlcjpwYXNz", HttpAuth.basic("user", "pass"));
+    }
+
+    @Test
+    void normalizeRewritesTwoTokenBasic() {
+        List<String[]> in = List.<String[]>of(new String[] {"Authorization", "Basic user pass"});
+        assertEquals("Basic dXNlcjpwYXNz", HttpAuth.normalizeHeaders(in).get(0)[1]);
+    }
+
+    @Test
+    void normalizeLeavesEncodedAndOtherHeaders() {
+        List<String[]> in = List.of(
+                new String[] {"Authorization", "Basic dXNlcjpwYXNz"},
+                new String[] {"Authorization", "Bearer xyz"},
+                new String[] {"Accept", "application/json"});
+        List<String[]> out = HttpAuth.normalizeHeaders(in);
+        assertEquals("Basic dXNlcjpwYXNz", out.get(0)[1]);
+        assertEquals("Bearer xyz", out.get(1)[1]);
+        assertEquals("application/json", out.get(2)[1]);
+    }
+}

--- a/src/test/java/com/editora/http/HttpDirectivesTest.java
+++ b/src/test/java/com/editora/http/HttpDirectivesTest.java
@@ -1,0 +1,79 @@
+package com.editora.http;
+
+import java.util.List;
+
+import com.editora.http.HttpFile.Parsed;
+import com.editora.http.HttpFile.Request;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/** Unit tests for the IntelliJ extensions: directives, external bodies, redirect operators. */
+class HttpDirectivesTest {
+
+    @Test
+    void parsesPerRequestDirectives() {
+        String text = """
+                ### one
+                # @no-redirect
+                # @no-cookie-jar
+                # @timeout 30
+                GET https://api.test/x
+                """;
+        Request r = HttpFile.parse(text).get(0);
+        HttpFile.Directives d = r.directives();
+        assertTrue(d.noRedirect());
+        assertTrue(d.noCookieJar());
+        assertEquals(30, d.timeoutSeconds());
+        assertFalse(d.noLog());
+    }
+
+    @Test
+    void rawExternalBodyReference() {
+        Parsed p = HttpFile.parseRequest("POST https://api.test/x\nContent-Type: application/json\n\n< ./body.json\n");
+        assertEquals("./body.json", p.bodyRef().path());
+        assertFalse(p.bodyRef().substitute());
+        assertEquals("", p.body());
+    }
+
+    @Test
+    void substitutedExternalBodyWithEncoding() {
+        Parsed p = HttpFile.parseRequest("POST https://api.test/x\n\n<@latin1 ./body.json\n");
+        assertTrue(p.bodyRef().substitute());
+        assertEquals("latin1", p.bodyRef().encoding());
+        assertEquals("./body.json", p.bodyRef().path());
+    }
+
+    @Test
+    void redirectOperatorsWithForceFlag() {
+        Parsed p = HttpFile.parseRequest("GET https://api.test/x\n\nbody\n\n>> ./out.json\n>>! ./forced.json\n");
+        assertEquals("body", p.body());
+        assertEquals(2, p.redirects().size());
+        assertEquals("./out.json", p.redirects().get(0).path());
+        assertFalse(p.redirects().get(0).force());
+        assertEquals("./forced.json", p.redirects().get(1).path());
+        assertTrue(p.redirects().get(1).force());
+    }
+
+    @Test
+    void parseRequestFromRequestCarriesNameAndDirectives() {
+        String text = "### login\n# @no-log\nPOST https://api.test/login\n";
+        Parsed p = HttpFile.parseRequest(HttpFile.parse(text).get(0));
+        assertEquals("login", p.name());
+        assertTrue(p.directives().noLog());
+    }
+
+    @Test
+    void plainRequestKeepsTheOldShape() {
+        Parsed p = HttpFile.parseRequest("GET https://api.test/x\nAccept: */*\n\nhello\n");
+        assertEquals("GET", p.method());
+        assertEquals("hello", p.body());
+        assertNull(p.bodyRef());
+        assertEquals(List.of(), p.redirects());
+        assertEquals(HttpFile.Directives.NONE, p.directives());
+        assertNull(p.name());
+    }
+}

--- a/src/test/java/com/editora/http/JsonPathTest.java
+++ b/src/test/java/com/editora/http/JsonPathTest.java
@@ -1,0 +1,55 @@
+package com.editora.http;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/** Unit tests for the JSONPath-subset evaluator used in request chaining. */
+class JsonPathTest {
+
+    private static final String JSON = """
+            {
+              "token": "abc",
+              "user": { "id": 7, "name": "Ada" },
+              "items": [ { "id": 10 }, { "id": 20 }, { "id": 30 } ],
+              "a.b": "dotted"
+            }
+            """;
+
+    @Test
+    void resolvesDottedFields() {
+        assertEquals("abc", JsonPath.eval(JSON, "$.token"));
+        assertEquals("Ada", JsonPath.eval(JSON, "$.user.name"));
+        assertEquals("7", JsonPath.eval(JSON, "$.user.id"));
+    }
+
+    @Test
+    void resolvesArrayIndices() {
+        assertEquals("20", JsonPath.eval(JSON, "$.items[1].id"));
+        assertEquals("10", JsonPath.eval(JSON, "$.items[0].id"));
+    }
+
+    @Test
+    void resolvesBracketedFieldWithDot() {
+        assertEquals("dotted", JsonPath.eval(JSON, "$[\"a.b\"]"));
+    }
+
+    @Test
+    void worksWithoutLeadingDollar() {
+        assertEquals("abc", JsonPath.eval(JSON, "token"));
+    }
+
+    @Test
+    void starOrEmptyReturnsWholeBody() {
+        assertEquals(JSON.replaceAll("\\s+", ""), JsonPath.eval(JSON, "*").replaceAll("\\s+", ""));
+        assertEquals(JSON.replaceAll("\\s+", ""), JsonPath.eval(JSON, "").replaceAll("\\s+", ""));
+    }
+
+    @Test
+    void missesYieldEmptyString() {
+        assertEquals("", JsonPath.eval(JSON, "$.nope"));
+        assertEquals("", JsonPath.eval(JSON, "$.items[9].id"));
+        assertEquals("", JsonPath.eval("not json", "$.x"));
+        assertEquals("", JsonPath.eval("", "$.x"));
+    }
+}

--- a/src/test/java/com/editora/http/MultipartTest.java
+++ b/src/test/java/com/editora/http/MultipartTest.java
@@ -1,0 +1,57 @@
+package com.editora.http;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/** Unit tests for the multipart/form-data parse + build. */
+class MultipartTest {
+
+    private static final String BODY = """
+            --X
+            Content-Disposition: form-data; name="field"
+
+            hello {{who}}
+            --X
+            Content-Disposition: form-data; name="file"; filename="a.txt"
+
+            < ./a.txt
+            --X--
+            """;
+
+    @Test
+    void boundaryOfReadsTheContentType() {
+        assertEquals("X", Multipart.boundaryOf("multipart/form-data; boundary=X"));
+        assertEquals("abc", Multipart.boundaryOf("multipart/form-data; boundary=\"abc\""));
+        assertTrue(Multipart.isMultipart("multipart/form-data; boundary=X"));
+    }
+
+    @Test
+    void parsesInlineAndFileParts() {
+        List<Multipart.Part> parts = Multipart.parse(BODY, "X");
+        assertEquals(2, parts.size());
+        assertEquals("form-data; name=\"field\"", parts.get(0).headers().get("Content-Disposition"));
+        assertEquals("hello {{who}}", parts.get(0).inlineBody());
+        assertEquals("./a.txt", parts.get(1).filePath());
+    }
+
+    @Test
+    void buildSubstitutesInlineAndSlurpsFiles(@TempDir Path dir) throws IOException {
+        Files.writeString(dir.resolve("a.txt"), "FILE-CONTENT");
+        List<Multipart.Part> parts = Multipart.parse(BODY, "X");
+        byte[] bytes = Multipart.build(parts, "X", dir, t -> t.replace("{{who}}", "world"));
+        String wire = new String(bytes, StandardCharsets.UTF_8);
+        assertTrue(wire.contains("--X\r\n"), wire);
+        assertTrue(wire.contains("hello world"), wire);
+        assertTrue(wire.contains("FILE-CONTENT"), wire);
+        assertTrue(wire.endsWith("--X--\r\n"), wire);
+    }
+}


### PR DESCRIPTION
Moves the `.http`/`.rest` HTTP Client much closer to IntelliJ's, **without a JavaScript engine** (response-handler scripts stay deferred). All new pure logic is unit-tested. **No new Maven dependency, no `module-info` change, no config schema bump** (`CookieManager`/`Base64` are `java.base`; response history is session-only). Full suite green — **755 tests, 0 failures** (37 new).

## Features

**Request chaining (no JS)** — reference an earlier named request's response: `{{name.response.body.$.path}}`, `.body.*`, `.headers.H`, `.status`. `runAll` threads a per-run `CapturedResponses` session so later requests see earlier ones. New `JsonPath` (Jackson-backed subset) + `CapturedResponses`.

**Bodies / multipart / redirects / directives** (additive `HttpFile.Parsed`) — `< ./file` (raw) and `<@ ./file` (substituted, optional encoding) external bodies; `multipart/form-data` with inline + `< ./file` parts (auto-generated boundary when absent); `>>` / `>>!` save-response-to-file operators; per-request `# @no-redirect` / `@no-cookie-jar` / `@no-log` / `@timeout N` directives. Existing parser tests stay green.

**Execution** (`HttpClientService`) — fresh `HttpClient` + `CookieManager` per run (cookie jar within a run), per-request variable resolution threading captured responses, multipart/external-body assembly, Basic-auth normalization (`Authorization: Basic user pass` → base64), directive honoring, and `>>`/`>>!` file writes. Returns an `HttpExchange` with the fully resolved request + its `HttpResult`.

**Dynamic vars** (`DynamicVars`) — `$random.integer/float/alphabetic/alphanumeric/hexadecimal/email`, `$datetime "fmt"`/`$localDatetime`, `$processEnv.X`, `$dotenv.X` (reads a sibling `.env`).

**Richer response viewer** (`HttpClientPanel`) — content-type-highlighted read-only `CodeArea` (reuses the editor's TextMate grammars), split status/headers vs body, in-memory history picker, **Copy as cURL**, **Open in editor tab**. New commands `http.importCurl` / `http.copyAsCurl` / `http.openResponseInTab` (palette-discoverable, `ifHttp`-gated, localized across all six catalogs).

## Performance
New parsing stays inside the single `HttpFile.parse` pass `recomputeRun` already runs (O(lines), `COMPACT_SCAN_LIMIT`-gated) — no per-keystroke work added. Execution + redirect file writes stay off the FX thread on the existing daemon executor.

## Deferred (unchanged)
JS response-handler scripts (`> {% client.test/assert/global.set %}`) are still recognized only to end the body, not executed — so the `client.global.set` capture form of chaining is out (the `{{name.response…}}` reference form is in).

## Verification
- `mvn test` → 755 passing, incl. 37 new pure-logic tests (`JsonPath`, `CapturedResponses`, `DynamicVars`, `DotEnv`, `HttpAuth`, `Multipart`, `CurlImport`, `CurlExport`, parser directives) and `MessagesTest` key parity.
- Startup smoke test: clean window/panel construction, no exceptions.
- Manual: a sample `verify.http` (+ `.env` / `http-client.env.json` / `payload.json`) exercises chaining, dynamic vars, Basic auth, `<@` body, multipart with a file part, and `>>!` against httpbin.org.

🤖 Generated with [Claude Code](https://claude.com/claude-code)