### PR TITLE
Add a characterization-test net + pure helpers for Git

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Refactor: a characterization-test net + pure helpers for the Git integration (developer-facing).** First
+  step of the Git extraction (the largest, least-tested subsystem): before moving any stateful code, this
+  adds a safety net — `GitStateFxTest` drives the `applyGitState`/`applyGitSupport` core directly with a
+  synthetic `RepoState` and pins the repo-root/branch/upstream state machine, and a new pure, unit-tested
+  `git/GitChangeBars` (the diff→CSS-class mapping + the background-buffer re-diff predicate) dedups the gutter
+  change-bar logic at its two call sites. No behavior change; sets up the subsequent `GitCoordinator`
+  extraction under the net.
+
 - **Refactor: extract the HTTP Client into an `HttpClientCoordinator` (developer-facing).** The fourth (and
   most window-entangled) feature coordinator peeled off `MainController`: the request runner, the response
   tool-window panel, response-tab opening, clipboard curl import/export, and `.env` scanning move to

--- a/src/main/java/com/editora/git/GitChangeBars.java
+++ b/src/main/java/com/editora/git/GitChangeBars.java
@@ -1,0 +1,39 @@
+package com.editora.git;
+
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Pure decision helpers for the editor's Git gutter change bars, extracted from {@code MainController} so the
+ * logic is unit-testable ahead of the larger Git-coordinator extraction. java.base + the git models only.
+ */
+public final class GitChangeBars {
+
+    private GitChangeBars() {}
+
+    /**
+     * Maps a diff's {@code line -> ChangeType} to the {@code line -> CSS class} the gutter draws (e.g.
+     * {@code git-added}/{@code git-modified}/{@code git-deleted}). An empty input yields an empty map (which
+     * still marks a buffer as tracked, reserving the gutter slot).
+     */
+    public static Map<Integer, String> cssClassesByLine(Map<Integer, ChangeType> changes) {
+        Map<Integer, String> classes = new HashMap<>();
+        if (changes != null) {
+            changes.forEach((line, type) -> classes.put(line, type.cssClass()));
+        }
+        return classes;
+    }
+
+    /**
+     * Whether a <em>background</em> open buffer should be re-diffed after a Git mutation (commit/stage/…): it
+     * must be a non-active, non-huge, on-disk file located inside the affected repository root. The active
+     * buffer is refreshed separately, so it returns {@code false} for it.
+     */
+    public static boolean shouldRediff(Path bufferPath, Path repoRoot, boolean active, boolean huge) {
+        if (bufferPath == null || repoRoot == null || active || huge) {
+            return false;
+        }
+        return bufferPath.toAbsolutePath().startsWith(repoRoot.toAbsolutePath());
+    }
+}

--- a/src/main/java/com/editora/ui/MainController.java
+++ b/src/main/java/com/editora/ui/MainController.java
@@ -4438,11 +4438,9 @@ public class MainController implements com.editora.mcp.McpBridge {
         statusBar.setGitBranch(status.branch(), status.ahead(), status.behind());
         gitPanel.setStatus(status);
         if (b != null && b.getPath() != null) {
-            java.util.Map<Integer, String> classes = new java.util.HashMap<>();
-            state.changes().forEach((line, type) -> classes.put(line, type.cssClass()));
             // An empty map still marks the buffer as tracked (reserves the slot); hunk text feeds the
             // change-bar hover tooltip.
-            b.setChangeBars(classes, state.hunks());
+            b.setChangeBars(com.editora.git.GitChangeBars.cssClassesByLine(state.changes()), state.hunks());
         }
         refreshBlame(b); // inline blame for the active file (no-op + clears when blame is off)
     }
@@ -4460,22 +4458,20 @@ public class MainController implements com.editora.mcp.McpBridge {
         if (root == null) {
             return;
         }
-        Path absRoot = root.toAbsolutePath();
         EditorBuffer active = activeBuffer();
         for (Tab tab : tabPane.getTabs()) {
             EditorBuffer buf = bufferOf(tab);
-            if (buf == null || buf == active || buf.getPath() == null || buf.isLargeFile()) {
-                continue; // active buffer is handled by refreshGit(); skip non-file/huge buffers
+            // The active buffer is handled by refreshGit(); skip non-file/huge buffers + files outside this repo.
+            if (buf == null
+                    || !com.editora.git.GitChangeBars.shouldRediff(
+                            buf.getPath(), root, buf == active, buf.isLargeFile())) {
+                continue;
             }
-            Path p = buf.getPath().toAbsolutePath();
-            if (!p.startsWith(absRoot)) {
-                continue; // only files inside the affected repo
-            }
-            gitService.diff(root, p, diff -> {
-                java.util.Map<Integer, String> classes = new java.util.HashMap<>();
-                diff.changes().forEach((line, type) -> classes.put(line, type.cssClass()));
-                buf.setChangeBars(classes, diff.hunks());
-            });
+            gitService.diff(
+                    root,
+                    buf.getPath().toAbsolutePath(),
+                    diff -> buf.setChangeBars(
+                            com.editora.git.GitChangeBars.cssClassesByLine(diff.changes()), diff.hunks()));
         }
         refreshOpenDiffs(); // a commit/stage/checkout changes HEAD/index/working → re-diff open diff tabs
     }

--- a/src/test/java/com/editora/git/GitChangeBarsTest.java
+++ b/src/test/java/com/editora/git/GitChangeBarsTest.java
@@ -1,0 +1,57 @@
+package com.editora.git;
+
+import java.nio.file.Path;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class GitChangeBarsTest {
+
+    @Test
+    void cssClassesByLineMapsEachChangeType() {
+        Map<Integer, ChangeType> changes = new LinkedHashMap<>();
+        changes.put(1, ChangeType.ADDED);
+        changes.put(5, ChangeType.MODIFIED);
+        changes.put(9, ChangeType.DELETED);
+
+        Map<Integer, String> classes = GitChangeBars.cssClassesByLine(changes);
+        assertEquals(ChangeType.ADDED.cssClass(), classes.get(1));
+        assertEquals(ChangeType.MODIFIED.cssClass(), classes.get(5));
+        assertEquals(ChangeType.DELETED.cssClass(), classes.get(9));
+        assertEquals(3, classes.size());
+    }
+
+    @Test
+    void cssClassesByLineEmptyOrNullIsEmpty() {
+        assertTrue(GitChangeBars.cssClassesByLine(Map.of()).isEmpty());
+        assertTrue(GitChangeBars.cssClassesByLine(null).isEmpty());
+    }
+
+    @Test
+    void shouldRediffOnlyBackgroundOnDiskFilesInsideTheRepo() {
+        Path root = Path.of("/work/repo");
+        Path inside = Path.of("/work/repo/src/Foo.java");
+        Path outside = Path.of("/work/other/Bar.java");
+
+        assertTrue(GitChangeBars.shouldRediff(inside, root, false, false), "background file inside the repo");
+        assertFalse(GitChangeBars.shouldRediff(inside, root, true, false), "the active buffer is handled separately");
+        assertFalse(GitChangeBars.shouldRediff(inside, root, false, true), "huge files have no gutter");
+        assertFalse(GitChangeBars.shouldRediff(outside, root, false, false), "files outside the affected repo");
+        assertFalse(GitChangeBars.shouldRediff(null, root, false, false), "an unsaved buffer has no path");
+        assertFalse(GitChangeBars.shouldRediff(inside, null, false, false), "no repo root");
+    }
+
+    @Test
+    void shouldRediffResolvesRelativePathsAgainstAbsoluteRoot() {
+        // A relative buffer path + an absolute root: comparison is on absolute paths, so equal cwd → inside.
+        Path cwd = Path.of("").toAbsolutePath();
+        Path root = cwd.resolve("repo");
+        Path relInside = Path.of("repo/file.txt");
+        assertTrue(GitChangeBars.shouldRediff(relInside, root, false, false));
+    }
+}

--- a/src/test/java/com/editora/ui/GitStateFxTest.java
+++ b/src/test/java/com/editora/ui/GitStateFxTest.java
@@ -1,0 +1,88 @@
+package com.editora.ui;
+
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+
+import com.editora.git.ChangeType;
+import com.editora.git.GitService;
+import com.editora.git.GitStatus;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+/**
+ * Characterization tests for the Git state machine — the {@code applyGitState}/{@code applyGitSupport} core
+ * that drives the status bar, Commit/Log windows, and gutter change bars. Built as a safety net <em>before</em>
+ * the larger Git-coordinator extraction: they drive {@code applyGitState} directly with a synthetic
+ * {@link GitService.RepoState} (no real repo, no async) and pin the repo-root/branch/upstream state, so a
+ * future move can't silently change it.
+ */
+@Tag("fx")
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class GitStateFxTest {
+
+    private FxWindowFixture fx;
+
+    @BeforeAll
+    void setUp() throws Exception {
+        FxTestSupport.bootToolkit();
+        fx = FxWindowFixture.create();
+        fx.shared.getSettings().setGitSupport(true);
+    }
+
+    @AfterAll
+    void tearDown() throws Exception {
+        if (fx != null) {
+            fx.dispose();
+        }
+    }
+
+    private void applyGitState(GitService.RepoState state) throws Exception {
+        FxTestSupport.runOnFx(() ->
+                FxTestSupport.call(fx.controller, "applyGitState", new Class<?>[] {GitService.RepoState.class}, state));
+    }
+
+    private static GitService.RepoState repo(Path root, String branch, String upstream, int ahead, int behind) {
+        GitStatus status = new GitStatus(true, branch, upstream, ahead, behind, List.of());
+        return new GitService.RepoState(root, status, Map.of(3, ChangeType.MODIFIED), Map.of());
+    }
+
+    @Test
+    void repoStateSetsRootBranchAndUpstream() throws Exception {
+        Path root = Path.of("/work/repo");
+        applyGitState(repo(root, "main", "origin/main", 2, 1));
+
+        assertEquals(root, FxTestSupport.field(fx.controller, "currentRepoRoot"));
+        assertEquals("main", FxTestSupport.field(fx.controller, "currentBranchName"));
+        assertEquals("origin/main", FxTestSupport.field(fx.controller, "currentUpstream"));
+    }
+
+    @Test
+    void noneStateClearsRepoInfo() throws Exception {
+        // First populate, then clear with NONE — the "not in a repo" path must wipe the repo state.
+        applyGitState(repo(Path.of("/work/repo"), "main", "origin/main", 0, 0));
+        applyGitState(GitService.RepoState.NONE);
+
+        assertNull(FxTestSupport.field(fx.controller, "currentRepoRoot"), "NONE clears the repo root");
+        assertEquals("", FxTestSupport.field(fx.controller, "currentBranchName"));
+        assertEquals("", FxTestSupport.field(fx.controller, "currentUpstream"));
+    }
+
+    @Test
+    void applyGitSupportOffClearsRepoState() throws Exception {
+        applyGitState(repo(Path.of("/work/repo"), "develop", "origin/develop", 0, 0));
+        fx.shared.getSettings().setGitSupport(false);
+        FxTestSupport.runOnFx(() -> FxTestSupport.invoke(fx.controller, "applyGitSupport"));
+
+        assertNull(FxTestSupport.field(fx.controller, "currentRepoRoot"), "disabling Git clears the repo root");
+        assertEquals("", FxTestSupport.field(fx.controller, "currentBranchName"));
+
+        fx.shared.getSettings().setGitSupport(true); // restore for any later test ordering
+    }
+}


### PR DESCRIPTION
**First step of extracting the Git integration** — the largest (~215 refs) and least-tested subsystem. Per the agreed "net first, then extract" approach, this PR adds a safety net **before** any stateful code moves, so the subsequent `GitCoordinator` extraction has something to catch silent regressions in git status / gutter / commit behavior.

## What changed
- **`GitStateFxTest`** — drives the engine's heart (`applyGitState` / `applyGitSupport`) directly with a synthetic `GitService.RepoState` (no real repo, no async), pinning the repo-root / branch / upstream state machine: a repo state sets them, `RepoState.NONE` clears them, and disabling Git clears them.
- **`git/GitChangeBars`** (pure, unit-tested) — the diff `ChangeType → CSS-class` mapping + the background-buffer re-diff predicate (inside-the-repo, non-active, non-huge, on-disk). Dedups the gutter change-bar logic that was inlined at both `applyGitState` and `afterGitMutation`.

## Why this shape
Git doesn't sub-divide cleanly (`GitService` is central to ~40 methods), and it's the least-covered code — so the prudent first move is the net, not a 140-rewire extraction. Subsequent PRs extract the stateful `GitCoordinator` under this net.

## Verification
No behavior change — full suite **1072 green** (+7: 3 characterization + 4 pure), spotless clean. No new dependency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)