### PR TITLE
HTTP Client: right-click the response body to copy it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **HTTP Client: you can now right-click the response body to copy it.** The response body is a read-only
+  RichTextFX editor, which (unlike the headers' text area) has no built-in context menu, so right-clicking the
+  JSON/XML/etc. output did nothing. It now has a **Copy** / **Select All** menu — Copy puts the selection, or
+  the whole body when nothing is selected, on the clipboard.
+
 - **Loading a large file (5–50 MB) with a language server enabled no longer freezes the editor.** Large-file
   mode already turns off syntax highlighting and the minimap, but LSP stayed on — so opening, say, a big
   `.json`/`.xml`/`.log` with its server enabled sent the whole document to the server and then mapped and

--- a/src/main/java/com/editora/ui/HttpClientPanel.java
+++ b/src/main/java/com/editora/ui/HttpClientPanel.java
@@ -9,9 +9,13 @@ import javafx.geometry.Orientation;
 import javafx.geometry.Pos;
 import javafx.scene.control.Button;
 import javafx.scene.control.ComboBox;
+import javafx.scene.control.ContextMenu;
 import javafx.scene.control.Label;
+import javafx.scene.control.MenuItem;
 import javafx.scene.control.SplitPane;
 import javafx.scene.control.TextArea;
+import javafx.scene.input.Clipboard;
+import javafx.scene.input.ClipboardContent;
 import javafx.scene.layout.HBox;
 import javafx.scene.layout.Priority;
 import javafx.scene.layout.Region;
@@ -152,6 +156,7 @@ public final class HttpClientPanel extends VBox implements ToolWindowContent {
         bodyArea.setFocusTraversable(true);
         bodyArea.setShowCaret(org.fxmisc.richtext.Caret.CaretVisibility.OFF);
         bodyArea.setWrapText(false);
+        installBodyContextMenu(); // RichTextFX has no default menu — add Copy / Select All for the response
         setEditorFont(fontFamily, fontSize);
 
         SplitPane split = new SplitPane(headersArea, new VirtualizedScrollPane<>(bodyArea));
@@ -175,6 +180,31 @@ public final class HttpClientPanel extends VBox implements ToolWindowContent {
         fontStyle = "-fx-font-family: \"" + fontFamily + "\"; -fx-font-size: " + fontSize + "px;";
         bodyArea.setStyle(fontStyle);
         headersArea.setStyle(fontStyle);
+    }
+
+    /**
+     * Right-click menu for the response body. The body is a read-only RichTextFX {@link CodeArea}, which —
+     * unlike a {@code TextArea} — has no built-in context menu, so without this there's no way to copy the
+     * response by mouse. Copy puts the selection (or the whole body when nothing is selected) on the
+     * clipboard without disturbing the selection.
+     */
+    private void installBodyContextMenu() {
+        MenuItem copy = new MenuItem(tr("editmenu.copy"), Icons.copy());
+        copy.setOnAction(e -> {
+            String text = bodyArea.getSelection().getLength() > 0 ? bodyArea.getSelectedText() : bodyArea.getText();
+            ClipboardContent cc = new ClipboardContent();
+            cc.putString(text);
+            Clipboard.getSystemClipboard().setContent(cc);
+        });
+        MenuItem selectAll = new MenuItem(tr("editmenu.selectAll"), Icons.selectAll());
+        selectAll.setOnAction(e -> bodyArea.selectAll());
+        ContextMenu menu = new ContextMenu(copy, selectAll);
+        // Use the UI font (not the body's inherited monospace), matching the editor right-click menu.
+        menu.getStyleClass().add("editor-context-menu");
+        bodyArea.setOnContextMenuRequested(e -> {
+            menu.show(bodyArea, e.getScreenX(), e.getScreenY());
+            e.consume();
+        });
     }
 
     /** No request run yet / cleared. */

--- a/src/main/java/com/editora/ui/Icons.java
+++ b/src/main/java/com/editora/ui/Icons.java
@@ -147,6 +147,14 @@ final class Icons {
                 + "0 2-.9 2-2V7c0-1.1-.9-2-2-2zm0 16H8V7h11v14z");
     }
 
+    /** Material "select_all". */
+    static Node selectAll() {
+        return of("M3 5h2V3c-1.1 0-2 .9-2 2zm0 8h2v-2H3v2zm4 8h2v-2H7v2zM3 9h2V7H3v2zm10-6h-2v2h2V3zm6 "
+                + "0v2h2c0-1.1-.9-2-2-2zM5 21v-2H3c0 1.1.9 2 2 2zm-2-4h2v-2H3v2zM9 3H7v2h2V3zm2 18h2v-2h-"
+                + "2v2zm8-8h2v-2h-2v2zm0 8c1.1 0 2-.9 2-2h-2v2zm0-12h2V7h-2v2zm0 8h2v-2h-2v2zm-4 4h2v-2h-"
+                + "2v2zm0-16h2V3h-2v2zM7 17h10V7H7v10zm2-8h6v6H9V9z");
+    }
+
     static Node paste() {
         return of("M19 2h-4.18C14.4.84 13.3 0 12 0c-1.3 0-2.4.84-2.82 2H5c-1.1 0-2 .9-2 2v16c0 1.1.9 "
                 + "2 2 2h14c1.1 0 2-.9 2-2V4c0-1.1-.9-2-2-2zm-7 0c.55 0 1 .45 1 1s-.45 1-1 1-1-.45-1-1 "


### PR DESCRIPTION
## Problem

In the HTTP Client tool window, right-clicking the JSON/XML response body did nothing — you couldn't copy it by mouse. The body is a read-only RichTextFX `CodeArea`, which (unlike the headers' `TextArea`) has no built-in context menu.

## Fix

`HttpClientPanel.bodyArea` now gets a context menu (via `setOnContextMenuRequested`, mirroring `EditorBuffer`):

- **Copy** — puts the selection, or the whole body when nothing is selected, on the clipboard (without disturbing the selection).
- **Select All**.

Consistent with the other right-click menus:
- **Icons** — `Icons.copy()` + a new `Icons.selectAll()` (the same 0.8-scale Material `toolbar-icon` glyphs the tab/project/git menus use).
- **Font** — the menu carries the `editor-context-menu` style class, so it uses the UI sans-serif font instead of inheriting the body's monospace (the same approach as the editor right-click menu).

Reuses the existing `editmenu.copy` / `editmenu.selectAll` i18n keys; no new dependency. `./mvnw verify` → BUILD SUCCESS, 788 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)