### PR TITLE
feat(plugin): custom tool-window stripe icons for plugins

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -180,7 +180,10 @@ icon (`Icons.findInFiles()`, `onFindInFiles → openSearchInFiles`) sits beside 
   modules via normal parent delegation; **no `ModuleLayer`**). Compile a plugin on a plain **classpath**, not
   the module path. **API (the exported `com.editora.plugin` package):** `interface Plugin {void start(ctx);
   default void stop()}`; `interface PluginContext` (`registerCommand(id,title,Runnable)`, `bindKey(chord,
-  commandId)`, `registerToolWindow(id,title,ToolWindowSide,Region,commandId)`, `addEditorMenuItem(label,
+  commandId)`, `registerToolWindow(id,title,ToolWindowSide,Region,commandId[,Supplier<Node> icon])` (the icon
+  overload sets the stripe glyph — a `Supplier<javafx.scene.Node>`, e.g. an `SVGPath` with the `toolbar-icon`
+  style class; the no-icon overload is a `default` delegating with `null` ⇒ the jigsaw `Icons.plugin()`),
+  `addEditorMenuItem(label,
   Consumer<ActiveEditor>)`, `addStatusBarSegment(label,commandId)`, `activeEditor()`, `pluginDir()/dataDir()/
   configDir()`, `log/setStatus`); `interface ActiveEditor` (narrow editor facade — `filePath/text/
   selectedText/replaceSelection/insertAtCaret/setText/openPath` (`setText` = whole-buffer replace, undoable —

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -91,7 +91,8 @@ public class HelloPlugin implements Plugin {
 | --- | --- |
 | `registerCommand(id, title, action)` | A palette command (id namespaced to the plugin). |
 | `bindKey(chord, commandId)` | A keybinding. |
-| `registerToolWindow(id, title, side, content, commandId)` | A dockable tool window (`LEFT`/`RIGHT`/`BOTTOM`). |
+| `registerToolWindow(id, title, side, content, commandId)` | A dockable tool window (`LEFT`/`RIGHT`/`BOTTOM`), using the default plugin (jigsaw) stripe icon. |
+| `registerToolWindow(id, title, side, content, commandId, icon)` | Same, with a custom stripe icon: `icon` is a `Supplier<javafx.scene.Node>` (e.g. an `SVGPath` with the `toolbar-icon` style class, themed for light/dark). Called per window/repaint, so it must return a fresh node each time; `null` (or a null result) falls back to the jigsaw. |
 | `addEditorMenuItem(label, action)` | An editor right-click item; the action gets an `ActiveEditor`. |
 | `addStatusBarSegment(label, commandId)` | A clickable status-bar segment. |
 | `activeEditor()` | The live active-buffer facade (`filePath`/`text`/`selectedText`/`replaceSelection`/`insertAtCaret`/`setText`/`openPath`). `setText` replaces the whole buffer (undoable) — for whole-file transforms like formatting. |

--- a/src/main/java/com/editora/plugin/PluginContext.java
+++ b/src/main/java/com/editora/plugin/PluginContext.java
@@ -2,7 +2,9 @@ package com.editora.plugin;
 
 import java.nio.file.Path;
 import java.util.function.Consumer;
+import java.util.function.Supplier;
 
+import javafx.scene.Node;
 import javafx.scene.layout.Region;
 
 /**
@@ -21,8 +23,24 @@ public interface PluginContext {
     /** Binds a chord (e.g. {@code "C-c x"}) to a command id (a plugin's or a built-in's). */
     void bindKey(String chord, String commandId);
 
-    /** Registers a dockable tool window with the given content node + a toggle command id. */
-    void registerToolWindow(String id, String title, ToolWindowSide side, Region content, String commandId);
+    /**
+     * Registers a dockable tool window with the given content node + a toggle command id, using the default
+     * plugin (jigsaw) stripe icon. Equivalent to {@link #registerToolWindow(String, String, ToolWindowSide,
+     * Region, String, Supplier)} with a {@code null} icon.
+     */
+    default void registerToolWindow(String id, String title, ToolWindowSide side, Region content, String commandId) {
+        registerToolWindow(id, title, side, content, commandId, null);
+    }
+
+    /**
+     * Registers a dockable tool window with a custom stripe icon. {@code icon} is a supplier of a fresh JavaFX
+     * node for the tool-window stripe button — typically a {@link javafx.scene.shape.SVGPath} carrying the
+     * {@code toolbar-icon} style class (which the app theme colors for light/dark). It is invoked per window
+     * and per repaint, so it <em>must</em> return a new node each call (a node can have only one parent). A
+     * {@code null} supplier, or one that returns {@code null}, falls back to the default plugin (jigsaw) icon.
+     */
+    void registerToolWindow(
+            String id, String title, ToolWindowSide side, Region content, String commandId, Supplier<Node> icon);
 
     /** Adds an item to the editor's right-click menu; the action receives the {@link ActiveEditor}. */
     void addEditorMenuItem(String label, Consumer<ActiveEditor> action);

--- a/src/main/java/com/editora/ui/MainController.java
+++ b/src/main/java/com/editora/ui/MainController.java
@@ -962,7 +962,8 @@ public class MainController implements com.editora.mcp.McpBridge {
                 String title,
                 com.editora.plugin.ToolWindowSide side,
                 javafx.scene.layout.Region content,
-                String commandId) {
+                String commandId,
+                java.util.function.Supplier<javafx.scene.Node> icon) {
             String twId = fullId(id);
             String cmd = commandId == null || commandId.isBlank() ? twId : fullId(commandId);
             ToolWindow.Side s =
@@ -971,7 +972,15 @@ public class MainController implements com.editora.mcp.McpBridge {
                         case RIGHT -> ToolWindow.Side.RIGHT;
                         case BOTTOM -> ToolWindow.Side.BOTTOM;
                     };
-            ToolWindow tw = new ToolWindow(twId, title == null ? twId : title, s, Icons::plugin, content, cmd);
+            // A null supplier (or one returning null) falls back to the default plugin (jigsaw) icon. The
+            // factory is invoked per window/repaint, so it must yield a fresh node each time.
+            java.util.function.Supplier<javafx.scene.Node> iconFactory = icon == null
+                    ? Icons::plugin
+                    : () -> {
+                        javafx.scene.Node n = icon.get();
+                        return n != null ? n : Icons.plugin();
+                    };
+            ToolWindow tw = new ToolWindow(twId, title == null ? twId : title, s, iconFactory, content, cmd);
             toolWindows.register(tw);
             registry.register(
                     com.editora.command.Command.of(cmd, title == null ? twId : title, () -> toolWindows.toggle(tw)));


### PR DESCRIPTION
## What

Adds an overload `PluginContext.registerToolWindow(id, title, side, content, commandId, Supplier<Node> icon)` so a plugin can set its own tool-window stripe glyph. The existing 5-arg method becomes a `default` that delegates with a `null` icon, so every existing plugin keeps the jigsaw (`Icons.plugin()`) — fully backward compatible.

`MainController`'s impl builds the stripe icon factory from the supplied supplier, falling back to `Icons::plugin` when it's `null` or returns `null`. The supplier is invoked per window/repaint (a JavaFX node can have only one parent), matching the existing `Icons::plugin` factory contract.

## Why

Today every plugin tool window is forced to the jigsaw icon. This lets registry plugins (calculator, color-picker, regex-tester, run-task, scratchpad, word-count) show icons relevant to their function. `Icons` is package-private, so plugins build their own `SVGPath` carrying the `toolbar-icon` style class (themed by the app for light/dark).

## Notes

- Docs updated: `docs/plugins.md`, `CLAUDE.md`.
- No schema/dependency/module-info change.
- Full test suite passes; `spotless:check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)