### PR TITLE
Disable Find/Replace bar controls while the Find field is empty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Find/Replace bar buttons disable when there's no search term.** Prev, Next, Replace, Replace-All, and
+  the case/regex/whole-word toggles are now disabled while the Find field is empty — nothing they do is
+  meaningful without a query (an empty *replacement* still works as "delete matches").
+
 - **Buffer-only tool windows are hidden when there's no buffer to act on.** The Structure, File Information,
   TODO, Markdown Lint, and External Tools stripe buttons no longer show on the Welcome page (or other
   non-buffer tabs) — they now gate their availability on an actionable active editor buffer (Markdown Lint

--- a/src/main/java/com/editora/ui/FindReplaceBar.java
+++ b/src/main/java/com/editora/ui/FindReplaceBar.java
@@ -80,6 +80,18 @@ public class FindReplaceBar extends HBox {
         replaceAll.setOnAction(e -> replaceAll());
         close.setOnAction(e -> hideBar());
 
+        // Disable everything that acts on the find query while the Find field is empty — navigation
+        // (Prev/Next), replace (Replace/All), and the match-option toggles (case/regex/whole-word) all
+        // need something to search for.
+        javafx.beans.binding.BooleanBinding noQuery = findField.textProperty().isEmpty();
+        prev.disableProperty().bind(noQuery);
+        next.disableProperty().bind(noQuery);
+        replace.disableProperty().bind(noQuery);
+        replaceAll.disableProperty().bind(noQuery);
+        caseSensitive.disableProperty().bind(noQuery);
+        regex.disableProperty().bind(noQuery);
+        wholeWord.disableProperty().bind(noQuery);
+
         findField.setOnAction(e -> findNext());
         findField.setOnKeyPressed(e -> {
             if (e.getCode() == KeyCode.ESCAPE) {


### PR DESCRIPTION
On the in-editor Find/Replace bar, **Prev**, **Next**, **Replace**, **Replace All**, and the **Aa / .\* / W** toggles are now disabled while the **Find** field is empty — they all act on the search query, so none are meaningful without one. Live property binding (`findField.textProperty().isEmpty()`), updates as you type.

An empty **replacement** is intentionally left alone (empty replacement = "delete matches", a valid op), matching the Find-in-Files panel's behavior.

`./mvnw verify` green (1088 tests, Spotless + JaCoCo). Docs: CHANGELOG.

🤖 Generated with [Claude Code](https://claude.com/claude-code)