### PR TITLE
Move inline Git blame into the GitCoordinator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Refactor: move inline Git blame into the `GitCoordinator` (developer-facing).** The blame annotation
+  engine — eligibility (`isBlameEnabled`), the off-thread per-file fetch (`applyBlame`/`refreshBlame`), and
+  the blame→`BlameInfo` mapping (author/date label, full-commit tooltip, age-heatmap tint) — moves out of
+  `MainController` into `GitCoordinator`, where `applyState` now drives it directly. That **removes the
+  `WindowOps.refreshBlame` Host hop** added when the engine was extracted: the coordinator owns blame end to
+  end and needs nothing new from the window (only the shared `CoordinatorHost`). The click→commit-diff
+  actions (`blameShowCommit`/`onGutterBlameClick`) stay in `MainController` since they open a diff tab. No
+  behavior change; full suite green.
+
 - **Refactor: extract the stateful Git core into a `GitCoordinator` (developer-facing).** Under the net added
   in the previous step, the engine of the Git integration moves out of `MainController` into
   `ui/GitCoordinator`: the `GitService` CLI facade, the repo state (root / branch / upstream), and the

--- a/src/main/java/com/editora/ui/GitCoordinator.java
+++ b/src/main/java/com/editora/ui/GitCoordinator.java
@@ -1,11 +1,20 @@
 package com.editora.ui;
 
 import java.nio.file.Path;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.util.ArrayList;
+import java.util.List;
 
+import com.editora.editor.BlameInfo;
 import com.editora.editor.EditorBuffer;
+import com.editora.git.BlameHeatmap;
+import com.editora.git.BlameParser;
 import com.editora.git.GitChangeBars;
+import com.editora.git.GitFormat;
 import com.editora.git.GitService;
 import com.editora.git.GitStatus;
+import com.editora.git.RelativeTime;
 import com.editora.vfs.Vfs;
 
 import static com.editora.i18n.Messages.tr;
@@ -13,13 +22,15 @@ import static com.editora.i18n.Messages.tr;
 /**
  * The stateful core of the Git integration: it owns the {@link GitService} (the off-thread CLI facade) plus
  * the current repo state (root / branch / upstream) and the state machine that keeps the status bar, the
- * Commit / Log tool windows, and the active buffer's gutter change bars in sync with what's on disk.
+ * Commit / Log tool windows, the active buffer's gutter change bars, and its inline blame annotations in
+ * sync with what's on disk.
  *
- * <p>{@code MainController} keeps the user-facing Git <em>operations</em> (commit, branch, log, blame, stash,
- * clone, diff) and reaches into this coordinator for the shared engine: {@link #service()} for the CLI
- * facade and {@link #repoRoot()} for the active repo. Everything the engine needs from the window goes
- * through the shared {@link CoordinatorHost} (settings, simple-mode gate, active buffer, status echo,
- * per-buffer iteration) plus a small git-specific {@link WindowOps} for the surfaces it drives.
+ * <p>{@code MainController} keeps the user-facing Git <em>operations</em> (commit, branch, log, blame
+ * click→commit-diff, stash, clone, diff) and reaches into this coordinator for the shared engine:
+ * {@link #service()} for the CLI facade and {@link #repoRoot()} for the active repo. Everything the engine
+ * needs from the window goes through the shared {@link CoordinatorHost} (settings, simple-mode gate, active
+ * buffer, theme brightness, per-buffer iteration) plus a small git-specific {@link WindowOps} for the
+ * surfaces it drives.
  *
  * <p>The {@code applyState}/{@code applySupport} state machine is pinned by {@code GitStateFxTest}.
  */
@@ -36,9 +47,6 @@ final class GitCoordinator {
         void setGitLogWindowAvailable(boolean available);
 
         void setGitPanelStatus(GitStatus status);
-
-        /** Refreshes (or clears) the active buffer's inline blame; no-op when blame is off. */
-        void refreshBlame(EditorBuffer buffer);
 
         /** Re-diffs any open diff tabs (a mutation moved HEAD/index/working). */
         void refreshOpenDiffs();
@@ -194,7 +202,7 @@ final class GitCoordinator {
             // change-bar hover tooltip.
             b.setChangeBars(GitChangeBars.cssClassesByLine(state.changes()), state.hunks());
         }
-        ops.refreshBlame(b); // inline blame for the active file (no-op + clears when blame is off)
+        refreshBlame(b); // inline blame for the active file (no-op + clears when blame is off)
     }
 
     /**
@@ -230,5 +238,106 @@ final class GitCoordinator {
 
     void shutdown() {
         service.shutdown();
+    }
+
+    // --- Inline blame annotations (IntelliJ-style gutter column) ---------------------------------
+
+    /** Whether blame annotations are effectively on (Git enabled + the setting + not Simple mode). */
+    boolean isBlameEnabled() {
+        return isEnabled() && host.settings().isGitBlameInline();
+    }
+
+    /** Pushes blame to the active buffer (and clears it everywhere else); runs on init / settings apply /
+     *  tab switch / git mutation. Only the focused buffer is annotated (blame is one git call per file). */
+    void applyBlame() {
+        EditorBuffer active = host.activeBuffer();
+        host.forEachBuffer(b -> {
+            if (b != active) {
+                b.setBlame(null);
+            }
+        });
+        refreshBlame(active);
+    }
+
+    /** Fetches blame for {@code b} off-thread and pushes formatted annotations (or clears when ineligible). */
+    void refreshBlame(EditorBuffer b) {
+        if (b == null) {
+            return;
+        }
+        if (!isBlameEnabled() || b.getPath() == null || b.isLargeFile() || !host.isLocalBuffer(b) || repoRoot == null) {
+            b.setBlame(null);
+            return;
+        }
+        Path file = b.getPath();
+        service.blame(repoRoot, file, lines -> {
+            if (host.activeBuffer() != b) {
+                return; // the user switched tabs while blame ran
+            }
+            b.setBlame(toBlameInfos(lines));
+        });
+    }
+
+    /** Maps git blame into the per-line annotation column (author + date, full-commit tooltip, age-heatmap
+     *  background). The heatmap is scaled across this file's oldest→newest committed lines and tinted for
+     *  the current theme. Uncommitted lines get a label only (no heatmap, no commit to open). */
+    private List<BlameInfo> toBlameInfos(List<BlameParser.BlameLine> lines) {
+        long now = System.currentTimeMillis() / 1000L;
+        long min = Long.MAX_VALUE;
+        long max = Long.MIN_VALUE;
+        for (BlameParser.BlameLine bl : lines) {
+            if (!bl.uncommitted()) {
+                min = Math.min(min, bl.epochSeconds());
+                max = Math.max(max, bl.epochSeconds());
+            }
+        }
+        boolean dark = host.appThemeDark();
+        List<BlameInfo> out = new ArrayList<>(lines.size());
+        for (BlameParser.BlameLine bl : lines) {
+            if (bl.uncommitted()) {
+                String label = tr("blame.uncommitted");
+                out.add(new BlameInfo(label, "", label, "", ""));
+                continue;
+            }
+            String date = blameDate(bl.epochSeconds());
+            String shortHash = bl.hash().substring(0, Math.min(8, bl.hash().length()));
+            String tooltip = tr(
+                    "blame.tooltip",
+                    bl.author(),
+                    date,
+                    relativeTimeLabel(bl.epochSeconds(), now),
+                    bl.summary(),
+                    shortHash);
+            double intensity = BlameHeatmap.intensity(bl.epochSeconds(), min, max);
+            out.add(new BlameInfo(
+                    GitFormat.shortAuthor(bl.author()),
+                    date,
+                    tooltip,
+                    BlameHeatmap.heatmapColor(intensity, dark),
+                    bl.hash()));
+        }
+        return out;
+    }
+
+    /** ISO {@code yyyy-MM-dd} commit date for the annotation column (technical, not localized). */
+    private static String blameDate(long epochSeconds) {
+        return Instant.ofEpochSecond(epochSeconds)
+                .atZone(ZoneId.systemDefault())
+                .toLocalDate()
+                .toString();
+    }
+
+    /** Localized "N days ago"-style label from the pure {@link RelativeTime} bucketing. */
+    private static String relativeTimeLabel(long epochSeconds, long nowSeconds) {
+        RelativeTime.Span span = RelativeTime.of(epochSeconds, nowSeconds);
+        long v = span.value();
+        return switch (span.unit()) {
+            case NOW -> tr("blame.now");
+            case MINUTES -> tr("blame.minutesAgo", v);
+            case HOURS -> tr("blame.hoursAgo", v);
+            case DAYS -> tr("blame.daysAgo", v);
+            case WEEKS -> tr("blame.weeksAgo", v);
+            case MONTHS -> tr("blame.monthsAgo", v);
+            case YEARS -> tr("blame.yearsAgo", v);
+        };
     }
 }

--- a/src/main/java/com/editora/ui/MainController.java
+++ b/src/main/java/com/editora/ui/MainController.java
@@ -2752,11 +2752,6 @@ public class MainController implements com.editora.mcp.McpBridge {
         }
 
         @Override
-        public void refreshBlame(EditorBuffer buffer) {
-            MainController.this.refreshBlame(buffer);
-        }
-
-        @Override
         public void refreshOpenDiffs() {
             MainController.this.refreshOpenDiffs();
         }
@@ -5230,110 +5225,9 @@ public class MainController implements com.editora.mcp.McpBridge {
     }
 
     // --- Git blame annotations (IntelliJ-style gutter column) ------------------------------------
-
-    /** Whether blame annotations are effectively on (Git enabled + the setting + not Simple mode). */
-    private boolean gitBlameEnabled() {
-        return git.isEnabled() && config.getSettings().isGitBlameInline();
-    }
-
-    /** Pushes blame to the active buffer (and clears it everywhere else); runs on init / settings apply /
-     *  tab switch / git mutation. Only the focused buffer is annotated (blame is one git call per file). */
-    private void applyGitBlame() {
-        EditorBuffer active = activeBuffer();
-        for (Tab tab : tabPane.getTabs()) {
-            EditorBuffer b = bufferOf(tab);
-            if (b != null && b != active) {
-                b.setBlame(null);
-            }
-        }
-        refreshBlame(active);
-    }
-
-    /** Fetches blame for {@code b} off-thread and pushes formatted annotations (or clears when ineligible). */
-    private void refreshBlame(EditorBuffer b) {
-        if (b == null) {
-            return;
-        }
-        if (!gitBlameEnabled()
-                || b.getPath() == null
-                || b.isLargeFile()
-                || !isLocalBuffer(b)
-                || git.repoRoot() == null) {
-            b.setBlame(null);
-            return;
-        }
-        Path file = b.getPath();
-        git.service().blame(git.repoRoot(), file, lines -> {
-            if (activeBuffer() != b) {
-                return; // the user switched tabs while blame ran
-            }
-            b.setBlame(toBlameInfos(lines));
-        });
-    }
-
-    /** Maps git blame into the per-line annotation column (author + date, full-commit tooltip, age-heatmap
-     *  background). The heatmap is scaled across this file's oldest→newest committed lines and tinted for
-     *  the current theme. Uncommitted lines get a label only (no heatmap, no commit to open). */
-    private List<com.editora.editor.BlameInfo> toBlameInfos(List<com.editora.git.BlameParser.BlameLine> lines) {
-        long now = System.currentTimeMillis() / 1000L;
-        long min = Long.MAX_VALUE;
-        long max = Long.MIN_VALUE;
-        for (com.editora.git.BlameParser.BlameLine bl : lines) {
-            if (!bl.uncommitted()) {
-                min = Math.min(min, bl.epochSeconds());
-                max = Math.max(max, bl.epochSeconds());
-            }
-        }
-        boolean dark = appThemeDark();
-        List<com.editora.editor.BlameInfo> out = new java.util.ArrayList<>(lines.size());
-        for (com.editora.git.BlameParser.BlameLine bl : lines) {
-            if (bl.uncommitted()) {
-                String label = tr("blame.uncommitted");
-                out.add(new com.editora.editor.BlameInfo(label, "", label, "", ""));
-                continue;
-            }
-            String date = blameDate(bl.epochSeconds());
-            String shortHash = bl.hash().substring(0, Math.min(8, bl.hash().length()));
-            String tooltip = tr(
-                    "blame.tooltip",
-                    bl.author(),
-                    date,
-                    relativeTimeLabel(bl.epochSeconds(), now),
-                    bl.summary(),
-                    shortHash);
-            double intensity = com.editora.git.BlameHeatmap.intensity(bl.epochSeconds(), min, max);
-            out.add(new com.editora.editor.BlameInfo(
-                    com.editora.git.GitFormat.shortAuthor(bl.author()),
-                    date,
-                    tooltip,
-                    com.editora.git.BlameHeatmap.heatmapColor(intensity, dark),
-                    bl.hash()));
-        }
-        return out;
-    }
-
-    /** ISO {@code yyyy-MM-dd} commit date for the annotation column (technical, not localized). */
-    private static String blameDate(long epochSeconds) {
-        return java.time.Instant.ofEpochSecond(epochSeconds)
-                .atZone(java.time.ZoneId.systemDefault())
-                .toLocalDate()
-                .toString();
-    }
-
-    /** Localized "N days ago"-style label from the pure {@link com.editora.git.RelativeTime} bucketing. */
-    private String relativeTimeLabel(long epochSeconds, long nowSeconds) {
-        com.editora.git.RelativeTime.Span span = com.editora.git.RelativeTime.of(epochSeconds, nowSeconds);
-        long v = span.value();
-        return switch (span.unit()) {
-            case NOW -> tr("blame.now");
-            case MINUTES -> tr("blame.minutesAgo", v);
-            case HOURS -> tr("blame.hoursAgo", v);
-            case DAYS -> tr("blame.daysAgo", v);
-            case WEEKS -> tr("blame.weeksAgo", v);
-            case MONTHS -> tr("blame.monthsAgo", v);
-            case YEARS -> tr("blame.yearsAgo", v);
-        };
-    }
+    // The annotation engine (eligibility, off-thread fetch, blame→BlameInfo mapping) lives in
+    // GitCoordinator; the click→commit-diff actions (blameShowCommit/onGutterBlameClick) stay below
+    // since they open a diff tab. applyGitBlame is reached via git.applyBlame().
 
     // --- Local File History --------------------------------------------------------------------
 
@@ -5536,7 +5430,7 @@ public class MainController implements com.editora.mcp.McpBridge {
             Settings s = config.getSettings();
             s.setGitBlameInline(!s.isGitBlameInline());
             requestSave();
-            applyGitBlame();
+            git.applyBlame();
             settingsWindow.syncGitBlameCheck();
             setStatus(tr("status.toggle.gitBlame", tr(s.isGitBlameInline() ? "common.on" : "common.off")));
         });
@@ -10760,7 +10654,7 @@ public class MainController implements com.editora.mcp.McpBridge {
         applyProjectSupport();
         git.applySupport();
         applyLocalHistory(); // re-gate the Local File History tool window + refresh its list
-        applyGitBlame(); // (re)apply inline blame to the active buffer (effective gate: git + setting + !simple)
+        git.applyBlame(); // (re)apply inline blame to the active buffer (effective gate: git + setting + !simple)
         applyNotesSupport();
         mermaid.applySupport();
         applyRipgrepSupport();


### PR DESCRIPTION
Third step of the Git extraction, continuing from #101 (the core engine).

## What moves
The **inline blame annotation engine** leaves `MainController` for `GitCoordinator`:

- `isBlameEnabled()` — the effective gate (Git on + the setting + not Simple mode),
- `applyBlame()` / `refreshBlame(buffer)` — clear blame on background tabs, fetch the active file's blame off-thread,
- `toBlameInfos(...)` + `blameDate`/`relativeTimeLabel` — map git blame into the per-line `BlameInfo` column (short author + ISO date, full-commit tooltip, age-heatmap tint scaled across the file and themed light/dark).

`applyState` now calls `refreshBlame` directly, so this **removes the `WindowOps.refreshBlame` Host hop** that was added in #101 — the coordinator owns blame end to end and needs nothing new from the window (only the shared `CoordinatorHost`: settings, active buffer, per-buffer iteration, theme brightness, local-buffer check). `applyGitBlame()` callers (`toggleGitBlame`, the view-settings apply) now call `git.applyBlame()`.

## What stays
The blame **click→commit-diff** actions (`blameShowCommit`, `onGutterBlameClick`, `showBlameCommit`) stay in `MainController` — they open a diff tab via the diff machinery, which remains an operation there.

## Safety
No behavior change (blame is off by default; the gating/fetch/mapping is a verbatim move). `GitStateFxTest` still green — `applyState` exercising the internal `refreshBlame(active)` on each call. Full suite **1072 green**, spotless clean, app boots clean under `--dev`. `MainController` 12,272 → 12,166 lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)