### PR TITLE
Make the gutter Run (play) glyph 30% larger

### DIFF
--- a/src/main/java/com/editora/editor/FoldManager.java
+++ b/src/main/java/com/editora/editor/FoldManager.java
@@ -721,8 +721,8 @@ public final class FoldManager {
         SVGPath svg = new SVGPath();
         svg.setContent(RUN_GLYPH_PATH);
         svg.getStyleClass().add("run-marker");
-        svg.setScaleX(0.78); // 30% larger than the other gutter glyphs so the Run target is easy to hit
-        svg.setScaleY(0.78);
+        svg.setScaleX(1.014); // 30% larger than before (0.78) so the Run target is easier to click; still fits the slot
+        svg.setScaleY(1.014);
         return new Group(svg);
     }
 


### PR DESCRIPTION
## Summary

The gutter **Run** (play) glyph was small and hard to click. Its scale goes **0.78 → 1.014** (30% larger). The click handler is on the glyph node itself, so the hit target grows with it.

At ~11.2px wide it still fits the 13px run-slot, so there's no clipping and no text-indent shift for runnable files.

## Verification
- `./mvnw test` → 841 tests, green.
- Visual (JavaFX, not unit-testable here): the ▶ in the gutter of a runnable file (compact Java / Python / shell / `.http` request) is noticeably bigger and easier to hit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)