### PR TITLE
Disable LSP & autocomplete in large-file mode (fix big-file load freeze)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Loading a large file (5–50 MB) with a language server enabled no longer freezes the editor.** Large-file
+  mode already turns off syntax highlighting and the minimap, but LSP stayed on — so opening, say, a big
+  `.json`/`.xml`/`.log` with its server enabled sent the whole document to the server and then mapped and
+  rendered the flood of diagnostics it returned (the Problems tree, minimap, and scrollbar stripes) on the UI
+  thread, locking up the editor. LSP is now disabled in large-file mode too (like highlighting, the minimap,
+  Git change bars, and inline blame), so the file just opens as fast, plain text. Autocomplete is likewise
+  disabled in large-file mode — it allocated the whole document on every keystroke to find the word prefix
+  (the same per-cursor-move cost brace matching already avoids), which made typing in a large file stutter.
+
 - **Diff viewer: next/previous-change no longer makes the scroll jump erratically.** The two side-by-side
   panes were kept in sync by copying the absolute pixel scroll position from one to the other, in both
   directions. That value is a RichTextFX *estimate* refined as lines are measured, so each pane settled to a

--- a/src/main/java/com/editora/editor/EditorBuffer.java
+++ b/src/main/java/com/editora/editor/EditorBuffer.java
@@ -1433,7 +1433,11 @@ public class EditorBuffer implements TabContent {
     /** Turns LSP rendering (diagnostics overlay + hover) on/off for this buffer. The controller drives
      *  document open/close + requests; this only gates the editor surface. */
     public void setLspActive(boolean on) {
-        this.lspActive = on && isLspLanguage() && !hugeFile;
+        // Large-file mode disables LSP just like syntax highlighting and the minimap: a 5–50 MB document
+        // would flood the FX thread with a full-text didOpen and tens/hundreds of thousands of diagnostics
+        // to map + render (the Problems tree, minimap + scrollbar stripes), freezing the editor. largeFile
+        // is implied by hugeFile (see setReadOnly), so this single guard covers both.
+        this.lspActive = on && isLspLanguage() && !largeFile;
         lspOverlay.setActive(this.lspActive);
         // The minimap stripes only draw while LSP is active for this file, regardless of any stale list.
         minimap.setDiagnosticsEnabled(this.lspActive);
@@ -3754,7 +3758,9 @@ public class EditorBuffer implements TabContent {
      *  minimum prefix length so an explicit invoke works on a single character. */
     private void updateCompletion(CodeArea a, boolean manual) {
         if (!autocompleteEnabled
-                || hugeFile
+                || largeFile // off in large-file mode: a.getText() below would allocate the whole document
+                // per trigger (the same per-keystroke cost brace matching is gated to avoid), and there is
+                // no LSP/grammar to complete against on a large file anyway. largeFile implies hugeFile.
                 || !isEditable()
                 || hasActiveSnippet()
                 || (suppressCompletion && !manual)

--- a/src/main/java/com/editora/ui/MainController.java
+++ b/src/main/java/com/editora/ui/MainController.java
@@ -3567,6 +3567,7 @@ public class MainController {
         boolean eligible = lspEnabled()
                 && path != null
                 && com.editora.vfs.Vfs.isLocal(path)
+                && !buffer.isLargeFile() // 5+ MB files skip LSP (like highlighting/minimap/git) — see setLspActive
                 && serverId != null
                 && serverEnabled(serverId)
                 && Boolean.TRUE.equals(lspServerAvailable.get(serverId));


### PR DESCRIPTION
## Problem

Loading a 50 MB file froze the editor indefinitely when a language server was enabled. Reported as a regression ("used to work before").

## Root cause

Large-file mode (≥5 MB) already disables syntax highlighting, the minimap, spell check, the search overlay, Git change bars, and inline blame. But two heavy features were gated on `hugeFile` (≥50 MiB read-only) instead of `largeFile` (≥5 MiB), so they stayed fully active on a 5–50 MB "large" file:

- **LSP** — a large LSP-language file (`.json`/`.xml`/`.yaml`/`.log`/…) was sent whole to the server via `didOpen` + `pullDiagnostics`, then the flood of returned diagnostics was mapped + rendered (Problems tree, minimap stripes, scrollbar stripe) on the FX thread → lock-up. The recent pull-diagnostics work amplified this, matching the regression report.
- **Autocomplete** — `updateCompletion` called `a.getText()` (the entire document) on every keystroke-triggered completion to find the word prefix — the same per-cursor-move full-text allocation that **brace matching is already gated to `largeFile` to avoid** — so typing in a large file stuttered.

(macOS Finder reports sizes in decimal MB, so a "50 MB" file ≈ 47.7 MiB — under the 50 MiB read-only cap, hence the full-read + LSP path.)

## Fix

Gate both on `largeFile`, joining the other heavy features that are off in large-file mode (`largeFile` implies `hugeFile`, so one guard covers both):

- `EditorBuffer.setLspActive` → `!largeFile`; `EditorBuffer.updateCompletion` → `largeFile` early-return (before `getText()`).
- `MainController.syncBufferLsp` → adds `!buffer.isLargeFile()`, so a large file never even opens to the server.

## Verification

- Reproduced with **pyright** + an 8 MB error-laden Python file (LSP on) via `jstack` thread dumps: **pre-fix** the server spawned and the FX thread churned; **post-fix** no server spawns (empty server ledger), FX thread idle — the file opens as plain text.
- Confirmed plain large text files (48 MiB, 50+ MiB, and a 45 MB long-line file) were already fine — the generic load path was never the issue.
- `./mvnw verify` → BUILD SUCCESS, 776 tests pass. Rebased on current master (#32).

## Perf

Strictly removes work for large files; zero cost on normal files (one boolean check). 5–50 MB files now open as fast, plain text — consistent with the documented large-file philosophy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)