### PR TITLE
Extract WindowManager/ToolWindowManager decision logic into pure, tested helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   toolbar-restore/Zen-exit buttons, tab pinning + Close-Others/Close-All, and command-palette feature gating.
   FX tests are tagged `fx` (run the pure suite alone with `-DexcludedGroups=fx`). No change to the app, the
   `dist`/`fatjar` builds, or `module-info` — Monocle is never shipped.
+- **Window/tool-window decision logic extracted + unit-tested (developer-facing).** The multi-window
+  restore-set / primary-window / orphan-session-GC logic (where a quit-vs-close drain bug once lived) moved
+  into the pure `ui/WindowKeys`, and the tool-window stripe/button visibility rules into `ui/ToolWindowVisibility`;
+  `WindowManager`/`ToolWindowManager` now delegate to them. No behavior change.
 
 - **External Tools (IntelliJ-style).** Define your own CLI commands in **Settings → External Tools** and run
   them on the current file/buffer. Command and arguments support `$Name$` macros (`$FilePath$`, `$FileDir$`,

--- a/src/main/java/com/editora/ui/ToolWindowManager.java
+++ b/src/main/java/com/editora/ui/ToolWindowManager.java
@@ -245,7 +245,7 @@ public class ToolWindowManager {
 
     /** Whether the stripe button should be present: the user keeps it visible AND it isn't context-hidden. */
     private boolean shouldShowButton(ToolWindow tw) {
-        return isVisible(tw) && !unavailable.contains(tw);
+        return ToolWindowVisibility.buttonShown(isVisible(tw), unavailable.contains(tw));
     }
 
     /**
@@ -374,8 +374,8 @@ public class ToolWindowManager {
     }
 
     private void setStripeShown(Pane stripe) {
-        boolean shown =
-                stripesEnabled && !zenHidesStripes && !stripe.getChildren().isEmpty();
+        boolean shown = ToolWindowVisibility.stripeShown(
+                stripesEnabled, zenHidesStripes, stripe.getChildren().isEmpty());
         stripe.setVisible(shown);
         stripe.setManaged(shown);
     }

--- a/src/main/java/com/editora/ui/ToolWindowVisibility.java
+++ b/src/main/java/com/editora/ui/ToolWindowVisibility.java
@@ -1,0 +1,22 @@
+package com.editora.ui;
+
+/**
+ * Pure visibility decisions for tool-window stripe buttons + the stripe panes (extracted from
+ * {@link ToolWindowManager} for unit-testing). The two preferences are deliberately distinct:
+ * {@code setVisible} is the user's persisted show/hide choice, while {@code setAvailable} is a transient,
+ * context-driven hide (e.g. the Commit window outside a Git repo) that must not clobber that choice.
+ */
+final class ToolWindowVisibility {
+
+    private ToolWindowVisibility() {}
+
+    /** A stripe button shows iff the user has it visible AND it isn't transiently unavailable. */
+    static boolean buttonShown(boolean visiblePref, boolean unavailable) {
+        return visiblePref && !unavailable;
+    }
+
+    /** A stripe pane shows iff stripes are enabled, Zen isn't hiding them, and it has at least one button. */
+    static boolean stripeShown(boolean stripesEnabled, boolean zenHidesStripes, boolean stripeEmpty) {
+        return stripesEnabled && !zenHidesStripes && !stripeEmpty;
+    }
+}

--- a/src/main/java/com/editora/ui/WindowKeys.java
+++ b/src/main/java/com/editora/ui/WindowKeys.java
@@ -1,0 +1,103 @@
+package com.editora.ui;
+
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.LinkedHashSet;
+import java.util.Set;
+
+/**
+ * Pure decision logic for the multi-window restore set (extracted from {@link WindowManager} so it can be
+ * unit-tested without the toolkit). A window is identified by a <em>key</em>:
+ *
+ * <ul>
+ *   <li>{@code ""} — the global, no-project window;
+ *   <li>{@code "untitled:<uuid>"} — an extra "New Window" (its session is {@code windows/<uuid>.json});
+ *   <li>any other string — a project id (its session lives under {@code projects/}).
+ * </ul>
+ *
+ * The restore/primary/orphan-GC decisions used to live inline in {@code WindowManager.launch} /
+ * {@code gcOrphanWindowSessions}; they're bug-prone (a quit-vs-close drain bug lived here), so they're pulled
+ * out here and tested directly.
+ */
+final class WindowKeys {
+
+    /** Prefix marking an "untitled" no-project window key ({@code untitled:<uuid>}). */
+    static final String UNTITLED_PREFIX = "untitled:";
+
+    private WindowKeys() {}
+
+    static boolean isUntitled(String key) {
+        return key.startsWith(UNTITLED_PREFIX);
+    }
+
+    static boolean isGlobal(String key) {
+        return key.isEmpty();
+    }
+
+    /** A project window: neither the global window nor an untitled one. */
+    static boolean isProject(String key) {
+        return !isGlobal(key) && !isUntitled(key);
+    }
+
+    /** The session file name ({@code <uuid>.json}) for an {@code untitled:<uuid>} key. */
+    static String untitledSessionFileName(String key) {
+        return key.substring(UNTITLED_PREFIX.length()) + ".json";
+    }
+
+    /**
+     * The ordered set of window keys to restore at launch. Starts from the saved open set, adds the CLI
+     * {@code --project} key when present, drops project windows when Projects are disabled (the global +
+     * untitled windows always restore), and falls back to the global window when nothing is left.
+     */
+    static LinkedHashSet<String> restoreKeys(Collection<String> saved, boolean projectsOn, String cliId) {
+        LinkedHashSet<String> toOpen = new LinkedHashSet<>(saved);
+        if (cliId != null) {
+            toOpen.add(cliId);
+        }
+        if (!projectsOn) {
+            toOpen.removeIf(WindowKeys::isProject);
+        }
+        if (toOpen.isEmpty()) {
+            toOpen.add(""); // nothing remembered ⇒ open the global window
+        }
+        return toOpen;
+    }
+
+    /**
+     * The window to focus after restore: the CLI project if given, else the global window if it's open, else
+     * the last-active project if it's in the set, else the first restored window. {@code toOpen} must be
+     * non-empty (see {@link #restoreKeys}).
+     */
+    static String primaryKey(String cliId, Collection<String> toOpen, String activeId) {
+        if (cliId != null) {
+            return cliId;
+        }
+        if (toOpen.contains("")) {
+            return "";
+        }
+        if (activeId != null && toOpen.contains(activeId)) {
+            return activeId;
+        }
+        return toOpen.iterator().next();
+    }
+
+    /**
+     * Which {@code windows/*.json} session files to delete: every existing {@code .json} file not backing a
+     * currently-open untitled window. (Project sessions live under {@code projects/}, so they're never here.)
+     */
+    static Set<String> orphanSessionFiles(Collection<String> openKeys, Collection<String> existingFileNames) {
+        Set<String> keep = new HashSet<>();
+        for (String k : openKeys) {
+            if (isUntitled(k)) {
+                keep.add(untitledSessionFileName(k));
+            }
+        }
+        Set<String> orphans = new HashSet<>();
+        for (String f : existingFileNames) {
+            if (f.endsWith(".json") && !keep.contains(f)) {
+                orphans.add(f);
+            }
+        }
+        return orphans;
+    }
+}

--- a/src/main/java/com/editora/ui/WindowManager.java
+++ b/src/main/java/com/editora/ui/WindowManager.java
@@ -103,7 +103,6 @@ public class WindowManager {
         Settings settings = shared.getSettings();
         boolean projectsOn = settings.isProjectSupport();
         ProjectManager pm = projects();
-        LinkedHashSet<String> toOpen = new LinkedHashSet<>(pm.openProjectIds());
         Project cli = null;
         if (projectsOn && projectArg != null) {
             Path root = Path.of(projectArg).toAbsolutePath().normalize();
@@ -112,27 +111,17 @@ public class WindowManager {
                     : root.getFileName().toString();
             cli = pm.createOrGet(name, root);
             pm.save();
-            toOpen.add(cli.id());
         }
-        // Restore the no-project windows (the global "" window + any untitled "New Window"s) regardless of
-        // the Projects feature; project windows restore only when Projects are enabled. So a project id in
-        // the saved set is dropped when Projects are off, but multiple plain windows still come back.
-        if (!projectsOn) {
-            toOpen.removeIf(key -> !key.isEmpty() && !key.startsWith(UNTITLED_PREFIX));
-        }
-        if (toOpen.isEmpty()) {
-            toOpen.add(""); // nothing remembered ⇒ open the global window
-        }
-        String primary = cli != null
-                ? cli.id()
-                : toOpen.contains("")
-                        ? ""
-                        : (pm.active() != null && toOpen.contains(pm.active().id()))
-                                ? pm.active().id()
-                                : toOpen.iterator().next();
+        String cliId = cli == null ? null : cli.id();
+        // The no-project windows (global "" + untitled "New Window"s) always restore; project windows only
+        // when Projects are enabled. The restore set + primary-window choice are the pure, unit-tested
+        // WindowKeys helpers (a quit-vs-close drain bug once lived in this logic).
+        LinkedHashSet<String> toOpen = WindowKeys.restoreKeys(pm.openProjectIds(), projectsOn, cliId);
+        String primary = WindowKeys.primaryKey(
+                cliId, toOpen, pm.active() == null ? null : pm.active().id());
 
         for (String key : toOpen) {
-            boolean untitled = key.startsWith(UNTITLED_PREFIX);
+            boolean untitled = WindowKeys.isUntitled(key);
             Project project = (key.isEmpty() || untitled) ? null : findProject(key);
             if (!key.isEmpty() && !untitled && project == null) {
                 continue; // a stale id (project deleted out from under the open set)
@@ -181,9 +170,6 @@ public class WindowManager {
         return stage;
     }
 
-    /** Prefix marking an "untitled" no-project window key ({@code untitled:<uuid>}); see {@link #newWindow()}. */
-    private static final String UNTITLED_PREFIX = "untitled:";
-
     /**
      * Opens a brand-new editor window not tied to any project (the palette "New Window" command). Unlike
      * {@link #openOrFocusGlobal()} (which focuses the single global window), this always <em>builds</em> a
@@ -194,7 +180,7 @@ public class WindowManager {
      */
     public Stage newWindow() {
         String uuid = java.util.UUID.randomUUID().toString().substring(0, 8);
-        String key = UNTITLED_PREFIX + uuid;
+        String key = WindowKeys.UNTITLED_PREFIX + uuid;
         Stage stage = buildWindow(key, null, untitledStateFile(key), List.of(), false, null, false);
         projects().markOpen(key);
         setActiveAndSave(key);
@@ -208,7 +194,7 @@ public class WindowManager {
 
     /** The session file for an {@code untitled:<uuid>} window key. */
     private Path untitledStateFile(String key) {
-        return windowsDir().resolve(key.substring(UNTITLED_PREFIX.length()) + ".json");
+        return windowsDir().resolve(WindowKeys.untitledSessionFileName(key));
     }
 
     /** Opens (or focuses) {@code project}'s window. A null/empty-id project routes to the global window. */
@@ -531,22 +517,20 @@ public class WindowManager {
         if (!java.nio.file.Files.isDirectory(dir)) {
             return;
         }
-        java.util.Set<String> keep = new java.util.HashSet<>();
-        for (String k : openKeys) {
-            if (k.startsWith(UNTITLED_PREFIX)) {
-                keep.add(k.substring(UNTITLED_PREFIX.length()) + ".json");
-            }
-        }
         try (var stream = java.nio.file.Files.list(dir)) {
-            stream.filter(p -> p.getFileName().toString().endsWith(".json"))
-                    .filter(p -> !keep.contains(p.getFileName().toString()))
-                    .forEach(p -> {
-                        try {
-                            java.nio.file.Files.deleteIfExists(p);
-                        } catch (java.io.IOException ignored) {
-                            // leave it; a later launch retries
-                        }
-                    });
+            java.util.List<Path> files = stream.toList();
+            java.util.List<String> names =
+                    files.stream().map(p -> p.getFileName().toString()).toList();
+            java.util.Set<String> orphans = WindowKeys.orphanSessionFiles(openKeys, names);
+            for (Path p : files) {
+                if (orphans.contains(p.getFileName().toString())) {
+                    try {
+                        java.nio.file.Files.deleteIfExists(p);
+                    } catch (java.io.IOException ignored) {
+                        // leave it; a later launch retries
+                    }
+                }
+            }
         } catch (java.io.IOException ignored) {
             // best-effort cleanup
         }

--- a/src/test/java/com/editora/ui/ToolWindowVisibilityTest.java
+++ b/src/test/java/com/editora/ui/ToolWindowVisibilityTest.java
@@ -1,0 +1,25 @@
+package com.editora.ui;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ToolWindowVisibilityTest {
+
+    @Test
+    void buttonShownNeedsVisibleAndAvailable() {
+        assertTrue(ToolWindowVisibility.buttonShown(true, false));
+        assertFalse(ToolWindowVisibility.buttonShown(false, false)); // user hid it
+        assertFalse(ToolWindowVisibility.buttonShown(true, true)); // transiently unavailable (e.g. not a repo)
+        assertFalse(ToolWindowVisibility.buttonShown(false, true));
+    }
+
+    @Test
+    void stripeShownNeedsEnabledNotZenAndNonEmpty() {
+        assertTrue(ToolWindowVisibility.stripeShown(true, false, false));
+        assertFalse(ToolWindowVisibility.stripeShown(false, false, false)); // stripes disabled in Settings
+        assertFalse(ToolWindowVisibility.stripeShown(true, true, false)); // Zen hides stripes
+        assertFalse(ToolWindowVisibility.stripeShown(true, false, true)); // no buttons on the stripe
+    }
+}

--- a/src/test/java/com/editora/ui/WindowKeysTest.java
+++ b/src/test/java/com/editora/ui/WindowKeysTest.java
@@ -1,0 +1,77 @@
+package com.editora.ui;
+
+import java.util.List;
+import java.util.Set;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class WindowKeysTest {
+
+    @Test
+    void classifiesKeys() {
+        assertTrue(WindowKeys.isGlobal(""));
+        assertFalse(WindowKeys.isUntitled(""));
+        assertFalse(WindowKeys.isProject(""));
+
+        assertTrue(WindowKeys.isUntitled("untitled:ab12cd34"));
+        assertFalse(WindowKeys.isProject("untitled:ab12cd34"));
+        assertFalse(WindowKeys.isGlobal("untitled:ab12cd34"));
+
+        assertTrue(WindowKeys.isProject("my-project-id"));
+        assertFalse(WindowKeys.isUntitled("my-project-id"));
+    }
+
+    @Test
+    void untitledSessionFileName() {
+        assertEquals("ab12cd34.json", WindowKeys.untitledSessionFileName("untitled:ab12cd34"));
+    }
+
+    @Test
+    void restoreKeysKeepsOrderAndAddsCli() {
+        var keys = WindowKeys.restoreKeys(List.of("", "proj-a", "untitled:x"), true, "proj-b");
+        assertEquals(List.of("", "proj-a", "untitled:x", "proj-b"), List.copyOf(keys));
+    }
+
+    @Test
+    void restoreKeysDropsProjectsWhenProjectsOff() {
+        // Projects disabled: project keys are dropped, the global + untitled windows survive.
+        var keys = WindowKeys.restoreKeys(List.of("", "proj-a", "untitled:x"), false, null);
+        assertEquals(List.of("", "untitled:x"), List.copyOf(keys));
+    }
+
+    @Test
+    void restoreKeysFallsBackToGlobalWhenEmpty() {
+        assertEquals(List.of(""), List.copyOf(WindowKeys.restoreKeys(List.of(), false, null)));
+        // Projects off + only project keys saved ⇒ all dropped ⇒ fall back to the global window.
+        assertEquals(List.of(""), List.copyOf(WindowKeys.restoreKeys(List.of("proj-a"), false, null)));
+    }
+
+    @Test
+    void primaryKeyPrefersCliThenGlobalThenActiveThenFirst() {
+        assertEquals("cli", WindowKeys.primaryKey("cli", List.of("", "cli"), "proj-a"));
+        assertEquals("", WindowKeys.primaryKey(null, List.of("", "proj-a"), "proj-a"));
+        assertEquals("proj-a", WindowKeys.primaryKey(null, List.of("proj-b", "proj-a"), "proj-a"));
+        // active not in the set ⇒ first restored window wins.
+        assertEquals("proj-b", WindowKeys.primaryKey(null, List.of("proj-b", "proj-c"), "proj-a"));
+        // no active ⇒ first.
+        assertEquals("proj-b", WindowKeys.primaryKey(null, List.of("proj-b", "proj-c"), null));
+    }
+
+    @Test
+    void orphanSessionFilesKeepsOnlyOpenUntitledSessions() {
+        var open = List.of("", "untitled:keep", "proj-a");
+        var existing = List.of("keep.json", "stale.json", "notjson.txt");
+        Set<String> orphans = WindowKeys.orphanSessionFiles(open, existing);
+        assertEquals(Set.of("stale.json"), orphans); // keep.json backs an open window; non-json ignored
+    }
+
+    @Test
+    void orphanSessionFilesDeletesAllWhenNoUntitledOpen() {
+        Set<String> orphans = WindowKeys.orphanSessionFiles(List.of("", "proj-a"), List.of("a.json", "b.json"));
+        assertEquals(Set.of("a.json", "b.json"), orphans);
+    }
+}


### PR DESCRIPTION
Continues the "lift pure decision helpers out of `ui/` and unit-test them" strategy (the cheap way to cover `ui/` without the toolkit). **No behavior change** — the managers delegate to the new helpers.

- **`ui/WindowKeys`** (pure) — window-key classification (global / untitled / project), the multi-window **restore set** (`restoreKeys`), the **primary-window** choice (`primaryKey`), and orphan `windows/*.json` **GC** (`orphanSessionFiles`). This is the logic where a quit-vs-close drain bug once lived. `WindowManager.launch`/`gcOrphanWindowSessions`/`untitledStateFile` delegate; the `UNTITLED_PREFIX` constant moved here.
- **`ui/ToolWindowVisibility`** (pure) — stripe-button (`buttonShown`) and stripe-pane (`stripeShown`) visibility, capturing the persisted-`setVisible` vs transient-`setAvailable` distinction and the stripes-enabled/Zen gates. `ToolWindowManager.shouldShowButton`/`setStripeShown` delegate.
- Tests: `WindowKeysTest` (8), `ToolWindowVisibilityTest` (2).

`./mvnw verify`: **1003 tests, 0 failures**, spotless clean, JaCoCo floors held.

🤖 Generated with [Claude Code](https://claude.com/claude-code)