### PR TITLE
Centralize the "no repo" guard on the GitCoordinator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Refactor: centralize the "no repo" guard on the `GitCoordinator` (developer-facing).** Every repo-only
+  Git operation opened with the same four-line guard — `if (repoRoot == null) { echo "not a repo" / "git not
+  installed"; return; }` — duplicated 11×. It's now one engine method, `git.reportIfNoRepo()`, and each call
+  site is a one-liner (`if (git.reportIfNoRepo()) return;`). The status string lives in exactly one place.
+  Pure consolidation, no behavior change; full suite green.
+
 - **Refactor: move inline Git blame into the `GitCoordinator` (developer-facing).** The blame annotation
   engine — eligibility (`isBlameEnabled`), the off-thread per-file fetch (`applyBlame`/`refreshBlame`), and
   the blame→`BlameInfo` mapping (author/date label, full-commit tooltip, age-heatmap tint) — moves out of

--- a/src/main/java/com/editora/ui/GitCoordinator.java
+++ b/src/main/java/com/editora/ui/GitCoordinator.java
@@ -109,6 +109,19 @@ final class GitCoordinator {
         }
     }
 
+    /**
+     * Guard shared by every repo-only operation: when there's no active repo, echoes the standard
+     * "not a repo" / "git not installed" status and returns {@code true} so the caller early-returns.
+     * Returns {@code false} (no echo) when a repo is present.
+     */
+    boolean reportIfNoRepo() {
+        if (repoRoot != null) {
+            return false;
+        }
+        host.setStatus(tr(service.gitAvailable() ? "status.notARepo" : "status.gitNotInstalled"));
+        return true;
+    }
+
     /** The path whose repo drives the Git UI: the active file, else the active project root, else null. */
     Path contextPath() {
         EditorBuffer b = host.activeBuffer();

--- a/src/main/java/com/editora/ui/MainController.java
+++ b/src/main/java/com/editora/ui/MainController.java
@@ -4519,8 +4519,7 @@ public class MainController implements com.editora.mcp.McpBridge {
             setStatus(tr("status.diff.noFile"));
             return;
         }
-        if (git.repoRoot() == null) {
-            setStatus(tr(git.service().gitAvailable() ? "status.notARepo" : "status.gitNotInstalled"));
+        if (git.reportIfNoRepo()) {
             return;
         }
         String rel = com.editora.git.GitService.repoRelative(git.repoRoot(), path);
@@ -4580,8 +4579,7 @@ public class MainController implements com.editora.mcp.McpBridge {
             setStatus(tr("status.diff.noFile"));
             return;
         }
-        if (git.repoRoot() == null) {
-            setStatus(tr(git.service().gitAvailable() ? "status.notARepo" : "status.gitNotInstalled"));
+        if (git.reportIfNoRepo()) {
             return;
         }
         String rel = com.editora.git.GitService.repoRelative(git.repoRoot(), b.getPath());
@@ -4719,8 +4717,7 @@ public class MainController implements com.editora.mcp.McpBridge {
     }
 
     private void gitOp(String successMessage, String... args) {
-        if (git.repoRoot() == null) {
-            setStatus(tr(git.service().gitAvailable() ? "status.notARepo" : "status.gitNotInstalled"));
+        if (git.reportIfNoRepo()) {
             return;
         }
         git.service()
@@ -4866,8 +4863,7 @@ public class MainController implements com.editora.mcp.McpBridge {
     }
 
     private void newBranch() {
-        if (git.repoRoot() == null) {
-            setStatus(tr(git.service().gitAvailable() ? "status.notARepo" : "status.gitNotInstalled"));
+        if (git.reportIfNoRepo()) {
             return;
         }
         promptText(tr("dialog.newBranch.title"), tr("dialog.newBranch.content"), "", input -> {
@@ -4893,8 +4889,7 @@ public class MainController implements com.editora.mcp.McpBridge {
     }
 
     private void gitSync(String label, String... args) {
-        if (git.repoRoot() == null) {
-            setStatus(tr(git.service().gitAvailable() ? "status.notARepo" : "status.gitNotInstalled"));
+        if (git.reportIfNoRepo()) {
             return;
         }
         setStatus(tr("status.gitRunning", label));
@@ -4919,8 +4914,7 @@ public class MainController implements com.editora.mcp.McpBridge {
      * (matching {@code push.autoSetupRemote}). Subsequent pushes use the tracked upstream.
      */
     private void gitPush() {
-        if (git.repoRoot() == null) {
-            setStatus(tr(git.service().gitAvailable() ? "status.notARepo" : "status.gitNotInstalled"));
+        if (git.reportIfNoRepo()) {
             return;
         }
         if (git.upstream().isBlank() && !git.branchName().isBlank()) {
@@ -5030,7 +5024,7 @@ public class MainController implements com.editora.mcp.McpBridge {
         gitLogFilter = file;
         if (git.repoRoot() == null) {
             gitLogPanel.setLog(List.of(), null);
-            setStatus(tr(git.service().gitAvailable() ? "status.notARepo" : "status.gitNotInstalled"));
+            git.reportIfNoRepo(); // echoes "not a repo" / "git not installed"
             return;
         }
         String name = file != null ? file.getFileName().toString() : null;
@@ -5057,8 +5051,7 @@ public class MainController implements com.editora.mcp.McpBridge {
 
     /** A history mutation (checkout/reset/revert/cherry-pick/branch): run, report, refresh + reload log. */
     private void gitMutate(String successMessage, String... args) {
-        if (git.repoRoot() == null) {
-            setStatus(tr(git.service().gitAvailable() ? "status.notARepo" : "status.gitNotInstalled"));
+        if (git.reportIfNoRepo()) {
             return;
         }
         git.service()
@@ -5467,8 +5460,7 @@ public class MainController implements com.editora.mcp.McpBridge {
 
     /** Stashes the working tree (optionally with a message). */
     private void gitStash() {
-        if (git.repoRoot() == null) {
-            setStatus(tr(git.service().gitAvailable() ? "status.notARepo" : "status.gitNotInstalled"));
+        if (git.reportIfNoRepo()) {
             return;
         }
         promptText(tr("stash.prompt.title"), tr("stash.prompt.label"), "", msg -> {
@@ -5510,8 +5502,7 @@ public class MainController implements com.editora.mcp.McpBridge {
     }
 
     private void chooseStash(String title, java.util.function.Consumer<com.editora.git.StashParser.StashEntry> onPick) {
-        if (git.repoRoot() == null) {
-            setStatus(tr(git.service().gitAvailable() ? "status.notARepo" : "status.gitNotInstalled"));
+        if (git.reportIfNoRepo()) {
             return;
         }
         git.service().stashList(git.repoRoot(), stashes -> {
@@ -5533,8 +5524,7 @@ public class MainController implements com.editora.mcp.McpBridge {
     }
 
     private void gitMutateStash(String successMessage, String... args) {
-        if (git.repoRoot() == null) {
-            setStatus(tr(git.service().gitAvailable() ? "status.notARepo" : "status.gitNotInstalled"));
+        if (git.reportIfNoRepo()) {
             return;
         }
         git.service()


### PR DESCRIPTION
Small follow-up to the Git-coordinator extraction (#101/#102).

Every repo-only Git operation (diff-vs-head/commit, commit, checkout, new branch, fetch/pull/push, stage, stash, log-mutate, …) opened with the **same four-line guard**:

```java
if (git.repoRoot() == null) {
    setStatus(tr(git.service().gitAvailable() ? "status.notARepo" : "status.gitNotInstalled"));
    return;
}
```

— duplicated **11 times**. This folds it into one engine method on the coordinator, `git.reportIfNoRepo()` (echoes the standard status and returns `true` so the caller early-returns), and rewrites each call site to a one-liner:

```java
if (git.reportIfNoRepo()) return;
```

The `"not a repo"` / `"git not installed"` decision now lives in exactly one place (`GitCoordinator`, which already owns `repoRoot` + the `GitService` availability probe). `loadGitLog` keeps its extra panel-clear and calls the helper for the echo, so the status string is no longer repeated anywhere.

Pure consolidation, no behavior change. Full suite **1072 green**, spotless clean, app boots clean under `--dev`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)