### PR TITLE
Fix erratic diff-viewer scroll on next/previous-change navigation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Diff viewer: next/previous-change no longer makes the scroll jump erratically.** The two side-by-side
+  panes were kept in sync by copying the absolute pixel scroll position from one to the other, in both
+  directions. That value is a RichTextFX *estimate* refined as lines are measured, so each pane settled to a
+  slightly different value and pushed the other back — a feedback loop, worst when navigation jumped into an
+  unmeasured region. Now only the *focused* (actively scrolled) pane drives the other, so interactive sync is
+  strictly one-directional and cannot oscillate. Next/previous-change navigation bypasses the sync entirely:
+  it pins *both* panes to the same top row explicitly (the rows are 1:1 aligned, so this can't desync) and
+  puts the selection caret at the block's top so caret-follow agrees with the scroll.
+
 - **Spell check no longer flags commands, URLs, paths, and identifiers.** Tokens like `./mvnw`,
   `javafx:run`, `https://github.com/…`, `path/to/file.txt`, `snake_case`, and `a@b.com` were getting red
   squiggles — in Markdown prose, in fenced ` ``` ` code blocks, and in comments/strings of Java/Python/Shell

--- a/src/main/java/com/editora/ui/DiffViewerPane.java
+++ b/src/main/java/com/editora/ui/DiffViewerPane.java
@@ -8,6 +8,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.function.IntFunction;
 
+import javafx.application.Platform;
 import javafx.geometry.Insets;
 import javafx.geometry.Pos;
 import javafx.scene.Node;
@@ -363,6 +364,8 @@ public final class DiffViewerPane implements TabContent {
         }
         installGutter(leftArea, leftNos, editableSide == EditableSide.LEFT);
         installGutter(rightArea, rightNos, editableSide == EditableSide.RIGHT);
+        installScrollFocus(leftArea);
+        installScrollFocus(rightArea);
         syncScroll(leftArea, rightArea);
         syncScroll(rightArea, leftArea);
 
@@ -386,16 +389,36 @@ public final class DiffViewerPane implements TabContent {
         return l;
     }
 
+    /**
+     * Keeps the two side-by-side panes aligned: copies the scroll position of the <b>focused</b> pane to
+     * the other. The rows are 1:1 aligned (filler lines), so the absolute scroll offsets match.
+     *
+     * <p>Only the focused pane drives, which makes the sync strictly one-directional at any moment and so
+     * <b>cannot oscillate</b>. (A naïve bidirectional copy fed back: RichTextFX refines {@code estimatedScrollY}
+     * as paragraphs are measured, so the follower settled to a slightly different value and pushed the leader
+     * back — a feedback loop, worst on a navigation jump into an unmeasured region.) A scroll gesture focuses
+     * its pane (see {@code installScrollFocus}), so the other pane follows it. This governs only interactive
+     * scrolling — next/prev navigation pins both panes explicitly (see {@link #scrollToRow(int)}).
+     */
     private void syncScroll(CodeArea from, CodeArea to) {
         from.estimatedScrollYProperty().addListener((o, ov, nv) -> {
-            if (syncing || nv == null) {
-                return;
+            if (syncing || nv == null || !from.isFocused()) {
+                return; // only the focused (actively scrolled) pane drives the other — no feedback loop
             }
             syncing = true;
             try {
                 to.estimatedScrollYProperty().setValue(nv);
             } finally {
                 syncing = false;
+            }
+        });
+    }
+
+    /** A scroll gesture on a pane focuses it, so it becomes the one that drives the other (see syncScroll). */
+    private static void installScrollFocus(CodeArea area) {
+        area.addEventFilter(javafx.scene.input.ScrollEvent.SCROLL, e -> {
+            if (!area.isFocused()) {
+                area.requestFocus();
             }
         });
     }
@@ -754,14 +777,30 @@ public final class DiffViewerPane implements TabContent {
         int sideEnd = blockEndFrom(sideRow);
         if (unified && unifiedArea != null) {
             int u = unifiedRowFor(sideRow);
-            unifiedArea.showParagraphAtTop(Math.max(0, u));
+            int top = Math.max(0, u);
             selectLines(unifiedArea, u, unifiedRowFor(sideEnd));
+            // Pin the row to the top AFTER the selection (selectRange schedules a caret-follow scroll that
+            // would otherwise leave the block bottom-aligned). One pulse later runs after that follow.
+            Platform.runLater(() -> unifiedArea.showParagraphAtTop(top));
         } else if (leftArea != null && rightArea != null) {
-            leftArea.showParagraphAtTop(Math.max(0, sideRow));
-            // Highlight the block on both panes; focus the editable side (or the left) so it's visible.
+            int top = Math.max(0, sideRow);
+            // Highlight the block on both panes (caret at the block top — see selectLines). The rows are 1:1
+            // aligned (filler lines), so navigation pins BOTH panes to the same top row explicitly, with the
+            // scroll sync suppressed. Relying on the focus-gated sync listener to align the follower fails on a
+            // backward jump: selectRange's caret-follow may already have left the driven pane at `top`, so its
+            // estimatedScrollY never changes, the listener never fires, and the follower is stranded at its own
+            // caret-follow position. Setting both deterministically can't desync.
             selectLines(leftArea, sideRow, sideEnd);
             selectLines(rightArea, sideRow, sideEnd);
-            (editableSide == EditableSide.RIGHT ? rightArea : leftArea).requestFocus();
+            Platform.runLater(() -> {
+                syncing = true;
+                try {
+                    leftArea.showParagraphAtTop(top);
+                    rightArea.showParagraphAtTop(top);
+                } finally {
+                    syncing = false;
+                }
+            });
         }
     }
 
@@ -773,7 +812,9 @@ public final class DiffViewerPane implements TabContent {
         }
         int s = Math.max(0, Math.min(start, pars - 1));
         int e = Math.max(s + 1, Math.min(end, pars));
-        area.selectRange(s, 0, e - 1, area.getParagraph(e - 1).length());
+        // Anchor at the block end, caret at the block START, so RichTextFX's caret-follow scroll targets the
+        // top of the block — agreeing with the explicit showParagraphAtTop instead of pulling to the bottom.
+        area.selectRange(e - 1, area.getParagraph(e - 1).length(), s, 0);
     }
 
     /** Maps a side-by-side row index to the first unified row at/after it (unified expands MODIFIED). */


### PR DESCRIPTION
## Problem

In the side-by-side diff viewer, clicking **next/previous change** could make the scroll jump erratically and leave the two panes desynced — most visibly on a backward (previous) jump.

## Root cause

The two panes were kept in sync by copying each pane's **absolute pixel** scroll position to the other, in **both directions**. RichTextFX's `estimatedScrollY` is an *estimate* refined as paragraphs get measured, so each pane settled to a slightly different value and pushed the other back — a feedback loop, worst when navigation jumped into an as-yet-unmeasured region.

## Fix

1. **Interactive sync is now one-directional** — only the *focused* (actively scrolled) pane drives the other (`!from.isFocused()` guard + an `installScrollFocus` filter that focuses a pane on its scroll gesture). One direction at a time cannot oscillate.
2. **Next/previous-change navigation bypasses the sync entirely** — it pins *both* panes to the same top row explicitly with the listener suppressed. The rows are 1:1 aligned (filler lines), so this is deterministic and cannot desync. This fixes the backward jump specifically: the old code relied on the sync listener firing to align the follower, but on a backward jump `selectRange`'s caret-follow could already have left the driven pane at the target, so its `estimatedScrollY` never changed and the follower was stranded. `selectLines` now anchors the caret at the block *top* so caret-follow agrees with the explicit scroll.

## Perf

Off the hot paths. The sync listener does the same single absolute-position copy as before, now additionally short-circuited unless the source pane is focused (one boolean check). The `installScrollFocus` filter only runs on user scroll gestures, not per-pulse. Navigation does one extra `runLater`. Negligible.

## Verification

`./mvnw verify` → BUILD SUCCESS, 763 tests pass (incl. the dist jlink step). Rebased onto current master (after #30).

🤖 Generated with [Claude Code](https://claude.com/claude-code)