### PR TITLE
Lazily attach inert editor overlays instead of building all per buffer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Performance: lazy-attach feature overlays (developer-facing).** Each editor buffer no longer eagerly
+  builds the five overlays that are inert for most files — find-match highlight, log-level, Mermaid-lint,
+  LSP-diagnostic, and AceJump. They're constructed (Canvas + scroll/edit subscriptions) only on first
+  activation and inserted in their original z-order, so a buffer with LSP off, no diagram, not a log, and
+  never searched/ace-jumped allocates none of them. Cuts per-buffer memory and per-pulse listener fan-out
+  when many tabs are open; no behavior change. Covered by a new headless-FX test (`LazyOverlayFxTest`).
+
 ### Added
 
 - **Server log viewer.** Opening a `.log` file now gets log-aware treatment: **level highlighting** (ERROR/

--- a/src/main/java/com/editora/editor/EditorBuffer.java
+++ b/src/main/java/com/editora/editor/EditorBuffer.java
@@ -271,7 +271,7 @@ public class EditorBuffer implements TabContent {
     private final Minimap minimap = new Minimap(area);
     private final WhitespaceOverlay whitespace = new WhitespaceOverlay(area);
     private final SpellCheckOverlay spellOverlay = new SpellCheckOverlay(area);
-    private final LogHighlightOverlay logOverlay = new LogHighlightOverlay(area);
+    private LogHighlightOverlay logOverlay; // lazily attached on first activation — see logOverlay()
     private final InlineValuesOverlay inlineValues = new InlineValuesOverlay(area);
     /** Per-line blame for the IntelliJ-style gutter "Annotate" column; null = blame off. */
     private java.util.List<BlameInfo> blameLines;
@@ -282,9 +282,9 @@ public class EditorBuffer implements TabContent {
      *  in {@code app.css} so the measured column width matches what's actually drawn (not the editor font). */
     private static final double BLAME_FONT_SIZE = 10;
 
-    private final MermaidLintOverlay lintOverlay = new MermaidLintOverlay(area);
+    private MermaidLintOverlay lintOverlay; // lazily attached — see lintOverlay()
     private final MarkdownLintOverlay mdLintOverlay = new MarkdownLintOverlay(area);
-    private final LspDiagnosticOverlay lspOverlay = new LspDiagnosticOverlay(area);
+    private LspDiagnosticOverlay lspOverlay; // lazily attached — see lspOverlay()
     /** Severity stripe over the editor scrollbar (shown whenever LSP is active), so diagnostics stay locatable. */
     private final DiagnosticStripe diagnosticStripe = new DiagnosticStripe(area);
     /** TODO/highlight overview stripe over the scrollbar (beside the diagnostic stripe). */
@@ -312,14 +312,14 @@ public class EditorBuffer implements TabContent {
     /** Fired (FX thread) when the runnable status flips, so the controller refreshes the Run button. */
     private Runnable onRunnableChanged = () -> {};
 
-    private final SearchHighlightOverlay searchOverlay = new SearchHighlightOverlay(area);
+    private SearchHighlightOverlay searchOverlay; // lazily attached — see searchOverlay()
     /** Highlights configured TODO/FIXME-style patterns (per-pattern color), behind the text. */
     private final TodoHighlightOverlay todoOverlay = new TodoHighlightOverlay(area);
     /** Injected matcher (compiled patterns) + on/off gate; null/false = no highlight. */
     private TodoMatcher todoMatcher;
 
     private boolean todoEnabled;
-    private final AceJumpOverlay aceJump = new AceJumpOverlay(area);
+    private AceJumpOverlay aceJump; // lazily attached — see aceJump()
     /** Async maid validator (text, callback) injected by the controller; null = no linting. */
     private java.util.function.BiConsumer<
                     String, java.util.function.Consumer<java.util.List<com.editora.mermaid.MaidOutput.Diagnostic>>>
@@ -976,20 +976,17 @@ public class EditorBuffer implements TabContent {
                 .addAll(
                         scrollPane,
                         noteOverlay,
-                        searchOverlay,
                         todoOverlay,
-                        logOverlay,
                         whitespace,
                         spellOverlay,
-                        lintOverlay,
                         mdLintOverlay,
-                        lspOverlay,
                         inlineValues,
-                        aceJump,
                         minimap,
                         diagnosticStripe,
                         todoStripe,
                         columnRuler);
+        // searchOverlay / logOverlay / lintOverlay / lspOverlay / aceJump are attached lazily on first
+        // activation (see their getters) so an off-feature buffer never builds their Canvas/subscriptions.
         AnchorPane.setTopAnchor(scrollPane, 0d);
         AnchorPane.setBottomAnchor(scrollPane, 0d);
         AnchorPane.setLeftAnchor(scrollPane, 0d);
@@ -1009,22 +1006,14 @@ public class EditorBuffer implements TabContent {
         spellOverlay.setChecker(spellChecker);
         spellOverlay.setProseMode(isProse());
         spellOverlay.setMarkdown(isMarkdown()); // skip fenced ``` code blocks from spell check
-        AnchorPane.setTopAnchor(lintOverlay, 0d);
-        AnchorPane.setBottomAnchor(lintOverlay, 0d);
-        AnchorPane.setLeftAnchor(lintOverlay, 0d);
-        AnchorPane.setRightAnchor(lintOverlay, Minimap.WIDTH);
-        installLintHover(area);
+        installLintHover(area); // hover reads lintOverlay only while mermaid lint is active (lazily attached)
         AnchorPane.setTopAnchor(mdLintOverlay, 0d);
         AnchorPane.setBottomAnchor(mdLintOverlay, 0d);
         AnchorPane.setLeftAnchor(mdLintOverlay, 0d);
         AnchorPane.setRightAnchor(mdLintOverlay, Minimap.WIDTH);
         installMarkdownLintHover(area);
         installImageDrop(area);
-        AnchorPane.setTopAnchor(lspOverlay, 0d);
-        AnchorPane.setBottomAnchor(lspOverlay, 0d);
-        AnchorPane.setLeftAnchor(lspOverlay, 0d);
-        AnchorPane.setRightAnchor(lspOverlay, Minimap.WIDTH);
-        installLspHover(area);
+        installLspHover(area); // hover reads lspOverlay only while LSP is active (lazily attached)
         // Inline debugger values share the text rectangle, mouse-transparent (active only while
         // execution is suspended in this file).
         AnchorPane.setTopAnchor(inlineValues, 0d);
@@ -1032,22 +1021,10 @@ public class EditorBuffer implements TabContent {
         AnchorPane.setLeftAnchor(inlineValues, 0d);
         AnchorPane.setRightAnchor(inlineValues, Minimap.WIDTH);
         installDebugHover(area);
-        AnchorPane.setTopAnchor(searchOverlay, 0d);
-        AnchorPane.setBottomAnchor(searchOverlay, 0d);
-        AnchorPane.setLeftAnchor(searchOverlay, 0d);
-        AnchorPane.setRightAnchor(searchOverlay, Minimap.WIDTH);
         AnchorPane.setTopAnchor(todoOverlay, 0d);
         AnchorPane.setBottomAnchor(todoOverlay, 0d);
         AnchorPane.setLeftAnchor(todoOverlay, 0d);
         AnchorPane.setRightAnchor(todoOverlay, Minimap.WIDTH);
-        AnchorPane.setTopAnchor(logOverlay, 0d);
-        AnchorPane.setBottomAnchor(logOverlay, 0d);
-        AnchorPane.setLeftAnchor(logOverlay, 0d);
-        AnchorPane.setRightAnchor(logOverlay, Minimap.WIDTH);
-        AnchorPane.setTopAnchor(aceJump, 0d);
-        AnchorPane.setBottomAnchor(aceJump, 0d);
-        AnchorPane.setLeftAnchor(aceJump, 0d);
-        AnchorPane.setRightAnchor(aceJump, Minimap.WIDTH);
         AnchorPane.setTopAnchor(noteOverlay, 0d);
         AnchorPane.setBottomAnchor(noteOverlay, 0d);
         AnchorPane.setLeftAnchor(noteOverlay, 0d);
@@ -1364,6 +1341,64 @@ public class EditorBuffer implements TabContent {
         return focusedArea;
     }
 
+    // --- Lazily-attached feature overlays --------------------------------------------------------------
+    // These overlays are inert for most buffers (LSP off, not a diagram, not a log, never searched/ace-jumped),
+    // so they are built + wired only on first activation rather than per buffer. Each is inserted just below a
+    // fixed eager sibling to preserve the z-order of the original construction.
+
+    /** Attaches {@code overlay} to the editor pane just below {@code below}, with the standard text-rect anchors. */
+    private <T extends javafx.scene.layout.Region> T attachLazyOverlay(T overlay, javafx.scene.Node below) {
+        AnchorPane.setTopAnchor(overlay, 0d);
+        AnchorPane.setBottomAnchor(overlay, 0d);
+        AnchorPane.setLeftAnchor(overlay, 0d);
+        AnchorPane.setRightAnchor(overlay, Minimap.WIDTH);
+        int idx = root.getChildren().indexOf(below);
+        if (idx < 0) {
+            idx = root.getChildren().indexOf(minimap); // fallback: just under the minimap
+        }
+        if (idx < 0) {
+            root.getChildren().add(overlay);
+        } else {
+            root.getChildren().add(idx, overlay);
+        }
+        return overlay;
+    }
+
+    private SearchHighlightOverlay searchOverlay() {
+        if (searchOverlay == null) {
+            searchOverlay = attachLazyOverlay(new SearchHighlightOverlay(area), todoOverlay);
+        }
+        return searchOverlay;
+    }
+
+    private LogHighlightOverlay logOverlay() {
+        if (logOverlay == null) {
+            logOverlay = attachLazyOverlay(new LogHighlightOverlay(area), whitespace);
+        }
+        return logOverlay;
+    }
+
+    private MermaidLintOverlay lintOverlay() {
+        if (lintOverlay == null) {
+            lintOverlay = attachLazyOverlay(new MermaidLintOverlay(area), mdLintOverlay);
+        }
+        return lintOverlay;
+    }
+
+    private LspDiagnosticOverlay lspOverlay() {
+        if (lspOverlay == null) {
+            lspOverlay = attachLazyOverlay(new LspDiagnosticOverlay(area), inlineValues);
+        }
+        return lspOverlay;
+    }
+
+    private AceJumpOverlay aceJump() {
+        if (aceJump == null) {
+            aceJump = attachLazyOverlay(new AceJumpOverlay(area), minimap);
+        }
+        return aceJump;
+    }
+
     /**
      * Highlights all find matches ({@code [start,end)} offset pairs) behind the text, emphasizing the
      * match at {@code activeIndex}. No-op in large-file mode (the find bar still selects the current
@@ -1373,12 +1408,14 @@ public class EditorBuffer implements TabContent {
         if (largeFile) {
             return;
         }
-        searchOverlay.setMatches(matches, activeIndex);
+        searchOverlay().setMatches(matches, activeIndex);
     }
 
     /** Clears the find-match highlight overlay. */
     public void clearSearchMatches() {
-        searchOverlay.setMatches(java.util.List.of(), -1);
+        if (searchOverlay != null) {
+            searchOverlay.setMatches(java.util.List.of(), -1);
+        }
     }
 
     /** Enables/disables the TODO-pattern highlight for this buffer and re-scans (the controller pushes the
@@ -1414,7 +1451,7 @@ public class EditorBuffer implements TabContent {
 
     /** Starts AceJump: the next typed character labels its visible occurrences to jump the caret. */
     public void startAceJump() {
-        aceJump.start();
+        aceJump().start();
     }
 
     /** The node to place in the scene: the read-only banner (when shown) above the editor view. */
@@ -1492,7 +1529,9 @@ public class EditorBuffer implements TabContent {
     /** Turns live linting on/off for this buffer (controller gates on mermaid enabled + maid detected). */
     public void setMermaidLintEnabled(boolean on) {
         this.mermaidLintEnabled = on && isDiagram();
-        lintOverlay.setActive(this.mermaidLintEnabled);
+        if (this.mermaidLintEnabled || lintOverlay != null) {
+            lintOverlay().setActive(this.mermaidLintEnabled);
+        }
         if (this.mermaidLintEnabled) {
             scheduleMermaidLint();
         }
@@ -1502,13 +1541,15 @@ public class EditorBuffer implements TabContent {
         if (!mermaidLintEnabled || !isDiagram() || hugeFile || mermaidValidator == null) {
             return;
         }
-        mermaidValidator.accept(area.getText(), lintOverlay::setDiagnostics);
+        mermaidValidator.accept(area.getText(), lintOverlay()::setDiagnostics);
     }
 
     /** Shows the maid message(s) in a tooltip when hovering a squiggled span (overlay is mouse-transparent). */
     private void installLintHover(CodeArea a) {
         a.addEventHandler(MouseEvent.MOUSE_MOVED, e -> {
-            if (!mermaidLintEnabled || lintOverlay.diagnostics().isEmpty()) {
+            if (!mermaidLintEnabled
+                    || lintOverlay == null
+                    || lintOverlay.diagnostics().isEmpty()) {
                 if (lintTooltip != null) {
                     lintTooltip.hide();
                 }
@@ -1893,11 +1934,15 @@ public class EditorBuffer implements TabContent {
         // to map + render (the Problems tree, minimap + scrollbar stripes), freezing the editor. largeFile
         // is implied by hugeFile (see setReadOnly), so this single guard covers both.
         this.lspActive = on && isLspLanguage() && !largeFile;
-        lspOverlay.setActive(this.lspActive);
+        if (this.lspActive || lspOverlay != null) {
+            lspOverlay().setActive(this.lspActive);
+        }
         // The minimap stripes only draw while LSP is active for this file, regardless of any stale list.
         minimap.setDiagnosticsEnabled(this.lspActive);
         if (!this.lspActive) {
-            lspOverlay.setDiagnostics(java.util.List.of());
+            if (lspOverlay != null) {
+                lspOverlay.setDiagnostics(java.util.List.of());
+            }
             minimap.setDiagnostics(java.util.List.of());
             diagnosticStripe.setDiagnostics(java.util.List.of());
         }
@@ -1910,7 +1955,9 @@ public class EditorBuffer implements TabContent {
 
     /** Pushes the latest diagnostics for this buffer into the overlay + minimap/scrollbar stripes. */
     public void setLspDiagnostics(java.util.List<LspDiagnostic> diagnostics) {
-        lspOverlay.setDiagnostics(diagnostics);
+        if (lspActive || lspOverlay != null) {
+            lspOverlay().setDiagnostics(diagnostics);
+        }
         minimap.setDiagnostics(diagnostics);
         diagnosticStripe.setDiagnostics(diagnostics);
     }
@@ -2030,7 +2077,7 @@ public class EditorBuffer implements TabContent {
     /** Shows the LSP diagnostic message(s) in a tooltip when hovering a squiggled span. */
     private void installLspHover(CodeArea a) {
         a.addEventHandler(MouseEvent.MOUSE_MOVED, e -> {
-            if (!lspActive || lspOverlay.diagnostics().isEmpty()) {
+            if (!lspActive || lspOverlay == null || lspOverlay.diagnostics().isEmpty()) {
                 if (lspTooltip != null) {
                     lspTooltip.hide();
                 }
@@ -2282,7 +2329,10 @@ public class EditorBuffer implements TabContent {
 
     /** Turns the size-independent level overlay on/off (controller gates on the feature + {@link #isLog()}). */
     public void setLogHighlightEnabled(boolean on) {
-        logOverlay.setActive(on && isLog());
+        boolean want = on && isLog();
+        if (want || logOverlay != null) {
+            logOverlay().setActive(want);
+        }
     }
 
     /** Whether a level/regex filter is currently narrowing the visible lines. */

--- a/src/test/java/com/editora/ui/LazyOverlayFxTest.java
+++ b/src/test/java/com/editora/ui/LazyOverlayFxTest.java
@@ -1,0 +1,103 @@
+package com.editora.ui;
+
+import java.util.List;
+
+import javafx.scene.Node;
+import javafx.scene.layout.AnchorPane;
+
+import com.editora.editor.EditorBuffer;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Verifies the lazy feature-overlay attachment in {@link EditorBuffer}: an off-feature buffer never
+ * builds the search / log / mermaid-lint / LSP / AceJump overlays (no Canvas, no subscriptions), and
+ * activating a feature attaches its overlay <em>in the correct z-order</em> — just below its fixed eager
+ * sibling. This is the reusable "feature ⇄ overlay" harness pattern for the buffer surface.
+ */
+@Tag("fx")
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class LazyOverlayFxTest {
+
+    @BeforeAll
+    void setUp() throws Exception {
+        FxTestSupport.bootToolkit();
+    }
+
+    private static EditorBuffer newBuffer() throws Exception {
+        return FxTestSupport.callOnFx(() -> new EditorBuffer());
+    }
+
+    @Test
+    void offFeatureBufferBuildsNoLazyOverlays() throws Exception {
+        EditorBuffer b = newBuffer();
+        for (String f : List.of("searchOverlay", "logOverlay", "lintOverlay", "lspOverlay", "aceJump")) {
+            assertNull(FxTestSupport.field(b, f), f + " must not be built for an off-feature buffer");
+        }
+    }
+
+    @Test
+    void searchActivationAttachesOverlayBelowTodo() throws Exception {
+        EditorBuffer b = newBuffer();
+        FxTestSupport.runOnFx(() -> b.setSearchMatches(List.of(new int[] {0, 0}), -1));
+
+        Node search = FxTestSupport.field(b, "searchOverlay");
+        Node todo = FxTestSupport.field(b, "todoOverlay");
+        AnchorPane root = FxTestSupport.field(b, "root");
+        assertNotNull(search, "searching attaches the search overlay");
+        assertTrue(root.getChildren().contains(search), "search overlay attached to the editor pane");
+        assertTrue(
+                root.getChildren().indexOf(search) < root.getChildren().indexOf(todo),
+                "search overlay sits below the todo overlay (original z-order preserved)");
+    }
+
+    @Test
+    void aceJumpActivationAttachesOverlay() throws Exception {
+        EditorBuffer b = newBuffer();
+        assertNull(FxTestSupport.field(b, "aceJump"));
+
+        FxTestSupport.runOnFx(b::startAceJump);
+
+        Node ace = FxTestSupport.field(b, "aceJump");
+        AnchorPane root = FxTestSupport.field(b, "root");
+        assertNotNull(ace, "AceJump attaches its overlay on first use");
+        assertTrue(root.getChildren().contains(ace), "AceJump overlay attached to the editor pane");
+    }
+
+    @Test
+    void logActivationAttachesOverlayBelowWhitespace() throws Exception {
+        EditorBuffer b = newBuffer();
+        FxTestSupport.runOnFx(() -> {
+            b.setLogViewForced(true); // make isLog() true without a file
+            b.setLogHighlightEnabled(true);
+        });
+
+        Node log = FxTestSupport.field(b, "logOverlay");
+        Node whitespace = FxTestSupport.field(b, "whitespace");
+        AnchorPane root = FxTestSupport.field(b, "root");
+        assertNotNull(log, "log highlighting on a log buffer attaches the overlay");
+        assertTrue(
+                root.getChildren().indexOf(log) < root.getChildren().indexOf(whitespace),
+                "log overlay sits below the whitespace overlay (original z-order preserved)");
+    }
+
+    @Test
+    void disablingAnUnbuiltOverlayStaysNull() throws Exception {
+        EditorBuffer b = newBuffer();
+        // Turning a feature OFF on a buffer that never had it must not allocate the overlay.
+        FxTestSupport.runOnFx(() -> {
+            b.setLogHighlightEnabled(false);
+            b.setLspActive(false);
+            b.clearSearchMatches();
+        });
+        assertNull(FxTestSupport.field(b, "logOverlay"));
+        assertNull(FxTestSupport.field(b, "lspOverlay"));
+        assertNull(FxTestSupport.field(b, "searchOverlay"));
+    }
+}


### PR DESCRIPTION
First of the architecture/perf improvements: stop building the editor overlays that are inert for most files.

## Problem
`EditorBuffer` eagerly constructed **13** `Canvas`-backed overlays per buffer (each with 3–4 scroll/edit/viewport subscriptions), even for features that are off. Open 40 files → ~520 overlay Regions + their subscriptions, most never used.

## Change
The **five overlays that only receive data while active** — find-match highlight, log-level, Mermaid-lint, LSP-diagnostic, AceJump — are now built **lazily on first activation** via getters that insert them just below a fixed eager sibling, so the z-order is byte-identical to before. A buffer with LSP off, no diagram, not a log, and never searched/ace-jumped allocates **none** of them.

Activation routes through the getters (`if (want || foo != null) foo().setActive(want)`); off/clear/read paths null-guard, with the invariant *feature active ⟹ overlay built* keeping the hover-handler reads safe.

The config-heavy / on-by-default overlays (spell, whitespace, todo, markdown-lint, inline-values) are deliberately left eager — they receive state (checker/prose/markdown/font/matcher) *before* activation, so lazy-ing them would risk dropping pushed config for little gain.

## Impact
Lower per-buffer memory and fewer per-pulse listener invocations when many tabs are open. No behavior change; one null-check per activation (negligible). No new dependency.

## Tests
New headless-FX `LazyOverlayFxTest` (the reusable "feature ⇄ overlay" harness pattern): off-feature buffer builds nothing; search/log/ace activation attaches in the correct z-order; disable-when-unbuilt stays null. Full suite green (**1038 tests**); spotless clean; 40s runtime smoke (opened a `.java` + a `.log`) threw nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)