### PR TITLE
Align file-type icons in the Project tree (fixed-size icon box)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **File-type icons now line up in the Project tree (and other file lists).** Each glyph's node bounds equal
+  its ink, which varies per file type, so the icon column had a ragged width and file names jumped left/right
+  (and the taller document glyphs sat high). Every file/folder glyph is now centered in a fixed-size box, so
+  names start at the same x and icons are vertically centered. Applies wherever file icons appear — the tree,
+  tabs, the Open-Files / Recent pickers, and the Switcher.
+
 - **Distinct icons for the tab right-click close menu.** The six close commands (Close, Close Other Tabs,
   Close All Tabs, Close Unmodified Tabs, Close Tabs to the Left/Right) all shared the plain ✕. They now each
   carry a variant of the ✕ so they're distinguishable at a glance: one small square (other), three squares

--- a/src/main/java/com/editora/ui/FileIcons.java
+++ b/src/main/java/com/editora/ui/FileIcons.java
@@ -3,7 +3,9 @@ package com.editora.ui;
 import java.util.Locale;
 import java.util.Map;
 
+import javafx.geometry.Pos;
 import javafx.scene.Node;
+import javafx.scene.layout.StackPane;
 
 import com.editora.editor.LanguageRegistry;
 
@@ -316,12 +318,36 @@ public final class FileIcons {
                             + ".223 12.223 0 0 0 5.32-10.604Z"));
 
     /**
-     * A fresh glyph node for {@code fileName}, reflecting its type. Falls back to the generic
-     * document glyph for unknown types.
+     * A fresh glyph node for {@code fileName}, reflecting its type, centered in a fixed-size box so
+     * names line up in a list (see {@link #boxed}). Falls back to the generic document glyph for
+     * unknown types.
      */
     public static Node forFileName(String fileName) {
         String path = PATHS.get(iconKeyFor(fileName));
-        return path == null ? Icons.fileSheet() : Icons.of(path);
+        return boxed(path == null ? Icons.fileSheet() : Icons.of(path));
+    }
+
+    /**
+     * Side of the fixed square every file/folder glyph is centered in. Each glyph's node bounds equal
+     * its <em>ink</em> bounds, which vary per glyph (a wide document sheet vs. a narrow {@code <>}), so
+     * placed raw they'd give the icon column a ragged width and shift the following label. Centering in
+     * a constant box gives one icon-column width and vertically centers the glyph. {@code 20} comfortably
+     * holds a 24dp glyph at the {@code Icons} 0.8 scale (19.2 px).
+     */
+    private static final double ICON_BOX = 20;
+
+    /**
+     * Wraps {@code icon} in a fixed-size, centered box so rows in a file list (the Project tree, tabs,
+     * pickers, the Switcher) align regardless of each glyph's intrinsic width/height.
+     */
+    public static Node boxed(Node icon) {
+        StackPane box = new StackPane(icon);
+        box.setMinSize(ICON_BOX, ICON_BOX);
+        box.setPrefSize(ICON_BOX, ICON_BOX);
+        box.setMaxSize(ICON_BOX, ICON_BOX);
+        box.setAlignment(Pos.CENTER);
+        box.setMouseTransparent(true); // purely decorative — let clicks reach the row
+        return box;
     }
 
     /**

--- a/src/main/java/com/editora/ui/ProjectPanel.java
+++ b/src/main/java/com/editora/ui/ProjectPanel.java
@@ -574,7 +574,12 @@ public class ProjectPanel extends VBox implements ToolWindowContent {
             }
             setText(dirty ? "• " + label : label);
             Path fileName = item.getFileName();
-            setGraphic(isDir ? Icons.project() : FileIcons.forFileName(fileName == null ? label : fileName.toString()));
+            // Box the folder glyph in the same fixed icon column as the (already-boxed) file glyphs, so
+            // folder and file rows share one icon width and every label starts at the same x.
+            setGraphic(
+                    isDir
+                            ? FileIcons.boxed(Icons.project())
+                            : FileIcons.forFileName(fileName == null ? label : fileName.toString()));
             setContextMenu(isRoot ? null : contextMenuFor(getTreeItem(), isDir));
         }
 


### PR DESCRIPTION
## Problem

In the Project tree, file-type icons were misaligned — the icon column had a ragged width so file names shifted left/right, and the taller document glyphs (AUTHORS, LICENSE, mvnw, NOTICE…) sat high. Folders lined up because they all share the one `Icons.project()` glyph; files didn't.

## Cause

Each glyph is an `SVGPath` wrapped in a `Group`, whose layout bounds equal the glyph's **ink** bounds. Those vary per file type (a full-width document sheet vs. the narrow `<>` for `pom.xml`), so the tree cell's graphic width varied and the following label moved.

## Fix

`FileIcons.boxed(Node)` centers any glyph in a fixed 20×20 box (min/pref/max + `Pos.CENTER`); `forFileName` returns the glyph boxed, and `ProjectPanel` boxes the folder glyph in the same column. Result: one constant icon-column width, every label starts at the same x, and glyphs are vertically centered.

- The box is `mouseTransparent`, so row clicks still register.
- Glyphs keep their `.toolbar-icon` styling and the folder/file theme colors (descendant CSS still matches through the wrapper).
- Applies wherever file icons appear: the tree, tabs, the Open-Files / Recent pickers, and the Switcher.

## Scope

UI layout only — no behavior change, no new dependency, no i18n. `./mvnw verify` → BUILD SUCCESS, 776 tests (`FileIconsTest` exercises the pure `iconKeyFor`, unaffected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)