### PR TITLE
Move file-size segment to the far right of the status bar

### DIFF
--- a/src/main/java/com/editora/ui/StatusBar.java
+++ b/src/main/java/com/editora/ui/StatusBar.java
@@ -133,8 +133,8 @@ public final class StatusBar extends HBox {
                         language,
                         indent,
                         endings,
-                        size,
-                        encoding);
+                        encoding,
+                        size);
         refresh();
     }
 


### PR DESCRIPTION
## Summary
- Reorder the status-bar segments so the file-size label is the last (rightmost) segment, sitting after the encoding segment.

## Notes
- Pure layout reorder of the children added to the status-bar `HBox` — no hot-path / performance impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)