### PR TITLE
Broaden LSP semantic highlighting: enable gopls + map more token types

### DIFF
--- a/src/main/java/com/editora/lsp/LspManager.java
+++ b/src/main/java/com/editora/lsp/LspManager.java
@@ -209,10 +209,18 @@ public final class LspManager {
             if (spec == null) {
                 return null;
             }
-            // jdtls gets the java-debug plugin via initializationOptions.bundles when debugging is on, so
-            // it registers the vscode.java.* debug commands. Other servers get no init options.
-            Object initOptions =
-                    "java".equals(serverId) && !debugBundles.isEmpty() ? Map.of("bundles", debugBundles) : null;
+            // Per-server initializationOptions:
+            //  - jdtls gets the java-debug plugin bundle (when debugging is on) so it registers the
+            //    vscode.java.* debug commands.
+            //  - gopls ships semantic tokens DISABLED and only advertises semanticTokensProvider when its
+            //    `semanticTokens` option is set at initialize (confirmed: the flat key works, `ui.` doesn't);
+            //    enabling it is free — gopls computes tokens only when we request them.
+            Object initOptions = null;
+            if ("java".equals(serverId) && !debugBundles.isEmpty()) {
+                initOptions = Map.of("bundles", debugBundles);
+            } else if ("go".equals(serverId)) {
+                initOptions = Map.of("semanticTokens", true);
+            }
             LanguageServerSession session = new LanguageServerSession(
                     spec,
                     root,

--- a/src/main/java/com/editora/lsp/SemanticTokenMapper.java
+++ b/src/main/java/com/editora/lsp/SemanticTokenMapper.java
@@ -32,7 +32,7 @@ public final class SemanticTokenMapper {
             return base + " sem-deprecated";
         }
         if (hasMod(modBits, modLegend, "readonly") || hasMod(modBits, modLegend, "static")) {
-            return base + " sem-constant";
+            return base.equals("sem-constant") ? base : base + " sem-constant"; // avoid "sem-constant sem-constant"
         }
         return base;
     }
@@ -44,11 +44,32 @@ public final class SemanticTokenMapper {
         }
         return switch (type) {
             case "parameter" -> "sem-parameter";
-            case "property", "enumMember", "event", "recordComponent" -> "sem-property";
+            // member (TS), field (C#), tomlTableKey/tomlArrayKey (taplo) are field/property-like.
+            case "property",
+                    "enumMember",
+                    "event",
+                    "recordComponent",
+                    "member",
+                    "field",
+                    "tomlTableKey",
+                    "tomlArrayKey" -> "sem-property";
             case "variable" -> "sem-variable";
             case "function", "method" -> "sem-function";
-            case "class", "interface", "enum", "struct", "type", "typeParameter", "namespace", "record" -> "sem-type";
+            // builtinType/typeAlias/union (rust-analyzer), concept (clangd) are type-like.
+            case "class",
+                    "interface",
+                    "enum",
+                    "struct",
+                    "type",
+                    "typeParameter",
+                    "namespace",
+                    "record",
+                    "builtinType",
+                    "typeAlias",
+                    "union",
+                    "concept" -> "sem-type";
             case "macro", "decorator", "annotation", "annotationMember" -> "sem-macro";
+            case "constant" -> "sem-constant"; // C# emits a 'constant' type
             default -> null; // keyword/comment/string/number/regexp/operator/modifier — TextMate nails these
         };
     }

--- a/src/test/java/com/editora/lsp/SemanticTokenMapperTest.java
+++ b/src/test/java/com/editora/lsp/SemanticTokenMapperTest.java
@@ -38,6 +38,29 @@ class SemanticTokenMapperTest {
     }
 
     @Test
+    void crossServerTypesMap() {
+        // Non-standard token types captured from the real legends of our other servers.
+        assertEquals("sem-property", SemanticTokenMapper.cssClass("member", 0, MODS)); // typescript
+        assertEquals("sem-property", SemanticTokenMapper.cssClass("field", 0, MODS)); // C#
+        assertEquals("sem-constant", SemanticTokenMapper.cssClass("constant", 0, MODS)); // C#
+        assertEquals("sem-type", SemanticTokenMapper.cssClass("builtinType", 0, MODS)); // rust-analyzer
+        assertEquals("sem-type", SemanticTokenMapper.cssClass("typeAlias", 0, MODS)); // rust-analyzer
+        assertEquals("sem-type", SemanticTokenMapper.cssClass("union", 0, MODS)); // rust-analyzer
+        assertEquals("sem-type", SemanticTokenMapper.cssClass("concept", 0, MODS)); // clangd (C++)
+        // taplo's only two token types — previously both unmapped, so TOML semantic highlight was a no-op.
+        assertEquals("sem-property", SemanticTokenMapper.cssClass("tomlTableKey", 0, MODS));
+        assertEquals("sem-property", SemanticTokenMapper.cssClass("tomlArrayKey", 0, MODS));
+    }
+
+    @Test
+    void constantTypeDoesNotDoubleEmphasis() {
+        // a 'constant' base + readonly/static must not yield "sem-constant sem-constant"
+        assertEquals("sem-constant", SemanticTokenMapper.cssClass("constant", bit(2), MODS)); // readonly
+        assertEquals("sem-constant", SemanticTokenMapper.cssClass("constant", bit(3), MODS)); // static
+        assertEquals("sem-constant sem-deprecated", SemanticTokenMapper.cssClass("constant", bit(4), MODS));
+    }
+
+    @Test
     void lexicalTypesDeferToTextMate() {
         for (String t : List.of("keyword", "comment", "string", "number", "regexp", "operator", "modifier")) {
             assertNull(SemanticTokenMapper.cssClass(t, 0, MODS), t + " should fall through to TextMate");


### PR DESCRIPTION
## Summary

Semantic highlighting is capability-driven, not Java-specific, so probing all 21 installed servers showed it **already works for 11 languages** with no code change (Java, TS/JS, Rust, Ruby, C/C++, Kotlin, C#, Lua, Dockerfile, Terraform, TOML). This PR adds the two gaps that probe surfaced.

## Changes

**1. Enable Go (gopls).** gopls ships semantic tokens *disabled* and only advertises `semanticTokensProvider` when its `semanticTokens` option is set at `initialize`. Verified against the real server with a standalone LSP probe: the flat `{"semanticTokens": true}` works (range + full, 15 standard types), the `ui.`-nested form does **not**. Passed via `initializationOptions` for the `go` server. Free — gopls computes tokens only when we request them, so it costs nothing when semantic highlighting is off.

**2. Broader `SemanticTokenMapper`.** Map non-standard-but-meaningful token types captured from the other servers' real legends:
- `member` (TypeScript), `field` (C#) → `sem-property`
- `constant` (C#) → `sem-constant` (with a guard so a readonly/static constant doesn't become `sem-constant sem-constant`)
- `builtinType` / `typeAlias` / `union` (rust-analyzer), `concept` (clangd) → `sem-type`
- `tomlTableKey` / `tomlArrayKey` (taplo) → `sem-property` — these are TOML's *only* two token types, so TOML semantic highlighting was previously a no-op

Lexical types (`keyword`/`string`/`number`/`comment`/`operator`) stay deferred to TextMate, by design.

## Tests

873 pass (`mvn test`), including new `SemanticTokenMapperTest` cases for every cross-server type and the constant double-emphasis guard. gopls verified end-to-end via the standalone probe (the in-app path is identical to the 11 already-working servers).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
