### PR TITLE
Right-click a tool-window stripe icon to hide it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -96,6 +96,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Right-click a tool-window icon → Hide.** Right-clicking a button in the tool-window stripe now offers
+  **Hide**, which removes that icon from the stripe (persisted). Bring it back from Settings → Tool Windows.
+
 - **Reveal in File Manager / Open Terminal Here from the breadcrumb.** Clicking a folder or file crumb in the
   navigation bar now lists **Reveal in File Manager** and **Open Terminal Here** for that crumb (above the
   folder-contents dropdown) — Reveal selects the file or opens the folder; Open Terminal opens at the folder

--- a/src/main/java/com/editora/ui/ToolWindowManager.java
+++ b/src/main/java/com/editora/ui/ToolWindowManager.java
@@ -16,6 +16,8 @@ import javafx.geometry.Pos;
 import javafx.scene.Node;
 import javafx.scene.SnapshotParameters;
 import javafx.scene.control.Button;
+import javafx.scene.control.ContextMenu;
+import javafx.scene.control.MenuItem;
 import javafx.scene.control.SplitPane;
 import javafx.scene.control.Tooltip;
 import javafx.scene.input.ClipboardContent;
@@ -31,6 +33,8 @@ import javafx.scene.paint.Color;
 import com.editora.command.KeymapManager;
 import com.editora.config.ConfigManager;
 import com.editora.config.WorkspaceState;
+
+import static com.editora.i18n.Messages.tr;
 
 /**
  * Lays out IntelliJ-style left/right/bottom stripes around the editor area, manages registered
@@ -125,6 +129,10 @@ public class ToolWindowManager {
         button.getStyleClass().addAll("tool-stripe-button", "flat");
         button.setTooltip(new Tooltip(tooltipFor(tw)));
         button.setOnAction(e -> toggle(tw));
+        // Right-click → Hide the icon (persisted; re-show from Settings → Tool Windows).
+        MenuItem hide = new MenuItem(tr("toolwindow.hide"), Icons.closeSmall());
+        hide.setOnAction(e -> setVisible(tw, false));
+        button.setContextMenu(new ContextMenu(hide));
         enableReorderDrag(tw, button);
         stripeButtons.put(tw, button);
         if (shouldShowButton(tw)) {


### PR DESCRIPTION
## What

Right-clicking a button in the tool-window stripe now offers **Hide**, which removes that icon from the stripe. The preference is persisted; bring the icon back from **Settings → Tool Windows**.

## How

Each stripe button gets a one-item `ContextMenu` whose action calls the existing `setVisible(tw, false)` — which already removes the button from the stripe, closes the window if it's open, and saves the per-window visibility preference. Reused the existing `toolwindow.hide` label (no new i18n), no new dependency.

`./mvnw verify` → BUILD SUCCESS, 788 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)