### PR TITLE
Add a minimal MCP server (loopback HTTP) exposing editor state + commands

### DIFF
--- a/src/main/java/com/editora/config/Settings.java
+++ b/src/main/java/com/editora/config/Settings.java
@@ -10,7 +10,7 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 public class Settings {
 
     /** Current on-disk schema version of {@code settings.toml}; bump when the format changes (+ a migration). */
-    public static final int SCHEMA_VERSION = 27;
+    public static final int SCHEMA_VERSION = 28;
 
     private int schemaVersion = SCHEMA_VERSION;
 
@@ -129,6 +129,9 @@ public class Settings {
     private boolean htmlPreviewSupport = false;
     /** The last-used browser id for the HTML preview ({@code ""} until the user picks one). */
     private String htmlPreviewBrowser = "";
+    /** MCP server (expose live editor state + the command registry to an LLM agent over a loopback
+     *  HTTP JSON-RPC endpoint, gated by a bearer token): off by default. */
+    private boolean mcpSupport = false;
     /** Java debugging (DAP) support: off by default. Layered on the Java LSP server (jdtls) + the
      *  Microsoft java-debug plugin; effective only when LSP is on, the java server is enabled/detected,
      *  and the plugin jar is found. */
@@ -328,6 +331,14 @@ public class Settings {
 
     public void setHtmlPreviewBrowser(String htmlPreviewBrowser) {
         this.htmlPreviewBrowser = htmlPreviewBrowser == null ? "" : htmlPreviewBrowser;
+    }
+
+    public boolean isMcpSupport() {
+        return mcpSupport;
+    }
+
+    public void setMcpSupport(boolean mcpSupport) {
+        this.mcpSupport = mcpSupport;
     }
 
     public String getIjhttpCommand() {

--- a/src/main/java/com/editora/config/migration/ConfigSchema.java
+++ b/src/main/java/com/editora/config/migration/ConfigSchema.java
@@ -63,7 +63,8 @@ public enum ConfigSchema {
                     Map.entry(23, (Migration) ConfigMigrations::identity), // v23→24: + pluginRequireSignature
                     Map.entry(24, (Migration) ConfigMigrations::identity), // v24→25: + htmlPreviewSupport/Browser
                     Map.entry(25, (Migration) ConfigMigrations::identity), // v25→26: + fillColumn (additive)
-                    Map.entry(26, (Migration) ConfigMigrations::identity))), // v26→27: + localHistory + limits
+                    Map.entry(26, (Migration) ConfigMigrations::identity), // v26→27: + localHistory + limits
+                    Map.entry(27, (Migration) ConfigMigrations::identity))), // v27→28: + mcpSupport (additive)
     WORKSPACE(WorkspaceState.SCHEMA_VERSION, 1, Map.of()),
     BOOKMARKS(BookmarkStore.SCHEMA_VERSION, 1, Map.of()),
     BREAKPOINTS(BreakpointStore.SCHEMA_VERSION, 1, Map.of()),

--- a/src/main/java/com/editora/mcp/JsonRpc.java
+++ b/src/main/java/com/editora/mcp/JsonRpc.java
@@ -1,0 +1,41 @@
+package com.editora.mcp;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+/**
+ * Minimal <a href="https://www.jsonrpc.org/specification">JSON-RPC 2.0</a> framing for the MCP
+ * endpoint: one request/response per POST (no batching). Pure response builders, unit-tested.
+ */
+public final class JsonRpc {
+
+    public static final int PARSE_ERROR = -32700;
+    public static final int INVALID_REQUEST = -32600;
+    public static final int METHOD_NOT_FOUND = -32601;
+    public static final int INVALID_PARAMS = -32602;
+    public static final int INTERNAL_ERROR = -32603;
+
+    private JsonRpc() {}
+
+    /** A success response: {@code {"jsonrpc":"2.0","id":<id>,"result":<result>}}. */
+    public static ObjectNode success(ObjectMapper m, JsonNode id, JsonNode result) {
+        ObjectNode r = m.createObjectNode();
+        r.put("jsonrpc", "2.0");
+        r.set("id", id == null ? m.nullNode() : id);
+        r.set("result", result == null ? m.nullNode() : result);
+        return r;
+    }
+
+    /** An error response: {@code {"jsonrpc":"2.0","id":<id>,"error":{"code":..,"message":..}}}. */
+    public static ObjectNode error(ObjectMapper m, JsonNode id, int code, String message) {
+        ObjectNode r = m.createObjectNode();
+        r.put("jsonrpc", "2.0");
+        r.set("id", id == null ? m.nullNode() : id);
+        ObjectNode err = m.createObjectNode();
+        err.put("code", code);
+        err.put("message", message == null ? "" : message);
+        r.set("error", err);
+        return r;
+    }
+}

--- a/src/main/java/com/editora/mcp/McpBridge.java
+++ b/src/main/java/com/editora/mcp/McpBridge.java
@@ -1,0 +1,50 @@
+package com.editora.mcp;
+
+import java.util.List;
+
+/**
+ * The seam between the off-FX MCP server thread and the FX-thread editor state. Implemented by
+ * {@code MainController}, so the {@code mcp} package never imports {@code ui} internals. Each method
+ * is called from an HTTP worker thread and is responsible for marshaling its reads onto the JavaFX
+ * thread (the controller does this with a blocking {@code Platform.runLater} helper).
+ *
+ * <p>The nested records are plain data carriers; {@link McpTools} maps them to JSON by hand (it never
+ * reflects on these types), so no {@code module-info} {@code opens} is needed for the {@code mcp}
+ * package.
+ */
+public interface McpBridge {
+
+    /** One open tab/buffer. {@code path} is null for an unsaved (untitled) buffer. */
+    record OpenFile(String path, String title, String language, boolean dirty, boolean active) {}
+
+    /** A buffer's live (possibly unsaved) text plus identity. */
+    record BufferContent(String path, String title, String language, boolean dirty, String text) {}
+
+    /** A flattened LSP diagnostic (1-based line/col for human/agent consumption). */
+    record Diagnostic(int line, int col, String severity, String message, String origin) {}
+
+    /** One find-in-files hit (1-based line/col). */
+    record SearchMatch(String file, int line, int col, String lineText) {}
+
+    /** A registered command the agent can run via {@code execute_command}. */
+    record CommandInfo(String id, String title, String description) {}
+
+    /** All open buffers, with which one is active. */
+    List<OpenFile> listOpenFiles();
+
+    /** The live text of the open buffer for {@code path}, or the active buffer when {@code path} is null;
+     *  null when there is no such buffer. */
+    BufferContent readBuffer(String path);
+
+    /** LSP diagnostics for {@code path} (or the active buffer's file when null); empty when none. */
+    List<Diagnostic> getDiagnostics(String path);
+
+    /** Runs a multi-file search over the active project root + open buffers (unsaved text respected). */
+    List<SearchMatch> findInFiles(String query, boolean caseSensitive, boolean regex, boolean wholeWord);
+
+    /** Every registered command (id + localized title + description). */
+    List<CommandInfo> listCommands();
+
+    /** Runs the command with {@code id} on the FX thread; false when no such command exists. */
+    boolean executeCommand(String id);
+}

--- a/src/main/java/com/editora/mcp/McpServer.java
+++ b/src/main/java/com/editora/mcp/McpServer.java
@@ -1,0 +1,200 @@
+package com.editora.mcp;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.security.SecureRandom;
+import java.util.HexFormat;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpServer;
+
+/**
+ * A tiny embedded <a href="https://modelcontextprotocol.io">Model Context Protocol</a> server,
+ * bound to <strong>loopback only</strong> (never the LAN), modeled on {@code web.LivePreviewServer}.
+ * It speaks JSON-RPC 2.0 over the MCP "Streamable HTTP" transport's request/response subset (one POST
+ * → one {@code application/json} response; no SSE). Every request must carry
+ * {@code Authorization: Bearer <token>} — the token is the gate against other local processes driving
+ * the editor. On start it writes {@code <configDir>/mcp-endpoint.json} (url + token) for discovery.
+ *
+ * <p>All editor reads go through {@link McpBridge} (implemented by the controller), which marshals
+ * onto the JavaFX thread; this class touches no JavaFX and runs entirely on its HTTP worker threads.
+ */
+public final class McpServer {
+
+    private static final Logger LOG = Logger.getLogger(McpServer.class.getName());
+    private static final String ENDPOINT_FILE = "mcp-endpoint.json";
+
+    private final McpBridge bridge;
+    private final Path configDir;
+    private final ObjectMapper mapper = new ObjectMapper();
+    private final McpTools tools;
+    private final String token;
+
+    private HttpServer server;
+    private ExecutorService pool;
+
+    public McpServer(McpBridge bridge, Path configDir) {
+        this.bridge = bridge;
+        this.configDir = configDir;
+        this.tools = new McpTools(bridge, mapper);
+        this.token = randomToken();
+    }
+
+    /** Starts the server on an ephemeral loopback port (idempotent); returns the bound port. */
+    public synchronized int start() throws IOException {
+        if (server != null) {
+            return server.getAddress().getPort();
+        }
+        server = HttpServer.create(new InetSocketAddress(InetAddress.getLoopbackAddress(), 0), 0);
+        pool = Executors.newCachedThreadPool(r -> {
+            Thread t = new Thread(r, "mcp-http");
+            t.setDaemon(true);
+            return t;
+        });
+        server.setExecutor(pool);
+        server.createContext("/mcp", this::handle);
+        server.start();
+        writeEndpointFile();
+        LOG.info("MCP server listening on " + url());
+        return server.getAddress().getPort();
+    }
+
+    public synchronized boolean isRunning() {
+        return server != null;
+    }
+
+    public synchronized int port() {
+        return server == null ? -1 : server.getAddress().getPort();
+    }
+
+    public String token() {
+        return token;
+    }
+
+    /** The loopback endpoint URL, or {@code ""} when not running. */
+    public synchronized String url() {
+        return server == null ? "" : "http://127.0.0.1:" + port() + "/mcp";
+    }
+
+    /** Stops the server + its thread pool and removes the endpoint file (idempotent). */
+    public synchronized void stop() {
+        if (server != null) {
+            server.stop(0);
+            server = null;
+        }
+        if (pool != null) {
+            pool.shutdownNow();
+            pool = null;
+        }
+        try {
+            Files.deleteIfExists(configDir.resolve(ENDPOINT_FILE));
+        } catch (IOException ignored) {
+            // best-effort cleanup
+        }
+    }
+
+    // --- request handling -------------------------------------------------------------------------
+
+    private void handle(HttpExchange ex) throws IOException {
+        try {
+            if (!"POST".equalsIgnoreCase(ex.getRequestMethod())) {
+                sendStatus(ex, 405); // GET (SSE) and others are unsupported in this minimal server
+                return;
+            }
+            if (!authorized(ex)) {
+                sendStatus(ex, 401);
+                return;
+            }
+            byte[] in = ex.getRequestBody().readAllBytes();
+            JsonNode req;
+            try {
+                req = mapper.readTree(in);
+            } catch (IOException parse) {
+                writeJson(ex, 200, JsonRpc.error(mapper, mapper.nullNode(), JsonRpc.PARSE_ERROR, "Parse error"));
+                return;
+            }
+            JsonNode id = req == null ? null : req.get("id");
+            String method =
+                    req != null && req.hasNonNull("method") ? req.get("method").asText() : "";
+            if (id == null) {
+                // A notification (e.g. notifications/initialized): acknowledge, no body.
+                sendStatus(ex, 202);
+                return;
+            }
+            ObjectNode response = dispatch(id, method, req.get("params"));
+            writeJson(ex, 200, response);
+        } catch (RuntimeException e) {
+            LOG.log(Level.FINE, "MCP request failed", e);
+            sendStatus(ex, 500);
+        } finally {
+            ex.close();
+        }
+    }
+
+    private ObjectNode dispatch(JsonNode id, String method, JsonNode params) {
+        try {
+            return switch (method) {
+                case "initialize" -> JsonRpc.success(mapper, id, tools.initializeResult());
+                case "tools/list" -> JsonRpc.success(mapper, id, tools.listToolsResult());
+                case "tools/call" -> JsonRpc.success(mapper, id, tools.callTool(params));
+                case "ping" -> JsonRpc.success(mapper, id, mapper.createObjectNode());
+                default -> JsonRpc.error(mapper, id, JsonRpc.METHOD_NOT_FOUND, "Method not found: " + method);
+            };
+        } catch (RuntimeException e) {
+            return JsonRpc.error(mapper, id, JsonRpc.INTERNAL_ERROR, String.valueOf(e.getMessage()));
+        }
+    }
+
+    private boolean authorized(HttpExchange ex) {
+        String header = ex.getRequestHeaders().getFirst("Authorization");
+        return header != null && header.equals("Bearer " + token);
+    }
+
+    private void writeEndpointFile() {
+        ObjectNode node = mapper.createObjectNode();
+        node.put("url", url());
+        node.put("token", token);
+        try {
+            Path file = configDir.resolve(ENDPOINT_FILE);
+            Files.createDirectories(configDir);
+            mapper.writerWithDefaultPrettyPrinter().writeValue(file.toFile(), node);
+        } catch (IOException e) {
+            LOG.log(Level.WARNING, "Could not write " + ENDPOINT_FILE, e);
+        }
+    }
+
+    private void writeJson(HttpExchange ex, int status, ObjectNode body) throws IOException {
+        byte[] bytes = mapper.writeValueAsBytes(body);
+        ex.getResponseHeaders().set("Content-Type", "application/json; charset=utf-8");
+        ex.getResponseHeaders().set("Cache-Control", "no-store");
+        ex.sendResponseHeaders(status, bytes.length);
+        try (OutputStream out = ex.getResponseBody()) {
+            out.write(bytes);
+        }
+    }
+
+    private static void sendStatus(HttpExchange ex, int status) {
+        try {
+            ex.sendResponseHeaders(status, -1);
+        } catch (IOException ignored) {
+            // client already gone
+        }
+    }
+
+    private static String randomToken() {
+        byte[] b = new byte[24];
+        new SecureRandom().nextBytes(b);
+        return HexFormat.of().formatHex(b);
+    }
+}

--- a/src/main/java/com/editora/mcp/McpTools.java
+++ b/src/main/java/com/editora/mcp/McpTools.java
@@ -1,0 +1,259 @@
+package com.editora.mcp;
+
+import java.util.List;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+/**
+ * The MCP tool set: schemas for {@code tools/list} and dispatch for {@code tools/call}. Bridge result
+ * records are mapped to JSON <em>by hand</em> (never via Jackson reflection on {@code mcp} types), so
+ * the package needs no {@code module-info opens}. Each tool returns the standard MCP result shape
+ * {@code {"content":[{"type":"text","text":<json>}],"isError":<bool>}}.
+ */
+final class McpTools {
+
+    /** The MCP protocol revision this server implements. */
+    static final String PROTOCOL_VERSION = "2024-11-05";
+
+    private final McpBridge bridge;
+    private final ObjectMapper m;
+
+    McpTools(McpBridge bridge, ObjectMapper m) {
+        this.bridge = bridge;
+        this.m = m;
+    }
+
+    // --- initialize -------------------------------------------------------------------------------
+
+    ObjectNode initializeResult() {
+        ObjectNode r = m.createObjectNode();
+        r.put("protocolVersion", PROTOCOL_VERSION);
+        ObjectNode caps = m.createObjectNode();
+        caps.set("tools", m.createObjectNode()); // we offer tools; no list-changed notifications
+        r.set("capabilities", caps);
+        ObjectNode info = m.createObjectNode();
+        info.put("name", "editora");
+        info.put("version", com.editora.AppInfo.VERSION);
+        r.set("serverInfo", info);
+        return r;
+    }
+
+    // --- tools/list -------------------------------------------------------------------------------
+
+    ObjectNode listToolsResult() {
+        ArrayNode tools = m.createArrayNode();
+        tools.add(tool("list_open_files", "List the editor's open files (path, language, dirty, active).", obj()));
+        tools.add(tool(
+                "read_buffer",
+                "Read a buffer's live (possibly unsaved) text. Omit 'path' for the active buffer.",
+                obj().set("path", strProp("Absolute path of an open file; omit for the active buffer."))));
+        tools.add(tool(
+                "get_diagnostics",
+                "Get LSP diagnostics for a file. Omit 'path' for the active buffer's file.",
+                obj().set("path", strProp("Absolute path of an open file; omit for the active buffer."))));
+        ObjectNode findProps = obj();
+        findProps.set("query", strProp("Text or regex to search for."));
+        findProps.set("caseSensitive", boolProp("Match case (default false)."));
+        findProps.set("regex", boolProp("Treat the query as a regular expression (default false)."));
+        findProps.set("wholeWord", boolProp("Match whole words only (default false)."));
+        tools.add(toolReq(
+                "find_in_files",
+                "Search the active project (and open buffers' unsaved text) for a query.",
+                findProps,
+                "query"));
+        tools.add(tool("list_commands", "List every command that execute_command can run.", obj()));
+        tools.add(toolReq(
+                "execute_command",
+                "Run a registered command by id (edits go through the undo stack). See list_commands.",
+                obj().set("id", strProp("The command id, e.g. \"file.save\".")),
+                "id"));
+        ObjectNode r = m.createObjectNode();
+        r.set("tools", tools);
+        return r;
+    }
+
+    // --- tools/call -------------------------------------------------------------------------------
+
+    /** Dispatches {@code tools/call} params {@code {name, arguments}} → an MCP tool result node. */
+    ObjectNode callTool(JsonNode params) {
+        if (params == null || !params.hasNonNull("name")) {
+            return errorResult("Missing tool name.");
+        }
+        String name = params.get("name").asText();
+        JsonNode args = params.get("arguments");
+        return switch (name) {
+            case "list_open_files" -> openFilesResult();
+            case "read_buffer" -> readBufferResult(text(args, "path"));
+            case "get_diagnostics" -> diagnosticsResult(text(args, "path"));
+            case "find_in_files" -> findResult(args);
+            case "list_commands" -> commandsResult();
+            case "execute_command" -> executeResult(text(args, "id"));
+            default -> errorResult("Unknown tool: " + name);
+        };
+    }
+
+    private ObjectNode openFilesResult() {
+        ArrayNode arr = m.createArrayNode();
+        for (McpBridge.OpenFile f : bridge.listOpenFiles()) {
+            ObjectNode o = m.createObjectNode();
+            o.put("path", f.path());
+            o.put("title", f.title());
+            o.put("language", f.language());
+            o.put("dirty", f.dirty());
+            o.put("active", f.active());
+            arr.add(o);
+        }
+        return textResult(arr);
+    }
+
+    private ObjectNode readBufferResult(String path) {
+        McpBridge.BufferContent b = bridge.readBuffer(path);
+        if (b == null) {
+            return errorResult(path == null ? "No active buffer." : "No open buffer for: " + path);
+        }
+        ObjectNode o = m.createObjectNode();
+        o.put("path", b.path());
+        o.put("title", b.title());
+        o.put("language", b.language());
+        o.put("dirty", b.dirty());
+        o.put("text", b.text());
+        return textResult(o);
+    }
+
+    private ObjectNode diagnosticsResult(String path) {
+        ArrayNode arr = m.createArrayNode();
+        for (McpBridge.Diagnostic d : bridge.getDiagnostics(path)) {
+            ObjectNode o = m.createObjectNode();
+            o.put("line", d.line());
+            o.put("col", d.col());
+            o.put("severity", d.severity());
+            o.put("message", d.message());
+            o.put("origin", d.origin());
+            arr.add(o);
+        }
+        return textResult(arr);
+    }
+
+    private ObjectNode findResult(JsonNode args) {
+        String query = text(args, "query");
+        if (query == null || query.isEmpty()) {
+            return errorResult("find_in_files requires a non-empty 'query'.");
+        }
+        List<McpBridge.SearchMatch> hits =
+                bridge.findInFiles(query, bool(args, "caseSensitive"), bool(args, "regex"), bool(args, "wholeWord"));
+        ArrayNode arr = m.createArrayNode();
+        for (McpBridge.SearchMatch h : hits) {
+            ObjectNode o = m.createObjectNode();
+            o.put("file", h.file());
+            o.put("line", h.line());
+            o.put("col", h.col());
+            o.put("lineText", h.lineText());
+            arr.add(o);
+        }
+        return textResult(arr);
+    }
+
+    private ObjectNode commandsResult() {
+        ArrayNode arr = m.createArrayNode();
+        for (McpBridge.CommandInfo c : bridge.listCommands()) {
+            ObjectNode o = m.createObjectNode();
+            o.put("id", c.id());
+            o.put("title", c.title());
+            o.put("description", c.description());
+            arr.add(o);
+        }
+        return textResult(arr);
+    }
+
+    private ObjectNode executeResult(String id) {
+        if (id == null || id.isEmpty()) {
+            return errorResult("execute_command requires an 'id'.");
+        }
+        boolean ran = bridge.executeCommand(id);
+        return ran
+                ? textResult(m.createObjectNode().put("ran", true).put("id", id))
+                : errorResult("No such command: " + id);
+    }
+
+    // --- result + schema helpers ------------------------------------------------------------------
+
+    /** Wraps {@code data} (serialized to pretty JSON) as a single MCP text content block. */
+    private ObjectNode textResult(JsonNode data) {
+        String text;
+        try {
+            text = m.writerWithDefaultPrettyPrinter().writeValueAsString(data);
+        } catch (Exception e) {
+            return errorResult("Serialization failed: " + e.getMessage());
+        }
+        ObjectNode block = m.createObjectNode();
+        block.put("type", "text");
+        block.put("text", text);
+        ObjectNode r = m.createObjectNode();
+        ArrayNode content = m.createArrayNode();
+        content.add(block);
+        r.set("content", content);
+        r.put("isError", false);
+        return r;
+    }
+
+    private ObjectNode errorResult(String message) {
+        ObjectNode block = m.createObjectNode();
+        block.put("type", "text");
+        block.put("text", message);
+        ObjectNode r = m.createObjectNode();
+        ArrayNode content = m.createArrayNode();
+        content.add(block);
+        r.set("content", content);
+        r.put("isError", true);
+        return r;
+    }
+
+    private ObjectNode tool(String name, String description, ObjectNode properties) {
+        return toolReq(name, description, properties);
+    }
+
+    private ObjectNode toolReq(String name, String description, ObjectNode properties, String... required) {
+        ObjectNode t = m.createObjectNode();
+        t.put("name", name);
+        t.put("description", description);
+        ObjectNode schema = m.createObjectNode();
+        schema.put("type", "object");
+        schema.set("properties", properties);
+        if (required.length > 0) {
+            ArrayNode req = m.createArrayNode();
+            for (String s : required) {
+                req.add(s);
+            }
+            schema.set("required", req);
+        }
+        t.set("inputSchema", schema);
+        return t;
+    }
+
+    private ObjectNode obj() {
+        return m.createObjectNode();
+    }
+
+    private ObjectNode strProp(String description) {
+        return m.createObjectNode().put("type", "string").put("description", description);
+    }
+
+    private ObjectNode boolProp(String description) {
+        return m.createObjectNode().put("type", "boolean").put("description", description);
+    }
+
+    private static String text(JsonNode args, String field) {
+        if (args == null || !args.hasNonNull(field)) {
+            return null;
+        }
+        String v = args.get(field).asText();
+        return v.isEmpty() ? null : v;
+    }
+
+    private static boolean bool(JsonNode args, String field) {
+        return args != null && args.hasNonNull(field) && args.get(field).asBoolean(false);
+    }
+}

--- a/src/main/java/com/editora/ui/MainController.java
+++ b/src/main/java/com/editora/ui/MainController.java
@@ -82,7 +82,7 @@ import org.fxmisc.richtext.NavigationActions.SelectionPolicy;
 import static com.editora.i18n.Messages.tr;
 
 /** Controls the main window: tabbed editors, menu actions, palette/find overlays, and status bar. */
-public class MainController {
+public class MainController implements com.editora.mcp.McpBridge {
 
     private static final java.util.logging.Logger LOG =
             java.util.logging.Logger.getLogger(MainController.class.getName());
@@ -278,6 +278,12 @@ public class MainController {
     private final com.editora.web.HtmlPreviewService htmlPreviewService =
             new com.editora.web.HtmlPreviewService(this::openExternalUrl);
     private java.util.List<com.editora.web.Browsers.Browser> htmlBrowsers = java.util.List.of();
+    // MCP server: a single app-wide loopback HTTP endpoint exposing live editor state + the command
+    // registry to an LLM agent. Static so only the first window with the feature on starts it (the
+    // setting is shared); that window's controller is the bridge. (Multi-window caveat: if the owner
+    // window closes, the server stops until a settings re-apply re-arms it from another window.)
+    private static com.editora.mcp.McpServer mcpServer;
+    private static MainController mcpOwner;
     private final com.editora.pdf.PdfExportService pdfService = new com.editora.pdf.PdfExportService();
     private final com.editora.print.PrintService printService = new com.editora.print.PrintService();
     private final com.editora.diff.DiffService diffService = new com.editora.diff.DiffService();
@@ -450,6 +456,7 @@ public class MainController {
                         && (httpEnabled() || (!c.id().startsWith("http.") && !c.id().equals("tool.http")))
                         && (htmlPreviewEnabled() || !c.id().startsWith("htmlPreview."))
                         && (localHistoryEnabled() || !c.id().equals("tool.fileHistory"))
+                        && (mcpEnabled() || !c.id().startsWith("mcp."))
                         && (pluginsEnabled() || !c.id().startsWith("plugins.")));
         this.findBar = new FindReplaceBar(this::activeBuffer, this::setStatus);
         // Find/replace bar sits between the toolbar and the tabs.
@@ -473,6 +480,7 @@ public class MainController {
                 this::showDebugLog);
         this.settingsWindow.setPluginManager(pluginManager); // shared; lists discovered plugins on the Plugins page
         this.settingsWindow.setPluginActions(this::browsePlugins, this::installPluginFromDisk, this::uninstallPlugin);
+        this.settingsWindow.setMcpConfirm(this::confirmEnableMcp); // security notice before enabling MCP
         this.settingsWindow.setOnKeymapChanged(this::reloadKeymap); // picker/combo → live keymap switch
         this.settingsWindow.setShortcutActions(new SettingsWindow.ShortcutActions() {
             @Override
@@ -526,6 +534,7 @@ public class MainController {
         applyMermaidSupport(); // wire mmdc/maid paths; mermaid rendering off when disabled (default)
         applyHttpClientSupport(); // configure ijhttp; .http run glyphs off when disabled (default)
         applyHtmlPreviewSupport(); // HTML "open in browser" control off when disabled (default)
+        applyMcpSupport(); // MCP server (loopback HTTP) off when disabled (default)
         applyLspSupport(); // configure the LSP manager; servers/diagnostics off when disabled (default)
         applyDebugSupport(); // configure DAP; debugging off when disabled (default) — after LSP (it layers on jdtls)
         setupWelcome(); // Welcome empty-state shown when no file tabs are open
@@ -1406,6 +1415,7 @@ public class MainController {
         searchService.shutdown();
         mermaidService.shutdown();
         htmlPreviewService.shutdown(); // stop the HTML-preview HTTP server + worker
+        stopMcpIfOwner(); // stop the MCP server if this window owns it
         pdfService.shutdown();
         printService.shutdown();
         runService.stop();
@@ -2617,6 +2627,247 @@ public class MainController {
         } else {
             setStatus(tr("statusbar.tip.htmlPreviewDisabled"));
         }
+    }
+
+    // --- MCP server (loopback HTTP, exposes editor state + commands to an LLM agent) --------------
+
+    private boolean mcpEnabled() {
+        // Simple UI mode disables the MCP server too (without changing the saved setting).
+        return config.getSettings().isMcpSupport() && !simpleModeActive();
+    }
+
+    /**
+     * Reconciles the MCP server with its setting (mirrors {@link #applyHttpClientSupport}). Starts the
+     * single app-wide loopback server when first enabled (this window becomes its bridge), or stops it
+     * when disabled. Runs at startup and on every settings apply.
+     */
+    private void applyMcpSupport() {
+        boolean on = mcpEnabled();
+        if (on && mcpServer == null) {
+            try {
+                com.editora.mcp.McpServer s = new com.editora.mcp.McpServer(this, config.getConfigDir());
+                s.start();
+                mcpServer = s;
+                mcpOwner = this;
+            } catch (Exception e) {
+                LOG.log(java.util.logging.Level.WARNING, "MCP server failed to start", e);
+                setStatus(tr("status.mcp.failed"));
+            }
+        } else if (!on && mcpServer != null && mcpOwner == this) {
+            mcpServer.stop();
+            mcpServer = null;
+            mcpOwner = null;
+        }
+        statusBar.setMcpRunning(mcpServer != null && mcpServer.isRunning());
+    }
+
+    /**
+     * A security-notice confirmation shown before the MCP server is enabled (from the palette toggle and
+     * the Settings checkbox). Returns true to proceed. Mirrors {@link #confirmEnablePlugin}.
+     */
+    private boolean confirmEnableMcp() {
+        Alert confirm =
+                new Alert(Alert.AlertType.WARNING, tr("dialog.mcp.enableBody"), ButtonType.OK, ButtonType.CANCEL);
+        confirm.initOwner(stage);
+        confirm.setTitle(tr("dialog.mcp.enableTitle"));
+        confirm.setHeaderText(tr("dialog.mcp.enableHeader"));
+        confirm.getDialogPane().setMinWidth(480);
+        return confirm.showAndWait().orElse(ButtonType.CANCEL) == ButtonType.OK;
+    }
+
+    /** Stops the MCP server if this window owns it (called from {@link #disposeWindow}). */
+    private void stopMcpIfOwner() {
+        if (mcpServer != null && mcpOwner == this) {
+            mcpServer.stop();
+            mcpServer = null;
+            mcpOwner = null;
+        }
+    }
+
+    /** Runs {@code action} only when the MCP server is enabled; otherwise reports it (no-op). */
+    private void ifMcp(Runnable action) {
+        if (mcpEnabled()) {
+            action.run();
+        } else {
+            setStatus(tr("statusbar.tip.mcpDisabled"));
+        }
+    }
+
+    /** {@code view.toggleMcp}: flip the feature (with a security notice before enabling), re-apply, re-sync. */
+    private void toggleMcpSupport() {
+        Settings s = config.getSettings();
+        boolean turningOn = !s.isMcpSupport();
+        if (turningOn && !confirmEnableMcp()) {
+            return; // user declined the security notice; leave the server off
+        }
+        s.setMcpSupport(turningOn);
+        config.save();
+        applyMcpSupport();
+        if (settingsWindow != null) {
+            settingsWindow.syncMcpCheck();
+        }
+        setStatus(tr("status.toggle.mcp", tr(s.isMcpSupport() ? "common.on" : "common.off")));
+    }
+
+    /** Copies a ready-to-paste {@code claude mcp add} command (endpoint URL + bearer token) to the clipboard. */
+    private void copyMcpEndpoint() {
+        if (mcpServer == null || !mcpServer.isRunning()) {
+            setStatus(tr("status.mcp.notRunning"));
+            return;
+        }
+        String cmd = "claude mcp add --transport http editora " + mcpServer.url() + " --header \"Authorization: Bearer "
+                + mcpServer.token() + "\"";
+        ClipboardContent cc = new ClipboardContent();
+        cc.putString(cmd);
+        javafx.scene.input.Clipboard.getSystemClipboard().setContent(cc);
+        setStatus(tr("status.mcp.endpointCopied"));
+    }
+
+    // --- McpBridge: marshals editor reads onto the FX thread for the off-FX HTTP worker -----------
+
+    /** Runs {@code task} on the FX thread and blocks (with a timeout) for its result. */
+    private static <T> T mcpOnFx(java.util.function.Supplier<T> task) {
+        if (javafx.application.Platform.isFxApplicationThread()) {
+            return task.get();
+        }
+        java.util.concurrent.CompletableFuture<T> f = new java.util.concurrent.CompletableFuture<>();
+        javafx.application.Platform.runLater(() -> {
+            try {
+                f.complete(task.get());
+            } catch (Throwable t) {
+                f.completeExceptionally(t);
+            }
+        });
+        try {
+            return f.get(5, java.util.concurrent.TimeUnit.SECONDS);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public java.util.List<OpenFile> listOpenFiles() {
+        return mcpOnFx(() -> {
+            EditorBuffer active = activeBuffer();
+            java.util.List<OpenFile> out = new java.util.ArrayList<>();
+            for (Tab tab : tabPane.getTabs()) {
+                EditorBuffer b = bufferOf(tab);
+                if (b == null) {
+                    continue;
+                }
+                out.add(new OpenFile(
+                        b.getPath() == null ? null : b.getPath().toString(),
+                        b.getTitle(),
+                        b.getLanguage(),
+                        b.isDirty(),
+                        b == active));
+            }
+            return out;
+        });
+    }
+
+    @Override
+    public BufferContent readBuffer(String path) {
+        return mcpOnFx(() -> {
+            EditorBuffer b = path == null ? activeBuffer() : openBufferForPath(path);
+            if (b == null) {
+                return null;
+            }
+            return new BufferContent(
+                    b.getPath() == null ? null : b.getPath().toString(),
+                    b.getTitle(),
+                    b.getLanguage(),
+                    b.isDirty(),
+                    b.getContent());
+        });
+    }
+
+    @Override
+    public java.util.List<Diagnostic> getDiagnostics(String path) {
+        return mcpOnFx(() -> {
+            Path target = path != null
+                    ? Path.of(path)
+                    : (activeBuffer() == null ? null : activeBuffer().getPath());
+            if (target == null) {
+                return java.util.List.<Diagnostic>of();
+            }
+            Path key = canonicalPath(target);
+            java.util.List<Diagnostic> out = new java.util.ArrayList<>();
+            for (var e : lspProblems.entrySet()) {
+                if (!canonicalPath(e.getKey()).equals(key)) {
+                    continue;
+                }
+                for (com.editora.editor.LspDiagnostic d : e.getValue()) {
+                    out.add(new Diagnostic(
+                            d.startLine() + 1, d.startCol() + 1, d.severity().name(), d.message(), d.origin()));
+                }
+            }
+            return out;
+        });
+    }
+
+    @Override
+    public java.util.List<SearchMatch> findInFiles(
+            String query, boolean caseSensitive, boolean regex, boolean wholeWord) {
+        com.editora.search.SearchQuery q = new com.editora.search.SearchQuery(query, caseSensitive, regex, wholeWord);
+        java.util.concurrent.CompletableFuture<com.editora.search.SearchService.Outcome> fut =
+                new java.util.concurrent.CompletableFuture<>();
+        javafx.application.Platform.runLater(() -> {
+            java.util.Map<Path, String> open = new java.util.HashMap<>();
+            for (Tab tab : tabPane.getTabs()) {
+                EditorBuffer b = bufferOf(tab);
+                if (b != null && b.getPath() != null) {
+                    open.put(b.getPath().toAbsolutePath().normalize(), b.getContent());
+                }
+            }
+            Path root = null;
+            Project p = projects == null ? null : projects.active();
+            if (p != null) {
+                root = Path.of(p.root());
+            }
+            searchService.search(q, root, open, fut::complete);
+        });
+        com.editora.search.SearchService.Outcome outcome;
+        try {
+            outcome = fut.get(20, java.util.concurrent.TimeUnit.SECONDS);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+        java.util.List<SearchMatch> out = new java.util.ArrayList<>();
+        for (com.editora.search.FileResult fr : outcome.files()) {
+            for (com.editora.search.LineMatch lm : fr.matches()) {
+                out.add(new SearchMatch(fr.file().toString(), lm.line(), lm.col(), lm.lineText()));
+            }
+        }
+        return out;
+    }
+
+    @Override
+    public java.util.List<CommandInfo> listCommands() {
+        return mcpOnFx(() -> {
+            java.util.List<CommandInfo> out = new java.util.ArrayList<>();
+            for (com.editora.command.Command c : registry.all()) {
+                out.add(new CommandInfo(c.id(), c.title(), c.description()));
+            }
+            return out;
+        });
+    }
+
+    @Override
+    public boolean executeCommand(String id) {
+        return mcpOnFx(() -> registry.run(id));
+    }
+
+    /** Finds the open buffer whose file matches {@code path} (by canonical path), or null. */
+    private EditorBuffer openBufferForPath(String path) {
+        Path key = canonicalPath(Path.of(path));
+        for (Tab tab : tabPane.getTabs()) {
+            EditorBuffer b = bufferOf(tab);
+            if (b != null && b.getPath() != null && canonicalPath(b.getPath()).equals(key)) {
+                return b;
+            }
+        }
+        return null;
     }
 
     // --- HTTP Client (.http via ijhttp) ----------------------------------------------------------
@@ -9611,6 +9862,7 @@ public class MainController {
         applyMermaidSupport();
         applyHttpClientSupport();
         applyHtmlPreviewSupport();
+        applyMcpSupport();
         applyAutoSave();
         applyAutocomplete();
         applyMultiCaret();
@@ -10131,6 +10383,8 @@ public class MainController {
         registry.register(Command.of("htmlPreview.open", () -> ifHtmlPreview(this::htmlPreviewOpen)));
         registry.register(Command.of("htmlPreview.openIn", () -> ifHtmlPreview(this::htmlPreviewOpenIn)));
         registry.register(Command.of("view.toggleHtmlPreview", this::toggleHtmlPreviewSupport));
+        registry.register(Command.of("mcp.copyEndpoint", () -> ifMcp(this::copyMcpEndpoint)));
+        registry.register(Command.of("view.toggleMcp", this::toggleMcpSupport));
         registry.register(Command.of("view.toggleLineHighlight", this::toggleLineHighlight));
         registry.register(Command.of("view.toggleLineNumbers", this::toggleLineNumbers));
         registry.register(Command.of("view.toggleMinimap", this::toggleMinimap));

--- a/src/main/java/com/editora/ui/SettingsWindow.java
+++ b/src/main/java/com/editora/ui/SettingsWindow.java
@@ -75,6 +75,7 @@ public class SettingsWindow {
         MERMAID(tr("settings.cat.mermaid"), false),
         HTTP_CLIENT(tr("settings.cat.httpClient"), false),
         HTML_PREVIEW(tr("settings.cat.htmlPreview"), false),
+        MCP(tr("settings.cat.mcp"), false),
         LSP(tr("settings.cat.lsp"), false),
         DEBUG(tr("settings.cat.debug"), false),
         KEYMAPS(tr("settings.cat.keymaps"), false),
@@ -100,6 +101,9 @@ public class SettingsWindow {
     private final Consumer<Path> onOpenFile;
     private final Runnable onExportConfig;
     private final Runnable onShowDebugLog;
+    /** Security-notice confirm shown before the MCP checkbox enables the server; null = no gate. */
+    private java.util.function.BooleanSupplier mcpConfirm;
+
     private final ToolWindowManager toolWindows;
     private final com.editora.git.GitService gitService;
     private final com.editora.mermaid.MermaidService mermaidService;
@@ -152,6 +156,7 @@ public class SettingsWindow {
     private CheckBox mermaidCheck;
     private CheckBox httpCheck;
     private CheckBox htmlPreviewCheck;
+    private CheckBox mcpCheck;
     private TextField mmdcPathField;
     private CheckBox debugCheck;
     /** Per-language debug-adapter controls, keyed by language id (java/python/javascript). */
@@ -285,6 +290,11 @@ public class SettingsWindow {
         this.onBrowsePlugins = onBrowse;
         this.onInstallPluginFromFile = onInstallFromFile;
         this.onUninstallPlugin = onUninstall;
+    }
+
+    /** Wires the security-notice confirm shown before the MCP checkbox enables the server. */
+    public void setMcpConfirm(java.util.function.BooleanSupplier confirm) {
+        this.mcpConfirm = confirm;
     }
 
     public void show(Window owner) {
@@ -650,6 +660,23 @@ public class SettingsWindow {
             apply();
         });
 
+        mcpCheck = new CheckBox(tr("settings.mcp.enable"));
+        mcpCheck.selectedProperty().addListener((obs, was, now) -> {
+            // A user-initiated enable shows a security notice first; declining reverts the checkbox.
+            if (!loading && now && mcpConfirm != null && !mcpConfirm.getAsBoolean()) {
+                boolean prev = loading;
+                loading = true;
+                try {
+                    mcpCheck.setSelected(false);
+                } finally {
+                    loading = prev;
+                }
+                return;
+            }
+            config.getSettings().setMcpSupport(now);
+            apply();
+        });
+
         pluginCheck = new CheckBox(tr("settings.enablePlugins"));
         pluginCheck.selectedProperty().addListener((obs, was, now) -> {
             config.getSettings().setPluginSupport(now);
@@ -813,6 +840,7 @@ public class SettingsWindow {
         pages.put(Category.MERMAID, mermaidPage());
         pages.put(Category.HTTP_CLIENT, httpClientPage());
         pages.put(Category.HTML_PREVIEW, htmlPreviewPage());
+        pages.put(Category.MCP, mcpPage());
         pages.put(Category.LSP, lspPage());
         pages.put(Category.DEBUG, debugPage());
         pages.put(Category.KEYMAPS, keymapsPage());
@@ -1212,6 +1240,16 @@ public class SettingsWindow {
         hint.setWrapText(true);
         hint.setMaxWidth(440);
         row(p, Category.HTML_PREVIEW, null, hint, "html preview browser safari chrome firefox edge server localhost");
+        return p;
+    }
+
+    private VBox mcpPage() {
+        VBox p = page(tr("settings.cat.mcp"));
+        row(p, Category.MCP, null, mcpCheck, "mcp model context protocol agent server enable ai claude");
+        Label hint = note(tr("settings.mcp.hint"));
+        hint.setWrapText(true);
+        hint.setMaxWidth(440);
+        row(p, Category.MCP, null, hint, "mcp agent llm command palette diagnostics search loopback token endpoint");
         return p;
     }
 
@@ -2429,6 +2467,7 @@ public class SettingsWindow {
             refreshMermaidStatus();
             httpCheck.setSelected(settings.isHttpClientSupport());
             htmlPreviewCheck.setSelected(settings.isHtmlPreviewSupport());
+            mcpCheck.setSelected(settings.isMcpSupport());
             pluginCheck.setSelected(settings.isPluginSupport());
             if (pluginRequireSigCheck != null) {
                 pluginRequireSigCheck.setSelected(settings.isPluginRequireSignature());
@@ -2788,6 +2827,19 @@ public class SettingsWindow {
         loading = true;
         try {
             htmlPreviewCheck.setSelected(config.getSettings().isHtmlPreviewSupport());
+        } finally {
+            loading = prev;
+        }
+    }
+
+    public void syncMcpCheck() {
+        if (!built) {
+            return;
+        }
+        boolean prev = loading;
+        loading = true;
+        try {
+            mcpCheck.setSelected(config.getSettings().isMcpSupport());
         } finally {
             loading = prev;
         }

--- a/src/main/java/com/editora/ui/StatusBar.java
+++ b/src/main/java/com/editora/ui/StatusBar.java
@@ -57,6 +57,9 @@ public final class StatusBar extends HBox {
     /** Indeterminate progress while the debug session is starting; hidden once running/suspended. */
     private final ProgressBar debugProgress = new ProgressBar(0);
 
+    /** MCP server running indicator; clickable → copy the connection command. Hidden when the server is off. */
+    private final Label mcp = segment("mcp.copyEndpoint", tr("statusbar.tip.mcp"));
+
     private final Label position = segment("nav.goToLine", tr("statusbar.tip.goToLine"));
     private final Label language = segment("buffer.setLanguage", tr("statusbar.tip.setLanguage"));
     private final Label indent = segment("buffer.setTabSize", tr("statusbar.tip.setTabSize"));
@@ -75,6 +78,8 @@ public final class StatusBar extends HBox {
     private String lspServerName = "";
 
     private boolean lspLoadingState;
+    /** Whether the app-wide MCP server is running, so Simple-mode toggling can re-apply its visibility. */
+    private boolean mcpRunning;
     /** A single listener refreshes every segment on caret / text / selection changes. */
     private final InvalidationListener changeListener = obs -> refresh();
 
@@ -100,6 +105,11 @@ public final class StatusBar extends HBox {
         lsp.getStyleClass().add("status-lsp");
         lsp.setVisible(false); // shown only when the active file is served by a language server
         lsp.setManaged(false);
+
+        mcp.getStyleClass().add("status-mcp");
+        mcp.setText(tr("statusbar.mcp"));
+        mcp.setVisible(false); // shown only while the MCP server is running
+        mcp.setManaged(false);
 
         lspProgress.getStyleClass().add("status-lsp-progress");
         lspProgress.setPrefWidth(90);
@@ -127,6 +137,7 @@ public final class StatusBar extends HBox {
                         lspProgress,
                         git,
                         lsp,
+                        mcp,
                         readOnly,
                         zoomGroup(),
                         position,
@@ -291,6 +302,18 @@ public final class StatusBar extends HBox {
         lspProgress.setManaged(showProgress);
     }
 
+    /** Shows/hides the MCP-server-running indicator (suppressed in Simple UI mode). */
+    public void setMcpRunning(boolean running) {
+        mcpRunning = running;
+        applyMcpStatusVisibility();
+    }
+
+    private void applyMcpStatusVisibility() {
+        boolean show = mcpRunning && !simpleMode;
+        mcp.setVisible(show);
+        mcp.setManaged(show);
+    }
+
     /** Shows/updates the Debug segment ({@code state} non-blank → "Debug: state"; null/blank → hidden). */
     public void setDebug(String state) {
         boolean show = state != null && !state.isBlank();
@@ -387,6 +410,7 @@ public final class StatusBar extends HBox {
             this.simpleMode = simpleMode;
             refresh();
             applyLspStatusVisibility(); // the LSP segment + loading bar are event-driven, not in refresh()
+            applyMcpStatusVisibility(); // the MCP segment is event-driven too
         }
     }
 

--- a/src/main/resources/com/editora/i18n/messages.properties
+++ b/src/main/resources/com/editora/i18n/messages.properties
@@ -1672,3 +1672,22 @@ httppanel.openInTab=Open in tab
 status.http.curlImported=Imported cURL command as a request
 status.http.curlCopied=Copied request as a curl command
 status.http.notCurl=No curl command on the clipboard
+
+# MCP server (loopback HTTP endpoint exposing editor state + commands to an LLM agent)
+command.mcp.copyEndpoint=MCP: Copy Endpoint Command
+command.mcp.copyEndpoint.desc=Copy a ready-to-paste "claude mcp add" command (endpoint URL + token) to the clipboard.
+command.view.toggleMcp=Toggle MCP Server
+command.view.toggleMcp.desc=Turn the MCP server (loopback HTTP endpoint for an LLM agent) on or off.
+settings.cat.mcp=MCP Server
+settings.mcp.enable=Enable MCP server (loopback HTTP endpoint for an LLM agent)
+settings.mcp.hint=Expose live editor state (open buffers, diagnostics, search) and the command registry to an LLM agent over a loopback HTTP endpoint, guarded by a bearer token. Run "MCP: Copy Endpoint Command" for a ready-to-paste connection command. Off by default.
+statusbar.tip.mcpDisabled=The MCP server is disabled (enable it in Settings → MCP Server)
+status.toggle.mcp=MCP server {0}
+status.mcp.endpointCopied=MCP connection command copied to the clipboard
+status.mcp.notRunning=The MCP server is not running
+status.mcp.failed=The MCP server failed to start (see the debug log)
+statusbar.mcp=MCP
+statusbar.tip.mcp=MCP server running — click to copy the connection command
+dialog.mcp.enableTitle=MCP Server — Security Notice
+dialog.mcp.enableHeader=Enable the MCP server?
+dialog.mcp.enableBody=Enabling the MCP server starts a local HTTP endpoint (bound to 127.0.0.1 only) that lets an AI agent read your open files, diagnostics and search results, and run editor commands on your behalf. Connections require a secret token, but any program running on this computer could attempt to use it. Only enable this if you understand and accept the risk.

--- a/src/main/resources/com/editora/i18n/messages_de.properties
+++ b/src/main/resources/com/editora/i18n/messages_de.properties
@@ -1664,3 +1664,22 @@ httppanel.openInTab=In Tab öffnen
 status.http.curlImported=cURL-Befehl als Anfrage importiert
 status.http.curlCopied=Anfrage als curl-Befehl kopiert
 status.http.notCurl=Kein curl-Befehl in der Zwischenablage
+
+# MCP-Server (lokaler HTTP-Endpunkt, der den Editor-Status + Befehle für einen LLM-Agenten bereitstellt)
+command.mcp.copyEndpoint=MCP: Endpunkt-Befehl kopieren
+command.mcp.copyEndpoint.desc=Kopiert einen einsatzbereiten „claude mcp add“-Befehl (Endpunkt-URL + Token) in die Zwischenablage.
+command.view.toggleMcp=MCP-Server umschalten
+command.view.toggleMcp.desc=Schaltet den MCP-Server (lokaler HTTP-Endpunkt für einen LLM-Agenten) ein oder aus.
+settings.cat.mcp=MCP-Server
+settings.mcp.enable=MCP-Server aktivieren (lokaler HTTP-Endpunkt für einen LLM-Agenten)
+settings.mcp.hint=Stellt den Live-Editor-Status (geöffnete Puffer, Diagnosen, Suche) und das Befehlsregister einem LLM-Agenten über einen lokalen HTTP-Endpunkt bereit, abgesichert durch ein Bearer-Token. Mit „MCP: Endpunkt-Befehl kopieren“ erhältst du einen einsatzbereiten Verbindungsbefehl. Standardmäßig deaktiviert.
+statusbar.tip.mcpDisabled=Der MCP-Server ist deaktiviert (aktiviere ihn unter Einstellungen → MCP-Server)
+status.toggle.mcp=MCP-Server {0}
+status.mcp.endpointCopied=MCP-Verbindungsbefehl in die Zwischenablage kopiert
+status.mcp.notRunning=Der MCP-Server läuft nicht
+status.mcp.failed=Der MCP-Server konnte nicht gestartet werden (siehe Debug-Protokoll)
+statusbar.mcp=MCP
+statusbar.tip.mcp=MCP-Server läuft — klicken, um den Verbindungsbefehl zu kopieren
+dialog.mcp.enableTitle=MCP-Server — Sicherheitshinweis
+dialog.mcp.enableHeader=MCP-Server aktivieren?
+dialog.mcp.enableBody=Beim Aktivieren des MCP-Servers wird ein lokaler HTTP-Endpunkt (nur an 127.0.0.1 gebunden) gestartet, über den ein KI-Agent deine geöffneten Dateien, Diagnosen und Suchergebnisse lesen und Editor-Befehle in deinem Namen ausführen kann. Verbindungen erfordern ein geheimes Token, aber jedes auf diesem Computer laufende Programm könnte versuchen, es zu verwenden. Aktiviere dies nur, wenn du das Risiko verstehst und akzeptierst.

--- a/src/main/resources/com/editora/i18n/messages_es.properties
+++ b/src/main/resources/com/editora/i18n/messages_es.properties
@@ -1664,3 +1664,22 @@ httppanel.openInTab=Abrir en pestaña
 status.http.curlImported=Comando cURL importado como solicitud
 status.http.curlCopied=Solicitud copiada como comando curl
 status.http.notCurl=No hay ningún comando curl en el portapapeles
+
+# Servidor MCP (endpoint HTTP local que expone el estado del editor + los comandos a un agente LLM)
+command.mcp.copyEndpoint=MCP: copiar comando de endpoint
+command.mcp.copyEndpoint.desc=Copia al portapapeles un comando "claude mcp add" listo para usar (URL del endpoint + token).
+command.view.toggleMcp=Activar o desactivar el servidor MCP
+command.view.toggleMcp.desc=Activa o desactiva el servidor MCP (endpoint HTTP local para un agente LLM).
+settings.cat.mcp=Servidor MCP
+settings.mcp.enable=Activar el servidor MCP (endpoint HTTP local para un agente LLM)
+settings.mcp.hint=Expone el estado del editor en tiempo real (búferes abiertos, diagnósticos, búsqueda) y el registro de comandos a un agente LLM mediante un endpoint HTTP local, protegido por un token bearer. Usa "MCP: copiar comando de endpoint" para obtener un comando de conexión listo para usar. Desactivado de forma predeterminada.
+statusbar.tip.mcpDisabled=El servidor MCP está desactivado (actívalo en Configuración → Servidor MCP)
+status.toggle.mcp=Servidor MCP {0}
+status.mcp.endpointCopied=Comando de conexión MCP copiado al portapapeles
+status.mcp.notRunning=El servidor MCP no está en ejecución
+status.mcp.failed=No se pudo iniciar el servidor MCP (consulta el registro de depuración)
+statusbar.mcp=MCP
+statusbar.tip.mcp=Servidor MCP en ejecución: haz clic para copiar el comando de conexión
+dialog.mcp.enableTitle=Servidor MCP: aviso de seguridad
+dialog.mcp.enableHeader=¿Activar el servidor MCP?
+dialog.mcp.enableBody=Al activar el servidor MCP se inicia un endpoint HTTP local (vinculado solo a 127.0.0.1) que permite a un agente de IA leer tus archivos abiertos, los diagnósticos y los resultados de búsqueda, y ejecutar comandos del editor en tu nombre. Las conexiones requieren un token secreto, pero cualquier programa que se ejecute en este equipo podría intentar usarlo. Actívalo solo si comprendes y aceptas el riesgo.

--- a/src/main/resources/com/editora/i18n/messages_fr.properties
+++ b/src/main/resources/com/editora/i18n/messages_fr.properties
@@ -1664,3 +1664,22 @@ httppanel.openInTab=Ouvrir dans un onglet
 status.http.curlImported=Commande cURL importée comme requête
 status.http.curlCopied=Requête copiée comme commande curl
 status.http.notCurl=Aucune commande curl dans le presse-papiers
+
+# Serveur MCP (point de terminaison HTTP local exposant l'état de l'éditeur + les commandes à un agent LLM)
+command.mcp.copyEndpoint=MCP : copier la commande du point de terminaison
+command.mcp.copyEndpoint.desc=Copie dans le presse-papiers une commande « claude mcp add » prête à l'emploi (URL du point de terminaison + jeton).
+command.view.toggleMcp=Activer/désactiver le serveur MCP
+command.view.toggleMcp.desc=Active ou désactive le serveur MCP (point de terminaison HTTP local pour un agent LLM).
+settings.cat.mcp=Serveur MCP
+settings.mcp.enable=Activer le serveur MCP (point de terminaison HTTP local pour un agent LLM)
+settings.mcp.hint=Expose l'état de l'éditeur en temps réel (tampons ouverts, diagnostics, recherche) et le registre des commandes à un agent LLM via un point de terminaison HTTP local, protégé par un jeton bearer. Utilisez « MCP : copier la commande du point de terminaison » pour obtenir une commande de connexion prête à l'emploi. Désactivé par défaut.
+statusbar.tip.mcpDisabled=Le serveur MCP est désactivé (activez-le dans Paramètres → Serveur MCP)
+status.toggle.mcp=Serveur MCP {0}
+status.mcp.endpointCopied=Commande de connexion MCP copiée dans le presse-papiers
+status.mcp.notRunning=Le serveur MCP n'est pas en cours d'exécution
+status.mcp.failed=Échec du démarrage du serveur MCP (voir le journal de débogage)
+statusbar.mcp=MCP
+statusbar.tip.mcp=Serveur MCP en cours d'exécution — cliquez pour copier la commande de connexion
+dialog.mcp.enableTitle=Serveur MCP — Avis de sécurité
+dialog.mcp.enableHeader=Activer le serveur MCP ?
+dialog.mcp.enableBody=L'activation du serveur MCP démarre un point de terminaison HTTP local (lié à 127.0.0.1 uniquement) qui permet à un agent IA de lire vos fichiers ouverts, les diagnostics et les résultats de recherche, et d'exécuter des commandes de l'éditeur en votre nom. Les connexions nécessitent un jeton secret, mais tout programme exécuté sur cet ordinateur pourrait tenter de l'utiliser. N'activez cette option que si vous comprenez et acceptez le risque.

--- a/src/main/resources/com/editora/i18n/messages_it.properties
+++ b/src/main/resources/com/editora/i18n/messages_it.properties
@@ -1664,3 +1664,22 @@ httppanel.openInTab=Apri in scheda
 status.http.curlImported=Comando cURL importato come richiesta
 status.http.curlCopied=Richiesta copiata come comando curl
 status.http.notCurl=Nessun comando curl negli appunti
+
+# Server MCP (endpoint HTTP locale che espone lo stato dell'editor + i comandi a un agente LLM)
+command.mcp.copyEndpoint=MCP: copia comando endpoint
+command.mcp.copyEndpoint.desc=Copia negli appunti un comando "claude mcp add" pronto all'uso (URL endpoint + token).
+command.view.toggleMcp=Attiva/disattiva il server MCP
+command.view.toggleMcp.desc=Attiva o disattiva il server MCP (endpoint HTTP locale per un agente LLM).
+settings.cat.mcp=Server MCP
+settings.mcp.enable=Abilita il server MCP (endpoint HTTP locale per un agente LLM)
+settings.mcp.hint=Espone lo stato dell'editor in tempo reale (buffer aperti, diagnostica, ricerca) e il registro dei comandi a un agente LLM tramite un endpoint HTTP locale, protetto da un token bearer. Usa "MCP: copia comando endpoint" per ottenere un comando di connessione pronto all'uso. Disattivato per impostazione predefinita.
+statusbar.tip.mcpDisabled=Il server MCP è disabilitato (abilitalo in Impostazioni → Server MCP)
+status.toggle.mcp=Server MCP {0}
+status.mcp.endpointCopied=Comando di connessione MCP copiato negli appunti
+status.mcp.notRunning=Il server MCP non è in esecuzione
+status.mcp.failed=Avvio del server MCP non riuscito (vedi il log di debug)
+statusbar.mcp=MCP
+statusbar.tip.mcp=Server MCP in esecuzione — clicca per copiare il comando di connessione
+dialog.mcp.enableTitle=Server MCP — Avviso di sicurezza
+dialog.mcp.enableHeader=Abilitare il server MCP?
+dialog.mcp.enableBody=Abilitando il server MCP si avvia un endpoint HTTP locale (associato solo a 127.0.0.1) che consente a un agente IA di leggere i file aperti, la diagnostica e i risultati di ricerca, e di eseguire comandi dell'editor per tuo conto. Le connessioni richiedono un token segreto, ma qualsiasi programma in esecuzione su questo computer potrebbe tentare di usarlo. Abilita questa funzione solo se ne comprendi e accetti il rischio.

--- a/src/main/resources/com/editora/i18n/messages_pt.properties
+++ b/src/main/resources/com/editora/i18n/messages_pt.properties
@@ -1664,3 +1664,22 @@ httppanel.openInTab=Abrir em aba
 status.http.curlImported=Comando cURL importado como requisição
 status.http.curlCopied=Requisição copiada como comando curl
 status.http.notCurl=Nenhum comando curl na área de transferência
+
+# Servidor MCP (endpoint HTTP local que expõe o estado do editor + os comandos a um agente LLM)
+command.mcp.copyEndpoint=MCP: copiar comando do endpoint
+command.mcp.copyEndpoint.desc=Copia para a área de transferência um comando "claude mcp add" pronto para usar (URL do endpoint + token).
+command.view.toggleMcp=Ativar/desativar o servidor MCP
+command.view.toggleMcp.desc=Ativa ou desativa o servidor MCP (endpoint HTTP local para um agente LLM).
+settings.cat.mcp=Servidor MCP
+settings.mcp.enable=Ativar o servidor MCP (endpoint HTTP local para um agente LLM)
+settings.mcp.hint=Expõe o estado do editor em tempo real (buffers abertos, diagnósticos, pesquisa) e o registro de comandos a um agente LLM por um endpoint HTTP local, protegido por um token bearer. Use "MCP: copiar comando do endpoint" para obter um comando de conexão pronto para usar. Desativado por padrão.
+statusbar.tip.mcpDisabled=O servidor MCP está desativado (ative-o em Configurações → Servidor MCP)
+status.toggle.mcp=Servidor MCP {0}
+status.mcp.endpointCopied=Comando de conexão MCP copiado para a área de transferência
+status.mcp.notRunning=O servidor MCP não está em execução
+status.mcp.failed=Falha ao iniciar o servidor MCP (consulte o log de depuração)
+statusbar.mcp=MCP
+statusbar.tip.mcp=Servidor MCP em execução — clique para copiar o comando de conexão
+dialog.mcp.enableTitle=Servidor MCP — Aviso de segurança
+dialog.mcp.enableHeader=Ativar o servidor MCP?
+dialog.mcp.enableBody=Ativar o servidor MCP inicia um endpoint HTTP local (vinculado apenas a 127.0.0.1) que permite a um agente de IA ler seus arquivos abertos, os diagnósticos e os resultados de pesquisa, e executar comandos do editor em seu nome. As conexões exigem um token secreto, mas qualquer programa em execução neste computador pode tentar usá-lo. Ative apenas se compreender e aceitar o risco.

--- a/src/main/resources/com/editora/styles/app.css
+++ b/src/main/resources/com/editora/styles/app.css
@@ -998,6 +998,18 @@
     -fx-text-fill: -color-accent-fg;
 }
 
+/* MCP server segment: a green "running" pill, deliberately noticeable (a local agent endpoint is live). */
+.status-bar .status-mcp {
+    -fx-text-fill: -color-success-fg;
+    -fx-font-weight: bold;
+    -fx-background-color: -color-success-subtle;
+    -fx-background-radius: 4;
+}
+
+.status-bar .status-mcp:hover {
+    -fx-background-color: -color-success-muted;
+}
+
 /* Read-only (View mode) toggle: muted "Editable" by default, amber/bold "Read-Only" when active. */
 .status-bar .status-readonly.active {
     -fx-text-fill: #bf8700;

--- a/src/test/java/com/editora/mcp/JsonRpcTest.java
+++ b/src/test/java/com/editora/mcp/JsonRpcTest.java
@@ -1,0 +1,40 @@
+package com.editora.mcp;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/** Unit tests for the pure JSON-RPC 2.0 response builders. */
+class JsonRpcTest {
+
+    private final ObjectMapper m = new ObjectMapper();
+
+    @Test
+    void successWrapsResult() {
+        ObjectNode r = JsonRpc.success(
+                m, m.getNodeFactory().numberNode(1), m.createObjectNode().put("ok", true));
+        assertEquals("2.0", r.get("jsonrpc").asText());
+        assertEquals(1, r.get("id").asInt());
+        assertTrue(r.get("result").get("ok").asBoolean());
+        assertFalse(r.has("error"));
+    }
+
+    @Test
+    void errorWrapsCodeAndMessage() {
+        ObjectNode r = JsonRpc.error(m, m.getNodeFactory().numberNode(2), JsonRpc.METHOD_NOT_FOUND, "nope");
+        assertEquals(2, r.get("id").asInt());
+        assertEquals(JsonRpc.METHOD_NOT_FOUND, r.get("error").get("code").asInt());
+        assertEquals("nope", r.get("error").get("message").asText());
+        assertFalse(r.has("result"));
+    }
+
+    @Test
+    void nullIdBecomesJsonNull() {
+        ObjectNode r = JsonRpc.success(m, null, m.nullNode());
+        assertTrue(r.get("id").isNull());
+    }
+}

--- a/src/test/java/com/editora/mcp/McpServerTest.java
+++ b/src/test/java/com/editora/mcp/McpServerTest.java
@@ -1,0 +1,124 @@
+package com.editora.mcp;
+
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * End-to-end tests for {@link McpServer} over real loopback HTTP, with a canned {@link McpBridge}
+ * (no JavaFX). Exercises auth, tools/list, and a tools/call dispatch + the endpoint-file lifecycle.
+ */
+class McpServerTest {
+
+    /** A bridge returning fixed data so the server can be tested off the FX thread. */
+    static final class FakeBridge implements McpBridge {
+        volatile String lastExecuted;
+
+        @Override
+        public List<OpenFile> listOpenFiles() {
+            return List.of(new OpenFile("/tmp/a.java", "a.java", "java", true, true));
+        }
+
+        @Override
+        public BufferContent readBuffer(String path) {
+            return new BufferContent("/tmp/a.java", "a.java", "java", true, "hello");
+        }
+
+        @Override
+        public List<Diagnostic> getDiagnostics(String path) {
+            return List.of();
+        }
+
+        @Override
+        public List<SearchMatch> findInFiles(String q, boolean cs, boolean rx, boolean ww) {
+            return List.of(new SearchMatch("/tmp/a.java", 1, 1, "hello"));
+        }
+
+        @Override
+        public List<CommandInfo> listCommands() {
+            return List.of(new CommandInfo("file.save", "Save", "Save the file"));
+        }
+
+        @Override
+        public boolean executeCommand(String id) {
+            lastExecuted = id;
+            return "file.save".equals(id);
+        }
+    }
+
+    @Test
+    void rejectsMissingToken(@TempDir Path dir) throws Exception {
+        McpServer s = new McpServer(new FakeBridge(), dir);
+        int port = s.start();
+        try {
+            HttpResponse<String> resp = post(port, null, "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"tools/list\"}");
+            assertEquals(401, resp.statusCode());
+        } finally {
+            s.stop();
+        }
+    }
+
+    @Test
+    void listsToolsWithToken(@TempDir Path dir) throws Exception {
+        McpServer s = new McpServer(new FakeBridge(), dir);
+        int port = s.start();
+        try {
+            HttpResponse<String> resp =
+                    post(port, s.token(), "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"tools/list\"}");
+            assertEquals(200, resp.statusCode());
+            assertTrue(resp.body().contains("list_open_files"));
+            assertTrue(resp.body().contains("execute_command"));
+        } finally {
+            s.stop();
+        }
+    }
+
+    @Test
+    void callsExecuteCommand(@TempDir Path dir) throws Exception {
+        FakeBridge bridge = new FakeBridge();
+        McpServer s = new McpServer(bridge, dir);
+        int port = s.start();
+        try {
+            String body = "{\"jsonrpc\":\"2.0\",\"id\":3,\"method\":\"tools/call\","
+                    + "\"params\":{\"name\":\"execute_command\",\"arguments\":{\"id\":\"file.save\"}}}";
+            HttpResponse<String> resp = post(port, s.token(), body);
+            assertEquals(200, resp.statusCode());
+            assertEquals("file.save", bridge.lastExecuted);
+            assertTrue(resp.body().contains("ran"));
+        } finally {
+            s.stop();
+        }
+    }
+
+    @Test
+    void writesAndRemovesEndpointFile(@TempDir Path dir) throws Exception {
+        McpServer s = new McpServer(new FakeBridge(), dir);
+        s.start();
+        Path ep = dir.resolve("mcp-endpoint.json");
+        assertTrue(Files.exists(ep));
+        s.stop();
+        assertFalse(Files.exists(ep));
+    }
+
+    private static HttpResponse<String> post(int port, String token, String body) throws Exception {
+        HttpRequest.Builder b = HttpRequest.newBuilder(URI.create("http://127.0.0.1:" + port + "/mcp"))
+                .timeout(Duration.ofSeconds(5))
+                .POST(HttpRequest.BodyPublishers.ofString(body));
+        if (token != null) {
+            b.header("Authorization", "Bearer " + token);
+        }
+        return HttpClient.newHttpClient().send(b.build(), HttpResponse.BodyHandlers.ofString());
+    }
+}


### PR DESCRIPTION
## Summary

Embeds a minimal **Model Context Protocol** server in the running editor so an LLM agent (Claude Code, Claude Desktop via a proxy, etc.) can observe live editor state and drive the command registry. Off by default, gated by `Settings.mcpSupport`. The differentiated value over a plain filesystem agent: it sees **unsaved** buffer text and **live** LSP diagnostics, and edits made via `execute_command` land in the undo stack.

### Architecture
- New `com.editora.mcp` package (no `module-info` change — `jdk.httpserver` + Jackson are already present):
  - `McpServer` — loopback-only `HttpServer` on an ephemeral port (modeled on `web.LivePreviewServer`), **bearer-token auth**, writes `<configDir>/mcp-endpoint.json` for discovery. JSON-RPC over the MCP Streamable-HTTP request/response subset (one POST → one JSON response; no SSE).
  - `McpTools` — 6 tools: `list_open_files`, `read_buffer`, `get_diagnostics`, `find_in_files`, `list_commands`, `execute_command`. Bridge records mapped to JSON by hand (no reflection on `mcp` types → no `opens`).
  - `JsonRpc` — pure 2.0 framing.
  - `McpBridge` — the seam; `MainController` implements it and marshals every read onto the FX thread.
- Wiring mirrors the existing gated-feature idiom (`applyMcpSupport`/`ifMcp`, palette filter, `view.toggleMcp` + `mcp.copyEndpoint`, Settings → **MCP Server** page).

### Security & UX
- **Loopback-only + per-session bearer token** is the gate; off by default.
- **Security-notice dialog** before enabling, at both arming points (palette toggle + Settings checkbox, which reverts on cancel).
- **Status-bar "MCP" indicator** — green/bold, clickable to copy the connection command; hidden when off and in Simple UI mode.
- Settings schema `27 → 28` (additive-identity migration); i18n in all six catalogs.

### Multi-window caveat
The server is a single app-wide instance — the first window with the feature on owns it and is the bridge. If that window closes, the server stops until a settings re-apply re-arms it. Documented in-code.

## Verification
- `mvn spotless:check` clean; `mvn test` → **783 tests pass** (incl. `MessagesTest` key-parity, config migration).
- New tests: `JsonRpcTest` (framing) + `McpServerTest` (real loopback HTTP round-trip: auth, `tools/list`, `tools/call`, endpoint-file lifecycle).
- Runtime (`--dev`): the real app started the server, wrote the endpoint descriptor, and a live `curl` confirmed 401-without-token, `tools/list`, `list_open_files` (live FX read), and `execute_command`.

## Connecting a client
`mcp.copyEndpoint` (or the status-bar segment) copies a ready-to-paste:
`claude mcp add --transport http editora <url> --header "Authorization: Bearer <token>"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)