### PR TITLE
Command palette: C-h opens the highlighted command's online docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -96,6 +96,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Open a command's online docs from the palette (C-h).** In the command palette, press **C-h** to open the
+  highlighted command's documentation page (`https://editora-project.dev/docs/commands/<id>`) in your system
+  default browser. The palette footer now lists `C-h docs` alongside the other shortcuts.
+
 - **Format Document command (LSP).** A new command-palette command **LSP: Format Document** reformats the
   whole active file via its language server (`textDocument/formatting`) — available when a server is running
   for the file's language and advertises formatting. Edits apply through the undoable buffer (so a single

--- a/src/main/java/com/editora/ui/CommandPalette.java
+++ b/src/main/java/com/editora/ui/CommandPalette.java
@@ -43,8 +43,14 @@ public class CommandPalette {
     private static final boolean IS_MAC =
             System.getProperty("os.name", "").toLowerCase(Locale.ROOT).contains("mac");
 
+    /** Base URL for per-command documentation on the website; the command id is appended. */
+    private static final String DOCS_BASE = "https://editora-project.dev/docs/commands/";
+
     private final CommandRegistry registry;
     private final KeymapManager keymap;
+    /** Injected: opens a URL in the system default browser (the highlighted command's docs, on C-h). */
+    private java.util.function.Consumer<String> docsOpener = url -> {};
+
     private Map<String, String> commandToKey;
     /** Only commands matching this predicate are listed (e.g. project commands hidden when disabled). */
     private final java.util.function.Predicate<Command> visible;
@@ -120,7 +126,7 @@ public class CommandPalette {
             String d = sel == null ? "" : sel.description();
             desc.setText(d.isEmpty() ? " " : d); // keep one line tall so the card never collapses/jitters
         });
-        Label hint = new Label("↑↓ / C-n C-p move  ·  ↵ run  ·  esc / C-g cancel");
+        Label hint = new Label(tr("palette.hint"));
         hint.getStyleClass().add("palette-hint");
         content = new VBox(6, header, input, list, desc, hint);
         content.getStyleClass().add("command-palette");
@@ -135,6 +141,11 @@ public class CommandPalette {
     /** Injects the shared overlay host used to show the palette card. */
     public void setOverlayHost(OverlayHost overlayHost) {
         this.overlayHost = overlayHost;
+    }
+
+    /** Injects the system-browser opener used by C-h to show the highlighted command's online docs. */
+    public void setDocsOpener(java.util.function.Consumer<String> docsOpener) {
+        this.docsOpener = docsOpener == null ? url -> {} : docsOpener;
     }
 
     private void onKey(KeyEvent e) {
@@ -173,8 +184,24 @@ public class CommandPalette {
                     e.consume();
                 }
             }
+            case H -> {
+                if (e.isControlDown()) {
+                    openDocs();
+                    e.consume();
+                }
+            }
             default -> {}
         }
+    }
+
+    /** C-h: open the highlighted command's online documentation in the system default browser. */
+    private void openDocs() {
+        Command command = list.getSelectionModel().getSelectedItem();
+        if (command == null) {
+            return;
+        }
+        hide();
+        docsOpener.accept(DOCS_BASE + command.id());
     }
 
     private void move(int delta) {

--- a/src/main/java/com/editora/ui/MainController.java
+++ b/src/main/java/com/editora/ui/MainController.java
@@ -1224,6 +1224,7 @@ public class MainController implements com.editora.mcp.McpBridge {
      */
     private void wireOverlayHost() {
         palette.setOverlayHost(overlayHost);
+        palette.setDocsOpener(this::openExternalUrl); // C-h → command docs in the system browser
         recentPalette.setOverlayHost(overlayHost);
         structurePalette.setOverlayHost(overlayHost);
         openFilesPalette.setOverlayHost(overlayHost);

--- a/src/main/resources/com/editora/i18n/messages.properties
+++ b/src/main/resources/com/editora/i18n/messages.properties
@@ -882,6 +882,7 @@ viewmode.note=Read-only on disk (no write permission)
 # ---- Command palette / finders / switcher ----
 palette.prompt=Run command…
 palette.header=Command Palette
+palette.hint=↑↓ / C-n C-p move  ·  ↵ run  ·  C-h docs  ·  esc / C-g cancel
 filefinder.title=Find File
 filefinder.prompt=Type a path…
 switcher.header=Open Files

--- a/src/main/resources/com/editora/i18n/messages_de.properties
+++ b/src/main/resources/com/editora/i18n/messages_de.properties
@@ -878,6 +878,7 @@ viewmode.note=Schreibgeschützt auf der Festplatte (keine Schreibberechtigung)
 # ---- Command palette / finders / switcher ----
 palette.prompt=Befehl ausführen…
 palette.header=Befehlspalette
+palette.hint=↑↓ / C-n C-p bewegen  ·  ↵ ausführen  ·  C-h Doku  ·  esc / C-g abbrechen
 filefinder.title=Datei suchen
 filefinder.prompt=Pfad eingeben…
 switcher.header=Geöffnete Dateien

--- a/src/main/resources/com/editora/i18n/messages_es.properties
+++ b/src/main/resources/com/editora/i18n/messages_es.properties
@@ -878,6 +878,7 @@ viewmode.note=Solo lectura en disco (sin permiso de escritura)
 # ---- Command palette / finders / switcher ----
 palette.prompt=Ejecutar comando…
 palette.header=Paleta de comandos
+palette.hint=↑↓ / C-n C-p mover  ·  ↵ ejecutar  ·  C-h documentación  ·  esc / C-g cancelar
 filefinder.title=Localizar archivo
 filefinder.prompt=Escribe una ruta…
 switcher.header=Archivos abiertos

--- a/src/main/resources/com/editora/i18n/messages_fr.properties
+++ b/src/main/resources/com/editora/i18n/messages_fr.properties
@@ -878,6 +878,7 @@ viewmode.note=Lecture seule sur le disque (pas de droit d'écriture)
 # ---- Command palette / finders / switcher ----
 palette.prompt=Exécuter une commande…
 palette.header=Palette de commandes
+palette.hint=↑↓ / C-n C-p déplacer  ·  ↵ exécuter  ·  C-h docs  ·  esc / C-g annuler
 filefinder.title=Trouver un fichier
 filefinder.prompt=Saisissez un chemin…
 switcher.header=Fichiers ouverts

--- a/src/main/resources/com/editora/i18n/messages_it.properties
+++ b/src/main/resources/com/editora/i18n/messages_it.properties
@@ -878,6 +878,7 @@ viewmode.note=Sola lettura su disco (nessun permesso di scrittura)
 # ---- Command palette / finders / switcher ----
 palette.prompt=Esegui comando…
 palette.header=Tavolozza comandi
+palette.hint=↑↓ / C-n C-p sposta  ·  ↵ esegui  ·  C-h documentazione  ·  esc / C-g annulla
 filefinder.title=Trova file
 filefinder.prompt=Digita un percorso…
 switcher.header=File aperti

--- a/src/main/resources/com/editora/i18n/messages_pt.properties
+++ b/src/main/resources/com/editora/i18n/messages_pt.properties
@@ -878,6 +878,7 @@ viewmode.note=Somente leitura no disco (sem permissão de escrita)
 # ---- Command palette / finders / switcher ----
 palette.prompt=Executar comando…
 palette.header=Paleta de comandos
+palette.hint=↑↓ / C-n C-p mover  ·  ↵ executar  ·  C-h docs  ·  esc / C-g cancelar
 filefinder.title=Localizar arquivo
 filefinder.prompt=Digite um caminho…
 switcher.header=Arquivos abertos


### PR DESCRIPTION
## What

In the command palette, pressing **C-h** opens the highlighted command's documentation page — `https://editora-project.dev/docs/commands/<command-id>` — in the **system default browser**, then closes the palette. The palette footer now advertises it: `↑↓ / C-n C-p move · ↵ run · C-h docs · esc / C-g cancel`.

## How

- `CommandPalette` handles `C-h` in its own key filter (it owns keys while open), checking `isControlDown()` so it's Control-H on every platform and is consumed before the text field treats it as backspace. No-ops when nothing is highlighted.
- The URL opener is injected — `CommandPalette.setDocsOpener(this::openExternalUrl)` (which uses `HostServices.showDocument`, the system browser).
- The footer hint was a hardcoded literal; it's now localized as `palette.hint` across all six catalogs (en/it/es/fr/pt/de), with the new `C-h docs` entry.

## Scope / perf

No new dependency. Trivial cost (one keypress branch + a browser launch). `./mvnw verify` → BUILD SUCCESS, 788 tests (incl. `MessagesTest` six-locale parity).

🤖 Generated with [Claude Code](https://claude.com/claude-code)