### PR TITLE
Add "Show Local History" + a "Git" submenu to the Project tree menu

### DIFF
--- a/src/main/java/com/editora/ui/MainController.java
+++ b/src/main/java/com/editora/ui/MainController.java
@@ -2031,6 +2031,37 @@ public class MainController implements com.editora.mcp.McpBridge {
         projectPanel.setOnNewFromTemplate(this::newFromTemplate); // folder "New From Template…"
         projectPanel.setOnReveal((p, dir) -> revealInFileManager(p, dir, com.editora.vfs.Vfs.isLocal(p)));
         projectPanel.setOnOpenTerminal((p, dir) -> openTerminalAt(p, dir, com.editora.vfs.Vfs.isLocal(p)));
+        projectPanel.setFileActions(new ProjectPanel.FileActions() {
+            @Override
+            public boolean localHistoryEnabled() {
+                return MainController.this.localHistoryEnabled();
+            }
+
+            @Override
+            public void showLocalHistory(Path file) {
+                showLocalHistoryForPath(file);
+            }
+
+            @Override
+            public boolean gitEnabled() {
+                return MainController.this.gitEnabled();
+            }
+
+            @Override
+            public void gitShowFileHistory(Path file) {
+                ifGit(() -> gitFileHistoryForPath(file));
+            }
+
+            @Override
+            public void gitCompareWithHead(Path file) {
+                ifGit(() -> diffPathVsHead(file));
+            }
+
+            @Override
+            public void gitStage(Path file) {
+                ifGit(() -> gitStageForPath(file));
+            }
+        });
         projectToolWindow = new ToolWindow(
                 "project",
                 tr("toolwindow.project"),
@@ -4476,16 +4507,24 @@ public class MainController implements com.editora.mcp.McpBridge {
             setStatus(tr("status.diff.noFile"));
             return;
         }
+        diffPathVsHead(b.getPath());
+    }
+
+    /** Opens a read-only diff of {@code path} at HEAD (left) vs its working-tree text (right). */
+    private void diffPathVsHead(Path path) {
+        if (path == null || Files.isDirectory(path)) {
+            setStatus(tr("status.diff.noFile"));
+            return;
+        }
         if (currentRepoRoot == null) {
             setStatus(tr(gitService.gitAvailable() ? "status.notARepo" : "status.gitNotInstalled"));
             return;
         }
-        String rel = com.editora.git.GitService.repoRelative(currentRepoRoot, b.getPath());
+        String rel = com.editora.git.GitService.repoRelative(currentRepoRoot, path);
         if (rel == null) {
             setStatus(tr("status.diff.notInRepo"));
             return;
         }
-        Path path = b.getPath();
         String name = path.getFileName().toString();
         openDiff(
                 tr("diff.title.vsHead", name),
@@ -5193,6 +5232,48 @@ public class MainController implements com.editora.mcp.McpBridge {
         }
         refreshLocalHistory();
         toolWindows.open(fileHistoryToolWindow);
+    }
+
+    // --- Project tree "Show Local History" / "Git" submenu (act on a tree path, not the active tab) ---
+
+    /**
+     * Project-tree "Show Local History": opens {@code file} (the Local History tool window is keyed to the
+     * active buffer) then shows its history. No-op for a folder / when the feature is off / a remote file.
+     */
+    private void showLocalHistoryForPath(Path file) {
+        if (!localHistoryEnabled()) {
+            setStatus(tr("status.history.disabled"));
+            return;
+        }
+        if (file == null || Files.isDirectory(file) || !com.editora.vfs.Vfs.isLocal(file)) {
+            setStatus(tr("status.history.noFile"));
+            return;
+        }
+        openPath(file); // makes it the active buffer, which the history tool window tracks
+        showLocalHistory();
+    }
+
+    /** Project-tree Git ▸ Show File History for {@code file}: loads that file's Git log + opens the window. */
+    private void gitFileHistoryForPath(Path file) {
+        if (file == null || Files.isDirectory(file)) {
+            setStatus(tr("status.diff.noFile"));
+            return;
+        }
+        loadGitLog(file);
+        toolWindows.open(gitLogToolWindow);
+    }
+
+    /** Project-tree Git ▸ Stage File for {@code file}: {@code git add -- <relpath>}. */
+    private void gitStageForPath(Path file) {
+        if (file == null || Files.isDirectory(file) || currentRepoRoot == null) {
+            setStatus(tr("status.noGitFile"));
+            return;
+        }
+        gitOp(
+                "Staged " + file.getFileName(),
+                "add",
+                "--",
+                currentRepoRoot.relativize(file.toAbsolutePath()).toString());
     }
 
     /** Opens a read-only diff of {@code revision} (left) vs the active file's current text (right). */

--- a/src/main/java/com/editora/ui/ProjectPanel.java
+++ b/src/main/java/com/editora/ui/ProjectPanel.java
@@ -25,6 +25,7 @@ import javafx.scene.control.Alert;
 import javafx.scene.control.ButtonType;
 import javafx.scene.control.ContextMenu;
 import javafx.scene.control.Label;
+import javafx.scene.control.Menu;
 import javafx.scene.control.MenuItem;
 import javafx.scene.control.TextField;
 import javafx.scene.control.TreeCell;
@@ -63,6 +64,27 @@ public class ProjectPanel extends VBox implements ToolWindowContent {
     private BiConsumer<Path, Boolean> onReveal;
     /** Injected by MainController: open a terminal at a path's folder. Args: (path, isDirectory). */
     private BiConsumer<Path, Boolean> onOpenTerminal;
+    /** Injected by MainController: per-file Local History + Git actions for the cell menu (files only). */
+    private FileActions fileActions;
+
+    /**
+     * File-scoped actions the Project tree's cell menu offers — Local History and Git. Injected by
+     * {@code MainController} so the panel stays decoupled from the editor/history/git internals. The
+     * {@code *Enabled} flags gate (disable) the corresponding menu entries to match the feature toggles.
+     */
+    public interface FileActions {
+        boolean localHistoryEnabled();
+
+        void showLocalHistory(Path file);
+
+        boolean gitEnabled();
+
+        void gitShowFileHistory(Path file);
+
+        void gitCompareWithHead(Path file);
+
+        void gitStage(Path file);
+    }
 
     /** In-scene single-line prompt (injected by MainController) used to rename a file/folder. */
     private OverlayInput.Prompt prompt;
@@ -421,6 +443,11 @@ public class ProjectPanel extends VBox implements ToolWindowContent {
         this.onOpenTerminal = onOpenTerminal;
     }
 
+    /** Injects the per-file Local History + Git actions shown on a file cell's menu. */
+    public void setFileActions(FileActions fileActions) {
+        this.fileActions = fileActions;
+    }
+
     private void renameItem(TreeItem<Path> item) {
         if (prompt == null) {
             return;
@@ -629,6 +656,36 @@ public class ProjectPanel extends VBox implements ToolWindowContent {
                 terminal.setGraphic(Icons.terminal());
                 terminal.setOnAction(e -> onOpenTerminal.accept(treeItem.getValue(), isDir));
                 menu.getItems().add(terminal);
+            }
+            // Local History + Git act on a concrete file (not a folder).
+            if (fileActions != null && !isDir) {
+                Path file = treeItem.getValue();
+                menu.getItems().add(new javafx.scene.control.SeparatorMenuItem());
+
+                MenuItem localHistory = new MenuItem(tr("project.menu.localHistory"));
+                localHistory.setGraphic(Icons.history());
+                localHistory.setOnAction(e -> fileActions.showLocalHistory(file));
+                menu.getItems().add(localHistory);
+
+                Menu git = new Menu(tr("project.menu.git"));
+                git.setGraphic(Icons.git());
+                MenuItem fileHistory = new MenuItem(tr("project.menu.git.fileHistory"));
+                fileHistory.setGraphic(Icons.gitLog());
+                fileHistory.setOnAction(e -> fileActions.gitShowFileHistory(file));
+                MenuItem compareHead = new MenuItem(tr("project.menu.git.compareHead"));
+                compareHead.setGraphic(Icons.diff());
+                compareHead.setOnAction(e -> fileActions.gitCompareWithHead(file));
+                MenuItem stage = new MenuItem(tr("project.menu.git.stage"));
+                stage.setGraphic(Icons.stageAll());
+                stage.setOnAction(e -> fileActions.gitStage(file));
+                git.getItems().addAll(fileHistory, compareHead, stage);
+                menu.getItems().add(git);
+
+                // Disable to match the live feature toggles, mirroring the tab context menu.
+                menu.setOnShowing(e -> {
+                    localHistory.setDisable(!fileActions.localHistoryEnabled());
+                    git.setDisable(!fileActions.gitEnabled());
+                });
             }
             return menu;
         }

--- a/src/main/resources/com/editora/i18n/messages.properties
+++ b/src/main/resources/com/editora/i18n/messages.properties
@@ -944,6 +944,11 @@ project.menu.rename=Rename…
 project.menu.delete=Delete…
 project.menu.revealInFileManager=Reveal in File Manager
 project.menu.openTerminal=Open Terminal Here
+project.menu.localHistory=Show Local History
+project.menu.git=Git
+project.menu.git.fileHistory=Show File History
+project.menu.git.compareHead=Compare with HEAD
+project.menu.git.stage=Stage File
 projectcombo.noProject=No Project
 projectcombo.deleteTip=Delete project
 

--- a/src/main/resources/com/editora/i18n/messages_de.properties
+++ b/src/main/resources/com/editora/i18n/messages_de.properties
@@ -940,6 +940,11 @@ project.menu.rename=Umbenennen…
 project.menu.delete=Löschen…
 project.menu.revealInFileManager=Im Dateimanager anzeigen
 project.menu.openTerminal=Terminal hier öffnen
+project.menu.localHistory=Lokalen Verlauf anzeigen
+project.menu.git=Git
+project.menu.git.fileHistory=Dateiverlauf anzeigen
+project.menu.git.compareHead=Mit HEAD vergleichen
+project.menu.git.stage=Datei vormerken
 projectcombo.noProject=Kein Projekt
 projectcombo.deleteTip=Projekt löschen
 

--- a/src/main/resources/com/editora/i18n/messages_es.properties
+++ b/src/main/resources/com/editora/i18n/messages_es.properties
@@ -940,6 +940,11 @@ project.menu.rename=Renombrar…
 project.menu.delete=Eliminar…
 project.menu.revealInFileManager=Mostrar en el explorador de archivos
 project.menu.openTerminal=Abrir terminal aquí
+project.menu.localHistory=Mostrar historial local
+project.menu.git=Git
+project.menu.git.fileHistory=Mostrar historial del archivo
+project.menu.git.compareHead=Comparar con HEAD
+project.menu.git.stage=Preparar archivo
 projectcombo.noProject=Sin proyecto
 projectcombo.deleteTip=Eliminar proyecto
 

--- a/src/main/resources/com/editora/i18n/messages_fr.properties
+++ b/src/main/resources/com/editora/i18n/messages_fr.properties
@@ -940,6 +940,11 @@ project.menu.rename=Renommer…
 project.menu.delete=Supprimer…
 project.menu.revealInFileManager=Afficher dans le gestionnaire de fichiers
 project.menu.openTerminal=Ouvrir un terminal ici
+project.menu.localHistory=Afficher l'historique local
+project.menu.git=Git
+project.menu.git.fileHistory=Afficher l'historique du fichier
+project.menu.git.compareHead=Comparer avec HEAD
+project.menu.git.stage=Indexer le fichier
 projectcombo.noProject=Aucun projet
 projectcombo.deleteTip=Supprimer le projet
 

--- a/src/main/resources/com/editora/i18n/messages_it.properties
+++ b/src/main/resources/com/editora/i18n/messages_it.properties
@@ -940,6 +940,11 @@ project.menu.rename=Rinomina…
 project.menu.delete=Elimina…
 project.menu.revealInFileManager=Mostra nel file manager
 project.menu.openTerminal=Apri terminale qui
+project.menu.localHistory=Mostra cronologia locale
+project.menu.git=Git
+project.menu.git.fileHistory=Mostra cronologia del file
+project.menu.git.compareHead=Confronta con HEAD
+project.menu.git.stage=Prepara file
 projectcombo.noProject=Nessun progetto
 projectcombo.deleteTip=Elimina progetto
 

--- a/src/main/resources/com/editora/i18n/messages_pt.properties
+++ b/src/main/resources/com/editora/i18n/messages_pt.properties
@@ -940,6 +940,11 @@ project.menu.rename=Renomear…
 project.menu.delete=Excluir…
 project.menu.revealInFileManager=Mostrar no gerenciador de arquivos
 project.menu.openTerminal=Abrir terminal aqui
+project.menu.localHistory=Mostrar histórico local
+project.menu.git=Git
+project.menu.git.fileHistory=Mostrar histórico do arquivo
+project.menu.git.compareHead=Comparar com HEAD
+project.menu.git.stage=Preparar arquivo
 projectcombo.noProject=Sem projeto
 projectcombo.deleteTip=Excluir projeto
 


### PR DESCRIPTION
Adds two file-scoped entries to the **Project tool window** right-click menu (files only, separated below the Reveal/Terminal group):

- **Show Local History** — opens the file and shows its Local File History tool window.
- **Git ▸** submenu — **Show File History**, **Compare with HEAD**, **Stage File**.

Both mirror actions already on the editor tab menu, but act on the **clicked tree path** rather than the active tab. Each is disabled (greyed) when its feature toggle is off, refreshed live via `setOnShowing`.

## Wiring
- **ProjectPanel** — a decoupled `FileActions` interface + `setFileActions(...)` injector (keeps the panel free of history/git internals); the menu items.
- **MainController** — implements `FileActions`; extracts a path-aware `diffPathVsHead(Path)` from `diffActiveVsHead()`, and adds `showLocalHistoryForPath` / `gitFileHistoryForPath` / `gitStageForPath` (Git ones `ifGit`-gated; reuse `loadGitLog(Path)` + the history tool window, so Git file-history forces no extra tab open).
- i18n: five `project.menu.*` keys across all six catalogs (reusing existing translated wording).

## Testing
- `mvn spotless:check test` green (full suite, Messages key-parity enforced); app boots and renders without error.

## Performance
Negligible — context-menu construction only, built per cell render as before; no hot-path impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)