### PR TITLE
Fix StructurePanel crash sorting an immutable list on no-buffer tabs

### DIFF
--- a/src/main/java/com/editora/ui/StructurePanel.java
+++ b/src/main/java/com/editora/ui/StructurePanel.java
@@ -378,7 +378,7 @@ public class StructurePanel extends VBox implements ToolWindowContent {
 
     private void rebuild() {
         if (buffer == null) {
-            roots = List.of();
+            roots = new ArrayList<>(); // mutable: sortNodes sorts roots in place (a diff/Welcome tab has no buffer)
         } else if (lspSymbols != null) {
             roots = fromLsp(lspSymbols); // LSP-served file: precise hierarchy + kinds
         } else {
@@ -433,7 +433,12 @@ public class StructurePanel extends VBox implements ToolWindowContent {
                                 .thenComparing(n -> n.label().toLowerCase(Locale.ROOT));
                     default -> Comparator.comparingInt(StructureNode::line);
                 };
-        nodes.sort(cmp);
+        // Guard: List.sort throws UnsupportedOperationException on an immutable list (even an empty one),
+        // and an empty/singleton list needs no sorting anyway. Lists of 2+ here are always mutable
+        // (roots + every node's children are built as ArrayLists), so the in-place sort is safe.
+        if (nodes.size() > 1) {
+            nodes.sort(cmp);
+        }
         for (StructureNode n : nodes) {
             sortNodes(n.children());
         }


### PR DESCRIPTION
## Summary

Fixes a pre-existing crash: selecting a **diff tab** (e.g. "Compare with HEAD" / Git panel "Show Diff") or the **Welcome tab** threw `java.lang.UnsupportedOperationException` on the JavaFX Application Thread.

## Root cause

A diff/Welcome tab has no `EditorBuffer`, so `StructurePanel.rebuild()` set `roots = List.of()` (immutable), and `sortNodes` then called `roots.sort(cmp)` — `ImmutableCollections.sort` throws even for an empty list.

```
at java.util.ImmutableCollections$AbstractImmutableList.sort
at com.editora.ui.StructurePanel.sortNodes(StructurePanel.java:436)
at com.editora.ui.StructurePanel.rebuild(StructurePanel.java:387)
at com.editora.ui.StructurePanel.attach(StructurePanel.java:179)
... (tab selection) ... openDiff
```

## Fix

- `roots = List.of()` → `new ArrayList<>()` so `roots` is consistently mutable (it's sorted in place, like the `fromLsp`/`buildNodes` branches).
- Guard `sortNodes`: `if (nodes.size() > 1) nodes.sort(cmp);` — never sorts a possibly-immutable empty/singleton list, while still recursing into children. Lists of 2+ are always mutable here.

The other sort in the file (`regions.sort`) operates on a fresh `ArrayList`, so it was never at risk.

## Tests

871 pass (`mvn test`). No unit test added — `StructureNode` is a private inner class and `sortNodes` is instance-private, so there's no clean pure helper to test without restructuring the panel; the one-line guard is verified by the suite + manual repro (open a diff tab, no crash).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
