### PR TITLE
Hide/disable Git menu items when there's no VCS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Git menu items are hidden/disabled when there's no VCS.** The tab right-click menu no longer shows
+  **Compare with HEAD** and **Git: Show File History** when the file isn't under Git (feature off, or not
+  inside a repo) — only "Compare With…" (which isn't a Git action) remains. The Project tool window's **Git**
+  submenu is greyed out in the same case. Both now key off "Git available" (enabled *and* inside a repo)
+  rather than just the feature toggle.
+
 - **HTTP Client: you can now right-click the response body to copy it.** The response body is a read-only
   RichTextFX editor, which (unlike the headers' text area) has no built-in context menu, so right-clicking the
   JSON/XML/etc. output did nothing. It now has a **Copy** / **Select All** menu — Copy puts the selection, or

--- a/src/main/java/com/editora/ui/MainController.java
+++ b/src/main/java/com/editora/ui/MainController.java
@@ -2073,8 +2073,8 @@ public class MainController implements com.editora.mcp.McpBridge {
             }
 
             @Override
-            public boolean gitEnabled() {
-                return MainController.this.gitEnabled();
+            public boolean gitAvailable() {
+                return MainController.this.gitAvailable();
             }
 
             @Override
@@ -2455,6 +2455,12 @@ public class MainController implements com.editora.mcp.McpBridge {
         // Simple UI mode disables Git (status-bar VCS segment, gutter change bars, Commit window); saved setting
         // unchanged.
         return config.getSettings().isGitSupport() && !simpleModeActive();
+    }
+
+    /** True when Git actions can actually run: the feature is on AND the active context is inside a repo
+     *  (the "No VCS" state has no repo). Drives whether repo-only menu items are shown/enabled. */
+    private boolean gitAvailable() {
+        return gitEnabled() && currentRepoRoot != null;
     }
 
     /** Effective Local File History gate: the setting, but off in Simple UI mode (saved setting unchanged). */
@@ -7387,8 +7393,12 @@ public class MainController implements com.editora.mcp.McpBridge {
             terminal.setDisable(!localPath);
             copyPath.setDisable(!hasPath);
             rename.setDisable(!hasPath);
-            compareWith.setDisable(!hasPath);
-            diffHead.setDisable(!hasPath || !gitEnabled());
+            compareWith.setDisable(!hasPath); // not a Git action — works on any two files
+            // Git-only items (Compare with HEAD, Show File History) are hidden entirely when there's no VCS
+            // available for this file (Git off, or not inside a repo) — not just disabled.
+            boolean gitFile = hasPath && gitAvailable();
+            diffHead.setVisible(gitFile);
+            history.setVisible(gitFile);
             // Save is a no-op for an unchanged, on-disk file; untitled/dirty buffers can always save.
             save.setDisable(hasPath && !buffer.isDirty());
             pin.setText(pinned.contains(tab) ? "Unpin Tab" : "Pin Tab");

--- a/src/main/java/com/editora/ui/ProjectPanel.java
+++ b/src/main/java/com/editora/ui/ProjectPanel.java
@@ -77,7 +77,8 @@ public class ProjectPanel extends VBox implements ToolWindowContent {
 
         void showLocalHistory(Path file);
 
-        boolean gitEnabled();
+        /** True when Git actions can run (the feature is on AND the context is inside a repo). */
+        boolean gitAvailable();
 
         void gitShowFileHistory(Path file);
 
@@ -689,7 +690,7 @@ public class ProjectPanel extends VBox implements ToolWindowContent {
                 // Disable to match the live feature toggles, mirroring the tab context menu.
                 menu.setOnShowing(e -> {
                     localHistory.setDisable(!fileActions.localHistoryEnabled());
-                    git.setDisable(!fileActions.gitEnabled());
+                    git.setDisable(!fileActions.gitAvailable()); // grey out the Git submenu when there's no VCS
                 });
             }
             return menu;


### PR DESCRIPTION
## What

Git-only menu entries now reflect whether the file is **actually under VCS** (Git enabled *and* inside a repo), not just the feature toggle.

- **Tab right-click menu** — **Compare with HEAD** and **Git: Show File History** are now **hidden** when there's no VCS (Git off, or the file isn't in a repo). **Compare With…** stays — it's a plain two-file diff, not a Git action.
- **Project tool window** — the **Git** submenu is **disabled** (greyed) in the same case. Previously it was gated only on the feature toggle, so it stayed enabled in a non-repo folder.

## How

- New `MainController.gitAvailable()` = `gitEnabled() && currentRepoRoot != null`.
- Tab menu's `onShowing` sets the two Git items' visibility from `gitAvailable() && hasPath`.
- `ProjectPanel.FileActions.gitEnabled` renamed to `gitAvailable`, wired to the new helper; the submenu's `onShowing` greys it out accordingly.

No new dependency, no new i18n. `./mvnw verify` → BUILD SUCCESS, 788 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)