### PR TITLE
Fix caret/focus not landing in the editor after the Switcher

### DIFF
--- a/src/main/java/com/editora/ui/MainController.java
+++ b/src/main/java/com/editora/ui/MainController.java
@@ -512,7 +512,7 @@ public class MainController implements com.editora.mcp.McpBridge {
         this.switcher = new Switcher(
                 () -> new java.util.ArrayList<>(tabPane.getTabs()), // list files in tab order
                 () -> tabPane.getSelectionModel().getSelectedItem(),
-                tab -> tabPane.getSelectionModel().select(tab),
+                this::activateAndFocusTab,
                 this::closeTabFromSwitcher);
         setupMruTracking();
         registerCommands();
@@ -1523,13 +1523,7 @@ public class MainController implements com.editora.mcp.McpBridge {
                 tab -> (isTabDirty(tab) ? "• " : "") + bufferTitle(tab), // dirty marker, like the tab
                 tab -> bufferParentDir(tab),
                 tab -> bufferTitle(tab), // search by the plain name (no "• " prefix)
-                tab -> {
-                    tabPane.getSelectionModel().select(tab);
-                    EditorBuffer b = bufferOf(tab);
-                    if (b != null) {
-                        b.getArea().requestFocus();
-                    }
-                });
+                this::activateAndFocusTab);
         openFilesPalette.setItemStyleClass(
                 tab -> isTabDirty(tab) ? "dirty-name" : null); // amber/italic, like a dirty tab
         openFilesPalette.setItemIcon(tab -> FileIcons.forFileName(bufferTitle(tab))); // file-type glyph
@@ -2037,6 +2031,22 @@ public class MainController implements com.editora.mcp.McpBridge {
 
     private void closeTabFromSwitcher(Tab tab) {
         closeTab(tab);
+    }
+
+    /**
+     * Selects a tab chosen in an overlay picker (the Switcher / "Jump to Open File") and moves the caret into
+     * its editor. The focus request is deferred via {@code Platform.runLater} because these pickers close through
+     * the shared {@link OverlayHost}, whose {@code hide()} synchronously restores focus to the previously-focused
+     * area — running the focus request afterward ensures the caret lands in the newly selected buffer instead of
+     * the old one (otherwise the user has to click to get a caret). Robust regardless of whether the picker
+     * hides before or after invoking this.
+     */
+    private void activateAndFocusTab(Tab tab) {
+        tabPane.getSelectionModel().select(tab);
+        EditorBuffer buffer = bufferOf(tab);
+        if (buffer != null) {
+            Platform.runLater(() -> buffer.getArea().requestFocus());
+        }
     }
 
     /**


### PR DESCRIPTION
## Problem

Switching buffers with the **Switcher** (Ctrl-Tab) left the editor unfocused — the caret only appeared after clicking with the mouse.

## Cause

The Switcher's activate callback only ran `tabPane.getSelectionModel().select(tab)` and never focused the editor. Because the Switcher closes through the shared `OverlayHost`, whose `hide()` **synchronously** restores focus to the previously-focused node (the *old* buffer's `CodeArea`, captured when the Switcher opened), focus ended up back on the old/hidden area — so the newly selected buffer had no caret.

## Fix

A shared `MainController.activateAndFocusTab(tab)` selects the tab and focuses its editor via `Platform.runLater`, so the focus request runs **after** the overlay's synchronous focus-restore — the caret lands in the newly selected buffer. The Switcher routes through it.

**"Jump to Open File"** (`buffer.jump`, a `QuickOpen`) already worked — `QuickOpen.chooseSelected()` calls `hide()` *before* `onChoose`, so its synchronous `requestFocus()` ran after the restore and survived — but it's now routed through the same helper to dedup the logic and guarantee both pickers are correct via one code path (robust regardless of hide/activate ordering).

## Notes
- GUI interaction, so not unit-testable here; verified by a dev run (Ctrl-Tab and Jump-to-Open-File both land the caret) and `./mvnw test` (841 tests green).
- Negligible cost: one extra `runLater` only on picker commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)