### PR TITLE
Fix right-click Copy/Cut/Paste on a column (box) selection

### DIFF
--- a/src/main/java/com/editora/editor/EditorBuffer.java
+++ b/src/main/java/com/editora/editor/EditorBuffer.java
@@ -981,20 +981,38 @@ public class EditorBuffer implements TabContent {
 
     /** The Cut/Copy/Paste/Undo/Redo/Select All items, with state for the current selection/clipboard. */
     private List<MenuItem> standardMenuItems() {
-        boolean hasSelection = area.getSelection().getLength() > 0;
+        // Cut/Copy/Paste route through the multi-caret-aware path first (falling back to the native single-
+        // caret op), so a box/column selection copies *every* caret's selection — matching the edit.cut/
+        // copy/paste commands. Without this, area.copy() only grabs the primary caret's row. A box selection
+        // makes copy/cut available even when the primary selection is empty (extra carets carry the rest).
+        boolean hasMulti = hasMultipleCarets();
+        boolean canCopy = area.getSelection().getLength() > 0 || hasMulti;
+        boolean editable = isEditable();
         boolean hasClipboardText = Clipboard.getSystemClipboard().hasString();
         MenuItem cut = new MenuItem(tr("editmenu.cut"));
         cut.setGraphic(MenuIcons.cut());
-        cut.setOnAction(e -> area.cut());
-        cut.setDisable(!hasSelection);
+        cut.setOnAction(e -> {
+            if (!multiCaretCut()) {
+                area.cut();
+            }
+        });
+        cut.setDisable(!canCopy || !editable);
         MenuItem copy = new MenuItem(tr("editmenu.copy"));
         copy.setGraphic(MenuIcons.copy());
-        copy.setOnAction(e -> area.copy());
-        copy.setDisable(!hasSelection);
+        copy.setOnAction(e -> {
+            if (!multiCaretCopy()) {
+                area.copy();
+            }
+        });
+        copy.setDisable(!canCopy);
         MenuItem paste = new MenuItem(tr("editmenu.paste"));
         paste.setGraphic(MenuIcons.paste());
-        paste.setOnAction(e -> area.paste());
-        paste.setDisable(!hasClipboardText);
+        paste.setOnAction(e -> {
+            if (!multiCaretPaste()) {
+                area.paste();
+            }
+        });
+        paste.setDisable(!hasClipboardText || !editable);
         MenuItem undo = new MenuItem(tr("editmenu.undo"));
         undo.setGraphic(MenuIcons.undo());
         undo.setOnAction(e -> area.undo());


### PR DESCRIPTION
## Bug
With a column/box selection (Alt+drag multi-caret), the editor's **right-click Copy** copied only part of the selection (the primary caret's row). The command palette and keybindings worked.

## Cause
The context-menu Cut/Copy/Paste called the native `area.cut()/copy()/paste()`, which only act on the **primary** caret's selection. The extra carets' selections live in the RichTextFX fork's `MultiCaretManager`, which the native ops ignore. `MainController.onCopy()` (the command) already routed through `buffer.multiCaretCopy()` first — hence the palette/keybinding path worked.

## Fix
In `EditorBuffer.standardMenuItems()`, route the three clipboard items through the multi-caret-aware methods (fallback to the native op when no extra carets), matching the command path:

```java
copy.setOnAction(e -> { if (!multiCaretCopy()) area.copy(); });
cut.setOnAction(e ->  { if (!multiCaretCut())  area.cut();  });
paste.setOnAction(e -> { if (!multiCaretPaste()) area.paste(); });
```

Plus: Cut/Copy enable on `hasSelection || hasMultipleCarets()` (a box of carets can copy its lines even with an empty primary selection), and Cut/Paste are gated on `isEditable()` since the multi-caret ops mutate text (the native ops silently no-op'd in read-only/View mode).

## Testing
- `mvn spotless:check test` green (full suite); app boots and renders without error.
- GUI wiring (column selection needs the multi-caret fork + mouse), so not unit-testable here — but it reuses the exact `multiCaretCopy/Cut/Paste` methods the palette/keybindings already use. Manually verified: Alt+drag column select → right-click → Copy → paste yields the full selection.

## Performance
Negligible — menu built only on right-click; the added checks are cheap flag reads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)