### PR TITLE
Document Markdown improvements (CHANGELOG, README, TODO)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Markdown support improvements.** A broad set of upgrades to the Markdown experience:
+  - **More CommonMark extensions** in the preview — **YAML front matter** (rendered as a metadata block),
+    **footnotes**, **heading anchors**, and **`++inserted++`** text, on top of the existing GFM tables /
+    task lists / strikethrough / autolinks.
+  - **Heading outline** — the **Structure** tool window now shows a Markdown document's `#`…`######` heading
+    tree (ATX + Setext), so long documents are navigable; click a heading to jump.
+  - **Markdown linting** — high-confidence rules (trailing whitespace, multiple blank lines, ATX hash
+    spacing, multiple top-level H1, fenced block without a language, missing final newline, broken
+    reference links) shown as inline squiggles with hover messages and listed in a **Markdown Lint** tool
+    window. On by default; toggle with **View: Toggle Markdown Lint**.
+  - **Image paste & drag-drop** — paste an image from the clipboard, or drop image files onto a saved
+    Markdown buffer, and the image is written into a sibling `assets/` folder with an `![](…)` link inserted.
+  - **Smart link paste** — paste a URL over a selection to wrap it as `[selection](url)`.
+  - **Table editing** — **Tab** / **Shift-Tab** move between pipe-table cells and **Enter** on the last row
+    adds a row, reflowing the table as you go.
+  - **LaTeX math** — render inline `$…$` and display `$$…$$` math in the preview (and block formulas in PDF
+    export) via JLaTeXMath, with GitHub-style delimiter rules so prose dollar amounts are left alone.
+    **Off by default** (Settings → Editor → *Render LaTeX math*, or **View: Toggle Math Rendering**).
+  - **Export to HTML** — export the rendered preview to a standalone, self-contained `.html` file (embedded
+    stylesheet, heading anchors, math as images) via **Preview: Export to HTML**.
+
 - **More Emacs editing & movement commands.** Filled the remaining gaps versus a standard Emacs
   `global-map`: **backward-kill-word** (`M-DEL`); case commands **upcase/downcase/capitalize-word**
   (`M-u`/`M-l`/`M-c`) and **upcase/downcase-region** (`C-x C-u`/`C-x C-l`); whitespace and line surgery —

--- a/README.md
+++ b/README.md
@@ -141,11 +141,25 @@ Emacs-style keymap or a fuzzy command palette.
   default and is independently selectable in Settings.
 - **Markdown preview** — IntelliJ-style 3-mode view (Editor / Editor + Preview / Preview) via a
   floating control top-right of the editor, rendered natively (CommonMark + GFM: tables, task lists,
-  strikethrough, autolinks) with **GitHub-style** output — task-list checkboxes, inline-code pills,
+  strikethrough, autolinks, plus **YAML front matter**, **footnotes**, **heading anchors**, and
+  **`++inserted++`** text) with **GitHub-style** output — task-list checkboxes, inline-code pills,
   underlined h1/h2, and **images** (local and remote). Live-updating and theme-matched; the mode is
   remembered per file. In Split mode the editor and preview scroll together (the pane under the mouse
   drives the other). Zoom the preview text with its `−`/`+` control or, in Preview mode,
-  **Ctrl + mouse wheel**.
+  **Ctrl + mouse wheel**. The **Structure** tool window shows the document's heading outline.
+- **Markdown authoring** — **paste or drag-drop images** into a saved Markdown file (saved into a sibling
+  `assets/` folder with an `![](…)` link inserted), **smart link paste** (paste a URL over a selection to
+  make `[selection](url)`), and **table editing** with **Tab** / **Shift-Tab** to move between cells and
+  **Enter** to add a row (reflowing as you go) — alongside the existing format bar and smart list/heading
+  editing.
+- **Markdown lint** — high-confidence rules (trailing whitespace, blank-line runs, heading-marker spacing,
+  multiple H1, fenced blocks missing a language, missing final newline, broken reference links) shown as
+  inline squiggles with hover messages and listed in a **Markdown Lint** tool window. On by default;
+  toggle with "View: Toggle Markdown Lint".
+- **LaTeX math** — render inline `$…$` and display `$$…$$` math in the preview (and block formulas in PDF
+  export) via the pure-Java **JLaTeXMath**, with GitHub-style delimiter rules so prose dollar amounts are
+  left alone. **Off by default** — enable under *Settings → Editor → Render LaTeX math* or with
+  "View: Toggle Math Rendering".
 - **Mermaid diagrams** — render Mermaid in the preview (standalone `.mmd` files and ` ```mermaid `
   fenced blocks inside Markdown), export a diagram to **SVG / PNG / PDF**, get live `maid` linting with
   inline error squiggles, and keyword + snippet autocomplete in `.mmd` files. Uses the external
@@ -156,6 +170,9 @@ Emacs-style keymap or a fuzzy command palette.
   vector text (headings, lists, tables, images, embedded diagrams), or a standalone Mermaid `.mmd`
   diagram. Run "File: Export to PDF" / "File: Export Preview to PDF" from the palette; choose line
   numbers, syntax highlighting, and page size (Letter / A4) under *Settings → Editor → PDF Export*.
+- **Export to HTML** — export a Markdown file's rendered preview to a standalone, self-contained `.html`
+  file (embedded stylesheet, heading anchors, math rendered as images). Run "Preview: Export to HTML" from
+  the palette.
 - **Print** — native printing of code or the rendered Markdown preview, with a print-preview window
   first (always light, what-you-preview-is-what-prints), reusing the PDF layout core. Run "File: Print"
   / "File: Print Preview" from the palette.

--- a/TODO.md
+++ b/TODO.md
@@ -3,6 +3,14 @@
 A backlog of planned features and improvements. Unordered within each section.
 
 ## Recently shipped
+- [x] Markdown support improvements — preview **CommonMark extensions** (YAML front matter, footnotes,
+      heading anchors, `++inserted++`); **heading outline** in the Structure tool window; **Markdown lint**
+      (squiggles + tool window; `View: Toggle Markdown Lint`, on by default); **image paste & drag-drop**
+      (into a sibling `assets/` folder); **smart link paste** (URL over a selection → `[sel](url)`); **table
+      cell navigation** (Tab/Shift-Tab between cells, Enter adds a row, reflow); **LaTeX math** via
+      JLaTeXMath (inline `$…$` + display `$$…$$` in the preview and PDF, off by default — `View: Toggle Math
+      Rendering`); and **Export to HTML** (`Preview: Export to HTML`, standalone self-contained file).
+      *Deferred: inline-math in PDF/print, live Mermaid in exported HTML, full base64 image embedding in HTML*
 - [x] TODO / highlight patterns (IntelliJ-style) — configurable regex patterns (TODO + FIXME by default,
       each with a color) highlighted wherever they match in the editor, and listed in a **TODO** tool
       window (`M-g o`) grouped by file (scans the open project's tree, else the open files; double-click to
@@ -88,6 +96,7 @@ A backlog of planned features and improvements. Unordered within each section.
 - [x] Markdown editing — IntelliJ-style floating format bar on selection (bold/italic/strikethrough/code/
       link/list + Normal–H1…H6), `C-c`-prefixed shortcuts + right-click Format menu; smart list/blockquote
       continuation on Enter, heading promote/demote, link helpers (Ctrl/Cmd-click to open), GFM table reflow
+      + cell navigation (Tab/Shift-Tab, Enter adds a row), image paste/drag-drop, and smart link paste
 - [x] Run a file from a gutter ▶ — Java 25 compact source (`java <file>`), Python (`python3`), and shell
       (`bash`, when the Bash LSP is enabled); streams output into a Run tool window (`M-9`); gated by LSP
 - [x] Print — native printing of code or the Markdown preview with a print-preview window (always light),


### PR DESCRIPTION
Follow-up docs for the Markdown support work in #79 — a CHANGELOG `[Unreleased]` entry, README feature bullets (preview extensions, authoring, lint, math, HTML export), and a TODO *Recently shipped* entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)