### PR TITLE
Keep the toolbar height constant when the project combo is hidden

### DIFF
--- a/src/main/java/com/editora/ui/MainController.java
+++ b/src/main/java/com/editora/ui/MainController.java
@@ -6053,6 +6053,28 @@ public class MainController implements com.editora.mcp.McpBridge {
         refreshSplitButtons();
         refreshEditState(); // start disabled (no buffer yet)
         refreshPasteState();
+        // Pin the toolbar height so it doesn't jump when the (taller) project combo is hidden — by
+        // Simple UI mode or by disabling Projects. Measured after the first layout pass (skin + CSS applied).
+        Platform.runLater(this::stabilizeToolbarHeight);
+    }
+
+    /**
+     * Keeps the toolbar a constant height regardless of whether the project combo is showing. The
+     * {@link ProjectCombo} is taller than the icon buttons, so toggling its visibility (Simple UI mode, or the
+     * Projects feature being off) would otherwise resize the whole bar. Pinning {@code minHeight} to the
+     * combo-driven height (measured, no magic number) makes that the bar's floor in every mode; it still grows
+     * for any taller child. No-op until the combo has a valid preferred height (after the first layout).
+     */
+    private void stabilizeToolbarHeight() {
+        if (toolBar == null || toolbarProjectCombo == null) {
+            return;
+        }
+        double comboH = toolbarProjectCombo.prefHeight(-1); // independent of the combo's current visibility
+        if (comboH <= 0) {
+            return;
+        }
+        javafx.geometry.Insets in = toolBar.getInsets();
+        toolBar.setMinHeight(Math.ceil(comboH + in.getTop() + in.getBottom()));
     }
 
     /**


### PR DESCRIPTION
## Problem

The toolbar visibly changed height when toggling **Simple UI mode** (and likewise when **Projects** is disabled — the default). The icons appeared to resize because the whole bar shrank.

## Cause

A `ToolBar`'s height is driven by its tallest managed child. The trailing `ProjectCombo` (a `ComboBox`) is taller than the icon buttons, so hiding it (Simple UI mode or Projects off) collapsed the bar to button height — and showing it grew the bar back.

## Fix

`MainController.stabilizeToolbarHeight()` pins the toolbar's `minHeight` to the combo-driven height — `toolbarProjectCombo.prefHeight(-1)` + the toolbar's vertical insets (measured, no hardcoded pixel value). That height becomes the bar's floor in every mode, so hiding the combo no longer shrinks it; it still grows for any taller child.

- `prefHeight(-1)` stays valid because the project group is hidden via `visible`/`managed`, never removed from the toolbar items (so the combo keeps its skin/CSS).
- Measured once after the first layout pass via `Platform.runLater`.

**Note:** this makes the bar consistently the *taller* (combo) height; an install that never enables Projects gets a slightly taller bar (a little extra vertical padding around the centered icons) — the cost of a constant height.

## Verification
- `./mvnw test` → 841 tests, green.
- Visual: dev run, toggling Simple UI mode and the Projects setting leaves the toolbar height unchanged. (JavaFX desktop UI — not unit-testable here.)

**Performance:** one-time startup measurement; no hot-path cost.

🤖 Generated with [Claude Code](https://claude.com/claude-code)