### PR TITLE
Extract the git push argv decision into a tested GitService.pushArgs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Refactor: extract the `git push` argv decision into a pure, tested `GitService.pushArgs` (developer-facing).**
+  The first-push-of-an-upstream-less-branch logic (`--set-upstream origin <branch>` so the first push "just
+  works", else a plain `push`) — including the guard that a blank/detached branch never emits
+  `--set-upstream origin <empty>` — moved out of `MainController.gitPush` into a pure static helper with a
+  focused `GitPushArgsTest` (6 cases). No behavior change; the decision is now unit-covered instead of buried
+  in the UI layer.
+
 - **Refactor: centralize the "no repo" guard on the `GitCoordinator` (developer-facing).** Every repo-only
   Git operation opened with the same four-line guard — `if (repoRoot == null) { echo "not a repo" / "git not
   installed"; return; }` — duplicated 11×. It's now one engine method, `git.reportIfNoRepo()`, and each call

--- a/src/main/java/com/editora/git/GitService.java
+++ b/src/main/java/com/editora/git/GitService.java
@@ -337,6 +337,22 @@ public final class GitService {
         return r.relativize(f).toString().replace('\\', '/');
     }
 
+    /**
+     * The {@code git push} argv for the current branch. A brand-new branch has no upstream, so a bare
+     * {@code git push} fails; in that case we push with {@code --set-upstream origin <branch>} so the
+     * first push "just works" (matching {@code push.autoSetupRemote}). Subsequent pushes (an upstream is
+     * already tracked) use a plain {@code push}. A blank/unknown branch name also falls back to a plain
+     * {@code push} — we never emit {@code --set-upstream origin} with an empty branch. Pure — unit-tested.
+     */
+    public static String[] pushArgs(String branch, String upstream) {
+        boolean noUpstream = upstream == null || upstream.isBlank();
+        boolean haveBranch = branch != null && !branch.isBlank();
+        if (noUpstream && haveBranch) {
+            return new String[] {"push", "--set-upstream", "origin", branch};
+        }
+        return new String[] {"push"};
+    }
+
     // --- branches --------------------------------------------------------------------------------
 
     /**

--- a/src/main/java/com/editora/ui/MainController.java
+++ b/src/main/java/com/editora/ui/MainController.java
@@ -4909,19 +4909,15 @@ public class MainController implements com.editora.mcp.McpBridge {
     }
 
     /**
-     * Pushes the current branch. A brand-new branch has no upstream, so {@code git push} alone fails;
-     * in that case we push with {@code --set-upstream origin <branch>} so the first push "just works"
-     * (matching {@code push.autoSetupRemote}). Subsequent pushes use the tracked upstream.
+     * Pushes the current branch. The argv decision (first push of an upstream-less branch →
+     * {@code --set-upstream origin <branch>}, else a plain {@code push}) is the pure, unit-tested
+     * {@link com.editora.git.GitService#pushArgs}.
      */
     private void gitPush() {
         if (git.reportIfNoRepo()) {
             return;
         }
-        if (git.upstream().isBlank() && !git.branchName().isBlank()) {
-            gitSync(tr("gitlabel.push"), "push", "--set-upstream", "origin", git.branchName());
-        } else {
-            gitSync(tr("gitlabel.push"), "push");
-        }
+        gitSync(tr("gitlabel.push"), com.editora.git.GitService.pushArgs(git.branchName(), git.upstream()));
     }
 
     // --- Git Log / History tool window -----------------------------------------------------------

--- a/src/test/java/com/editora/git/GitPushArgsTest.java
+++ b/src/test/java/com/editora/git/GitPushArgsTest.java
@@ -1,0 +1,37 @@
+package com.editora.git;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+
+/**
+ * The pure {@code git push} argv decision: a branch with no upstream gets {@code --set-upstream origin
+ * <branch>} on its first push, everything else is a plain {@code push} — and a blank branch never produces
+ * a {@code --set-upstream origin} with an empty ref.
+ */
+class GitPushArgsTest {
+
+    @Test
+    void firstPushOfUpstreamlessBranchSetsUpstream() {
+        assertArrayEquals(
+                new String[] {"push", "--set-upstream", "origin", "feature"}, GitService.pushArgs("feature", ""));
+        // a null upstream is equivalent to a blank one
+        assertArrayEquals(new String[] {"push", "--set-upstream", "origin", "main"}, GitService.pushArgs("main", null));
+    }
+
+    @Test
+    void trackedBranchUsesPlainPush() {
+        assertArrayEquals(new String[] {"push"}, GitService.pushArgs("main", "origin/main"));
+        assertArrayEquals(new String[] {"push"}, GitService.pushArgs("feature", "origin/feature"));
+    }
+
+    @Test
+    void blankOrNullBranchNeverSetsUpstream() {
+        // Detached HEAD / unknown branch: never emit "--set-upstream origin <empty>".
+        assertArrayEquals(new String[] {"push"}, GitService.pushArgs("", ""));
+        assertArrayEquals(new String[] {"push"}, GitService.pushArgs(null, null));
+        assertArrayEquals(new String[] {"push"}, GitService.pushArgs("   ", ""));
+        // upstream present but branch blank still falls back to a plain push
+        assertArrayEquals(new String[] {"push"}, GitService.pushArgs("", "origin/main"));
+    }
+}


### PR DESCRIPTION
Continues the clean-up spirit of the Git-coordinator work by pulling one real decision out of the UI layer and putting it under test.

`MainController.gitPush` carried the push-argv logic inline:

```java
if (git.upstream().isBlank() && !git.branchName().isBlank()) {
    gitSync(..., "push", "--set-upstream", "origin", git.branchName());
} else {
    gitSync(..., "push");
}
```

This moves it to a pure static `GitService.pushArgs(branch, upstream)` (beside the existing pure `repoRelative`), so `gitPush` is now a one-liner:

```java
gitSync(tr("gitlabel.push"), GitService.pushArgs(git.branchName(), git.upstream()));
```

The decision has real correctness nuance worth pinning:
- a brand-new branch (no upstream) gets `--set-upstream origin <branch>` so the first push works (matching `push.autoSetupRemote`);
- a tracked branch uses a plain `push`;
- a **blank/detached branch never emits `--set-upstream origin <empty>`** — the guard that was the reason for the original `!isBlank()` check.

`GitPushArgsTest` covers all six cases (upstream-less + branch, null upstream, tracked, blank branch, null branch, whitespace branch, upstream-present-but-branch-blank). No behavior change. Full suite **1075 green** (+3), spotless clean, app boots clean under `--dev`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)