### PR TITLE
Broaden the headless-FX harness (floating buttons, tab pinning, palette gating)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,10 +11,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Headless-JavaFX test harness (developer-facing).** `ui/` controller behavior is now covered by real,
   headless FX tests — TestFX over a self-built JavaFX 25 Monocle backend (vendored in `m2-repo`, test scope
-  only), so they run on CI with no display/xvfb. First tests lock down Zen mode hiding/restoring chrome,
-  Simple-mode toolbar stripping, chrome-visibility prefs, and the tab/buffer lifecycle. FX tests are tagged
-  `fx` (run the pure suite alone with `-DexcludedGroups=fx`). No change to the app, the `dist`/`fatjar` builds,
-  or `module-info` — Monocle is never shipped.
+  only), so they run on CI with no display/xvfb. Tests lock down Zen mode hiding/restoring chrome,
+  Simple-mode toolbar stripping, chrome-visibility prefs, the tab/buffer lifecycle, the floating
+  toolbar-restore/Zen-exit buttons, tab pinning + Close-Others/Close-All, and command-palette feature gating.
+  FX tests are tagged `fx` (run the pure suite alone with `-DexcludedGroups=fx`). No change to the app, the
+  `dist`/`fatjar` builds, or `module-info` — Monocle is never shipped.
 
 - **External Tools (IntelliJ-style).** Define your own CLI commands in **Settings → External Tools** and run
   them on the current file/buffer. Command and arguments support `$Name$` macros (`$FilePath$`, `$FileDir$`,

--- a/src/test/java/com/editora/ui/FloatingButtonsFxTest.java
+++ b/src/test/java/com/editora/ui/FloatingButtonsFxTest.java
@@ -1,0 +1,79 @@
+package com.editora.ui;
+
+import javafx.scene.control.Button;
+
+import com.editora.config.ConfigManager;
+import com.editora.config.Settings;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * End-to-end coverage of the two floating overlay buttons {@code installZenOverlay} adds: the
+ * <b>toolbar-restore</b> "Tool" button (shown only when the toolbar is hidden and not in Zen, so a user
+ * who hid the toolbar can always bring it back) and the <b>Zen-exit</b> "Z" button (shown only in Zen).
+ * They never coexist.
+ */
+@Tag("fx")
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class FloatingButtonsFxTest {
+
+    private FxWindowFixture fx;
+    private Settings settings;
+
+    @BeforeAll
+    void setUp() throws Exception {
+        FxTestSupport.bootToolkit();
+        fx = FxWindowFixture.create();
+        ConfigManager config = FxTestSupport.field(fx.controller, "config");
+        settings = config.getSettings();
+    }
+
+    @AfterAll
+    void tearDown() throws Exception {
+        if (fx != null) {
+            fx.dispose();
+        }
+    }
+
+    @Test
+    void restoreAndZenExitButtonsTrackChromeState() throws Exception {
+        Button restore = FxTestSupport.field(fx.controller, "toolbarRestoreButton");
+        Button zenExit = FxTestSupport.field(fx.controller, "zenExitButton");
+
+        // Default: toolbar shown, not Zen → neither floating button is shown.
+        applyChrome(() -> settings.setShowToolbar(true));
+        assertFalse(FxTestSupport.callOnFx(restore::isVisible), "restore hidden when toolbar shown");
+        assertFalse(FxTestSupport.callOnFx(zenExit::isVisible), "Zen-exit hidden when not in Zen");
+
+        // Hide the toolbar (not Zen) → the restore button appears; Zen-exit stays hidden.
+        applyChrome(() -> settings.setShowToolbar(false));
+        assertTrue(FxTestSupport.callOnFx(restore::isVisible), "restore shown when toolbar hidden");
+        assertFalse(FxTestSupport.callOnFx(zenExit::isVisible), "Zen-exit still hidden (not Zen)");
+
+        // Enter Zen → restore button must NOT show in Zen; the Zen-exit "Z" does.
+        FxTestSupport.runOnFx(() -> fx.controller.setZenMode(true));
+        assertFalse(FxTestSupport.callOnFx(restore::isVisible), "restore hidden in Zen");
+        assertTrue(FxTestSupport.callOnFx(zenExit::isVisible), "Zen-exit shown in Zen");
+
+        // Leave Zen (toolbar still hidden) → restore returns, Zen-exit gone.
+        FxTestSupport.runOnFx(() -> fx.controller.setZenMode(false));
+        assertTrue(FxTestSupport.callOnFx(restore::isVisible), "restore returns after Zen");
+        assertFalse(FxTestSupport.callOnFx(zenExit::isVisible), "Zen-exit gone after Zen");
+
+        // Restore the default so the shared fixture is left clean.
+        applyChrome(() -> settings.setShowToolbar(true));
+    }
+
+    private void applyChrome(Runnable mutateSettings) throws Exception {
+        FxTestSupport.runOnFx(() -> {
+            mutateSettings.run();
+            FxTestSupport.invoke(fx.controller, "applyChromeVisibility");
+        });
+    }
+}

--- a/src/test/java/com/editora/ui/PaletteGatingFxTest.java
+++ b/src/test/java/com/editora/ui/PaletteGatingFxTest.java
@@ -1,0 +1,81 @@
+package com.editora.ui;
+
+import com.editora.config.ConfigManager;
+import com.editora.config.Settings;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * End-to-end coverage of command-palette feature gating: the controller's {@code paletteGates()} must
+ * reflect the live {@link Settings} feature flags AND the Simple-mode override, and {@link Chrome#paletteVisible}
+ * must then hide a feature's commands. Complements the pure {@code ChromeTest} (which tests the decision in
+ * isolation) by exercising the controller's {@code gitEnabled()}/{@code simpleModeActive()} composition.
+ */
+@Tag("fx")
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class PaletteGatingFxTest {
+
+    private FxWindowFixture fx;
+    private Settings settings;
+
+    @BeforeAll
+    void setUp() throws Exception {
+        FxTestSupport.bootToolkit();
+        fx = FxWindowFixture.create();
+        ConfigManager config = FxTestSupport.field(fx.controller, "config");
+        settings = config.getSettings();
+    }
+
+    @AfterAll
+    void tearDown() throws Exception {
+        if (fx != null) {
+            fx.dispose();
+        }
+    }
+
+    @Test
+    void gitCommandsGatedByGitSupportAndSimpleMode() throws Exception {
+        // Git off by default → git gate false → git.commit hidden from the palette.
+        FxTestSupport.runOnFx(() -> {
+            settings.setGitSupport(false);
+            settings.setSimpleMode(false);
+        });
+        assertFalse(gitGate(), "git gate off when gitSupport=false");
+        assertFalse(gitCommitVisible(), "git.commit hidden when Git disabled");
+
+        // Enable Git → gate true → git.commit visible.
+        FxTestSupport.runOnFx(() -> settings.setGitSupport(true));
+        assertTrue(gitGate(), "git gate on when gitSupport=true");
+        assertTrue(gitCommitVisible(), "git.commit visible when Git enabled");
+
+        // Simple UI mode disables the heavier features even with gitSupport on.
+        FxTestSupport.runOnFx(() -> settings.setSimpleMode(true));
+        assertFalse(gitGate(), "git gate forced off in Simple mode");
+        assertFalse(gitCommitVisible(), "git.commit hidden in Simple mode");
+
+        // Leave the shared fixture clean.
+        FxTestSupport.runOnFx(() -> {
+            settings.setSimpleMode(false);
+            settings.setGitSupport(false);
+        });
+    }
+
+    private boolean gitGate() throws Exception {
+        return FxTestSupport.callOnFx(
+                () -> ((Chrome.PaletteGates) FxTestSupport.call(fx.controller, "paletteGates", new Class[] {})).git());
+    }
+
+    private boolean gitCommitVisible() throws Exception {
+        return FxTestSupport.callOnFx(() -> {
+            Chrome.PaletteGates gates =
+                    (Chrome.PaletteGates) FxTestSupport.call(fx.controller, "paletteGates", new Class[] {});
+            return Chrome.paletteVisible("git.commit", gates);
+        });
+    }
+}

--- a/src/test/java/com/editora/ui/TabManagementFxTest.java
+++ b/src/test/java/com/editora/ui/TabManagementFxTest.java
@@ -1,0 +1,80 @@
+package com.editora.ui;
+
+import javafx.scene.control.Tab;
+import javafx.scene.control.TabPane;
+
+import com.editora.editor.EditorBuffer;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * End-to-end coverage of pinning + bulk-close through {@link MainController}: a pinned tab survives both
+ * "Close Others" and "Close All" while unpinned tabs are removed.
+ */
+@Tag("fx")
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class TabManagementFxTest {
+
+    private FxWindowFixture fx;
+
+    @BeforeAll
+    void setUp() throws Exception {
+        FxTestSupport.bootToolkit();
+        fx = FxWindowFixture.create();
+    }
+
+    @AfterAll
+    void tearDown() throws Exception {
+        if (fx != null) {
+            fx.dispose();
+        }
+    }
+
+    @Test
+    void pinnedTabSurvivesCloseOthersAndCloseAll() throws Exception {
+        TabPane tabPane = FxTestSupport.field(fx.controller, "tabPane");
+
+        Tab a = addBuffer();
+        Tab pinnedTab = addBuffer();
+        Tab c = addBuffer();
+
+        // Pin the middle tab.
+        FxTestSupport.runOnFx(() -> FxTestSupport.call(fx.controller, "togglePin", new Class[] {Tab.class}, pinnedTab));
+
+        // Close Others (keep = a): everything except `a` and the pinned tab is closed.
+        FxTestSupport.runOnFx(() -> FxTestSupport.call(fx.controller, "closeOtherTabs", new Class[] {Tab.class}, a));
+        assertTrue(FxTestSupport.callOnFx(() -> tabPane.getTabs().contains(a)), "kept tab survives Close Others");
+        assertTrue(
+                FxTestSupport.callOnFx(() -> tabPane.getTabs().contains(pinnedTab)),
+                "pinned tab survives Close Others");
+        assertFalse(FxTestSupport.callOnFx(() -> tabPane.getTabs().contains(c)), "unpinned non-kept tab closed");
+
+        // Close All: only the pinned tab remains.
+        FxTestSupport.runOnFx(() -> FxTestSupport.invoke(fx.controller, "closeAllTabs"));
+        assertTrue(
+                FxTestSupport.callOnFx(() -> tabPane.getTabs().contains(pinnedTab)), "pinned tab survives Close All");
+        assertFalse(
+                FxTestSupport.callOnFx(() -> tabPane.getTabs().contains(a)),
+                "kept-but-unpinned tab closed by Close All");
+
+        // Unpin + close so the shared fixture is left clean.
+        FxTestSupport.runOnFx(() -> {
+            FxTestSupport.call(fx.controller, "togglePin", new Class[] {Tab.class}, pinnedTab);
+            FxTestSupport.call(fx.controller, "closeTab", new Class[] {Tab.class}, pinnedTab);
+        });
+    }
+
+    private Tab addBuffer() throws Exception {
+        return FxTestSupport.callOnFx(() -> {
+            EditorBuffer buffer = new EditorBuffer();
+            return (Tab) FxTestSupport.call(
+                    fx.controller, "addBuffer", new Class[] {EditorBuffer.class, boolean.class}, buffer, true);
+        });
+    }
+}


### PR DESCRIPTION
Three more end-to-end `ui/` tests on the headless-FX harness from #87 — **pure test additions, no production code changes**.

- **`FloatingButtonsFxTest`** — the toolbar-restore button shows only when the toolbar is hidden and not in Zen; the Zen-exit "Z" shows only in Zen; they never coexist.
- **`TabManagementFxTest`** — a pinned tab survives both **Close Others** and **Close All** while unpinned tabs are removed (real `togglePin`/`closeOtherTabs`/`closeAllTabs`).
- **`PaletteGatingFxTest`** — `git.*` palette commands hide when Git is off **and** when Simple mode is on, exercising the controller's `paletteGates()`/`gitEnabled()`/`simpleModeActive()` composition end-to-end (complements the pure `ChromeTest`).

A cross-window settings-broadcast test was intentionally skipped: `reapplyAfterSharedSettingsChange` doesn't re-apply chrome (only view settings/tooltips), so the obvious "toolbar propagates across windows" assertion would test behavior the code doesn't have.

`./mvnw verify`: **993 tests, 0 failures**, spotless clean, JaCoCo floors held. Run the pure suite alone with `-DexcludedGroups=fx`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)