### PR TITLE
Fix Settings 'Enable log viewer' checkbox not reflecting the setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Settings → Editor → "Enable log viewer" checkbox now reflects the actual setting.** It was omitted from
+  the Settings window's `load()` (the value was only synced in `syncViewChecks()`, which `load()` doesn't
+  call), so the box always rendered unchecked even though the log viewer was on. The feature itself was
+  unaffected — only the checkbox display.
+
 ### Changed
 
 - **More features on out of the box (new installs only).** The default `settings.toml` now enables:

--- a/src/main/java/com/editora/ui/SettingsWindow.java
+++ b/src/main/java/com/editora/ui/SettingsWindow.java
@@ -2905,6 +2905,7 @@ public class SettingsWindow {
             markdownLintCheck.setSelected(settings.isMarkdownLint());
             mathSupportCheck.setSelected(settings.isMathSupport());
             editorConfigCheck.setSelected(settings.isEditorConfigSupport());
+            logViewerCheck.setSelected(settings.isLogViewer());
             todoHighlightCheck.setSelected(settings.isTodoHighlight());
             rebuildTodoRows();
             multiCaretCheck.setSelected(settings.isMultiCaret());


### PR DESCRIPTION
## Bug
On a fresh config, *Settings → Editor → Logs → Enable log viewer (.log files)* always rendered **unchecked**, even though `Settings.logViewer` defaults to `true` (and was `true` on disk). The log-viewer feature itself worked — only the checkbox display was wrong.

## Cause
`SettingsWindow.load()` (run on every `show()`) initializes every checkbox from the settings — but `logViewerCheck.setSelected(...)` was **missing** from it. That line existed only in `syncViewChecks()`, which `load()` does not call. So the checkbox kept its default-unchecked state on open, regardless of the actual value. Every other Editor checkbox (EditorConfig, math, multi-caret, …) was in `load()`, which is why only this one looked wrong. Pre-existing; surfaced now while auditing the "on by default" features.

## Fix
One line: add `logViewerCheck.setSelected(settings.isLogViewer());` to `load()`, mirroring its sibling checkboxes.

Reproduced on a guaranteed-fresh temp config (`logViewer = true` on disk, checkbox unchecked); root cause confirmed by reading the full `load()` method. `./mvnw verify` green (1088 tests, Spotless + JaCoCo pass).

🤖 Generated with [Claude Code](https://claude.com/claude-code)