### PR TITLE
Document the new Emacs editing/movement commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **More Emacs editing & movement commands.** Filled the remaining gaps versus a standard Emacs
+  `global-map`: **backward-kill-word** (`M-DEL`); case commands **upcase/downcase/capitalize-word**
+  (`M-u`/`M-l`/`M-c`) and **upcase/downcase-region** (`C-x C-u`/`C-x C-l`); whitespace and line surgery —
+  **join-line / delete-indentation** (`M-^`), **delete-horizontal-space** (`M-\`), **just-one-space**
+  (`M-SPC`), **delete-blank-lines** (`C-x C-o`), **open-line** (`C-o`), **kill-whole-line** (`C-S-DEL`),
+  and **zap-to-char** (`M-z`); structural navigation — **forward/backward-sexp** (`C-M-f`/`C-M-b`),
+  **mark-sexp** (`C-M-SPC`), **kill-sexp** (`C-M-k`), **beginning/end-of-defun** (`C-M-a`/`C-M-e`, heuristic
+  in a language-agnostic editor), and **mark-paragraph** (`M-h`); plus **mark-whole-buffer** (`C-x h`) and
+  **move-to-window-line-top-bottom** (`M-r`). All are palette-discoverable and rebindable like any command.
+  *Kill-ring behavior (yank-pop, consecutive-kill accumulation) remains deferred — these "kill" commands
+  delete, and cut/copy/paste still use the system clipboard.*
+
 - **Keyboard macros (Emacs-style).** Record a sequence of editor actions and replay it. Recording captures
   the faithful interleaved stream of **invoked commands and literally typed text**, and replay reproduces the
   exact sequence — replayed typing runs through the same auto-close / auto-indent assists as live typing.

--- a/README.md
+++ b/README.md
@@ -86,6 +86,11 @@ Emacs-style keymap or a fuzzy command palette.
 - **Fill paragraph** (`M-q`) — re-wrap a paragraph (or the selection, with "Fill Region") to a fill column
   (`C-x f`, default 70), preserving its indentation and an adaptive fill prefix — line comments, Markdown
   blockquotes (`>`), and Javadoc (`*`) — so code comments and quoted text wrap correctly.
+- **Emacs editing & movement commands** — the full set beyond the basics: backward-kill-word (`M-DEL`),
+  word/region case conversion (`M-u`/`M-l`/`M-c`, `C-x C-u`/`C-x C-l`), join-line (`M-^`), whitespace
+  fixups (`M-\`, `M-SPC`), delete-blank-lines (`C-x C-o`), open-line (`C-o`), kill-whole-line (`C-S-DEL`),
+  zap-to-char (`M-z`), balanced-expression motion (`C-M-f`/`C-M-b`, mark/kill-sexp), defun motion
+  (`C-M-a`/`C-M-e`), and mark-paragraph / mark-whole-buffer. All palette-discoverable and rebindable.
 - **Multiple cursors & column selection** — VS Code–style multi-caret editing: add a caret at the next
   occurrence of the selection / above / below, type or edit everywhere at once, `Esc` to collapse; plus
   Alt-drag column/box selection. (Powered by a personal RichTextFX fork.)

--- a/TODO.md
+++ b/TODO.md
@@ -185,7 +185,13 @@ A backlog of planned features and improvements. Unordered within each section.
 - [ ] Log mode support
 
 ## Keybindings
-- [ ] Complete emacs movement/text manipulation keybindings
+- [x] Complete emacs movement/text manipulation keybindings — backward-kill-word (`M-DEL`),
+      upcase/downcase/capitalize-word + region (`M-u`/`M-l`/`M-c`, `C-x C-u`/`C-x C-l`), join-line (`M-^`),
+      delete-horizontal-space (`M-\`), just-one-space (`M-SPC`), delete-blank-lines (`C-x C-o`),
+      open-line (`C-o`), kill-whole-line (`C-S-DEL`), zap-to-char (`M-z`), forward/backward-sexp +
+      mark/kill-sexp (`C-M-f`/`C-M-b`/`C-M-SPC`/`C-M-k`), beginning/end-of-defun (`C-M-a`/`C-M-e`),
+      mark-paragraph (`M-h`), mark-whole-buffer (`C-x h`), move-to-window-line (`M-r`). *Kill ring
+      (yank-pop / consecutive-kill accumulation) still deferred.*
 - [x] Fully configurable shortcuts — keybinding editor in Settings → Keymaps: searchable command list,
       multi-key chord recorder, conflict warnings, per-command + global reset; live (no restart), persisted
       as overrides on top of the active keymap theme


### PR DESCRIPTION
Updates the user-facing docs to reflect the commands added in #76 (they were code-only).

- **CHANGELOG.md** — an `## [Unreleased] → ### Added` entry covering the new editing/movement commands.
- **README.md** — a feature bullet beside the comment/fill/multi-caret ones.
- **TODO.md** — checks off "Complete emacs movement/text manipulation keybindings" with the shipped scope; notes the kill ring is still deferred.

Docs only — no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)