### PR TITLE
Extract path-identity/keying into pure, tested config/PathKeys

### DIFF
--- a/src/main/java/com/editora/config/PathKeys.java
+++ b/src/main/java/com/editora/config/PathKeys.java
@@ -1,0 +1,86 @@
+package com.editora.config;
+
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+
+import com.editora.vfs.Vfs;
+
+/**
+ * Pure, unit-tested path-identity + store-keying helpers extracted from {@code MainController}. These decide
+ * when two paths refer to the same file and produce the string keys the per-project stores (notes, history)
+ * are indexed by. The logic is bug-prone — a past defect compared a server-reported <em>canonical</em> path
+ * ({@code /private/tmp/…}) against a buffer's as-opened path ({@code /tmp/…}) with plain {@code normalize()}
+ * and silently dropped diagnostics — so it's worth isolating and testing.
+ *
+ * <p>Touches the filesystem ({@code toRealPath}) but is otherwise dependency-light; verify with a temp dir.
+ */
+public final class PathKeys {
+
+    private PathKeys() {}
+
+    /**
+     * A path for cross-source identity comparison: the real (symlink-resolved) path when it exists, else the
+     * absolute-normalized form. Matching by {@code normalize()} alone misses a symlinked path that a tool
+     * reports under its real URI.
+     */
+    public static Path canonical(Path p) {
+        try {
+            return p.toRealPath();
+        } catch (java.io.IOException | RuntimeException e) {
+            return p.toAbsolutePath().normalize();
+        }
+    }
+
+    /**
+     * A provider-safe string identity key: the {@code sftp://} URI for a remote path, the canonical string
+     * for a local one. Avoids {@code Path.equals} across filesystems (a MINA SFTP path throws
+     * {@link java.nio.file.ProviderMismatchException} when compared to a local path) and a network
+     * {@code toRealPath()} for remote files.
+     */
+    public static String key(Path p) {
+        return Vfs.isRemote(p) ? Vfs.toStorableString(p) : canonical(p).toString();
+    }
+
+    /** The absolute-normalized string (the Local File History index key — never symlink-resolved). */
+    public static String normalizedKey(Path p) {
+        return p.toAbsolutePath().normalize().toString();
+    }
+
+    /** The canonical string key for a buffer path, or {@code ""} for a null path (the notes-store key). */
+    public static String canonicalKey(Path p) {
+        return p == null ? "" : canonical(p).toString();
+    }
+
+    /** Whether two paths are the same file by absolute-normalized form, with a defensive equality fallback. */
+    public static boolean sameNormalized(Path a, Path b) {
+        if (a == null || b == null) {
+            return false;
+        }
+        try {
+            return a.toAbsolutePath().normalize().equals(b.toAbsolutePath().normalize());
+        } catch (RuntimeException e) {
+            return a.equals(b);
+        }
+    }
+
+    /**
+     * The first bucket key whose any note's {@link FileIdentity} matches {@code id} by content hash or
+     * canonical path (used to re-home a buffer's notes when the path key has changed but the file is the
+     * same). Returns {@code null} for a null {@code id} or no match.
+     */
+    public static String findKeyByIdentity(Map<String, List<PersonalNote>> map, FileIdentity id) {
+        if (id == null) {
+            return null;
+        }
+        for (var entry : map.entrySet()) {
+            for (PersonalNote n : entry.getValue()) {
+                FileIdentity.Match m = FileIdentity.match(n.file(), id);
+                if (m == FileIdentity.Match.CONTENT_HASH || m == FileIdentity.Match.CANONICAL_PATH) {
+                    return entry.getKey();
+                }
+            }
+        }
+        return null;
+    }
+}

--- a/src/main/java/com/editora/ui/MainController.java
+++ b/src/main/java/com/editora/ui/MainController.java
@@ -3778,14 +3778,7 @@ public class MainController implements com.editora.mcp.McpBridge {
 
     /** Whether two paths refer to the same file (normalized absolute comparison; null-safe). */
     private static boolean samePath(Path a, Path b) {
-        if (a == null || b == null) {
-            return false;
-        }
-        try {
-            return a.toAbsolutePath().normalize().equals(b.toAbsolutePath().normalize());
-        } catch (RuntimeException e) {
-            return a.equals(b);
-        }
+        return com.editora.config.PathKeys.sameNormalized(a, b);
     }
 
     /** Resumes and stops at the active buffer's caret line via a one-shot temporary breakpoint. */
@@ -5751,7 +5744,7 @@ public class MainController implements com.editora.mcp.McpBridge {
 
     /** The per-file key used in the history bucket (absolute path string). */
     private static String historyKey(Path file) {
-        return file.toAbsolutePath().normalize().toString();
+        return com.editora.config.PathKeys.normalizedKey(file);
     }
 
     /**
@@ -8129,21 +8122,12 @@ public class MainController implements com.editora.mcp.McpBridge {
      *  {@link java.nio.file.ProviderMismatchException} when compared to a local path) and a network
      *  {@code toRealPath()} for remote files. */
     private static String pathKey(Path p) {
-        return com.editora.vfs.Vfs.isRemote(p)
-                ? com.editora.vfs.Vfs.toStorableString(p)
-                : canonicalPath(p).toString();
+        return com.editora.config.PathKeys.key(p);
     }
 
-    /** A path for cross-source identity comparison: the real (symlink-resolved) path when it exists,
-     *  else the absolute-normalized form. A language server reports diagnostics under the file's
-     *  <em>canonical</em> URI (e.g. {@code /private/tmp/…} for a {@code /tmp/…} symlink on macOS); a buffer
-     *  keeps the path as opened, so matching by {@code normalize()} alone misses it and drops diagnostics. */
+    /** @see com.editora.config.PathKeys#canonical(Path) */
     static Path canonicalPath(Path p) {
-        try {
-            return p.toRealPath();
-        } catch (java.io.IOException | RuntimeException e) {
-            return p.toAbsolutePath().normalize();
-        }
+        return com.editora.config.PathKeys.canonical(p);
     }
 
     @FXML
@@ -10388,15 +10372,7 @@ public class MainController implements com.editora.mcp.McpBridge {
 
     /** Canonical-path key for a buffer's notes in the store (cheap; no content hashing). */
     private static String noteKey(EditorBuffer buffer) {
-        Path p = buffer.getPath();
-        if (p == null) {
-            return "";
-        }
-        try {
-            return p.toRealPath().toString();
-        } catch (IOException e) {
-            return p.toAbsolutePath().normalize().toString();
-        }
+        return com.editora.config.PathKeys.canonicalKey(buffer.getPath());
     }
 
     private Tab tabForKey(String fileKey) {
@@ -10488,19 +10464,7 @@ public class MainController implements com.editora.mcp.McpBridge {
 
     private static String findNoteKeyByIdentity(
             Map<String, List<com.editora.config.PersonalNote>> map, com.editora.config.FileIdentity id) {
-        if (id == null) {
-            return null;
-        }
-        for (var entry : map.entrySet()) {
-            for (com.editora.config.PersonalNote n : entry.getValue()) {
-                com.editora.config.FileIdentity.Match m = com.editora.config.FileIdentity.match(n.file(), id);
-                if (m == com.editora.config.FileIdentity.Match.CONTENT_HASH
-                        || m == com.editora.config.FileIdentity.Match.CANONICAL_PATH) {
-                    return entry.getKey();
-                }
-            }
-        }
-        return null;
+        return com.editora.config.PathKeys.findKeyByIdentity(map, id);
     }
 
     /** "Add Personal Note" (context menu / command): captures the selection/caret anchor, prompts for a body. */

--- a/src/test/java/com/editora/config/PathKeysTest.java
+++ b/src/test/java/com/editora/config/PathKeysTest.java
@@ -1,0 +1,86 @@
+package com.editora.config;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+/** Path identity + store-keying decisions (the bug-prone canonical-vs-normalized matching). */
+class PathKeysTest {
+
+    @Test
+    void canonicalResolvesSymlinkSoServerDiagnosticsMatchTheBuffer(@TempDir Path tmp) throws IOException {
+        // A language server reports diagnostics under the file's real path (e.g. /private/tmp/… for a
+        // /tmp/… symlink on macOS); a buffer keeps the path as opened. canonical() must map both to the
+        // same Path — otherwise tabForPath misses the tab and diagnostics are silently dropped.
+        Path realDir = Files.createDirectory(tmp.resolve("real"));
+        Path realFile = Files.writeString(realDir.resolve("A.java"), "class A {}");
+        Path link;
+        try {
+            link = Files.createSymbolicLink(tmp.resolve("link"), realDir);
+        } catch (IOException | UnsupportedOperationException e) {
+            assumeTrue(false, "symlinks not supported on this platform/filesystem");
+            return;
+        }
+        Path viaLink = link.resolve("A.java"); // same file reached through the symlinked directory
+        assertEquals(PathKeys.canonical(realFile), PathKeys.canonical(viaLink));
+        assertEquals(PathKeys.key(realFile), PathKeys.key(viaLink)); // string key agrees too
+    }
+
+    @Test
+    void canonicalFallsBackToNormalizeForMissingFile(@TempDir Path tmp) {
+        // A not-yet-on-disk path (e.g. an unsaved buffer) can't be realpath'd; fall back to normalize().
+        Path missing = tmp.resolve("nope/../ghost.java");
+        assertEquals(missing.toAbsolutePath().normalize(), PathKeys.canonical(missing));
+    }
+
+    @Test
+    void localKeyIsTheCanonicalString(@TempDir Path tmp) throws IOException {
+        Path f = Files.writeString(tmp.resolve("x.txt"), "hi");
+        assertEquals(PathKeys.canonical(f).toString(), PathKeys.key(f)); // local → canonical string
+    }
+
+    @Test
+    void normalizedKeyCollapsesDotSegmentsWithoutResolvingSymlinks() {
+        Path p = Path.of("/a/b/../c/file.txt");
+        assertEquals(p.toAbsolutePath().normalize().toString(), PathKeys.normalizedKey(p));
+    }
+
+    @Test
+    void canonicalKeyIsEmptyForNullPath() {
+        assertEquals("", PathKeys.canonicalKey(null));
+    }
+
+    @Test
+    void sameNormalizedTreatsDotSegmentsAsEqualAndGuardsNulls() {
+        assertTrue(PathKeys.sameNormalized(Path.of("/a/b/c.txt"), Path.of("/a/x/../b/c.txt")));
+        assertFalse(PathKeys.sameNormalized(Path.of("/a/b.txt"), Path.of("/a/c.txt")));
+        assertFalse(PathKeys.sameNormalized(null, Path.of("/a")));
+        assertFalse(PathKeys.sameNormalized(Path.of("/a"), null));
+    }
+
+    @Test
+    void findKeyByIdentityMatchesByCanonicalPathAcrossBucketKeys(@TempDir Path tmp) throws IOException {
+        Path f = Files.writeString(tmp.resolve("note.md"), "body");
+        FileIdentity id = FileIdentity.of(f);
+        PersonalNote note = PersonalNote.create(id, NoteScope.LINE, null, "n", List.of());
+        Map<String, List<PersonalNote>> map = Map.of(
+                "other-key", List.of(),
+                "the-key", List.of(note));
+        assertEquals("the-key", PathKeys.findKeyByIdentity(map, id));
+        assertNull(PathKeys.findKeyByIdentity(map, null));
+        // A different file (different identity) → no match.
+        Path g = Files.writeString(tmp.resolve("z.md"), "elsewhere");
+        assertNull(PathKeys.findKeyByIdentity(map, FileIdentity.of(g)));
+    }
+}

--- a/src/test/java/com/editora/ui/MainControllerTest.java
+++ b/src/test/java/com/editora/ui/MainControllerTest.java
@@ -1,16 +1,10 @@
 package com.editora.ui;
 
-import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Path;
-
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.io.TempDir;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 /** Unit tests for pure helpers in {@link MainController} (no toolkit needed). */
 class MainControllerTest {
@@ -46,35 +40,8 @@ class MainControllerTest {
         assertEquals("", MainController.repoNameFromUrl("   "));
     }
 
-    // (C-a smart-line-start column logic moved to editor/TextNavTest along with the rest of the
-    //  Emacs caret-navigation math.)
-
-    // --- canonicalPath: a symlinked path and the real path must compare equal ---
-
-    @Test
-    void canonicalPathResolvesSymlinkSoServerDiagnosticsMatchTheBuffer(@TempDir Path tmp) throws IOException {
-        // A language server reports diagnostics under the file's real path (e.g. /private/tmp/… for a
-        // /tmp/… symlink on macOS); a buffer keeps the path as opened. canonicalPath() must map both to
-        // the same Path so tabForPath finds the tab — otherwise diagnostics are silently dropped.
-        Path realDir = Files.createDirectory(tmp.resolve("real"));
-        Path realFile = Files.writeString(realDir.resolve("A.java"), "class A {}");
-        Path link;
-        try {
-            link = Files.createSymbolicLink(tmp.resolve("link"), realDir);
-        } catch (IOException | UnsupportedOperationException e) {
-            assumeTrue(false, "symlinks not supported on this platform/filesystem");
-            return;
-        }
-        Path viaLink = link.resolve("A.java"); // same file reached through the symlinked directory
-        assertEquals(MainController.canonicalPath(realFile), MainController.canonicalPath(viaLink));
-    }
-
-    @Test
-    void canonicalPathFallsBackForMissingFile(@TempDir Path tmp) {
-        // A not-yet-on-disk path (e.g. an unsaved buffer) can't be realpath'd; fall back to normalize().
-        Path missing = tmp.resolve("nope/../ghost.java");
-        assertEquals(missing.toAbsolutePath().normalize(), MainController.canonicalPath(missing));
-    }
+    // (C-a smart-line-start column logic moved to editor/TextNavTest; path-identity/keying — canonicalPath,
+    //  pathKey, historyKey, noteKey, sameNormalized, findKeyByIdentity — moved to config/PathKeysTest.)
 
     @Test
     void compactSourceNoiseMatchesImplicitClassComplaintsOnly() {


### PR DESCRIPTION
Tier 2 of the MainController pure-helper extractions.

## What
The path-equality + store-keying logic lived as private helpers in toolkit-bound `MainController`. A past defect there — comparing a server's canonical `/private/tmp/…` path against a buffer's as-opened `/tmp/…` path with plain `normalize()` — silently dropped LSP diagnostics, so this logic is worth isolating + testing.

Moved it to a pure **`config/PathKeys`**:
- `canonical(Path)` (real path, normalize fallback), `key(Path)` (sftp URI for remote / canonical string for local), `normalizedKey` (history index key), `canonicalKey` (notes-store key, null→`""`), `sameNormalized(a,b)`, `findKeyByIdentity(map, FileIdentity)`.
- `MainController.canonicalPath`/`pathKey`/`historyKey`/`noteKey`/`samePath`/`findNoteKeyByIdentity` are now one-line delegates, so all call sites are untouched — single tested source of truth, minimal risk.
- `canonicalPath`'s symlink/fallback tests relocated from `MainControllerTest` to the new `PathKeysTest`.

## Tests
`PathKeysTest` (7) covers the symlink resolution the diagnostics bug hinged on (and that `key()` agrees), the missing-file fallback, local key = canonical string, `normalizedKey` collapsing `..` without resolving symlinks, `sameNormalized` dot-segment equality + null guards, and `findKeyByIdentity` matching by canonical path across bucket keys (with null + different-file negatives).

`./mvnw test` → **977 passing**; Spotless clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)