### PR TITLE
Project tool window: optional "show hidden files" toggle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Project tool window can show hidden files.** A new *Settings → Tool Windows → "Show hidden files in the
+  project tree"* checkbox (and the `view.toggleProjectHidden` palette command) reveals dot-files/folders in
+  the project tree and its filter search. Off by default. Persisted in `settings.toml` (schema 38→39).
+
 ### Fixed
 
 - **Find/Replace bar buttons disable when there's no search term.** Prev, Next, Replace, Replace-All, and

--- a/src/main/java/com/editora/config/Settings.java
+++ b/src/main/java/com/editora/config/Settings.java
@@ -10,7 +10,7 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 public class Settings {
 
     /** Current on-disk schema version of {@code settings.toml}; bump when the format changes (+ a migration). */
-    public static final int SCHEMA_VERSION = 38;
+    public static final int SCHEMA_VERSION = 39;
 
     private int schemaVersion = SCHEMA_VERSION;
 
@@ -113,6 +113,8 @@ public class Settings {
     private int autoSaveDelayMillis = 1000;
     /** Projects feature: off by default — hides all project UI/commands until enabled. */
     private boolean projectSupport = false;
+    /** Show hidden (dot) files and folders in the Project tool window's tree + filter search. Off by default. */
+    private boolean projectShowHidden = false;
     /** Git integration: on by default — the status-bar VCS segment, Commit tool window, gutter change bars,
      *  and Git commands/keybindings. Self-gates on detection: when {@code git} isn't on PATH it stays inert
      *  (so this is effectively "on when Git is installed"). */
@@ -660,6 +662,14 @@ public class Settings {
 
     public void setProjectSupport(boolean projectSupport) {
         this.projectSupport = projectSupport;
+    }
+
+    public boolean isProjectShowHidden() {
+        return projectShowHidden;
+    }
+
+    public void setProjectShowHidden(boolean projectShowHidden) {
+        this.projectShowHidden = projectShowHidden;
     }
 
     public boolean isGitSupport() {

--- a/src/main/java/com/editora/config/migration/ConfigSchema.java
+++ b/src/main/java/com/editora/config/migration/ConfigSchema.java
@@ -76,7 +76,8 @@ public enum ConfigSchema {
                     Map.entry(34, (Migration) ConfigMigrations::identity), // v34→35: + mathSupport
                     Map.entry(35, (Migration) ConfigMigrations::identity), // v35→36: + externalTools (additive)
                     Map.entry(36, (Migration) ConfigMigrations::identity), // v36→37: + ripgrepSearch/Command
-                    Map.entry(37, (Migration) ConfigMigrations::identity))), // v37→38: + logViewer (additive)
+                    Map.entry(37, (Migration) ConfigMigrations::identity), // v37→38: + logViewer (additive)
+                    Map.entry(38, (Migration) ConfigMigrations::identity))), // v38→39: + projectShowHidden
     WORKSPACE(WorkspaceState.SCHEMA_VERSION, 1, Map.of()),
     BOOKMARKS(BookmarkStore.SCHEMA_VERSION, 1, Map.of()),
     BREAKPOINTS(BreakpointStore.SCHEMA_VERSION, 1, Map.of()),

--- a/src/main/java/com/editora/ui/MainController.java
+++ b/src/main/java/com/editora/ui/MainController.java
@@ -1758,6 +1758,7 @@ public class MainController implements com.editora.mcp.McpBridge {
 
     /** Shows/hides all project UI per the "Enable projects" setting: toolbar icon + combo, tool window. */
     private void applyProjectSupport() {
+        projectPanel.setShowHidden(config.getSettings().isProjectShowHidden()); // hidden-files toggle (init + apply)
         boolean on = projectsEnabled();
         // Turning projects off just hides the project chrome — each window keeps editing its open files
         // (windows no longer share one session that could be "stranded"). On the next launch with projects
@@ -11733,6 +11734,13 @@ public class MainController implements com.editora.mcp.McpBridge {
                         v -> config.getSettings().setEditorConfigSupport(v),
                         this::applyEditorConfigSupport)));
         registry.register(Command.of("editorConfig.openActive", this::openActiveEditorConfig));
+        registry.register(Command.of(
+                "view.toggleProjectHidden",
+                () -> toggleSetting(
+                        "view.toggleProjectHidden",
+                        () -> config.getSettings().isProjectShowHidden(),
+                        v -> config.getSettings().setProjectShowHidden(v),
+                        () -> projectPanel.setShowHidden(config.getSettings().isProjectShowHidden()))));
         registry.register(Command.of(
                 "view.toggleNoteIndicators",
                 () -> toggleSetting(

--- a/src/main/java/com/editora/ui/ProjectPanel.java
+++ b/src/main/java/com/editora/ui/ProjectPanel.java
@@ -124,6 +124,8 @@ public class ProjectPanel extends VBox implements ToolWindowContent {
     private Path root;
     private boolean filtering;
     private boolean loading;
+    /** Show hidden (dot) files/folders in the tree + filter search. Toggled from Settings. */
+    private boolean showHidden;
 
     public ProjectPanel(
             Consumer<Path> onOpenFile,
@@ -270,6 +272,17 @@ public class ProjectPanel extends VBox implements ToolWindowContent {
         return root;
     }
 
+    /** Show/hide hidden (dot) files and folders; rebuilds the tree when the value changes. */
+    public void setShowHidden(boolean showHidden) {
+        if (this.showHidden == showHidden) {
+            return;
+        }
+        this.showHidden = showHidden;
+        if (root != null) {
+            rebuildBody(); // recreate the tree (PathItems capture the flag) with the new visibility
+        }
+    }
+
     /** Rebuilds the body: placeholder (no project), filtered flat results, or the lazy tree. */
     private void rebuildBody() {
         long gen = searchGen.incrementAndGet(); // invalidate any in-flight search
@@ -280,18 +293,19 @@ public class ProjectPanel extends VBox implements ToolWindowContent {
         String q = filterField.getText().trim();
         if (q.isEmpty()) {
             filtering = false;
-            PathItem rootItem = new PathItem(root);
+            PathItem rootItem = new PathItem(root, showHidden);
             rootItem.setExpanded(true);
             tree.setRoot(rootItem);
         } else {
             filtering = true;
             // Walk off the FX thread (up to MAX_VISIT entries); apply results back under the gen guard.
             Path searchRoot = root;
+            boolean includeHidden = showHidden;
             TreeItem<Path> pending = new TreeItem<>(root);
             pending.setExpanded(true);
             tree.setRoot(pending);
             searchExecutor.submit(() -> {
-                List<Path> matches = search(searchRoot, q);
+                List<Path> matches = search(searchRoot, q, includeHidden);
                 Platform.runLater(() -> {
                     if (gen != searchGen.get()) {
                         return; // a newer query (or a tree switch) superseded this one
@@ -421,7 +435,7 @@ public class ProjectPanel extends VBox implements ToolWindowContent {
     }
 
     /** Bounded project-wide filename search: dot-dirs skipped, capped on entries visited and matches. */
-    private static List<Path> search(Path root, String query) {
+    private static List<Path> search(Path root, String query, boolean includeHidden) {
         String q = query.toLowerCase(Locale.ROOT);
         List<Path> matches = new ArrayList<>();
         int[] visited = {0};
@@ -433,7 +447,8 @@ public class ProjectPanel extends VBox implements ToolWindowContent {
                     new SimpleFileVisitor<>() {
                         @Override
                         public FileVisitResult preVisitDirectory(Path dir, BasicFileAttributes a) {
-                            if (!dir.equals(root)
+                            if (!includeHidden
+                                    && !dir.equals(root)
                                     && dir.getFileName().toString().startsWith(".")) {
                                 return FileVisitResult.SKIP_SUBTREE; // skip .git, etc.
                             }
@@ -443,7 +458,7 @@ public class ProjectPanel extends VBox implements ToolWindowContent {
                         @Override
                         public FileVisitResult visitFile(Path file, BasicFileAttributes a) {
                             String name = file.getFileName().toString();
-                            if (!name.startsWith(".")
+                            if ((includeHidden || !name.startsWith("."))
                                     && name.toLowerCase(Locale.ROOT).contains(q)) {
                                 matches.add(file);
                             }
@@ -690,9 +705,11 @@ public class ProjectPanel extends VBox implements ToolWindowContent {
     private static final class PathItem extends TreeItem<Path> {
         private boolean loaded;
         private Boolean leaf;
+        private final boolean showHidden;
 
-        PathItem(Path path) {
+        PathItem(Path path, boolean showHidden) {
             super(path);
+            this.showHidden = showHidden;
         }
 
         @Override
@@ -709,8 +726,8 @@ public class ProjectPanel extends VBox implements ToolWindowContent {
                 loaded = true;
                 if (Files.isDirectory(getValue())) {
                     List<TreeItem<Path>> kids = new ArrayList<>();
-                    for (Path child : listDir(getValue())) {
-                        kids.add(new PathItem(child));
+                    for (Path child : listDir(getValue(), showHidden)) {
+                        kids.add(new PathItem(child, showHidden));
                     }
                     super.getChildren().setAll(kids);
                 }
@@ -725,13 +742,14 @@ public class ProjectPanel extends VBox implements ToolWindowContent {
         }
     }
 
-    /** Directory children: directories first then files, case-insensitive; dotfiles hidden; empty on error. */
-    private static List<Path> listDir(Path dir) {
+    /** Directory children: directories first then files, case-insensitive; dotfiles hidden unless
+     *  {@code includeHidden}; empty on error. */
+    private static List<Path> listDir(Path dir, boolean includeHidden) {
         List<Path> dirs = new ArrayList<>();
         List<Path> files = new ArrayList<>();
         try (Stream<Path> entries = Files.list(dir)) {
             entries.forEach(p -> {
-                if (p.getFileName().toString().startsWith(".")) {
+                if (!includeHidden && p.getFileName().toString().startsWith(".")) {
                     return;
                 }
                 (Files.isDirectory(p) ? dirs : files).add(p);

--- a/src/main/java/com/editora/ui/SettingsWindow.java
+++ b/src/main/java/com/editora/ui/SettingsWindow.java
@@ -148,6 +148,7 @@ public class SettingsWindow {
     private CheckBox breadcrumbCheck;
     private CheckBox simpleModeCheck;
     private CheckBox toolStripeCheck;
+    private CheckBox projectHiddenCheck;
     private CheckBox markdownFormatBarCheck;
     private CheckBox markdownLintCheck;
     private CheckBox mathSupportCheck;
@@ -639,6 +640,7 @@ public class SettingsWindow {
         breadcrumbCheck = viewCheck(tr("settings.showBreadcrumb"), Settings::setShowBreadcrumb);
         simpleModeCheck = viewCheck(tr("settings.simpleMode"), Settings::setSimpleMode);
         toolStripeCheck = viewCheck(tr("settings.showToolStripe"), Settings::setShowToolStripe);
+        projectHiddenCheck = viewCheck(tr("settings.projectShowHidden"), Settings::setProjectShowHidden);
         markdownFormatBarCheck = viewCheck(tr("settings.markdownFormatBar"), Settings::setMarkdownFormatBar);
         markdownLintCheck = viewCheck(tr("settings.markdownLint"), Settings::setMarkdownLint);
         mathSupportCheck = viewCheck(tr("settings.mathSupport"), Settings::setMathSupport);
@@ -2437,6 +2439,9 @@ public class SettingsWindow {
         p.getChildren().add(toolStripeCheck);
         p.getChildren().add(note(tr("settings.toolWindows.stripeNote")));
 
+        // Project tree: show hidden (dot) files/folders.
+        p.getChildren().add(projectHiddenCheck);
+
         List<Runnable> moveRefreshers = new ArrayList<>();
         Runnable refreshMoves = () -> moveRefreshers.forEach(Runnable::run);
         for (ToolWindow tw : toolWindows.getRegisteredToolWindows()) {
@@ -2901,6 +2906,7 @@ public class SettingsWindow {
             simpleModeCheck.setSelected(settings.isSimpleMode());
             templateAuthorField.setText(settings.getAuthorNameRaw());
             toolStripeCheck.setSelected(settings.isShowToolStripe());
+            projectHiddenCheck.setSelected(settings.isProjectShowHidden());
             markdownFormatBarCheck.setSelected(settings.isMarkdownFormatBar());
             markdownLintCheck.setSelected(settings.isMarkdownLint());
             mathSupportCheck.setSelected(settings.isMathSupport());
@@ -3391,6 +3397,7 @@ public class SettingsWindow {
             toolbarCheck.setSelected(s.isShowToolbar());
             statusBarCheck.setSelected(s.isShowStatusBar());
             tabBarCheck.setSelected(s.isShowTabBar());
+            projectHiddenCheck.setSelected(s.isProjectShowHidden());
             breadcrumbCheck.setSelected(s.isShowBreadcrumb());
             simpleModeCheck.setSelected(s.isSimpleMode());
             toolStripeCheck.setSelected(s.isShowToolStripe());

--- a/src/main/resources/com/editora/i18n/messages.properties
+++ b/src/main/resources/com/editora/i18n/messages.properties
@@ -2040,3 +2040,7 @@ search.backendRipgrepTip=Using ripgrep for faster, .gitignore-aware search
 search.includePrompt=Files to include (e.g. *.java, src/**)
 search.excludePrompt=Files to exclude (e.g. **/test/**)
 search.globsTip=Comma-separated globs (gitignore-style)
+
+settings.projectShowHidden=Show hidden files in the project tree
+command.view.toggleProjectHidden=Toggle Hidden Files in Project Tree
+command.view.toggleProjectHidden.desc=Show or hide hidden (dot) files and folders in the Project tool window

--- a/src/main/resources/com/editora/i18n/messages_de.properties
+++ b/src/main/resources/com/editora/i18n/messages_de.properties
@@ -2032,3 +2032,7 @@ search.backendRipgrepTip=Suche mit ripgrep: schneller und .gitignore-bewusst
 search.includePrompt=Einzuschlie\u00DFende Dateien (z. B. *.java, src/**)
 search.excludePrompt=Auszuschlie\u00DFende Dateien (z. B. **/test/**)
 search.globsTip=Kommagetrennte Globs (im .gitignore-Stil)
+
+settings.projectShowHidden=Versteckte Dateien im Projektbaum anzeigen
+command.view.toggleProjectHidden=Versteckte Dateien im Projektbaum umschalten
+command.view.toggleProjectHidden.desc=Versteckte (Punkt-)Dateien und -Ordner im Projektfenster ein- oder ausblenden

--- a/src/main/resources/com/editora/i18n/messages_es.properties
+++ b/src/main/resources/com/editora/i18n/messages_es.properties
@@ -2032,3 +2032,7 @@ search.backendRipgrepTip=B\u00FAsqueda con ripgrep: m\u00E1s r\u00E1pida y respe
 search.includePrompt=Archivos a incluir (p. ej. *.java, src/**)
 search.excludePrompt=Archivos a excluir (p. ej. **/test/**)
 search.globsTip=Globs separados por comas (estilo .gitignore)
+
+settings.projectShowHidden=Mostrar archivos ocultos en el \u00E1rbol del proyecto
+command.view.toggleProjectHidden=Alternar archivos ocultos en el \u00E1rbol del proyecto
+command.view.toggleProjectHidden.desc=Muestra u oculta los archivos y carpetas ocultos (con punto) en la ventana Proyecto

--- a/src/main/resources/com/editora/i18n/messages_fr.properties
+++ b/src/main/resources/com/editora/i18n/messages_fr.properties
@@ -2032,3 +2032,7 @@ search.backendRipgrepTip=Recherche via ripgrep : plus rapide et respectant .giti
 search.includePrompt=Fichiers \u00E0 inclure (ex. *.java, src/**)
 search.excludePrompt=Fichiers \u00E0 exclure (ex. **/test/**)
 search.globsTip=Globs s\u00E9par\u00E9s par des virgules (style .gitignore)
+
+settings.projectShowHidden=Afficher les fichiers cachés dans l'arborescence du projet
+command.view.toggleProjectHidden=Basculer les fichiers cachés dans l'arborescence du projet
+command.view.toggleProjectHidden.desc=Affiche ou masque les fichiers et dossiers cachés (avec un point) dans la fenêtre Projet

--- a/src/main/resources/com/editora/i18n/messages_it.properties
+++ b/src/main/resources/com/editora/i18n/messages_it.properties
@@ -2032,3 +2032,7 @@ search.backendRipgrepTip=Ricerca con ripgrep: pi\u00F9 veloce e rispettosa di .g
 search.includePrompt=File da includere (es. *.java, src/**)
 search.excludePrompt=File da escludere (es. **/test/**)
 search.globsTip=Glob separati da virgola (stile .gitignore)
+
+settings.projectShowHidden=Mostra i file nascosti nell'albero del progetto
+command.view.toggleProjectHidden=Attiva/disattiva i file nascosti nell'albero del progetto
+command.view.toggleProjectHidden.desc=Mostra o nasconde i file e le cartelle nascosti (con punto) nella finestra Progetto

--- a/src/main/resources/com/editora/i18n/messages_pt.properties
+++ b/src/main/resources/com/editora/i18n/messages_pt.properties
@@ -2032,3 +2032,7 @@ search.backendRipgrepTip=Pesquisa com ripgrep: mais r\u00E1pida e respeitando o 
 search.includePrompt=Arquivos a incluir (ex. *.java, src/**)
 search.excludePrompt=Arquivos a excluir (ex. **/test/**)
 search.globsTip=Globs separados por v\u00EDrgula (estilo .gitignore)
+
+settings.projectShowHidden=Mostrar arquivos ocultos na árvore do projeto
+command.view.toggleProjectHidden=Alternar arquivos ocultos na árvore do projeto
+command.view.toggleProjectHidden.desc=Mostra ou oculta arquivos e pastas ocultos (com ponto) na janela Projeto


### PR DESCRIPTION
Adds optional support for showing hidden (dot) files/folders in the **Project** tool window.

## What
- **Settings → Tool Windows → "Show hidden files in the project tree"** checkbox + the **`view.toggleProjectHidden`** palette command. Off by default.
- `Settings.projectShowHidden` (schema **38 → 39**, additive-identity migration).
- `ProjectPanel.setShowHidden(...)` threads an `includeHidden` flag through both the lazy file tree (`listDir`) and the filter-search walk (`search`), so `.git`/`.gitignore`/etc. appear in both when enabled; rebuilds the tree on change.
- `MainController` applies it at init + on every settings apply (`applyProjectSupport`) and live on toggle (Settings checkbox via the apply path; palette command directly). i18n added to all six catalogs.

## Verification
`./mvnw verify` green: **1088 tests**, Spotless + JaCoCo, `MessagesTest` key-parity (i18n), config-versioning. Docs: CHANGELOG.

Followup idea (not included): an in-tree right-click "Show Hidden Files" toggle for in-place discoverability.

🤖 Generated with [Claude Code](https://claude.com/claude-code)