### PR TITLE
docs: sync CHANGELOG/README/TODO with recent features

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -118,6 +118,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   The bar now re-runs the search on each (debounced) edit and re-highlights at the new positions — without
   moving the caret or selection, so it doesn't interfere with typing.
 
+- **Right-click Cut/Copy/Paste now act on a column (box) selection.** The editor context menu's
+  Cut/Copy/Paste called the native single-caret operations, so on an Alt+drag column/box selection they only
+  touched the primary row — even though the `edit.cut`/`copy`/`paste` *commands* already worked (they route
+  through the multi-caret-aware path). The menu items now use that same path (falling back to the native op
+  when there's a single caret), Cut/Copy are enabled on a box selection even when the primary selection is
+  empty, and the mutating Cut/Paste are gated to editable buffers.
+
+- **Every window that was open at quit now reopens.** With multiple project windows open, a Cmd-Q / OS quit
+  fired each window's close handler in turn, and the eager "mark closed" drained the saved open-window set
+  down to just the last window — so only one reopened on the next launch. Closing a window is now reconciled
+  on a short debounce that can't elapse during a quit's close-handler burst: a genuine single close persists
+  the reduced set (that window is forgotten), but a quit exits the JVM before the timer fires, leaving the
+  full pre-quit set on disk so every window reopens. (`app.quit` already worked — it fires no close handlers.)
+
 ### Added
 
 - **Open a command's online docs from the palette (C-h).** In the command palette, press **C-h** to open the
@@ -145,6 +159,45 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   code-area context menu now offers Comment / Uncomment (the same action as the `M-;` keybinding and the
   command palette) — it line-comments the caret's line or block/line-comments the selection, and toggles back
   off when already commented. Hidden for plaintext (no comment syntax) and while read-only.
+
+- **MCP server (Model Context Protocol).** Editora can run a small **Model Context Protocol** server so an
+  LLM agent (Claude Code, etc.) can observe live editor state and drive the command registry. It's a
+  **loopback-only** HTTP/JSON-RPC server with **bearer-token auth** that writes its endpoint to
+  `<configDir>/mcp-endpoint.json` for discovery, and exposes six tools: `list_open_files`, `read_buffer`,
+  `get_diagnostics`, `find_in_files`, `list_commands`, and `execute_command`. A status-bar **MCP** indicator
+  shows when it's running (click to copy the connection command) and is hidden in Simple UI mode. Off by
+  default and gated by a security-notice dialog — enable it under **Settings → MCP Server** (or the
+  **Toggle MCP Server** command, `view.toggleMcp`; `mcp.copyEndpoint` copies the endpoint). No new
+  dependency (the JDK's built-in `HttpServer` + Jackson).
+
+- **Reveal in File Manager / Open Terminal Here (built-in).** Revealing a file in Finder/Explorer/your file
+  manager and opening a terminal at a folder are now core features (previously an example plugin), reachable
+  from the **command palette** (`file.revealInFileManager` / `file.openTerminal`), the **tab right-click
+  menu**, and the **Project tool window** menu (both files and folders). Local saved files only; per-OS argv
+  (Finder/Explorer select, `xdg-open` on Linux) launched off the UI thread. (The breadcrumb crumb menu — see
+  below — surfaces the same two actions.)
+
+- **Show Local History + a Git submenu in the Project tree menu.** The Project tool window's per-file
+  right-click menu gained **Show Local History** and a **Git** submenu (Show File History, Compare with HEAD,
+  Stage File), mirroring the editor tab menu but acting on the clicked tree path. The Git items grey out when
+  Git is off, and Local History when it's off.
+
+- **HTTP Client — request chaining, multipart, dynamic vars, and a richer viewer.** The `.http`/`.rest`
+  client moved much closer to IntelliJ's: reference an earlier named request's response in a later one
+  (`{{name.response.body.$.path}}` / `.headers.H` / `.status`, threaded across a run-all), **multipart/
+  form-data** bodies (inline + `< ./file` parts), **external request bodies** (`< ./file` raw, `<@ ./file`
+  substituted), **response-to-file** redirects (`>> file` / `>>! file`), per-request directives
+  (`# @no-redirect` / `@no-cookie-jar` / `@no-log` / `@timeout N`), a per-run cookie jar, and the full
+  **dynamic-variable** family (`{{$random.*}}`, `{{$datetime "fmt"}}`, `{{$processEnv.X}}`, `{{$dotenv.X}}`).
+  The response viewer is now a content-type-highlighted read-only editor with split status/headers/body, an
+  in-session history picker, **Copy as cURL**, **Import cURL**, and **Open in editor tab**. No new dependency.
+
+- **HTTP Client — Digest auth, URL auto-encoding, date math, and `$shared` env.** A second IntelliJ-parity
+  pass: the `Authorization: Digest user pass` shorthand now performs the 401-challenge round-trip
+  (RFC 2617); request URLs are **percent-encoded automatically** after substitution (disable with
+  `# @no-auto-encoding`); `{{$datetime}}` / `{{$localDatetime}}` / `{{$timestamp}}` take signed **offsets**
+  (`y/M/w/d/h/m/s/ms`); and a `$shared` section in `http-client.env.json` merges its variables under every
+  environment (and is hidden from the picker). New directive `# @connection-timeout N`.
 
 - **Per-file-type icons.** File icons now reflect the file's type instead of a single generic document glyph.
   Editing `Main.java` shows the Java logo, `app.py` the Python logo, `style.css` the CSS logo, an image its

--- a/README.md
+++ b/README.md
@@ -36,7 +36,8 @@ Emacs-style keymap or a fuzzy command palette.
 ## Features
 
 - **Command-driven core** — every action is a `Command`; bind it to a chord or run it
-  from the M-x command palette.
+  from the M-x command palette, which shows each command's one-line description and opens its online
+  docs with `C-h`.
 - **Keyboard "Jump to…" popups** — fuzzy pickers for recent files (`C-x C-r`), the active file's
   structure/symbols (`M-g i`), open files/tabs (`C-x b`), and tool windows (`M-g t`) — keyboard-first
   alternatives to their list/tool-window UIs.
@@ -46,7 +47,9 @@ Emacs-style keymap or a fuzzy command palette.
 - **Projects** (off by default; enable in Settings) — VSCode single-folder-workspace style: a root
   folder + its own saved session (open files, layout, folds), shown as a filterable file tree in the
   Project tool window with a project switcher in the toolbar. Open (`C-x C-p`)/switch (`C-x p`)/close
-  via the palette or toolbar; switching restores that project's files and layout.
+  via the palette or toolbar; switching restores that project's files and layout. With no project open, the
+  Project tool window becomes a **"Current Folder"** explorer rooted at the active file's directory, tracking
+  the focused tab.
 - **Keybinding themes** — choose **Emacs** (default), **CUA**, **Sublime Text**, **VSCode**, or
   **IntelliJ IDEA** in Settings → Keymaps (or the `Keymap: Select…` command); switching is live, no
   restart, and each theme adapts to macOS (Cmd) vs Windows/Linux (Ctrl). Emacs uses multi-key chord
@@ -73,6 +76,9 @@ Emacs-style keymap or a fuzzy command palette.
   bracket matching the one next to the caret is highlighted.
 - **Comment / uncomment** (`M-;`) — toggles a line comment for a single line and a block/region comment
   for a multi-line selection, using the language's comment syntax (`//`, `#`, `<!-- -->`, `/* */`, `--`, …).
+- **Fill paragraph** (`M-q`) — re-wrap a paragraph (or the selection, with "Fill Region") to a fill column
+  (`C-x f`, default 70), preserving its indentation and an adaptive fill prefix — line comments, Markdown
+  blockquotes (`>`), and Javadoc (`*`) — so code comments and quoted text wrap correctly.
 - **Multiple cursors & column selection** — VS Code–style multi-caret editing: add a caret at the next
   occurrence of the selection / above / below, type or edit everywhere at once, `Esc` to collapse; plus
   Alt-drag column/box selection. (Powered by a personal RichTextFX fork.)
@@ -85,8 +91,9 @@ Emacs-style keymap or a fuzzy command palette.
   auto-detected on `PATH` (Java/JDT LS, TypeScript/JavaScript, Python/Pyright, Go, Rust, C/C++/clangd,
   C#, PHP, Ruby, Kotlin, Lua, Bash, XML, JSON, YAML, HTML, CSS, Dockerfile, SQL, Terraform, TOML).
   Inline diagnostics + a Problems tool window (`M-8`) + minimap/scrollbar stripes, go-to-definition
-  (`M-.`), find references (`M-?`), hover docs (`C-c h`), LSP-backed completion, and auto-imports.
-  Off by default; per-server command + enable in *Settings → LSP*.
+  (`M-.`), find references (`M-?`), hover docs (`C-c h`), LSP-backed completion, auto-imports, and
+  **Format Document** (whole-file reformat via the server, when it advertises formatting — palette or the
+  editor right-click menu). Off by default; per-server command + enable in *Settings → LSP*.
 - **Search** — incremental find bar (`C-s`/`C-r`) with regex, case, and whole-word toggles, a match
   count, and live highlight-all; **Find in Files** (`C-S-f`) across the project + open buffers with
   replace-in-files and a results tool window (`M-6`); and **AceJump** (`M-g j`) — type a character, then
@@ -124,7 +131,8 @@ Emacs-style keymap or a fuzzy command palette.
   floating control top-right of the editor, rendered natively (CommonMark + GFM: tables, task lists,
   strikethrough, autolinks) with **GitHub-style** output — task-list checkboxes, inline-code pills,
   underlined h1/h2, and **images** (local and remote). Live-updating and theme-matched; the mode is
-  remembered per file. Zoom the preview text with its `−`/`+` control or, in Preview mode,
+  remembered per file. In Split mode the editor and preview scroll together (the pane under the mouse
+  drives the other). Zoom the preview text with its `−`/`+` control or, in Preview mode,
   **Ctrl + mouse wheel**.
 - **Mermaid diagrams** — render Mermaid in the preview (standalone `.mmd` files and ` ```mermaid `
   fenced blocks inside Markdown), export a diagram to **SVG / PNG / PDF**, get live `maid` linting with
@@ -158,6 +166,10 @@ Emacs-style keymap or a fuzzy command palette.
   area when no files are open, instead of a blank Untitled buffer; `--new-file[=name]` opens a fresh buffer
   instead.
 - **Recent files** — persistent most-recently-used list.
+- **File-type icons** — every file shows a glyph for its type (the Java/Python/CSS/… logo, an image,
+  archive, PDF, table, … glyph, or a generic document fallback) everywhere it's listed: editor tabs, the
+  Project tree, the Open-Files / Recent pickers, the Switcher, and the file/folder finders. Monochrome
+  single-path glyphs that track the light/dark theme (Simple Icons + Material Design Icons).
 - **Bookmarks** — toggle line bookmarks (`C-c m`) with a gutter marker and optional notes; the
   Bookmarks tool window lists them across all files, `C-c ]`/`C-c [` cycle within a file, and `M-g b`
   is a cross-file jump picker. Reorder bookmarks (and file groups) in the tool window with Alt+Up/Down,
@@ -198,9 +210,13 @@ Emacs-style keymap or a fuzzy command palette.
   size/project). On by default; local-only; off in Simple UI mode.
 - **HTTP client** _(Beta)_ — open a `.http`/`.rest` file and click the green ▶ next to a request to run it with
   Editora's **built-in** HTTP client; the response (status, headers, pretty-printed JSON body, timing/
-  size) shows in an HTTP Client tool window (`M-0`). Supports `{{variable}}`/`@var` substitution,
-  environment files (`http-client.env.json`) with a picker, run-whole-file, and saving the response. Off
-  by default (*Settings → HTTP Client*).
+  size) shows in an HTTP Client tool window (`M-0`) with a content-type-highlighted viewer, an in-session
+  history, **Copy as cURL** / **Import cURL**, and Open-in-editor. Close to IntelliJ's HTTP Client: `{{var}}`/
+  `@var` substitution and **dynamic variables** (`{{$random.*}}`, `{{$datetime}}` with date math, `{{$dotenv.X}}`,
+  …), **request chaining** (reference an earlier request's response), **multipart** and external-file bodies,
+  **environment files** (`http-client.env.json` + a `$shared` section) with a picker, **Basic/Digest auth**
+  shorthand, automatic URL encoding, response-to-file redirects, per-request directives, run-whole-file, and
+  saving the response. Off by default (*Settings → HTTP Client*).
 - **HTML live preview** _(Beta)_ — a floating browser icon on any HTML file opens it in a detected desktop
   browser (Safari, Chrome, Firefox, Edge, or the system default), served over a tiny **loopback** web server
   so its CSS/JS/images load. The page **reloads live as you type** (unsaved edits included). Off by default
@@ -225,6 +241,14 @@ Emacs-style keymap or a fuzzy command palette.
   *who* published — not a sandbox. See [`docs/plugins.md`](docs/plugins.md),
   [`examples/example-plugin/`](examples/example-plugin/), and
   [`examples/editora-plugins-registry/`](examples/editora-plugins-registry/).
+- **MCP server** _(Beta)_ — embed a [Model Context Protocol](https://modelcontextprotocol.io) server in the
+  running editor so an LLM agent (Claude Code, etc.) can observe live editor state and drive the command
+  registry. A small **loopback-only** HTTP/JSON-RPC server with **bearer-token auth** exposes six tools —
+  `list_open_files`, `read_buffer`, `get_diagnostics`, `find_in_files`, `list_commands`, and
+  `execute_command` — and writes its endpoint to `<configDir>/mcp-endpoint.json` for discovery. A status-bar
+  **MCP** indicator shows when it's running (click to copy the connection command). Off by default and
+  guarded by a security-notice dialog — enable it under *Settings → MCP Server* (or the **Toggle MCP Server**
+  command). No external tool or new dependency (the JDK's built-in `HttpServer`).
 - **Tool windows** — IntelliJ-style dockable panels (Project, Commit, Git Log, File History, Structure, File
   Information, Bookmarks, Personal Notes, Problems, Search Results, Run, Debug, HTTP Client) — plus any
   contributed by a plugin.

--- a/TODO.md
+++ b/TODO.md
@@ -3,6 +3,20 @@
 A backlog of planned features and improvements. Unordered within each section.
 
 ## Recently shipped
+- [x] MCP server — a minimal Model Context Protocol server (loopback HTTP + bearer-token auth) embedded in
+      the editor, exposing live state + the command registry to an LLM agent (six tools); off by default
+      behind a security notice (Settings → MCP Server). No new dependency
+- [x] Local file history — IntelliJ-style snapshots of local files on save / auto-save / before an
+      external reload, independent of any VCS; a **File History** tool window (`M-g l`) lists revisions
+      (date/time, reason, size; latest tagged *Current*), double-click for a read-only diff vs current,
+      restore = undoable whole-file replace. Gzip'd content-addressed blobs under `<configDir>/history/`,
+      deduped, configurable retention. On by default; local-only; off in Simple UI
+- [x] Emacs fill commands — Fill Paragraph (`M-q`), Fill Region, Set Fill Column (`C-x f`): re-wrap to a
+      fill column, preserving indentation + an adaptive fill prefix (line comments, `>` quotes, Javadoc `*`)
+- [x] LSP Format Document — whole-file reformat via the language server (palette + editor right-click),
+      undoable, when the server advertises formatting
+- [x] File-type icons — per-type glyphs everywhere a file is listed (tabs, Project tree, pickers, Switcher,
+      finders); plus a "Current Folder" Project explorer when no project is open
 - [x] Plugin support + a signed plugin registry — extend Editora via a Java SPI or a declarative
       `plugin.json` (commands, keybindings, tool windows, editor menu items, status-bar segments;
       snippets/templates). Off by default, full-trust, loaded via a child `URLClassLoader` so the same jar
@@ -31,8 +45,11 @@ A backlog of planned features and improvements. Unordered within each section.
       for remote files. Off by default; built on Apache MINA SSHD (Remote: Connect / Saved Connections /
       Open File / Disconnect)
 - [x] HTTP Client (`.http`/`.rest` files) — a green ▶ on every request runs it with the built-in JDK
-      HTTP client; response (status/headers/pretty-JSON/timing) in an HTTP Client tool window (`M-0`);
-      `{{var}}`/`@var` substitution, environment files (`http-client.env.json`), run-whole-file
+      HTTP client; response (status/headers/pretty-JSON/timing) in an HTTP Client tool window (`M-0`) with a
+      highlighted viewer, history, Copy/Import as cURL. Near IntelliJ parity: `{{var}}`/`@var` + dynamic vars
+      (`$random`/`$datetime` with date math/`$dotenv`), request chaining, multipart + external-file bodies,
+      environment files (`http-client.env.json` + `$shared`), Basic/Digest auth, auto URL-encoding,
+      response-to-file, per-request directives, run-whole-file
 - [x] HTML Live Preview — a floating browser icon on `.html`/`.htm`/`.xhtml` files opens them in a detected
       browser (Safari/Chrome/Firefox/Edge/system default) served over a loopback JDK `HttpServer`, with
       live-as-you-type reload (assets load from disk; the page from the live buffer text); off by default
@@ -99,9 +116,13 @@ A backlog of planned features and improvements. Unordered within each section.
 - [x] Autoclose `()[]{}` and quotes
 - [x] Highlight matching braces
 - [x] Comment/uncomment code region
+- [x] Fill paragraph/region (Emacs `M-q` / Fill Region / `C-x f` set fill column) — re-wrap to a fill
+      column, preserving indentation + an adaptive fill prefix (line comments, `>` quotes, Javadoc `*`)
 - [x] Smart line start (`C-a`) — first press to the first non-whitespace, second toggles to column 0
 - [x] Markdown formatting — format bar + smart list/heading/link/table editing (see "Recently shipped")
-- [ ] Format document — whole-document reformat (will ride LSP formatting; GFM table reflow exists)
+- [x] Format document — **LSP: Format Document** reformats the whole file via the language server
+      (`textDocument/formatting`, when it advertises formatting), undoable; palette + editor right-click.
+      (GFM table reflow also exists.)
 - [x] Column select support — column/block selection (overlay + column-aware edits)
 - [x] Multiple cursors support — VS Code–style multi-caret (add at next occurrence / above / below) +
       Alt-drag column selection (personal RichTextFX fork); see "Recently shipped"
@@ -122,8 +143,9 @@ A backlog of planned features and improvements. Unordered within each section.
       `C-M-i`/`M-/` trigger; Settings toggle. (Next: document-words, LSP, fuzzy matching.)
 - [x] LSP support — **21 servers** (see "Recently shipped"): diagnostics + Problems window (`M-8`) +
       minimap/scrollbar stripes, go-to-definition (`M-.`), find references (`M-?`), hover (`C-c h`),
-      LSP-backed completion, and TS/PHP auto-imports. Server-centric registry, per-server Settings, off by
-      default. (Next: formatting / format-on-save; rename, code actions, quick fixes; document symbols.)
+      LSP-backed completion, TS/PHP auto-imports, and **Format Document** (whole-file reformat).
+      Server-centric registry, per-server Settings, off by default. (Next: format-on-save; rename, code
+      actions, quick fixes; document symbols.)
 - [ ] Fix structure for the 21 languages we support
 - [x] Multi language support — UI string translation (en/it/es/fr/pt/de); see "UI localization (i18n)"
       under "Recently shipped"
@@ -161,7 +183,11 @@ A backlog of planned features and improvements. Unordered within each section.
 ## UI / UX
 - [ ] UI final touches (fonts, colors, etc.)
 - [x] Pretty up Settings Window — sidebar categories, search, live preview, reset
-- [ ] Upgrade breadcrumbs support
+- [x] File-type icons — a per-type glyph (language logos, image/archive/PDF/table/…, generic fallback)
+      everywhere a file is listed: tabs, Project tree, Open-Files/Recent pickers, Switcher, file/folder finders
+- [x] "Current Folder" explorer — with no project open, the Project tool window roots at the active file's
+      folder and follows the focused tab
+- [ ] Upgrade breadcrumbs support — _partial:_ Reveal in File Manager / Open Terminal Here on a crumb
 - [ ] Fix Zen mode
 
 ## Extensibility & integration
@@ -182,7 +208,13 @@ A backlog of planned features and improvements. Unordered within each section.
   *Deferred: sandboxing, hot reload, gutter-marker contributions, GitHub-API/per-repo discovery,
   per-plugin/TOFU signing, auto-update.*
 - [ ] External Tools support
-- [ ] MCP support
+- [x] MCP support — a minimal **Model Context Protocol** server embedded in the editor (loopback HTTP +
+      bearer-token auth) so an LLM agent (Claude Code, …) can observe state + drive the command registry.
+      Six tools: `list_open_files`, `read_buffer`, `get_diagnostics`, `find_in_files`, `list_commands`,
+      `execute_command`; writes `<configDir>/mcp-endpoint.json` for discovery; status-bar indicator
+      (click to copy the connection command). Off by default behind a security-notice dialog
+      (Settings → MCP Server; `view.toggleMcp` / `mcp.copyEndpoint`). No new dependency (`jdk.httpserver`).
+      (Next: more tools, resources/prompts, stdio transport.)
 - [ ] Headless support
 
 ## Packaging


### PR DESCRIPTION
Brings the docs in line with shipped work that hadn't been recorded.

## CHANGELOG (`[Unreleased]`)
Backfills seven entries for features/fixes that merged without a changelog line:
- **MCP server** (#36) — loopback MCP server exposing editor state + commands
- **Reveal in File Manager / Open Terminal Here**, built-in (#37)
- **Show Local History + Git submenu** in the Project tree menu (#39)
- **HTTP Client → IntelliJ parity** — chaining, multipart, dynamic vars, richer viewer (#30)
- **HTTP Client** — Digest auth, URL auto-encoding, `$datetime` offsets, `$shared` env (#32)
- *Fixed:* right-click Cut/Copy/Paste on a column (box) selection (#43)
- *Fixed:* every window open at quit now reopens (Cmd-Q drain) (#41)

## README
Adds the MCP server, file-type icons, "Current Folder" project view, Fill Paragraph, palette command
descriptions + `C-h` docs, LSP Format Document, and Markdown split-scroll; expands the HTTP Client bullet.

## TODO
Marks Format Document and MCP support shipped; adds Fill commands, file-type icons, and Local File History
to *Recently shipped*; refreshes the HTTP Client entry.

Docs-only — no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)