### PR TITLE
Add Comment / Uncomment to the editor right-click menu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -96,6 +96,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **"Comment / Uncomment" in the editor right-click menu.** For files whose language has comment syntax, the
+  code-area context menu now offers Comment / Uncomment (the same action as the `M-;` keybinding and the
+  command palette) — it line-comments the caret's line or block/line-comments the selection, and toggles back
+  off when already commented. Hidden for plaintext (no comment syntax) and while read-only.
+
 - **Per-file-type icons.** File icons now reflect the file's type instead of a single generic document glyph.
   Editing `Main.java` shows the Java logo, `app.py` the Python logo, `style.css` the CSS logo, an image its
   picture glyph, a `.zip` an archive glyph, and so on — covering every language/format Editora supports

--- a/src/main/java/com/editora/editor/EditorBuffer.java
+++ b/src/main/java/com/editora/editor/EditorBuffer.java
@@ -625,6 +625,39 @@ public class EditorBuffer implements TabContent {
         a.requestFocus();
     }
 
+    /**
+     * True when this buffer's language has comment syntax and the buffer is editable — i.e. the
+     * "Comment / Uncomment" action is offered (right-click menu) and would do something. Plaintext has
+     * no comment syntax, so it's excluded.
+     */
+    public boolean supportsComments() {
+        Commenter.CommentStyle s = Commenter.styleFor(language);
+        return (s.hasLine() || s.hasBlock()) && isEditable() && !largeFile;
+    }
+
+    /**
+     * Toggles line/region comments on the selection (or the caret's line when nothing is selected),
+     * Emacs comment-dwim style. Returns {@code false} when the language has no comment syntax or the
+     * buffer isn't editable. Kept in {@code editor} (mirroring the Markdown format methods) so the editor
+     * context menu can invoke it without depending on {@code ui}; {@code MainController.toggleComment}
+     * delegates here.
+     */
+    public boolean toggleComment() {
+        if (!isEditable() || largeFile) {
+            return false;
+        }
+        CodeArea a = focusedArea != null ? focusedArea : area;
+        Commenter.Edit edit = Commenter.toggle(
+                a.getText(), a.getSelection().getStart(), a.getSelection().getEnd(), Commenter.styleFor(language));
+        if (edit == null) {
+            return false;
+        }
+        a.replaceText(edit.from(), edit.to(), edit.replacement());
+        a.selectRange(edit.selStart(), edit.selEnd());
+        a.requestFocus();
+        return true;
+    }
+
     /** Toggles an inline marker ({@code **}/{@code *}/{@code ~~}/{@code `}) around the selection. */
     public void formatInline(String marker) {
         if (!canFormatMarkdown()) {
@@ -848,6 +881,13 @@ public class EditorBuffer implements TabContent {
             }
             if (canFormatMarkdown()) {
                 items.addAll(markdownMenuItems());
+                items.add(new SeparatorMenuItem());
+            }
+            if (supportsComments()) {
+                MenuItem comment = new MenuItem(tr("editmenu.toggleComment"));
+                comment.setGraphic(MenuIcons.comment());
+                comment.setOnAction(ev -> toggleComment());
+                items.add(comment);
                 items.add(new SeparatorMenuItem());
             }
             items.addAll(standardMenuItems());

--- a/src/main/java/com/editora/editor/MenuIcons.java
+++ b/src/main/java/com/editora/editor/MenuIcons.java
@@ -93,6 +93,11 @@ final class MenuIcons {
         return of("M9.4 16.6L4.8 12l4.6-4.6L8 6l-6 6 6 6 1.4-1.4zm5.2 0l4.6-4.6-4.6-4.6L16 6l6 6-6 6-1.4-1.4z");
     }
 
+    /** Two slashes "//" — comment / uncomment. */
+    static Node comment() {
+        return of("M4 18 8 6 10 6 6 18z M12 18 16 6 18 6 14 18z");
+    }
+
     /** Material "insert_link". */
     static Node link() {
         return of("M3.9 12c0-1.71 1.39-3.1 3.1-3.1h4V7H7c-2.76 0-5 2.24-5 5s2.24 5 5 5h4v-1.9H7c-1.71 "

--- a/src/main/java/com/editora/ui/MainController.java
+++ b/src/main/java/com/editora/ui/MainController.java
@@ -10224,20 +10224,10 @@ public class MainController implements com.editora.mcp.McpBridge {
         if (buffer == null) {
             return;
         }
-        CodeArea area = buffer.getFocusedArea();
-        com.editora.editor.Commenter.CommentStyle style = com.editora.editor.Commenter.styleFor(buffer.getLanguage());
-        com.editora.editor.Commenter.Edit edit = com.editora.editor.Commenter.toggle(
-                area.getText(),
-                area.getSelection().getStart(),
-                area.getSelection().getEnd(),
-                style);
-        if (edit == null) {
+        // The comment logic lives on the buffer (so the editor right-click menu can invoke it too).
+        if (!buffer.toggleComment()) {
             setStatus(tr("status.noCommentSyntax"));
-            return;
         }
-        area.replaceText(edit.from(), edit.to(), edit.replacement());
-        area.selectRange(edit.selStart(), edit.selEnd());
-        area.requestFocus();
     }
 
     /** Applies an Emacs transpose (chars/words/lines) to the active editable buffer at the caret. */

--- a/src/main/resources/com/editora/i18n/messages.properties
+++ b/src/main/resources/com/editora/i18n/messages.properties
@@ -867,6 +867,7 @@ editmenu.paste=Paste
 editmenu.undo=Undo
 editmenu.redo=Redo
 editmenu.selectAll=Select All
+editmenu.toggleComment=Comment / Uncomment
 editmenu.noSuggestions=No suggestions
 editmenu.addToDictionary=Add to Dictionary
 editmenu.ignore=Ignore

--- a/src/main/resources/com/editora/i18n/messages_de.properties
+++ b/src/main/resources/com/editora/i18n/messages_de.properties
@@ -863,6 +863,7 @@ editmenu.paste=Einfügen
 editmenu.undo=Rückgängig
 editmenu.redo=Wiederholen
 editmenu.selectAll=Alles auswählen
+editmenu.toggleComment=Ein-/Auskommentieren
 editmenu.noSuggestions=Keine Vorschläge
 editmenu.addToDictionary=Zum Wörterbuch hinzufügen
 editmenu.ignore=Ignorieren

--- a/src/main/resources/com/editora/i18n/messages_es.properties
+++ b/src/main/resources/com/editora/i18n/messages_es.properties
@@ -863,6 +863,7 @@ editmenu.paste=Pegar
 editmenu.undo=Deshacer
 editmenu.redo=Rehacer
 editmenu.selectAll=Seleccionar todo
+editmenu.toggleComment=Comentar / Descomentar
 editmenu.noSuggestions=Sin sugerencias
 editmenu.addToDictionary=Añadir al diccionario
 editmenu.ignore=Ignorar

--- a/src/main/resources/com/editora/i18n/messages_fr.properties
+++ b/src/main/resources/com/editora/i18n/messages_fr.properties
@@ -863,6 +863,7 @@ editmenu.paste=Coller
 editmenu.undo=Annuler
 editmenu.redo=Rétablir
 editmenu.selectAll=Tout sélectionner
+editmenu.toggleComment=Commenter / Décommenter
 editmenu.noSuggestions=Aucune suggestion
 editmenu.addToDictionary=Ajouter au dictionnaire
 editmenu.ignore=Ignorer

--- a/src/main/resources/com/editora/i18n/messages_it.properties
+++ b/src/main/resources/com/editora/i18n/messages_it.properties
@@ -863,6 +863,7 @@ editmenu.paste=Incolla
 editmenu.undo=Annulla
 editmenu.redo=Ripeti
 editmenu.selectAll=Seleziona tutto
+editmenu.toggleComment=Commenta / Decommenta
 editmenu.noSuggestions=Nessun suggerimento
 editmenu.addToDictionary=Aggiungi al dizionario
 editmenu.ignore=Ignora

--- a/src/main/resources/com/editora/i18n/messages_pt.properties
+++ b/src/main/resources/com/editora/i18n/messages_pt.properties
@@ -863,6 +863,7 @@ editmenu.paste=Colar
 editmenu.undo=Desfazer
 editmenu.redo=Refazer
 editmenu.selectAll=Selecionar tudo
+editmenu.toggleComment=Comentar / Descomentar
 editmenu.noSuggestions=Sem sugestões
 editmenu.addToDictionary=Adicionar ao dicionário
 editmenu.ignore=Ignorar


### PR DESCRIPTION
## What

For files whose language has comment syntax, the code-area right-click menu now offers **Comment / Uncomment** — the same action as the `M-;` keybinding and the command palette. It line-comments the caret's line, block/line-comments a selection, and toggles back off when already commented. Hidden for plaintext (no comment syntax) and while the buffer is read-only.

## How

- `EditorBuffer.supportsComments()` (language has comment syntax via `Commenter.styleFor`, editable, not large-file) gates the menu item; `EditorBuffer.toggleComment()` applies the existing pure `Commenter` to the focused area — kept in `editor` (mirroring the Markdown format methods) so the context menu can invoke it without depending on `ui`.
- `MainController.toggleComment()` (the `M-;` command) now delegates to `buffer.toggleComment()` instead of duplicating the `Commenter` logic — same behavior, plus it still shows the "no comment syntax" status on the keymap path.
- New `MenuIcons.comment()` glyph ("//"); `editmenu.toggleComment` added to all six i18n catalogs.

## Scope / perf

No behavior change to the existing command; no new dependency. `supportsComments()` is a cheap language `switch`, evaluated only when the menu opens. `./mvnw verify` → BUILD SUCCESS, 787 tests (incl. `MessagesTest` six-locale parity).

🤖 Generated with [Claude Code](https://claude.com/claude-code)