### PR TITLE
Add LSP semantic-token highlighting overlaid on TextMate

### DIFF
--- a/src/main/java/com/editora/config/Settings.java
+++ b/src/main/java/com/editora/config/Settings.java
@@ -10,7 +10,7 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 public class Settings {
 
     /** Current on-disk schema version of {@code settings.toml}; bump when the format changes (+ a migration). */
-    public static final int SCHEMA_VERSION = 31;
+    public static final int SCHEMA_VERSION = 32;
 
     private int schemaVersion = SCHEMA_VERSION;
 
@@ -80,6 +80,9 @@ public class Settings {
     private boolean autocompleteMermaid = true;
     /** Auto-show the IntelliJ-style documentation popup beside the completion list (Ctrl+Q toggles it). */
     private boolean completionDoc = true;
+    /** Overlay LSP semantic tokens on the syntax highlight (resolved types/params/deprecated, …); on by
+     *  default but only effective when LSP is enabled and the server advertises range semantic tokens. */
+    private boolean semanticHighlight = true;
     /** Honor a project's {@code .editorconfig} (indent, EOL, charset, trim/final-newline, max line length). */
     private boolean editorConfigSupport = true;
 
@@ -470,6 +473,14 @@ public class Settings {
 
     public void setCompletionDoc(boolean completionDoc) {
         this.completionDoc = completionDoc;
+    }
+
+    public boolean isSemanticHighlight() {
+        return semanticHighlight;
+    }
+
+    public void setSemanticHighlight(boolean semanticHighlight) {
+        this.semanticHighlight = semanticHighlight;
     }
 
     public boolean isEditorConfigSupport() {

--- a/src/main/java/com/editora/config/migration/ConfigSchema.java
+++ b/src/main/java/com/editora/config/migration/ConfigSchema.java
@@ -67,7 +67,8 @@ public enum ConfigSchema {
                     Map.entry(27, (Migration) ConfigMigrations::identity), // v27→28: + mcpSupport (additive)
                     Map.entry(28, (Migration) ConfigMigrations::identity), // v28→29: + completionDoc (additive)
                     Map.entry(29, (Migration) ConfigMigrations::identity), // v29→30: + editorConfigSupport
-                    Map.entry(30, (Migration) ConfigMigrations::identity))), // v30→31: + indentStyle (additive)
+                    Map.entry(30, (Migration) ConfigMigrations::identity), // v30→31: + indentStyle (additive)
+                    Map.entry(31, (Migration) ConfigMigrations::identity))), // v31→32: + semanticHighlight
     WORKSPACE(WorkspaceState.SCHEMA_VERSION, 1, Map.of()),
     BOOKMARKS(BookmarkStore.SCHEMA_VERSION, 1, Map.of()),
     BREAKPOINTS(BreakpointStore.SCHEMA_VERSION, 1, Map.of()),

--- a/src/main/java/com/editora/editor/EditorBuffer.java
+++ b/src/main/java/com/editora/editor/EditorBuffer.java
@@ -50,6 +50,7 @@ import org.fxmisc.flowless.VirtualizedScrollPane;
 import org.fxmisc.richtext.CodeArea;
 import org.fxmisc.richtext.LineNumberFactory;
 import org.fxmisc.richtext.NavigationActions.SelectionPolicy;
+import org.fxmisc.richtext.model.StyleSpans;
 import org.fxmisc.richtext.model.StyleSpansBuilder;
 import org.fxmisc.richtext.multi.MultiCaretController;
 import org.fxmisc.richtext.util.UndoUtils;
@@ -306,6 +307,19 @@ public class EditorBuffer implements TabContent {
     private java.util.function.Consumer<String> lspChangeListener;
     /** Debounced pull-diagnostics request (servers that answer textDocument/diagnostic); null = none. */
     private Runnable lspDiagnosticsRequester;
+    /** Debounced semantic-tokens request (servers advertising range semantic tokens); null = none. */
+    private Runnable semanticTokensRequester;
+    /** LSP semantic highlighting active for this buffer (server supports it + the feature is on). */
+    private boolean semanticActive;
+    /** Latest server semantic tokens (absolute positions), overlaid onto the TextMate highlight. */
+    private java.util.List<SemanticToken> semanticTokens = java.util.List.of();
+    /** True once the document changed after {@link #semanticTokens} were captured — suppresses the overlay
+     *  (so we never mis-color shifted text) until a fresh response lands via {@link #setSemanticTokens}. */
+    private boolean semanticStale;
+    /** Debounces a viewport semantic-tokens re-request after scrolling settles (so a new region gets
+     *  tokens without firing a server request per scroll frame). */
+    private final javafx.animation.PauseTransition semanticScrollDebounce =
+            new javafx.animation.PauseTransition(javafx.util.Duration.millis(250));
     /** Completion trigger characters the server advertised (e.g. {@code .} for Java, {@code <} for HTML). */
     private java.util.Set<Character> lspTriggerChars = java.util.Set.of();
 
@@ -485,6 +499,11 @@ public class EditorBuffer implements TabContent {
                         .getMajor();
                 dirtyFromLine = Math.min(dirtyFromLine, line);
             }
+            // The cached semantic tokens now point at shifted offsets; suppress the overlay until the
+            // next response re-anchors them (one boolean write — off the per-char path's cost budget).
+            if (semanticActive && !semanticStale) {
+                semanticStale = true;
+            }
         });
         area.multiPlainChanges().successionEnds(Duration.ofMillis(150)).subscribe(ignore -> {
             applyHighlighting();
@@ -502,6 +521,16 @@ public class EditorBuffer implements TabContent {
             }
             if (lspActive && lspDiagnosticsRequester != null) {
                 lspDiagnosticsRequester.run();
+            }
+            if (semanticActive && semanticTokensRequester != null) {
+                semanticTokensRequester.run();
+            }
+        });
+        // After scrolling settles, re-request semantic tokens for the now-visible region (debounced so a
+        // drag-scroll doesn't fire a request per frame). Inert unless semantic highlighting is active.
+        semanticScrollDebounce.setOnFinished(e -> {
+            if (semanticActive && semanticTokensRequester != null) {
+                semanticTokensRequester.run();
             }
         });
         // HTML live preview: debounced reload pulse for HTML buffers (only while a browser preview is open).
@@ -606,6 +635,11 @@ public class EditorBuffer implements TabContent {
         a.selectionProperty().addListener((obs, old, now) -> scheduleFormatBar());
         a.estimatedScrollYProperty().addListener((obs, old, now) -> scheduleFormatBar());
         a.estimatedScrollXProperty().addListener((obs, old, now) -> scheduleFormatBar());
+        a.estimatedScrollYProperty().addListener((obs, old, now) -> {
+            if (semanticActive) {
+                semanticScrollDebounce.playFromStart(); // re-request tokens for the scrolled-to region
+            }
+        });
         a.focusedProperty().addListener((obs, was, now) -> {
             if (!now) {
                 hideFormatBar();
@@ -1631,6 +1665,59 @@ public class EditorBuffer implements TabContent {
         lspOverlay.setDiagnostics(diagnostics);
         minimap.setDiagnostics(diagnostics);
         diagnosticStripe.setDiagnostics(diagnostics);
+    }
+
+    /** The debounced semantic-tokens request (fired on the 300 ms didChange pulse while active); null = none. */
+    public void setSemanticTokensRequester(Runnable requester) {
+        this.semanticTokensRequester = requester;
+    }
+
+    /** Turns LSP semantic highlighting on/off for this buffer (server supports it + feature enabled). Off in
+     *  large-file mode, like the diagnostics overlay. Re-applies the highlight so the overlay appears/clears. */
+    public void setSemanticActive(boolean on) {
+        boolean next = on && !largeFile;
+        if (next == semanticActive) {
+            return;
+        }
+        semanticActive = next;
+        if (!semanticActive) {
+            semanticTokens = java.util.List.of();
+            semanticStale = false;
+        }
+        invalidateHighlighting(); // force a full re-tokenize so the overlay is added/removed everywhere
+        applyHighlighting();
+    }
+
+    public boolean isSemanticActive() {
+        return semanticActive;
+    }
+
+    /** Pushes fresh server semantic tokens (absolute positions) and re-applies so they overlay the
+     *  TextMate highlight immediately. No-op when semantic highlighting is off for this buffer. */
+    public void setSemanticTokens(java.util.List<SemanticToken> tokens) {
+        if (!semanticActive) {
+            return;
+        }
+        semanticTokens = tokens == null ? java.util.List.of() : tokens;
+        semanticStale = false; // these are anchored to the current text → safe to overlay again
+        invalidateHighlighting();
+        applyHighlighting();
+    }
+
+    /** The inclusive 0-based line range currently visible in the editor (for a viewport semantic-tokens
+     *  request). Falls back to the whole document if the viewport indices aren't available yet. */
+    public int[] visibleLineWindow() {
+        int paragraphs = area.getParagraphs().size();
+        try {
+            int first = area.firstVisibleParToAllParIndex();
+            int last = area.lastVisibleParToAllParIndex();
+            if (last >= first && first >= 0) {
+                return new int[] {first, Math.min(last, Math.max(0, paragraphs - 1))};
+            }
+        } catch (RuntimeException ignore) {
+            // viewport not laid out yet — fall through to the whole-document window
+        }
+        return new int[] {0, Math.max(0, paragraphs - 1)};
     }
 
     /** The scrollbar stripe is shown whenever LSP is active for this buffer (minimap on or off). It sits
@@ -4841,7 +4928,16 @@ public class EditorBuffer implements TabContent {
                 if (a.fromOffset() + a.spans().length() != area.getLength()) {
                     return;
                 }
-                area.setStyleSpans(a.fromOffset(), a.spans());
+                StyleSpans<Collection<String>> spans = a.spans();
+                // Overlay the server's semantic tokens on top of the lexical highlight (semantic wins
+                // where present). Suppressed while stale (doc edited since the tokens were anchored).
+                if (semanticActive && !semanticStale && !semanticTokens.isEmpty()) {
+                    StyleSpans<Collection<String>> sem = buildSemanticSpans(a.fromOffset(), spans.length());
+                    if (sem != null) {
+                        spans = spans.overlay(sem, (lex, s) -> s.isEmpty() ? lex : s);
+                    }
+                }
+                area.setStyleSpans(a.fromOffset(), spans);
                 scheduleBraceMatch(); // re-apply the match highlight the spans just overwrote
                 // Replace per-line end-states from fromLine onward (the prefix is unchanged).
                 while (lineStates.size() > fromLine) {
@@ -4860,5 +4956,46 @@ public class EditorBuffer implements TabContent {
                 onSymbolsChanged.run();
             });
         });
+    }
+
+    /**
+     * A sparse {@link StyleSpans} of length {@code windowLen} (so it can {@code overlay} the TextMate
+     * spans starting at {@code windowStart}) carrying each cached semantic token's CSS class; gaps and
+     * out-of-window tokens are empty styles. Returns {@code null} if no token falls in the window.
+     *
+     * <p>Tokens are sorted by position (the decoder preserves wire order), so a single forward cursor
+     * builds the spans; an out-of-order or overlapping token is skipped defensively. Positions map
+     * through the live document (the {@code area}) — the {@code editor} package stays {@code lsp}-free.
+     */
+    private StyleSpans<Collection<String>> buildSemanticSpans(int windowStart, int windowLen) {
+        StyleSpansBuilder<Collection<String>> b = new StyleSpansBuilder<>();
+        int cursor = 0; // offset within the window of the next unstyled char
+        int paragraphs = area.getParagraphs().size();
+        for (SemanticToken t : semanticTokens) {
+            if (t.line() < 0 || t.line() >= paragraphs) {
+                continue; // line no longer exists (shrunk doc); the stale guard usually precludes this
+            }
+            int col = Math.min(t.startChar(), area.getParagraphLength(t.line()));
+            int off = area.getAbsolutePosition(t.line(), col) - windowStart;
+            if (off < cursor || off >= windowLen) {
+                continue; // before the cursor (overlap/out-of-order) or past the window end
+            }
+            int len = Math.min(t.length(), windowLen - off);
+            if (len <= 0) {
+                continue;
+            }
+            if (off > cursor) {
+                b.add(Collections.emptyList(), off - cursor);
+            }
+            b.add(List.of(t.cssClasses().split(" ")), len);
+            cursor = off + len;
+        }
+        if (cursor == 0) {
+            return null; // no token in this window — skip the overlay entirely
+        }
+        if (cursor < windowLen) {
+            b.add(Collections.emptyList(), windowLen - cursor);
+        }
+        return b.create();
     }
 }

--- a/src/main/java/com/editora/editor/SemanticToken.java
+++ b/src/main/java/com/editora/editor/SemanticToken.java
@@ -1,0 +1,12 @@
+package com.editora.editor;
+
+/**
+ * A resolved highlight span from an LSP server's semantic tokens: 0-based {@code line} and
+ * {@code startChar}, a character {@code length}, and a space-separated CSS class string
+ * (e.g. {@code "sem-parameter"} or {@code "sem-type sem-deprecated"}).
+ *
+ * <p>This is a neutral value type so the {@code editor} package never imports lsp4j — it mirrors
+ * {@link LspDiagnostic} / {@link LspTextEdit}. The {@code lsp} layer decodes the wire format into
+ * these; {@code EditorBuffer} overlays them onto the TextMate highlight.
+ */
+public record SemanticToken(int line, int startChar, int length, String cssClasses) {}

--- a/src/main/java/com/editora/lsp/LanguageServerSession.java
+++ b/src/main/java/com/editora/lsp/LanguageServerSession.java
@@ -184,6 +184,48 @@ final class LanguageServerSession implements LanguageClient {
                 });
     }
 
+    /**
+     * The semantic token types/modifiers we understand (the standard LSP 3.16 legend). The server
+     * intersects these with its own and reports the <em>effective</em> legend in its capabilities, which
+     * {@code LspManager} reads to decode responses — so this list only bounds what a server may send.
+     */
+    private static final java.util.List<String> SEMANTIC_TOKEN_TYPES = java.util.List.of(
+            org.eclipse.lsp4j.SemanticTokenTypes.Namespace,
+            org.eclipse.lsp4j.SemanticTokenTypes.Type,
+            org.eclipse.lsp4j.SemanticTokenTypes.Class,
+            org.eclipse.lsp4j.SemanticTokenTypes.Enum,
+            org.eclipse.lsp4j.SemanticTokenTypes.Interface,
+            org.eclipse.lsp4j.SemanticTokenTypes.Struct,
+            org.eclipse.lsp4j.SemanticTokenTypes.TypeParameter,
+            org.eclipse.lsp4j.SemanticTokenTypes.Parameter,
+            org.eclipse.lsp4j.SemanticTokenTypes.Variable,
+            org.eclipse.lsp4j.SemanticTokenTypes.Property,
+            org.eclipse.lsp4j.SemanticTokenTypes.EnumMember,
+            org.eclipse.lsp4j.SemanticTokenTypes.Event,
+            org.eclipse.lsp4j.SemanticTokenTypes.Function,
+            org.eclipse.lsp4j.SemanticTokenTypes.Method,
+            org.eclipse.lsp4j.SemanticTokenTypes.Macro,
+            org.eclipse.lsp4j.SemanticTokenTypes.Keyword,
+            org.eclipse.lsp4j.SemanticTokenTypes.Modifier,
+            org.eclipse.lsp4j.SemanticTokenTypes.Comment,
+            org.eclipse.lsp4j.SemanticTokenTypes.String,
+            org.eclipse.lsp4j.SemanticTokenTypes.Number,
+            org.eclipse.lsp4j.SemanticTokenTypes.Regexp,
+            org.eclipse.lsp4j.SemanticTokenTypes.Operator,
+            org.eclipse.lsp4j.SemanticTokenTypes.Decorator);
+
+    private static final java.util.List<String> SEMANTIC_TOKEN_MODIFIERS = java.util.List.of(
+            org.eclipse.lsp4j.SemanticTokenModifiers.Declaration,
+            org.eclipse.lsp4j.SemanticTokenModifiers.Definition,
+            org.eclipse.lsp4j.SemanticTokenModifiers.Readonly,
+            org.eclipse.lsp4j.SemanticTokenModifiers.Static,
+            org.eclipse.lsp4j.SemanticTokenModifiers.Deprecated,
+            org.eclipse.lsp4j.SemanticTokenModifiers.Abstract,
+            org.eclipse.lsp4j.SemanticTokenModifiers.Async,
+            org.eclipse.lsp4j.SemanticTokenModifiers.Modification,
+            org.eclipse.lsp4j.SemanticTokenModifiers.Documentation,
+            org.eclipse.lsp4j.SemanticTokenModifiers.DefaultLibrary);
+
     private static ClientCapabilities clientCapabilities() {
         TextDocumentClientCapabilities td = new TextDocumentClientCapabilities();
         td.setSynchronization(new SynchronizationCapabilities(false, false, true));
@@ -202,6 +244,13 @@ final class LanguageServerSession implements LanguageClient {
         // diagnostics only on a textDocument/diagnostic *request* (a diagnosticProvider) instead of
         // pushing publishDiagnostics. Declaring this lets us pull them (see LspManager.pullDiagnostics).
         td.setDiagnostic(new org.eclipse.lsp4j.DiagnosticCapabilities(false));
+        // Semantic tokens (LSP 3.16): a server-resolved classification we overlay onto TextMate — it
+        // distinguishes a parameter from a field from a type and flags deprecated/static/readonly. We
+        // advertise both encodings (the decoder handles either); LspManager prefers range and falls back to
+        // a full request for range-less servers (e.g. jdtls, which advertises range=false, full=true).
+        var stRequests = new org.eclipse.lsp4j.SemanticTokensClientCapabilitiesRequests(true, true); // full, range
+        td.setSemanticTokens(new org.eclipse.lsp4j.SemanticTokensCapabilities(
+                stRequests, SEMANTIC_TOKEN_TYPES, SEMANTIC_TOKEN_MODIFIERS, java.util.List.of("relative")));
         ClientCapabilities cc = new ClientCapabilities();
         cc.setTextDocument(td);
         // Declare we answer workspace/configuration — otherwise Pyright never asks for
@@ -421,6 +470,28 @@ final class LanguageServerSession implements LanguageClient {
         }
         return server.getTextDocumentService()
                 .diagnostic(new org.eclipse.lsp4j.DocumentDiagnosticParams(new TextDocumentIdentifier(uri)));
+    }
+
+    /** Semantic tokens over {@code range} ({@code textDocument/semanticTokens/range}); null when not ready. */
+    CompletableFuture<org.eclipse.lsp4j.SemanticTokens> semanticTokensRange(String uri, org.eclipse.lsp4j.Range range) {
+        if (!ready()) {
+            return CompletableFuture.completedFuture(null);
+        }
+        return server.getTextDocumentService()
+                .semanticTokensRange(
+                        new org.eclipse.lsp4j.SemanticTokensRangeParams(new TextDocumentIdentifier(uri), range))
+                .exceptionally(t -> null);
+    }
+
+    /** Whole-document semantic tokens ({@code textDocument/semanticTokens/full}), for servers that don't
+     *  advertise range requests; null when the session isn't ready. */
+    CompletableFuture<org.eclipse.lsp4j.SemanticTokens> semanticTokensFull(String uri) {
+        if (!ready()) {
+            return CompletableFuture.completedFuture(null);
+        }
+        return server.getTextDocumentService()
+                .semanticTokensFull(new org.eclipse.lsp4j.SemanticTokensParams(new TextDocumentIdentifier(uri)))
+                .exceptionally(t -> null);
     }
 
     private boolean ready() {

--- a/src/main/java/com/editora/lsp/LspManager.java
+++ b/src/main/java/com/editora/lsp/LspManager.java
@@ -447,6 +447,69 @@ public final class LspManager {
         });
     }
 
+    /** True if {@code file}'s server is ready and advertises range semantic tokens (viewport highlighting). */
+    public boolean supportsSemanticTokens(Path file) {
+        LanguageServerSession s = sessionFor(file);
+        return s != null && semanticTokensProvider(s.capabilities()) != null;
+    }
+
+    /**
+     * Pure: the server's semantic-tokens registration options if it supports range <em>or</em> full
+     * requests (and carries a legend), else {@code null}. Null-safe — gates {@link #requestSemanticTokens},
+     * which prefers range (viewport) and falls back to full for range-less servers.
+     */
+    static org.eclipse.lsp4j.SemanticTokensWithRegistrationOptions semanticTokensProvider(
+            org.eclipse.lsp4j.ServerCapabilities caps) {
+        if (caps == null) {
+            return null;
+        }
+        var p = caps.getSemanticTokensProvider();
+        if (p == null || p.getLegend() == null) {
+            return null;
+        }
+        return (eitherTrue(p.getRange()) || eitherTrue(p.getFull())) ? p : null;
+    }
+
+    /** True if an LSP {@code Either<Boolean, ?>} capability is present (right form) or explicitly true. */
+    private static boolean eitherTrue(org.eclipse.lsp4j.jsonrpc.messages.Either<Boolean, ?> e) {
+        return e != null && (e.isRight() || Boolean.TRUE.equals(e.getLeft()));
+    }
+
+    /**
+     * Requests semantic tokens over the line window {@code [startLine..endLine]} (inclusive) and delivers
+     * the decoded, CSS-classed {@link com.editora.editor.SemanticToken}s to {@code cb} on the FX thread
+     * (empty when unsupported / on error). The window bounds cost on large files — the caller passes the
+     * visible paragraph range. Decoding uses the server's effective legend, never hardcoded indices.
+     */
+    public void requestSemanticTokens(
+            Path file, int startLine, int endLine, Consumer<List<com.editora.editor.SemanticToken>> cb) {
+        LanguageServerSession s = sessionFor(file);
+        var prov = s == null ? null : semanticTokensProvider(s.capabilities());
+        if (prov == null) {
+            Platform.runLater(() -> cb.accept(List.of()));
+            return;
+        }
+        var legend = prov.getLegend();
+        // Prefer a range (viewport) request to bound cost; fall back to a whole-document request for a
+        // server that advertises only `full` (no range).
+        java.util.concurrent.CompletableFuture<org.eclipse.lsp4j.SemanticTokens> fut;
+        if (eitherTrue(prov.getRange())) {
+            // [startLine,0) .. [endLine+1,0) covers whole lines startLine..endLine; clamp start to >= 0.
+            var range = new org.eclipse.lsp4j.Range(
+                    new Position(Math.max(0, startLine), 0), new Position(Math.max(0, endLine) + 1, 0));
+            fut = s.semanticTokensRange(uri(file), range);
+        } else {
+            fut = s.semanticTokensFull(uri(file));
+        }
+        fut.whenComplete((tokens, error) -> {
+            List<com.editora.editor.SemanticToken> out = (error != null || tokens == null)
+                    ? List.of()
+                    : SemanticTokensDecoder.decode(
+                            tokens.getData(), legend.getTokenTypes(), legend.getTokenModifiers());
+            Platform.runLater(() -> cb.accept(out));
+        });
+    }
+
     public void hover(Path file, int line, int character, Consumer<String> cb) {
         LanguageServerSession s = sessionFor(file);
         if (s == null) {

--- a/src/main/java/com/editora/lsp/SemanticTokenMapper.java
+++ b/src/main/java/com/editora/lsp/SemanticTokenMapper.java
@@ -1,0 +1,64 @@
+package com.editora.lsp;
+
+import java.util.List;
+
+/**
+ * Pure mapping of a semantic-token <em>type name</em> + modifier bitset to a single CSS class string
+ * (or {@code null} = "leave TextMate's lexical class in place"). The mapping is driven by the server's
+ * <em>legend</em> (the ordered token-type / modifier name lists from {@code initialize}), never by
+ * hardcoded indices — jdtls, rust-analyzer, etc. each publish a different legend.
+ *
+ * <p>Modifier emphasis is folded into the class name ({@code "sem-function sem-deprecated"}) so
+ * {@code styles/syntax.css} stays a flat list of {@code .text.sem-*} rules with no per-modifier logic.
+ * Side-effect-free and toolkit-free so it can be unit-tested directly.
+ */
+public final class SemanticTokenMapper {
+
+    private SemanticTokenMapper() {}
+
+    /**
+     * The CSS class(es) for a token of type {@code type} with the given {@code modBits}, resolved against
+     * {@code modLegend}; {@code null} for a type TextMate already classifies well (keyword/comment/
+     * string/number/operator), so those fall through to the lexical highlight.
+     */
+    static String cssClass(String type, int modBits, List<String> modLegend) {
+        String base = baseClass(type);
+        if (base == null) {
+            return null;
+        }
+        // deprecated wins — it's a visible strikethrough TextMate can never produce. Otherwise a
+        // readonly/static symbol gets a subtle constant-like emphasis.
+        if (hasMod(modBits, modLegend, "deprecated")) {
+            return base + " sem-deprecated";
+        }
+        if (hasMod(modBits, modLegend, "readonly") || hasMod(modBits, modLegend, "static")) {
+            return base + " sem-constant";
+        }
+        return base;
+    }
+
+    /** The base {@code sem-*} class for a semantic token type, or {@code null} to defer to TextMate. */
+    private static String baseClass(String type) {
+        if (type == null) {
+            return null;
+        }
+        return switch (type) {
+            case "parameter" -> "sem-parameter";
+            case "property", "enumMember", "event", "recordComponent" -> "sem-property";
+            case "variable" -> "sem-variable";
+            case "function", "method" -> "sem-function";
+            case "class", "interface", "enum", "struct", "type", "typeParameter", "namespace", "record" -> "sem-type";
+            case "macro", "decorator", "annotation", "annotationMember" -> "sem-macro";
+            default -> null; // keyword/comment/string/number/regexp/operator/modifier — TextMate nails these
+        };
+    }
+
+    /** Whether bit {@code name} (looked up in {@code modLegend}) is set in {@code bits}. Null-safe. */
+    private static boolean hasMod(int bits, List<String> modLegend, String name) {
+        if (modLegend == null) {
+            return false;
+        }
+        int idx = modLegend.indexOf(name);
+        return idx >= 0 && idx < 32 && (bits & (1 << idx)) != 0;
+    }
+}

--- a/src/main/java/com/editora/lsp/SemanticTokensDecoder.java
+++ b/src/main/java/com/editora/lsp/SemanticTokensDecoder.java
@@ -1,0 +1,64 @@
+package com.editora.lsp;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import com.editora.editor.SemanticToken;
+
+/**
+ * Pure decode of an LSP semantic-tokens {@code data} array into absolute, CSS-classed
+ * {@link SemanticToken}s.
+ *
+ * <p>The wire format (LSP 3.16) is a flat {@code int[]} of <b>5 ints per token</b>, each token
+ * <b>delta-encoded</b> relative to the previous one:
+ * <pre>[deltaLine, deltaStartChar, length, tokenTypeIndex, tokenModifiersBitset]</pre>
+ * {@code deltaLine} is relative to the previous token's line; {@code deltaStartChar} is relative to
+ * the previous token's start <em>when on the same line</em>, else absolute. Indices reference the
+ * server's legend (the ordered type/modifier name lists from {@code initialize}); positions are
+ * UTF-16 based, which is exactly a Java {@code String} index — see {@link LspPositions}.
+ *
+ * <p>Tokens whose type maps to {@code null} (keyword/comment/… — already handled by TextMate) are
+ * dropped, but the running line/char cursor still advances through them so later tokens stay aligned.
+ * Side-effect-free and toolkit-free for direct unit testing.
+ */
+public final class SemanticTokensDecoder {
+
+    private SemanticTokensDecoder() {}
+
+    /**
+     * Decodes {@code data} against the server's {@code typeLegend}/{@code modLegend}. Returns an empty
+     * list for null/too-short data or a missing type legend; never throws on malformed input (a partial
+     * trailing group, an out-of-range type index) — such entries are skipped.
+     */
+    public static List<SemanticToken> decode(List<Integer> data, List<String> typeLegend, List<String> modLegend) {
+        List<SemanticToken> out = new ArrayList<>();
+        if (data == null || data.size() < 5 || typeLegend == null) {
+            return out;
+        }
+        int line = 0;
+        int startChar = 0;
+        for (int i = 0; i + 4 < data.size(); i += 5) {
+            int deltaLine = val(data.get(i));
+            int deltaStart = val(data.get(i + 1));
+            int length = val(data.get(i + 2));
+            int typeIdx = val(data.get(i + 3));
+            int modBits = val(data.get(i + 4));
+
+            line += deltaLine;
+            startChar = (deltaLine == 0) ? startChar + deltaStart : deltaStart; // absolute on a new line
+
+            if (length <= 0 || typeIdx < 0 || typeIdx >= typeLegend.size()) {
+                continue; // malformed/zero-length — cursor already advanced, just skip emitting
+            }
+            String css = SemanticTokenMapper.cssClass(typeLegend.get(typeIdx), modBits, modLegend);
+            if (css != null) {
+                out.add(new SemanticToken(line, startChar, length, css));
+            }
+        }
+        return out;
+    }
+
+    private static int val(Integer n) {
+        return n == null ? 0 : n;
+    }
+}

--- a/src/main/java/com/editora/ui/MainController.java
+++ b/src/main/java/com/editora/ui/MainController.java
@@ -3561,6 +3561,9 @@ public class MainController implements com.editora.mcp.McpBridge {
     private EditorBuffer debugValuesBuffer;
     /** Inline-value fetch cap — frames can hold hundreds of locals; the overlay needs a name→value map. */
     private static final int MAX_INLINE_VALUES = 100;
+    /** Lines of over-scan above/below the viewport when requesting semantic tokens, so small scrolls stay
+     *  within the cached band and don't trigger a fresh server request. */
+    private static final int SEMANTIC_WINDOW_PAD = 200;
 
     /** Fetches the selected frame's local variables and paints them as inline values in the frame's
      *  file buffer; also arms the hover value tooltip there (IntelliJ's editor surfaces). */
@@ -3992,6 +3995,46 @@ public class MainController implements com.editora.mcp.McpBridge {
         updateLspStatusBar();
     }
 
+    /**
+     * Requests semantic tokens for {@code buffer}'s visible region (padded by {@link #SEMANTIC_WINDOW_PAD})
+     * and pushes them into the buffer when the response lands — but only if it's still the active buffer
+     * (a background tab's tokens would overlay nothing useful and waste an apply). No-op when semantic
+     * highlighting isn't active for the buffer / it isn't server-managed.
+     */
+    private void requestSemanticTokens(EditorBuffer buffer) {
+        Path path = buffer.getPath();
+        if (path == null || !buffer.isSemanticActive() || !lspManager.isManaged(path)) {
+            return;
+        }
+        int[] window = buffer.visibleLineWindow();
+        lspManager.requestSemanticTokens(
+                path, window[0] - SEMANTIC_WINDOW_PAD, window[1] + SEMANTIC_WINDOW_PAD, tokens -> {
+                    if (buffer == activeBuffer()) {
+                        buffer.setSemanticTokens(tokens);
+                    }
+                });
+    }
+
+    /**
+     * Re-gates LSP semantic highlighting against {@code Settings.semanticHighlight} for every open buffer
+     * (the palette toggle's apply). Doesn't disturb the language-server sessions — just flips each managed
+     * buffer's overlay on/off and fetches tokens when turning on.
+     */
+    private void applySemanticHighlight() {
+        boolean want = config.getSettings().isSemanticHighlight();
+        for (Tab tab : tabPane.getTabs()) {
+            EditorBuffer b = bufferOf(tab);
+            if (b == null || b.getPath() == null) {
+                continue;
+            }
+            boolean on = want && lspManager.isManaged(b.getPath()) && lspManager.supportsSemanticTokens(b.getPath());
+            b.setSemanticActive(on);
+            if (on) {
+                requestSemanticTokens(b);
+            }
+        }
+    }
+
     /** Opens+activates an eligible buffer on its language's server, or deactivates+closes it otherwise. */
     /**
      * Refreshes the Structure tool window's outline for {@code buffer} from the language server
@@ -4037,11 +4080,19 @@ public class MainController implements com.editora.mcp.McpBridge {
             buffer.setLspFormatAvailable(lspManager.supportsFormatting(path));
             buffer.setLspRangeFormatAvailable(lspManager.supportsRangeFormatting(path));
             lspManager.pullDiagnostics(path);
+            // Semantic highlighting: gate on the setting + the server's capability; request the initial
+            // viewport (a no-op until the server reports ready, then onLspServerStatus refreshes it).
+            boolean semantic = config.getSettings().isSemanticHighlight() && lspManager.supportsSemanticTokens(path);
+            buffer.setSemanticActive(semantic);
+            if (semantic) {
+                requestSemanticTokens(buffer);
+            }
         } else {
             buffer.setLspActive(false);
             buffer.setLspTriggerChars(java.util.Set.of());
             buffer.setLspFormatAvailable(false);
             buffer.setLspRangeFormatAvailable(false);
+            buffer.setSemanticActive(false);
             if (path != null && lspManager.isManaged(path)) {
                 lspManager.closeDocument(path);
                 lspProblems.remove(path);
@@ -4186,6 +4237,13 @@ public class MainController implements com.editora.mcp.McpBridge {
                         b.setLspFormatAvailable(lspManager.supportsFormatting(b.getPath()));
                         b.setLspRangeFormatAvailable(lspManager.supportsRangeFormatting(b.getPath()));
                         lspManager.pullDiagnostics(b.getPath());
+                        // Capabilities are known now — (re)gate semantic highlighting + fetch initial tokens.
+                        boolean sem = config.getSettings().isSemanticHighlight()
+                                && lspManager.supportsSemanticTokens(b.getPath());
+                        b.setSemanticActive(sem);
+                        if (sem) {
+                            requestSemanticTokens(b);
+                        }
                     }
                 }
                 requestStructureSymbols(activeBuffer()); // the outline can now be populated from the server
@@ -6656,6 +6714,8 @@ public class MainController implements com.editora.mcp.McpBridge {
                 lspManager.pullDiagnostics(buffer.getPath());
             }
         });
+        // Semantic tokens re-request (fired on the same debounce as didChange + on scroll-settle).
+        buffer.setSemanticTokensRequester(() -> requestSemanticTokens(buffer));
         buffer.setLspCompletionProvider((pos, cb) -> {
             if (buffer.getPath() != null && lspManager.isManaged(buffer.getPath())) {
                 lspManager.completion(
@@ -11631,6 +11691,13 @@ public class MainController implements com.editora.mcp.McpBridge {
         registry.register(Command.of("lsp.restartServers", () -> ifLsp(this::restartLspServers)));
         registry.register(Command.of("lsp.formatDocument", () -> ifLsp(this::formatDocument)));
         registry.register(Command.of("view.toggleLsp", this::toggleLsp));
+        registry.register(Command.of(
+                "view.toggleSemanticHighlight",
+                () -> toggleSetting(
+                        "view.toggleSemanticHighlight",
+                        () -> config.getSettings().isSemanticHighlight(),
+                        config.getSettings()::setSemanticHighlight,
+                        this::applySemanticHighlight)));
         registry.register(Command.of("tool.commit", () -> ifGit(() -> toolWindows.toggle(commitToolWindow))));
         // Git (native CLI). Gated by the "Enable Git" setting (default off); also no-op when Git is
         // absent / not in a repo. The ifGit wrapper disables the commands + keybindings when Git is off.

--- a/src/main/java/com/editora/ui/SettingsWindow.java
+++ b/src/main/java/com/editora/ui/SettingsWindow.java
@@ -137,6 +137,7 @@ public class SettingsWindow {
     private CheckBox autocompleteSnippetsCheck;
     private CheckBox autocompleteMermaidCheck;
     private CheckBox completionDocCheck;
+    private CheckBox semanticHighlightCheck;
     private CheckBox spellCheckBox;
     private ComboBox<String> spellLanguageCombo;
     private CheckBox toolbarCheck;
@@ -530,6 +531,7 @@ public class SettingsWindow {
         autocompleteSnippetsCheck = viewCheck(tr("settings.autocomplete.snippets"), Settings::setAutocompleteSnippets);
         autocompleteMermaidCheck = viewCheck(tr("settings.autocomplete.mermaid"), Settings::setAutocompleteMermaid);
         completionDocCheck = viewCheck(tr("settings.completionDoc"), Settings::setCompletionDoc);
+        semanticHighlightCheck = viewCheck(tr("settings.semanticHighlight"), Settings::setSemanticHighlight);
         // The per-source toggles are only meaningful while the master switch is on.
         autocompleteCheck.selectedProperty().addListener((obs, was, now) -> {
             autocompleteProseCheck.setDisable(!now);
@@ -1127,6 +1129,12 @@ public class SettingsWindow {
                 completion,
                 completionDocCheck,
                 "completion documentation quick doc popup javadoc ctrl q");
+        row(
+                p,
+                Category.EDITOR,
+                completion,
+                semanticHighlightCheck,
+                "semantic highlighting lsp tokens types parameters fields deprecated");
         Label markdown = section(p, tr("settings.section.markdown"));
         row(
                 p,
@@ -2480,6 +2488,7 @@ public class SettingsWindow {
             autocompleteSnippetsCheck.setDisable(!settings.isAutocomplete());
             autocompleteMermaidCheck.setDisable(!settings.isAutocomplete());
             completionDocCheck.setSelected(settings.isCompletionDoc());
+            semanticHighlightCheck.setSelected(settings.isSemanticHighlight());
             pdfLineNumbersCheck.setSelected(settings.isPdfLineNumbers());
             pdfHighlightCheck.setSelected(settings.isPdfSyntaxHighlighting());
             pdfPageSizeCombo.setValue(settings.getPdfPageSize());
@@ -2921,6 +2930,7 @@ public class SettingsWindow {
             autocompleteSnippetsCheck.setDisable(!s.isAutocomplete());
             autocompleteMermaidCheck.setDisable(!s.isAutocomplete());
             completionDocCheck.setSelected(s.isCompletionDoc());
+            semanticHighlightCheck.setSelected(s.isSemanticHighlight());
         } finally {
             loading = prev;
         }

--- a/src/main/resources/com/editora/i18n/messages.properties
+++ b/src/main/resources/com/editora/i18n/messages.properties
@@ -1801,3 +1801,6 @@ structure.sort.position=Position
 structure.sort.name=Name
 structure.sort.kind=Kind
 structure.filter.kinds=Filter by kind
+command.view.toggleSemanticHighlight=Toggle Semantic Highlighting
+command.view.toggleSemanticHighlight.desc=Turn LSP semantic token highlighting on or off.
+settings.semanticHighlight=Semantic highlighting (LSP)

--- a/src/main/resources/com/editora/i18n/messages_de.properties
+++ b/src/main/resources/com/editora/i18n/messages_de.properties
@@ -1793,3 +1793,6 @@ structure.sort.position=Position
 structure.sort.name=Name
 structure.sort.kind=Art
 structure.filter.kinds=Nach Art filtern
+command.view.toggleSemanticHighlight=Semantische Hervorhebung umschalten
+command.view.toggleSemanticHighlight.desc=Die semantische Token-Hervorhebung über LSP ein- oder ausschalten.
+settings.semanticHighlight=Semantische Hervorhebung (LSP)

--- a/src/main/resources/com/editora/i18n/messages_es.properties
+++ b/src/main/resources/com/editora/i18n/messages_es.properties
@@ -1793,3 +1793,6 @@ structure.sort.position=Posición
 structure.sort.name=Nombre
 structure.sort.kind=Tipo
 structure.filter.kinds=Filtrar por tipo
+command.view.toggleSemanticHighlight=Activar/desactivar resaltado semántico
+command.view.toggleSemanticHighlight.desc=Activar o desactivar el resaltado mediante tokens semánticos de LSP.
+settings.semanticHighlight=Resaltado semántico (LSP)

--- a/src/main/resources/com/editora/i18n/messages_fr.properties
+++ b/src/main/resources/com/editora/i18n/messages_fr.properties
@@ -1793,3 +1793,6 @@ structure.sort.position=Position
 structure.sort.name=Nom
 structure.sort.kind=Type
 structure.filter.kinds=Filtrer par type
+command.view.toggleSemanticHighlight=Activer/désactiver la coloration sémantique
+command.view.toggleSemanticHighlight.desc=Activer ou désactiver la coloration par jetons sémantiques LSP.
+settings.semanticHighlight=Coloration sémantique (LSP)

--- a/src/main/resources/com/editora/i18n/messages_it.properties
+++ b/src/main/resources/com/editora/i18n/messages_it.properties
@@ -1793,3 +1793,6 @@ structure.sort.position=Posizione
 structure.sort.name=Nome
 structure.sort.kind=Tipo
 structure.filter.kinds=Filtra per tipo
+command.view.toggleSemanticHighlight=Attiva/disattiva evidenziazione semantica
+command.view.toggleSemanticHighlight.desc=Attiva o disattiva l'evidenziazione tramite token semantici LSP.
+settings.semanticHighlight=Evidenziazione semantica (LSP)

--- a/src/main/resources/com/editora/i18n/messages_pt.properties
+++ b/src/main/resources/com/editora/i18n/messages_pt.properties
@@ -1793,3 +1793,6 @@ structure.sort.position=Posição
 structure.sort.name=Nome
 structure.sort.kind=Tipo
 structure.filter.kinds=Filtrar por tipo
+command.view.toggleSemanticHighlight=Ativar/desativar realce semântico
+command.view.toggleSemanticHighlight.desc=Ativa ou desativa o realce por tokens semânticos do LSP.
+settings.semanticHighlight=Realce semântico (LSP)

--- a/src/main/resources/com/editora/styles/editor-themes/cupertino-dark.css
+++ b/src/main/resources/com/editora/styles/editor-themes/cupertino-dark.css
@@ -39,6 +39,16 @@
 .text.bold       { -fx-fill: #dfdfe0; -fx-font-weight: bold; }
 .text.italic     { -fx-fill: #dfdfe0; -fx-font-style: italic; }
 
+/* LSP semantic tokens — mirror this theme's lexical token colors (overlaid on TextMate). */
+.text.sem-parameter { -fx-fill: #dfdfe0; -fx-font-style: italic; }
+.text.sem-variable  { -fx-fill: #dfdfe0; }
+.text.sem-property  { -fx-fill: #d0bf69; }
+.text.sem-function  { -fx-fill: #67b7a4; }
+.text.sem-type      { -fx-fill: #5dd8ff; }
+.text.sem-macro     { -fx-fill: #5dd8ff; }
+.text.sem-constant  { -fx-fill: #d0bf69; }
+.text.sem-deprecated { -fx-fill: #6c7986; -fx-strikethrough: true; }
+
 /* Project tree: folder accent + muted file, matching this theme. */
 .project-tree { -project-folder-color: #0a84ff; -project-file-color: #6f6f73; }
 

--- a/src/main/resources/com/editora/styles/editor-themes/cupertino-light.css
+++ b/src/main/resources/com/editora/styles/editor-themes/cupertino-light.css
@@ -39,6 +39,16 @@
 .text.bold       { -fx-fill: #1d1d1f; -fx-font-weight: bold; }
 .text.italic     { -fx-fill: #1d1d1f; -fx-font-style: italic; }
 
+/* LSP semantic tokens — mirror this theme's lexical token colors (overlaid on TextMate). */
+.text.sem-parameter { -fx-fill: #1d1d1f; -fx-font-style: italic; }
+.text.sem-variable  { -fx-fill: #1d1d1f; }
+.text.sem-property  { -fx-fill: #1c00cf; }
+.text.sem-function  { -fx-fill: #3e6d74; }
+.text.sem-type      { -fx-fill: #3900a0; }
+.text.sem-macro     { -fx-fill: #3900a0; }
+.text.sem-constant  { -fx-fill: #1c00cf; }
+.text.sem-deprecated { -fx-fill: #5d6c79; -fx-strikethrough: true; }
+
 /* Project tree: folder accent + muted file, matching this theme. */
 .project-tree { -project-folder-color: #0a84ff; -project-file-color: #a0a0a8; }
 

--- a/src/main/resources/com/editora/styles/editor-themes/dracula.css
+++ b/src/main/resources/com/editora/styles/editor-themes/dracula.css
@@ -39,6 +39,16 @@
 .text.bold       { -fx-fill: #f8f8f2; -fx-font-weight: bold; }
 .text.italic     { -fx-fill: #f8f8f2; -fx-font-style: italic; }
 
+/* LSP semantic tokens — mirror this theme's lexical token colors (overlaid on TextMate). */
+.text.sem-parameter { -fx-fill: #f8f8f2; -fx-font-style: italic; }
+.text.sem-variable  { -fx-fill: #f8f8f2; }
+.text.sem-property  { -fx-fill: #8be9fd; }
+.text.sem-function  { -fx-fill: #50fa7b; }
+.text.sem-type      { -fx-fill: #8be9fd; }
+.text.sem-macro     { -fx-fill: #8be9fd; }
+.text.sem-constant  { -fx-fill: #bd93f9; }
+.text.sem-deprecated { -fx-fill: #6272a4; -fx-strikethrough: true; }
+
 /* Project tree: folder accent + muted file, matching this theme. */
 .project-tree { -project-folder-color: #bd93f9; -project-file-color: #6272a4; }
 

--- a/src/main/resources/com/editora/styles/editor-themes/islands-dark.css
+++ b/src/main/resources/com/editora/styles/editor-themes/islands-dark.css
@@ -41,6 +41,16 @@
 .text.bold       { -fx-fill: #bcbec4; -fx-font-weight: bold; }
 .text.italic     { -fx-fill: #bcbec4; -fx-font-style: italic; }
 
+/* LSP semantic tokens — mirror this theme's lexical token colors (overlaid on TextMate). */
+.text.sem-parameter { -fx-fill: #bcbec4; -fx-font-style: italic; }
+.text.sem-variable  { -fx-fill: #bcbec4; }
+.text.sem-property  { -fx-fill: #c77dbb; }
+.text.sem-function  { -fx-fill: #56a8f5; }
+.text.sem-type      { -fx-fill: #bcbec4; }
+.text.sem-macro     { -fx-fill: #bcbec4; }
+.text.sem-constant  { -fx-fill: #c77dbb; }
+.text.sem-deprecated { -fx-fill: #7a7e85; -fx-strikethrough: true; }
+
 /* Project tree: folder accent + muted file, matching this theme. */
 .project-tree { -project-folder-color: #56a8f5; -project-file-color: #7a7e85; }
 

--- a/src/main/resources/com/editora/styles/editor-themes/islands-light.css
+++ b/src/main/resources/com/editora/styles/editor-themes/islands-light.css
@@ -41,6 +41,16 @@
 .text.bold       { -fx-fill: #080808; -fx-font-weight: bold; }
 .text.italic     { -fx-fill: #080808; -fx-font-style: italic; }
 
+/* LSP semantic tokens — mirror this theme's lexical token colors (overlaid on TextMate). */
+.text.sem-parameter { -fx-fill: #080808; -fx-font-style: italic; }
+.text.sem-variable  { -fx-fill: #080808; }
+.text.sem-property  { -fx-fill: #871094; }
+.text.sem-function  { -fx-fill: #00627a; }
+.text.sem-type      { -fx-fill: #080808; }
+.text.sem-macro     { -fx-fill: #080808; }
+.text.sem-constant  { -fx-fill: #871094; }
+.text.sem-deprecated { -fx-fill: #8c8c8c; -fx-strikethrough: true; }
+
 /* Project tree: folder accent + muted file, matching this theme. */
 .project-tree { -project-folder-color: #3574f0; -project-file-color: #adadad; }
 

--- a/src/main/resources/com/editora/styles/editor-themes/nord-dark.css
+++ b/src/main/resources/com/editora/styles/editor-themes/nord-dark.css
@@ -39,6 +39,16 @@
 .text.bold       { -fx-fill: #d8dee9; -fx-font-weight: bold; }
 .text.italic     { -fx-fill: #d8dee9; -fx-font-style: italic; }
 
+/* LSP semantic tokens — mirror this theme's lexical token colors (overlaid on TextMate). */
+.text.sem-parameter { -fx-fill: #d8dee9; -fx-font-style: italic; }
+.text.sem-variable  { -fx-fill: #d8dee9; }
+.text.sem-property  { -fx-fill: #88c0d0; }
+.text.sem-function  { -fx-fill: #88c0d0; }
+.text.sem-type      { -fx-fill: #8fbcbb; }
+.text.sem-macro     { -fx-fill: #8fbcbb; }
+.text.sem-constant  { -fx-fill: #b48ead; }
+.text.sem-deprecated { -fx-fill: #7b88a1; -fx-strikethrough: true; }
+
 /* Project tree: folder accent + muted file, matching this theme. */
 .project-tree { -project-folder-color: #88c0d0; -project-file-color: #6c7689; }
 

--- a/src/main/resources/com/editora/styles/editor-themes/nord-light.css
+++ b/src/main/resources/com/editora/styles/editor-themes/nord-light.css
@@ -39,6 +39,16 @@
 .text.bold       { -fx-fill: #2e3440; -fx-font-weight: bold; }
 .text.italic     { -fx-fill: #2e3440; -fx-font-style: italic; }
 
+/* LSP semantic tokens — mirror this theme's lexical token colors (overlaid on TextMate). */
+.text.sem-parameter { -fx-fill: #2e3440; -fx-font-style: italic; }
+.text.sem-variable  { -fx-fill: #2e3440; }
+.text.sem-property  { -fx-fill: #5d80ae; }
+.text.sem-function  { -fx-fill: #5d80ae; }
+.text.sem-type      { -fx-fill: #8fa1b3; }
+.text.sem-macro     { -fx-fill: #8fa1b3; }
+.text.sem-constant  { -fx-fill: #b48ead; }
+.text.sem-deprecated { -fx-fill: #7b88a1; -fx-strikethrough: true; }
+
 /* Project tree: folder accent + muted file, matching this theme. */
 .project-tree { -project-folder-color: #5e81ac; -project-file-color: #9aa3b2; }
 

--- a/src/main/resources/com/editora/styles/editor-themes/primer-dark.css
+++ b/src/main/resources/com/editora/styles/editor-themes/primer-dark.css
@@ -40,6 +40,16 @@
 .text.bold       { -fx-fill: #c9d1d9; -fx-font-weight: bold; }
 .text.italic     { -fx-fill: #c9d1d9; -fx-font-style: italic; }
 
+/* LSP semantic tokens — mirror this theme's lexical token colors (overlaid on TextMate). */
+.text.sem-parameter { -fx-fill: #c9d1d9; -fx-font-style: italic; }
+.text.sem-variable  { -fx-fill: #c9d1d9; }
+.text.sem-property  { -fx-fill: #79c0ff; }
+.text.sem-function  { -fx-fill: #d2a8ff; }
+.text.sem-type      { -fx-fill: #ffa657; }
+.text.sem-macro     { -fx-fill: #ffa657; }
+.text.sem-constant  { -fx-fill: #79c0ff; }
+.text.sem-deprecated { -fx-fill: #8b949e; -fx-strikethrough: true; }
+
 /* Project tree: folder accent + muted file, matching this theme. */
 .project-tree { -project-folder-color: #58a6ff; -project-file-color: #6e7681; }
 

--- a/src/main/resources/com/editora/styles/syntax.css
+++ b/src/main/resources/com/editora/styles/syntax.css
@@ -34,6 +34,21 @@
 .text.bold       { -fx-fill: #24292f; -fx-font-weight: bold; }
 .text.italic     { -fx-fill: #24292f; -fx-font-style: italic; }
 
+/* LSP semantic tokens (Primer Light defaults). These OVERLAY the lexical TextMate classes — a
+   semantically classified span carries only its `sem-*` class(es), so there's no conflict with the
+   token rules above. Same compound `.text.<class>` form + cache rules. The modifier classes
+   `sem-constant`/`sem-deprecated` are listed LAST so, when appended to a base class (e.g.
+   `sem-variable sem-constant`), they win the fill on source order. Each editor theme overrides these
+   (see editor-themes/*.css) just like the lexical classes; these base values suit Primer Light. */
+.text.sem-parameter { -fx-fill: #24292f; -fx-font-style: italic; }
+.text.sem-variable  { -fx-fill: #24292f; }
+.text.sem-property  { -fx-fill: #0550ae; }
+.text.sem-function  { -fx-fill: #8250df; }
+.text.sem-type      { -fx-fill: #953800; }
+.text.sem-macro     { -fx-fill: #953800; }
+.text.sem-constant  { -fx-fill: #0550ae; } /* readonly/static emphasis */
+.text.sem-deprecated { -fx-fill: #6e7781; -fx-strikethrough: true; } /* TextMate can never do this */
+
 /* Matching-bracket highlight (combined with the bracket's token class, so it keeps its color). A
    semi-transparent box reads on both light and dark editor themes, so no per-theme override is needed.
    Compound `.text.<class>` like the token rules (no descendant combinator → keeps the style cache). */

--- a/src/test/java/com/editora/lsp/LspManagerTest.java
+++ b/src/test/java/com/editora/lsp/LspManagerTest.java
@@ -4,14 +4,32 @@ import java.util.List;
 import java.util.Set;
 
 import org.eclipse.lsp4j.CompletionOptions;
+import org.eclipse.lsp4j.SemanticTokensLegend;
+import org.eclipse.lsp4j.SemanticTokensWithRegistrationOptions;
 import org.eclipse.lsp4j.ServerCapabilities;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-/** Unit tests for {@link LspManager}'s pure helper that extracts completion trigger characters. */
+/** Unit tests for {@link LspManager}'s pure capability helpers (trigger chars, semantic-tokens gate). */
 class LspManagerTest {
+
+    private static SemanticTokensWithRegistrationOptions stProvider(boolean withLegend, Boolean range, Boolean full) {
+        var opts = new SemanticTokensWithRegistrationOptions(); // no-arg: legend stays null (ctor rejects null)
+        if (withLegend) {
+            opts.setLegend(new SemanticTokensLegend(List.of("keyword"), List.of("static")));
+        }
+        if (range != null) {
+            opts.setRange(range);
+        }
+        if (full != null) {
+            opts.setFull(full);
+        }
+        return opts;
+    }
 
     @Test
     void extractsTriggerCharactersFromCapabilities() {
@@ -34,5 +52,37 @@ class LspManagerTest {
         ServerCapabilities noTriggers = new ServerCapabilities();
         noTriggers.setCompletionProvider(new CompletionOptions()); // completionProvider, null triggerCharacters
         assertTrue(LspManager.triggerCharsOf(noTriggers).isEmpty());
+    }
+
+    @Test
+    void semanticTokensProviderSupportedWithRangeOrFull() {
+        ServerCapabilities range = new ServerCapabilities();
+        range.setSemanticTokensProvider(stProvider(true, true, null));
+        assertNotNull(LspManager.semanticTokensProvider(range)); // legend + range → supported
+
+        ServerCapabilities fullOnly = new ServerCapabilities();
+        fullOnly.setSemanticTokensProvider(stProvider(true, false, true));
+        assertNotNull(LspManager.semanticTokensProvider(
+                fullOnly)); // full-only (e.g. some servers) → supported, full fallback
+    }
+
+    @Test
+    void semanticTokensProviderNullWhenNeitherRangeNorFull() {
+        ServerCapabilities neither = new ServerCapabilities();
+        neither.setSemanticTokensProvider(stProvider(true, false, false));
+        assertNull(LspManager.semanticTokensProvider(neither));
+
+        ServerCapabilities unset = new ServerCapabilities();
+        unset.setSemanticTokensProvider(stProvider(true, null, null));
+        assertNull(LspManager.semanticTokensProvider(unset)); // range + full both unset
+    }
+
+    @Test
+    void semanticTokensProviderNullWhenAbsentOrNoLegend() {
+        assertNull(LspManager.semanticTokensProvider(null));
+        assertNull(LspManager.semanticTokensProvider(new ServerCapabilities())); // no provider at all
+        ServerCapabilities noLegend = new ServerCapabilities();
+        noLegend.setSemanticTokensProvider(stProvider(false, true, true));
+        assertNull(LspManager.semanticTokensProvider(noLegend)); // can't decode without a legend
     }
 }

--- a/src/test/java/com/editora/lsp/SemanticTokenMapperTest.java
+++ b/src/test/java/com/editora/lsp/SemanticTokenMapperTest.java
@@ -1,0 +1,73 @@
+package com.editora.lsp;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+class SemanticTokenMapperTest {
+
+    private static final List<String> MODS =
+            List.of("declaration", "definition", "readonly", "static", "deprecated", "abstract", "async");
+
+    private static int bit(int index) {
+        return 1 << index;
+    }
+
+    @Test
+    void typesMapToBaseClasses() {
+        assertEquals("sem-parameter", SemanticTokenMapper.cssClass("parameter", 0, MODS));
+        assertEquals("sem-variable", SemanticTokenMapper.cssClass("variable", 0, MODS));
+        assertEquals("sem-property", SemanticTokenMapper.cssClass("property", 0, MODS));
+        assertEquals("sem-property", SemanticTokenMapper.cssClass("enumMember", 0, MODS));
+        assertEquals("sem-function", SemanticTokenMapper.cssClass("method", 0, MODS));
+        assertEquals("sem-function", SemanticTokenMapper.cssClass("function", 0, MODS));
+        assertEquals("sem-type", SemanticTokenMapper.cssClass("class", 0, MODS));
+        assertEquals("sem-type", SemanticTokenMapper.cssClass("interface", 0, MODS));
+        assertEquals("sem-macro", SemanticTokenMapper.cssClass("decorator", 0, MODS));
+    }
+
+    @Test
+    void jdtlsSpecificTypesMap() {
+        // jdtls publishes these beyond the standard set
+        assertEquals("sem-type", SemanticTokenMapper.cssClass("record", 0, MODS));
+        assertEquals("sem-property", SemanticTokenMapper.cssClass("recordComponent", 0, MODS));
+        assertEquals("sem-macro", SemanticTokenMapper.cssClass("annotation", 0, MODS));
+    }
+
+    @Test
+    void lexicalTypesDeferToTextMate() {
+        for (String t : List.of("keyword", "comment", "string", "number", "regexp", "operator", "modifier")) {
+            assertNull(SemanticTokenMapper.cssClass(t, 0, MODS), t + " should fall through to TextMate");
+        }
+        assertNull(SemanticTokenMapper.cssClass("somethingNew", 0, MODS));
+        assertNull(SemanticTokenMapper.cssClass(null, 0, MODS));
+    }
+
+    @Test
+    void deprecatedTakesPrecedenceOverReadonly() {
+        int both = bit(2) | bit(4); // readonly + deprecated
+        assertEquals("sem-function sem-deprecated", SemanticTokenMapper.cssClass("method", both, MODS));
+    }
+
+    @Test
+    void readonlyOrStaticEmphasis() {
+        assertEquals("sem-variable sem-constant", SemanticTokenMapper.cssClass("variable", bit(2), MODS));
+        assertEquals("sem-type sem-constant", SemanticTokenMapper.cssClass("class", bit(3), MODS));
+    }
+
+    @Test
+    void unrelatedModifiersDoNotEmphasize() {
+        assertEquals("sem-parameter", SemanticTokenMapper.cssClass("parameter", bit(0) | bit(1), MODS));
+    }
+
+    @Test
+    void modifierLegendIsNullSafe() {
+        // No legend → modifiers can't be resolved, so just the base class (never throws even with all bits set).
+        assertEquals("sem-function", SemanticTokenMapper.cssClass("method", 0xFFFF, null));
+        // A modifier name absent from this server's legend is simply not set (deprecated bit, but no such entry).
+        assertEquals("sem-variable", SemanticTokenMapper.cssClass("variable", bit(4), List.of("declaration")));
+    }
+}

--- a/src/test/java/com/editora/lsp/SemanticTokensDecoderTest.java
+++ b/src/test/java/com/editora/lsp/SemanticTokensDecoderTest.java
@@ -1,0 +1,163 @@
+package com.editora.lsp;
+
+import java.util.List;
+
+import com.editora.editor.SemanticToken;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class SemanticTokensDecoderTest {
+
+    /** The standard LSP token-type legend (index = position), as a server reports in its capabilities. */
+    private static final List<String> TYPES = List.of(
+            "namespace", // 0
+            "type", // 1
+            "class", // 2
+            "enum", // 3
+            "interface", // 4
+            "struct", // 5
+            "typeParameter", // 6
+            "parameter", // 7
+            "variable", // 8
+            "property", // 9
+            "enumMember", // 10
+            "event", // 11
+            "function", // 12
+            "method", // 13
+            "macro", // 14
+            "keyword", // 15
+            "modifier", // 16
+            "comment", // 17
+            "string", // 18
+            "number", // 19
+            "regexp", // 20
+            "operator", // 21
+            "decorator"); // 22
+
+    private static final List<String> MODS =
+            List.of("declaration", "definition", "readonly", "static", "deprecated", "abstract", "async");
+
+    private static int bit(int index) {
+        return 1 << index;
+    }
+
+    @Test
+    void singleTokenAbsolutePosition() {
+        // one parameter at line 2, char 13, length 1
+        List<SemanticToken> out = SemanticTokensDecoder.decode(List.of(2, 13, 1, 7, 0), TYPES, MODS);
+        assertEquals(1, out.size());
+        SemanticToken t = out.get(0);
+        assertEquals(2, t.line());
+        assertEquals(13, t.startChar());
+        assertEquals(1, t.length());
+        assertEquals("sem-parameter", t.cssClasses());
+    }
+
+    @Test
+    void twoTokensOnSameLineUseRelativeStartChar() {
+        // property at (3,4) len 5, then parameter at (3,12) len 1 — second deltaStartChar = 12-4 = 8.
+        List<SemanticToken> out = SemanticTokensDecoder.decode(List.of(3, 4, 5, 9, 0, 0, 8, 1, 7, 0), TYPES, MODS);
+        assertEquals(2, out.size());
+        assertEquals(3, out.get(0).line());
+        assertEquals(4, out.get(0).startChar());
+        assertEquals("sem-property", out.get(0).cssClasses());
+        assertEquals(3, out.get(1).line()); // deltaLine 0 → same line
+        assertEquals(12, out.get(1).startChar()); // 4 + 8
+        assertEquals("sem-parameter", out.get(1).cssClasses());
+    }
+
+    @Test
+    void newLineResetsStartCharToAbsolute() {
+        // token A at (0,10), token B one line down at absolute char 4 (deltaLine 1 ⇒ startChar = 4, not 14).
+        List<SemanticToken> out = SemanticTokensDecoder.decode(List.of(0, 10, 2, 8, 0, 1, 4, 3, 13, 0), TYPES, MODS);
+        assertEquals(2, out.size());
+        assertEquals(0, out.get(0).line());
+        assertEquals(10, out.get(0).startChar());
+        assertEquals(1, out.get(1).line());
+        assertEquals(4, out.get(1).startChar()); // absolute, NOT 10+4
+    }
+
+    @Test
+    void deprecatedModifierAppendsStrikeClass() {
+        List<SemanticToken> out = SemanticTokensDecoder.decode(List.of(5, 2, 3, 13, bit(4)), TYPES, MODS);
+        assertEquals("sem-function sem-deprecated", out.get(0).cssClasses());
+    }
+
+    @Test
+    void readonlyAndStaticGetConstantEmphasis() {
+        assertEquals(
+                "sem-variable sem-constant",
+                SemanticTokensDecoder.decode(List.of(1, 0, 3, 8, bit(2)), TYPES, MODS)
+                        .get(0)
+                        .cssClasses());
+        assertEquals(
+                "sem-property sem-constant",
+                SemanticTokensDecoder.decode(List.of(1, 0, 3, 9, bit(3)), TYPES, MODS)
+                        .get(0)
+                        .cssClasses());
+    }
+
+    @Test
+    void unmappedTypeIsDroppedButCursorStillAdvances() {
+        // keyword (type 15) at (0,0) len 5 is dropped; parameter follows on the same line at char 6.
+        List<SemanticToken> out = SemanticTokensDecoder.decode(List.of(0, 0, 5, 15, 0, 0, 6, 1, 7, 0), TYPES, MODS);
+        assertEquals(1, out.size()); // keyword not emitted
+        assertEquals(0, out.get(0).line());
+        assertEquals(6, out.get(0).startChar()); // the dropped keyword still advanced startChar
+        assertEquals("sem-parameter", out.get(0).cssClasses());
+    }
+
+    @Test
+    void multiLineSequenceDecodesAllPositions() {
+        // Models:  class A { int field; void m(int p) { field = p; } }
+        //   field   @ (1,6)  property
+        //   m       @ (2,7)  method (declaration)
+        //   p       @ (2,13) parameter   (same line as m → relative)
+        //   field   @ (3,4)  property
+        //   p       @ (3,12) parameter   (same line → relative)
+        List<Integer> data = List.of(
+                1, 6, 5, 9, 0, // field
+                1, 7, 1, 13, bit(0), // m (deltaLine 1 from field's line)
+                0, 6, 1, 7, 0, // p  (same line, 13-7=6)
+                1, 4, 5, 9, 0, // field (deltaLine 1)
+                0, 8, 1, 7, 0); // p  (same line, 12-4=8)
+        List<SemanticToken> out = SemanticTokensDecoder.decode(data, TYPES, MODS);
+        assertEquals(5, out.size());
+        assertEquals(1, out.get(0).line());
+        assertEquals(6, out.get(0).startChar());
+        assertEquals(2, out.get(1).line());
+        assertEquals(7, out.get(1).startChar());
+        assertEquals("sem-function", out.get(1).cssClasses());
+        assertEquals(2, out.get(2).line());
+        assertEquals(13, out.get(2).startChar());
+        assertEquals(3, out.get(3).line());
+        assertEquals(4, out.get(3).startChar());
+        assertEquals(3, out.get(4).line());
+        assertEquals(12, out.get(4).startChar());
+    }
+
+    @Test
+    void malformedInputsAreToleratedNotThrown() {
+        assertTrue(SemanticTokensDecoder.decode(null, TYPES, MODS).isEmpty());
+        assertTrue(SemanticTokensDecoder.decode(List.of(), TYPES, MODS).isEmpty());
+        assertTrue(SemanticTokensDecoder.decode(List.of(1, 2, 3), TYPES, MODS).isEmpty()); // partial group
+        assertTrue(
+                SemanticTokensDecoder.decode(List.of(0, 0, 1, 7, 0), null, MODS).isEmpty()); // no legend
+        // type index past the legend → skipped, no throw
+        assertTrue(SemanticTokensDecoder.decode(List.of(0, 0, 1, 99, 0), TYPES, MODS)
+                .isEmpty());
+        // trailing partial group after a valid one: only the valid token is decoded
+        assertEquals(
+                1,
+                SemanticTokensDecoder.decode(List.of(0, 0, 1, 7, 0, 9, 9), TYPES, MODS)
+                        .size());
+    }
+
+    @Test
+    void zeroLengthTokenSkipped() {
+        assertTrue(SemanticTokensDecoder.decode(List.of(0, 0, 0, 7, 0), TYPES, MODS)
+                .isEmpty());
+    }
+}


### PR DESCRIPTION
## Summary

LSP **semantic-token highlighting**, overlaid on the existing TextMate syntax highlight (augments, never replaces). Surfaces resolved info TextMate fundamentally can't know — parameter vs field vs type, `@Deprecated` strikethrough, static/readonly emphasis — a beat after the instant lexical pass.

Verified live against jdtls (parameters render italic, a `@Deprecated` method's call site + declaration strike through), and confirmed end-to-end via a standalone LSP probe (jdtls returns 43 tokens for a small file).

## What's included

- **Pure, unit-tested core** — `lsp/SemanticTokensDecoder` (delta-encoded `int[]` → absolute tokens), `lsp/SemanticTokenMapper` (server legend → `sem-*` CSS class), `editor/SemanticToken` (neutral record, keeps `editor` lsp4j-free).
- **Capability handling** — `LspManager` gate accepts **range or full**, and requests `textDocument/semanticTokens/full` when range is absent. This is the crux: **jdtls advertises `range: false, full: true`**, so a range-only client silently never activates.
- **Overlay** — `EditorBuffer.applyHighlighting` overlays cached tokens onto the TextMate `StyleSpans` via `StyleSpans.overlay` (replace-on-present). Positions map through `area.getAbsolutePosition` (no `editor`→`lsp` dependency). Stale-suppress while typing so shifted offsets never mis-color. Requests on the existing debounced didChange pulse + a 250 ms scroll-settle.
- **Settings/UX** — `Settings.semanticHighlight` (default on; schema 31→32 additive), palette `view.toggleSemanticHighlight`, Settings → Editor checkbox, i18n across all six catalogs.
- **Theming** — `.text.sem-*` in `syntax.css` + matched overrides in all eight editor themes.

## Tests

871 pass (`mvn test`). New: `SemanticTokensDecoderTest`, `SemanticTokenMapperTest`, plus the semantic-tokens capability-gate cases in `LspManagerTest`.

## Perf

Zero hot-path cost when off (byte-identical highlight path). When on: one `StyleSpans.overlay` inside an apply that already runs, gated to semantic-active buffers; requests are debounced, never per-keystroke/scroll-pulse.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
