### PR TITLE
Hide buffer-only tool windows when there's no buffer to act on

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Buffer-only tool windows are hidden when there's no buffer to act on.** The Structure, File Information,
+  TODO, Markdown Lint, and External Tools stripe buttons no longer show on the Welcome page (or other
+  non-buffer tabs) — they now gate their availability on an actionable active editor buffer (Markdown Lint
+  additionally needs a Markdown buffer; External Tools needs a buffer and non-Simple mode), mirroring how
+  Run / Debug / HTTP / Commit already gate their buttons.
+
 - **Settings → Editor → "Enable log viewer" checkbox now reflects the actual setting.** It was omitted from
   the Settings window's `load()` (the value was only synced in `syncViewChecks()`, which `load()` doesn't
   call), so the box always rendered unchecked even though the log viewer was on. The feature itself was

--- a/src/main/java/com/editora/ui/MainController.java
+++ b/src/main/java/com/editora/ui/MainController.java
@@ -1431,6 +1431,7 @@ public class MainController implements com.editora.mcp.McpBridge {
     /** Re-applies preferences + the editor theme to this window after a Settings change in any window. */
     public void reapplyAfterSharedSettingsChange(Settings settings) {
         applyViewSettingsToAllBuffers(settings);
+        updateBufferToolWindows(); // a feature toggle (Markdown lint, external tools, …) may re-gate a window
         // The keymap may have switched (it's shared); refresh every chord hint so none stays frozen to the
         // old keymap. Cheap (~25 tooltips + one palette/welcome relabel) and only on a settings/keymap apply.
         refreshToolbarTooltips();
@@ -2030,6 +2031,7 @@ public class MainController implements com.editora.mcp.McpBridge {
             updateLspStatusBar(); // show/hide the "LSP: <server>" segment + Problems window for the new file
             updateDebugAvailability(); // show the Debug window only for a debuggable file (or a live session)
             updateRunButton(); // show the Run button only for a compact source file
+            updateBufferToolWindows(); // hide buffer-only tool windows when there's no actionable buffer
             refreshLocalHistory(); // re-gate + reload the Local File History list for the new active file
         });
         tabPane.getTabs().addListener((ListChangeListener<Tab>) c -> {
@@ -2436,6 +2438,7 @@ public class MainController implements com.editora.mcp.McpBridge {
         toolWindows.register(httpToolWindow);
         toolWindows.setAvailable(httpToolWindow, false); // shown only for a .http file with the feature on
         toolWindows.register(externalToolToolWindow);
+        updateBufferToolWindows(); // hide buffer-only windows until there's an actionable buffer (no Welcome flash)
         // Detect a *user* open/close of the HTTP window (vs. our own auto show/hide, guarded by
         // httpAutoMutating) so a manual close is remembered per .http buffer and a manual open clears it.
         toolWindows.setStateListener((tw, opened) -> {
@@ -8053,6 +8056,34 @@ public class MainController implements com.editora.mcp.McpBridge {
         }
         if (httpActive) {
             httpClient.refreshEnvironments(buffer);
+        }
+    }
+
+    /**
+     * Gates the stripe buttons of tool windows whose content comes from the <b>active editor buffer</b>, so
+     * they only advertise themselves when there is something to act on — hidden on the Welcome page and other
+     * non-buffer tabs (mirroring how Run/Debug/HTTP/Commit already gate their buttons). Structure / File
+     * Information / TODO need any buffer; Markdown Lint additionally needs a Markdown buffer (with the feature
+     * on); External Tools needs a buffer and to not be in Simple mode. Uses transient
+     * {@code setAvailable} (never persisted), so the user's show/hide preference is preserved.
+     */
+    private void updateBufferToolWindows() {
+        EditorBuffer b = activeBuffer();
+        boolean buffer = b != null;
+        if (structureToolWindow != null) {
+            toolWindows.setAvailable(structureToolWindow, buffer);
+        }
+        if (fileInfoToolWindow != null) {
+            toolWindows.setAvailable(fileInfoToolWindow, buffer);
+        }
+        if (todoToolWindow != null) {
+            toolWindows.setAvailable(todoToolWindow, buffer);
+        }
+        if (markdownLintToolWindow != null) {
+            toolWindows.setAvailable(markdownLintToolWindow, buffer && b.isMarkdown() && markdownLintEnabled());
+        }
+        if (externalToolToolWindow != null) {
+            toolWindows.setAvailable(externalToolToolWindow, buffer && externalToolsEnabled());
         }
     }
 


### PR DESCRIPTION
## Problem
On the Welcome page (and other non-buffer tabs) the **Structure**, **File Information**, **TODO**, **Markdown Lint**, and **External Tools** stripe buttons were shown even though their content is derived from the active editor buffer — there's nothing for them to act on.

## Fix
New `updateBufferToolWindows()` (called from the tab-selection listener, `reapplyAfterSharedSettingsChange`, and once at init) gates these via the **transient** `ToolWindowManager.setAvailable(...)`, mirroring how Run / Debug / HTTP / Commit already gate their buttons:

| Tool window | Available when |
|---|---|
| Structure / File Information / TODO | active tab is an editor buffer |
| Markdown Lint | active buffer is **Markdown** (+ lint enabled) |
| External Tools | active buffer + not Simple mode |

**Bookmarks / Notes / Project / Find-in-Files stay** — they're project/collection-scoped, not tied to the active buffer. `setAvailable` is transient (never persisted), so the user's show/hide preference is preserved; returning to a buffer restores the buttons (same semantics as the Commit/Run windows — the panel isn't auto-reopened).

## Verification
`./mvnw verify` green (1088 tests, Spotless + JaCoCo). The fresh-config app lands on the Welcome page, so the gating path runs; no test asserted the old always-available behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)