### PR TITLE
Extract Emacs caret navigation into pure, tested editor/TextNav

### DIFF
--- a/src/main/java/com/editora/editor/TextNav.java
+++ b/src/main/java/com/editora/editor/TextNav.java
@@ -1,0 +1,153 @@
+package com.editora.editor;
+
+/**
+ * Pure, unit-tested caret-navigation math for the Emacs-style motion commands — extracted from
+ * {@code MainController} so it can be tested without the JavaFX toolkit. Every method takes the whole
+ * document {@code text} plus an absolute {@code caret} offset and returns the destination offset; line
+ * boundaries are computed from the text's {@code '\n'} separators, matching the RichTextFX
+ * {@code CodeArea}'s paragraph model (one paragraph per {@code '\n'}-delimited line, newline excluded).
+ */
+public final class TextNav {
+
+    private TextNav() {}
+
+    /** Absolute offset of the start of the line containing {@code caret} (the char after the prior newline). */
+    public static int lineStart(String text, int caret) {
+        return text.lastIndexOf('\n', Math.max(0, caret) - 1) + 1;
+    }
+
+    /**
+     * Target column for a "smart" line start (C-a): the first non-whitespace column (the start of the
+     * line's <em>text</em>), or column 0 when the caret is already there — so a second press toggles to the
+     * true line start.
+     */
+    public static int smartLineStartColumn(String lineText, int caretCol) {
+        int indent = 0;
+        while (indent < lineText.length() && (lineText.charAt(indent) == ' ' || lineText.charAt(indent) == '\t')) {
+            indent++;
+        }
+        return caretCol == indent ? 0 : indent;
+    }
+
+    /** Absolute offset of the smart line start for {@code caret} (see {@link #smartLineStartColumn}). */
+    public static int smartLineStart(String text, int caret) {
+        int ls = lineStart(text, caret);
+        int lineEnd = text.indexOf('\n', ls);
+        String lineText = text.substring(ls, lineEnd < 0 ? text.length() : lineEnd);
+        return ls + smartLineStartColumn(lineText, caret - ls);
+    }
+
+    /** Absolute offset of the first non-whitespace char on the caret's line (Emacs M-m). */
+    public static int backToIndentation(String text, int caret) {
+        int i = lineStart(text, caret);
+        while (i < text.length() && (text.charAt(i) == ' ' || text.charAt(i) == '\t')) {
+            i++; // stops at the line's first non-blank, or the trailing '\n' (not a space/tab)
+        }
+        return i;
+    }
+
+    /** Start of the blank line below the current block, or document end (Emacs M-}). */
+    public static int forwardParagraph(String text, int caret) {
+        String[] lines = text.split("\n", -1);
+        int[] starts = lineStarts(lines);
+        int n = lines.length;
+        int p = paragraphIndex(text, caret) + 1;
+        while (p < n && lines[p].isBlank()) {
+            p++; // skip blank lines we're sitting on
+        }
+        while (p < n && !lines[p].isBlank()) {
+            p++; // through the text block
+        }
+        return p >= n ? text.length() : starts[p];
+    }
+
+    /** Start of the blank line above the current block, or document start (Emacs M-{). */
+    public static int backwardParagraph(String text, int caret) {
+        String[] lines = text.split("\n", -1);
+        int[] starts = lineStarts(lines);
+        int p = paragraphIndex(text, caret) - 1;
+        while (p >= 0 && lines[p].isBlank()) {
+            p--;
+        }
+        while (p >= 0 && !lines[p].isBlank()) {
+            p--;
+        }
+        return p < 0 ? 0 : starts[p];
+    }
+
+    /** Offset at the start of the next sentence after {@code caret} (Emacs M-e). */
+    public static int forwardSentence(String text, int caret) {
+        int n = text.length();
+        int i = caret;
+        while (i < n) {
+            char c = text.charAt(i++);
+            if (isSentenceEnd(c)) {
+                while (i < n
+                        && (text.charAt(i) == '"'
+                                || text.charAt(i) == '\''
+                                || text.charAt(i) == ')'
+                                || text.charAt(i) == ']')) {
+                    i++; // closing quotes/brackets stay with the sentence
+                }
+                if (i >= n || Character.isWhitespace(text.charAt(i))) {
+                    while (i < n && Character.isWhitespace(text.charAt(i))) {
+                        i++;
+                    }
+                    return i;
+                }
+            }
+        }
+        return n;
+    }
+
+    /** Offset at the start of the sentence containing/just before {@code caret} (Emacs M-a). */
+    public static int backwardSentence(String text, int caret) {
+        int i = caret - 1;
+        while (i >= 0 && Character.isWhitespace(text.charAt(i))) {
+            i--; // skip whitespace immediately before the caret
+        }
+        // If we're sitting right after a terminator (caret already at a sentence start), skip it so
+        // repeated presses keep moving back instead of landing on the same spot.
+        while (i >= 0 && isSentenceEnd(text.charAt(i))) {
+            i--;
+        }
+        while (i >= 0 && !isSentenceEnd(text.charAt(i))) {
+            i--; // back over the sentence body to the previous sentence's terminator
+        }
+        if (i < 0) {
+            return 0;
+        }
+        int j = i + 1;
+        while (j < text.length() && Character.isWhitespace(text.charAt(j))) {
+            j++;
+        }
+        return j;
+    }
+
+    private static boolean isSentenceEnd(char c) {
+        return c == '.' || c == '!' || c == '?';
+    }
+
+    /** The paragraph (line) index of {@code caret} = the number of {@code '\n'} before it. */
+    private static int paragraphIndex(String text, int caret) {
+        int count = 0;
+        int limit = Math.min(caret, text.length());
+        for (int i = 0; i < limit; i++) {
+            if (text.charAt(i) == '\n') {
+                count++;
+            }
+        }
+        return count;
+    }
+
+    /** Absolute start offset of each line produced by {@code text.split("\n", -1)}. */
+    private static int[] lineStarts(String[] lines) {
+        int[] starts = new int[lines.length];
+        int off = 0;
+        for (int i = 0; i < lines.length; i++) {
+            starts[i] = off;
+            off += lines[i].length() + 1; // + the '\n' that split removed
+        }
+        return starts;
+    }
+}

--- a/src/main/java/com/editora/ui/MainController.java
+++ b/src/main/java/com/editora/ui/MainController.java
@@ -75,6 +75,7 @@ import com.editora.editor.GrammarRegistry;
 import com.editora.editor.LanguageRegistry;
 import com.editora.editor.SpellDictionaries;
 import com.editora.editor.TabContent;
+import com.editora.editor.TextNav;
 import com.editora.macro.Macro;
 import com.editora.macro.MacroService;
 import org.fxmisc.richtext.CodeArea;
@@ -11694,114 +11695,6 @@ public class MainController implements com.editora.mcp.McpBridge {
     }
 
     /** Absolute offset of the first non-whitespace char on the caret's line (Emacs M-m). */
-    private static int backToIndentation(CodeArea a) {
-        int par = a.getCurrentParagraph();
-        String line = a.getParagraph(par).getText();
-        int col = 0;
-        while (col < line.length() && (line.charAt(col) == ' ' || line.charAt(col) == '\t')) {
-            col++;
-        }
-        return a.getAbsolutePosition(par, col);
-    }
-
-    /**
-     * Target column for a "smart" line start (C-a): the first non-whitespace column — the beginning of
-     * the line's <em>text</em> — or column 0 when the caret is already there (so a second press toggles
-     * to the true line start). Pure for unit testing.
-     */
-    static int smartLineStartColumn(String lineText, int caretCol) {
-        int indent = 0;
-        while (indent < lineText.length() && (lineText.charAt(indent) == ' ' || lineText.charAt(indent) == '\t')) {
-            indent++;
-        }
-        return caretCol == indent ? 0 : indent;
-    }
-
-    /** Absolute offset for the smart line start on the caret's current line (see {@link #smartLineStartColumn}). */
-    private static int smartLineStart(CodeArea a) {
-        int par = a.getCurrentParagraph();
-        int col = smartLineStartColumn(a.getParagraph(par).getText(), a.getCaretColumn());
-        return a.getAbsolutePosition(par, col);
-    }
-
-    /** Start of the blank line below the current block, or document end (Emacs M-}). */
-    private static int forwardParagraph(CodeArea a) {
-        int n = a.getParagraphs().size();
-        int p = a.getCurrentParagraph() + 1;
-        while (p < n && a.getParagraph(p).getText().isBlank()) {
-            p++; // skip blank lines we're sitting on
-        }
-        while (p < n && !a.getParagraph(p).getText().isBlank()) {
-            p++; // through the text block
-        }
-        return p >= n ? a.getLength() : a.getAbsolutePosition(p, 0);
-    }
-
-    /** Start of the blank line above the current block, or document start (Emacs M-{). */
-    private static int backwardParagraph(CodeArea a) {
-        int p = a.getCurrentParagraph() - 1;
-        while (p >= 0 && a.getParagraph(p).getText().isBlank()) {
-            p--;
-        }
-        while (p >= 0 && !a.getParagraph(p).getText().isBlank()) {
-            p--;
-        }
-        return p < 0 ? 0 : a.getAbsolutePosition(p, 0);
-    }
-
-    /** Offset at the start of the next sentence after {@code caret} (Emacs M-e). */
-    private static int forwardSentence(String text, int caret) {
-        int n = text.length();
-        int i = caret;
-        while (i < n) {
-            char c = text.charAt(i++);
-            if (isSentenceEnd(c)) {
-                while (i < n
-                        && (text.charAt(i) == '"'
-                                || text.charAt(i) == '\''
-                                || text.charAt(i) == ')'
-                                || text.charAt(i) == ']')) {
-                    i++; // closing quotes/brackets stay with the sentence
-                }
-                if (i >= n || Character.isWhitespace(text.charAt(i))) {
-                    while (i < n && Character.isWhitespace(text.charAt(i))) {
-                        i++;
-                    }
-                    return i;
-                }
-            }
-        }
-        return n;
-    }
-
-    /** Offset at the start of the sentence containing/just before {@code caret} (Emacs M-a). */
-    private static int backwardSentence(String text, int caret) {
-        int i = caret - 1;
-        while (i >= 0 && Character.isWhitespace(text.charAt(i))) {
-            i--; // skip whitespace immediately before the caret
-        }
-        // If we're sitting right after a terminator (caret already at a sentence start), skip it so
-        // repeated presses keep moving back instead of landing on the same spot.
-        while (i >= 0 && isSentenceEnd(text.charAt(i))) {
-            i--;
-        }
-        while (i >= 0 && !isSentenceEnd(text.charAt(i))) {
-            i--; // back over the sentence body to the previous sentence's terminator
-        }
-        if (i < 0) {
-            return 0;
-        }
-        int j = i + 1;
-        while (j < text.length() && Character.isWhitespace(text.charAt(j))) {
-            j++;
-        }
-        return j;
-    }
-
-    private static boolean isSentenceEnd(char c) {
-        return c == '.' || c == '!' || c == '?';
-    }
-
     /** Scrolls so the caret's line is vertically centered in the viewport (Emacs C-l, center). */
     private void recenterCaret() {
         CodeArea a = activeArea();
@@ -12671,7 +12564,9 @@ public class MainController implements com.editora.mcp.McpBridge {
         // C-a: smart line start — first press to the beginning of the line's text (first non-whitespace),
         // a second press toggles to the true line start (column 0).
         registry.register(Command.of(
-                "nav.lineStart", () -> moveAndFollow(a -> a.moveTo(smartLineStart(a), selPolicy()))));
+                "nav.lineStart",
+                () -> moveAndFollow(
+                        a -> a.moveTo(TextNav.smartLineStart(a.getText(), a.getCaretPosition()), selPolicy()))));
         registry.register(Command.of("nav.lineEnd", () -> moveAndFollow(a -> a.lineEnd(selPolicy()))));
         registry.register(Command.of("nav.docStart", () -> moveAndFollow(a -> a.start(selPolicy()))));
         registry.register(Command.of("nav.docEnd", () -> moveAndFollow(a -> a.end(selPolicy()))));
@@ -12700,17 +12595,25 @@ public class MainController implements com.editora.mcp.McpBridge {
             }
         }));
         registry.register(Command.of(
-                "nav.backToIndentation", () -> moveAndFollow(a -> a.moveTo(backToIndentation(a), selPolicy()))));
+                "nav.backToIndentation",
+                () -> moveAndFollow(
+                        a -> a.moveTo(TextNav.backToIndentation(a.getText(), a.getCaretPosition()), selPolicy()))));
         registry.register(Command.of(
-                "nav.paragraphForward", () -> moveAndFollow(a -> a.moveTo(forwardParagraph(a), selPolicy()))));
+                "nav.paragraphForward",
+                () -> moveAndFollow(
+                        a -> a.moveTo(TextNav.forwardParagraph(a.getText(), a.getCaretPosition()), selPolicy()))));
         registry.register(Command.of(
-                "nav.paragraphBackward", () -> moveAndFollow(a -> a.moveTo(backwardParagraph(a), selPolicy()))));
+                "nav.paragraphBackward",
+                () -> moveAndFollow(
+                        a -> a.moveTo(TextNav.backwardParagraph(a.getText(), a.getCaretPosition()), selPolicy()))));
         registry.register(Command.of(
                 "nav.sentenceForward",
-                () -> moveAndFollow(a -> a.moveTo(forwardSentence(a.getText(), a.getCaretPosition()), selPolicy()))));
+                () -> moveAndFollow(
+                        a -> a.moveTo(TextNav.forwardSentence(a.getText(), a.getCaretPosition()), selPolicy()))));
         registry.register(Command.of(
                 "nav.sentenceBackward",
-                () -> moveAndFollow(a -> a.moveTo(backwardSentence(a.getText(), a.getCaretPosition()), selPolicy()))));
+                () -> moveAndFollow(
+                        a -> a.moveTo(TextNav.backwardSentence(a.getText(), a.getCaretPosition()), selPolicy()))));
         registry.register(Command.of("nav.recenter", this::recenterCaret));
         registry.register(Command.of("edit.setMark", this::setMark));
         registry.register(Command.of("edit.exchangePointAndMark", this::exchangePointAndMark));

--- a/src/test/java/com/editora/editor/TextNavTest.java
+++ b/src/test/java/com/editora/editor/TextNavTest.java
@@ -1,0 +1,108 @@
+package com.editora.editor;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/** Pure Emacs caret-navigation math: smart line start, back-to-indentation, paragraph + sentence motion. */
+class TextNavTest {
+
+    // --- smartLineStartColumn (C-a: first non-whitespace ↔ column 0 toggle) ---
+
+    @Test
+    void smartLineStartColumnGoesToFirstNonWhitespace() {
+        assertEquals(4, TextNav.smartLineStartColumn("    foo", 7)); // caret in text → indent
+        assertEquals(4, TextNav.smartLineStartColumn("    foo", 2)); // within indent → indent
+        assertEquals(4, TextNav.smartLineStartColumn("    foo", 0)); // col 0 → indent
+        assertEquals(0, TextNav.smartLineStartColumn("    foo", 4)); // already at indent → toggle to 0
+    }
+
+    @Test
+    void smartLineStartColumnEdgeCases() {
+        assertEquals(0, TextNav.smartLineStartColumn("\tbar", 1)); // one-tab indent, caret at text → 0
+        assertEquals(2, TextNav.smartLineStartColumn("  baz", 1));
+        assertEquals(0, TextNav.smartLineStartColumn("hello", 3)); // no indent
+        assertEquals(0, TextNav.smartLineStartColumn("", 0));
+    }
+
+    // --- lineStart / smartLineStart / backToIndentation as absolute offsets in a multi-line doc ---
+
+    @Test
+    void lineStartFindsTheStartOfTheCaretsLine() {
+        String t = "abc\n  def\nghi";
+        assertEquals(0, TextNav.lineStart(t, 0));
+        assertEquals(0, TextNav.lineStart(t, 3)); // end of line 0
+        assertEquals(4, TextNav.lineStart(t, 4)); // start of line 1
+        assertEquals(4, TextNav.lineStart(t, 9)); // within line 1
+        assertEquals(10, TextNav.lineStart(t, 12)); // line 2
+    }
+
+    @Test
+    void smartLineStartOnSecondLineTogglesAroundItsIndent() {
+        String t = "abc\n  def"; // line 1 starts at offset 4, indent 2 → text at offset 6
+        assertEquals(6, TextNav.smartLineStart(t, 9)); // caret in "def" → first non-ws
+        assertEquals(4, TextNav.smartLineStart(t, 6)); // caret at text → toggle to true line start
+        assertEquals(6, TextNav.smartLineStart(t, 5)); // caret inside indent → text start
+    }
+
+    @Test
+    void backToIndentationOffset() {
+        String t = "abc\n\t qux"; // line 1 start 4, indent "\t " (2 chars) → first non-ws at offset 6
+        assertEquals(6, TextNav.backToIndentation(t, 9));
+        assertEquals(0, TextNav.backToIndentation("foo", 2)); // no indent
+        assertEquals(7, TextNav.backToIndentation("foo\n   ", 6)); // all-whitespace line → runs to its end
+    }
+
+    // --- paragraph motion (M-} / M-{): a "paragraph" is a run of non-blank lines, bounded by blanks ---
+
+    @Test
+    void forwardParagraphStopsAtTheBlankLineBelowTheBlock() {
+        // lines: 0"a"(0) 1"b"(2) 2""(4) 3"c"(5)   offsets in parens
+        String t = "a\nb\n\nc";
+        assertEquals(4, TextNav.forwardParagraph(t, 0)); // from line 0 → the blank line at offset 4
+        assertEquals(t.length(), TextNav.forwardParagraph(t, 5)); // from the last block → document end
+        // From a blank line you're sitting on, skip to the end of the next block (then its trailing blank
+        // or the doc end) — here the next block "c" runs to the end.
+        assertEquals(t.length(), TextNav.forwardParagraph(t, 4));
+    }
+
+    @Test
+    void backwardParagraphStopsAtTheBlankLineAboveTheBlock() {
+        String t = "a\n\nb\nc"; // lines: 0"a"(0) 1""(2) 2"b"(3) 3"c"(5)
+        assertEquals(2, TextNav.backwardParagraph(t, 5)); // from line 3 → blank line at offset 2
+        assertEquals(0, TextNav.backwardParagraph(t, 0)); // already at start
+    }
+
+    // --- sentence motion (M-e / M-a) ---
+
+    @Test
+    void forwardSentenceLandsAfterTheTerminatorAndTrailingSpace() {
+        String t = "One. Two. Three.";
+        assertEquals(5, TextNav.forwardSentence(t, 0)); // start of "Two."
+        assertEquals(10, TextNav.forwardSentence(t, 5)); // start of "Three."
+        assertEquals(t.length(), TextNav.forwardSentence(t, 10)); // last sentence → end
+    }
+
+    @Test
+    void forwardSentenceKeepsTrailingQuotesAndBracketsWithTheSentence() {
+        String t = "He said \"hi.\" Then left.";
+        // The '.' is followed by a closing quote, so the sentence ends after the quote, not at the period.
+        int after = TextNav.forwardSentence(t, 0);
+        assertEquals("Then left.", t.substring(after));
+    }
+
+    @Test
+    void abbreviationDotMidWordIsNotASentenceEnd() {
+        String t = "see e.g. this"; // the dots in "e.g." aren't followed by whitespace until after "g."
+        // "e." is followed by "g" (not whitespace) so it's skipped; "g." is followed by a space → boundary.
+        assertEquals("this", t.substring(TextNav.forwardSentence(t, 0)));
+    }
+
+    @Test
+    void backwardSentenceGoesToTheStartOfTheCurrentSentence() {
+        String t = "One. Two. Three.";
+        assertEquals(10, TextNav.backwardSentence(t, 16)); // from end → start of "Three."
+        assertEquals(5, TextNav.backwardSentence(t, 10)); // sitting at "Three." start → back to "Two."
+        assertEquals(0, TextNav.backwardSentence(t, 4)); // within first sentence → 0
+    }
+}

--- a/src/test/java/com/editora/ui/MainControllerTest.java
+++ b/src/test/java/com/editora/ui/MainControllerTest.java
@@ -46,35 +46,8 @@ class MainControllerTest {
         assertEquals("", MainController.repoNameFromUrl("   "));
     }
 
-    // --- C-a smart line start (first non-whitespace ↔ column 0 toggle) ---
-
-    @Test
-    void smartLineStartGoesToFirstNonWhitespace() {
-        // From the text (or anywhere not exactly at the indent), jump to the first non-whitespace column.
-        assertEquals(4, MainController.smartLineStartColumn("    foo", 7)); // caret in text → indent
-        assertEquals(4, MainController.smartLineStartColumn("    foo", 2)); // caret within indent → indent
-        assertEquals(4, MainController.smartLineStartColumn("    foo", 0)); // caret at col 0 → indent
-        // Caret already at the indent → toggle to the true line start (column 0).
-        assertEquals(0, MainController.smartLineStartColumn("    foo", 4));
-    }
-
-    @Test
-    void smartLineStartTogglesToColumnZero() {
-        // Caret at the first non-whitespace char → toggle to the true line start.
-        assertEquals(0, MainController.smartLineStartColumn("\tbar", 1)); // indent is 1 (one tab)
-        // Caret inside the leading whitespace → still go to the text start.
-        assertEquals(2, MainController.smartLineStartColumn("  baz", 1));
-        assertEquals(2, MainController.smartLineStartColumn("  baz", 0));
-    }
-
-    @Test
-    void smartLineStartNoIndent() {
-        // No leading whitespace: indent is 0; from mid-line go to 0, and at 0 it stays 0.
-        assertEquals(0, MainController.smartLineStartColumn("hello", 3));
-        assertEquals(0, MainController.smartLineStartColumn("hello", 0));
-        // Blank/empty line.
-        assertEquals(0, MainController.smartLineStartColumn("", 0));
-    }
+    // (C-a smart-line-start column logic moved to editor/TextNavTest along with the rest of the
+    //  Emacs caret-navigation math.)
 
     // --- canonicalPath: a symlinked path and the real path must compare equal ---
 


### PR DESCRIPTION
Tier 1 of the MainController pure-helper extractions (continuing the testing-improvements work).

## What
The Emacs caret-navigation math lived as private helpers in toolkit-bound `MainController`, so it couldn't be unit-tested. Moved it into a pure **`editor/TextNav`** operating on `(String text, int caret)` offsets — line boundaries computed from `\n`, matching the RichTextFX `CodeArea` paragraph model — and the `nav.*` command handlers now delegate to it.

- `TextNav`: `lineStart`, `smartLineStart`/`smartLineStartColumn` (C-a), `backToIndentation` (M-m), `forwardParagraph`/`backwardParagraph` (M-}/M-{), `forwardSentence`/`backwardSentence` (M-e/M-a).
- **Behavior-preserving** — the offset math reproduces the old `getCurrentParagraph()`/`getAbsolutePosition()` results.
- Old `MainController` private methods deleted; `smartLineStartColumn`'s tests relocated from `MainControllerTest` to the new `TextNavTest`.

## Tests
`TextNavTest` (11 cases) covers the regression-prone bits: the C-a indent↔col-0 toggle, all-whitespace lines, paragraph motion across blank lines, and sentence motion with trailing quotes/brackets and `e.g.`-style mid-word dots. (Writing them caught two wrong assumptions about the *existing* behavior, corrected to match the preserved algorithm.)

`./mvnw test` → **972 passing**; Spotless clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)