### PR TITLE
Markdown lint: more rules, per-rule config, stripe, fix; own Settings page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Markdown lint, substantially expanded.** The Markdown linter now covers more of the markdownlint rule
+  set — MD001 (heading-level increment), MD010 (hard tabs), MD022 (headings surrounded by blank lines),
+  MD023 (heading indent), MD026 (heading trailing punctuation), MD031 (fenced code surrounded by blank
+  lines), MD034 (bare URLs), and MD041 (first line should be a top-level heading) — joining the existing
+  MD009/012/018/019/025/040/047/052. New capabilities:
+  - **Per-rule configuration.** Turn individual rules off in *Settings → Markdown* (a per-rule
+    checklist) or via the `markdownLint.toggleRule` palette picker; persisted in `settings.toml`
+    (`markdownLintDisabledRules`, schema 39→40).
+  - **Inline disable comments.** `<!-- markdownlint-disable [MDxxx] -->` / `enable` / `disable-line` /
+    `disable-next-line` are honored, matching markdownlint.
+  - **`.markdownlint.json` discovery.** The nearest config file (walking up from the file) is merged into
+    the disabled-rule set (`{"MD013": false}` / `{"default": false}` forms).
+  - **Auto-fix.** `markdownLint.fix` (palette) corrects the safely-mechanical issues in the active file
+    (trailing whitespace, tabs→spaces, blank-line runs, heading-marker spacing, heading indent, heading
+    trailing punctuation, final newline) as one undoable edit.
+  - **Overview stripe + minimap ticks.** Lint warnings now appear as an IntelliJ-style stripe over the
+    scrollbar (click to jump, hover for the rule + message) and as ticks on the minimap, beside the TODO
+    and LSP-diagnostic stripes.
+  - **Dedicated Settings page.** The Markdown options (format bar, math preview, lint enable + per-rule
+    checklist) moved out of *Editor* into their own *Settings → Markdown* page.
+
+- **Export to HTML opens the result in a tab.** After *Preview: Export to HTML* writes the file, the
+  generated `.html` now opens in a new editor tab (re-selecting it if already open).
+
 - **Project tool window can show hidden files.** A new *Settings → Tool Windows → "Show hidden files in the
   project tree"* checkbox (and the `view.toggleProjectHidden` palette command) reveals dot-files/folders in
   the project tree and its filter search. Off by default. Persisted in `settings.toml` (schema 38→39).

--- a/README.md
+++ b/README.md
@@ -163,10 +163,14 @@ Emacs-style keymap or a fuzzy command palette.
   make `[selection](url)`), and **table editing** with **Tab** / **Shift-Tab** to move between cells and
   **Enter** to add a row (reflowing as you go) — alongside the existing format bar and smart list/heading
   editing.
-- **Markdown lint** — high-confidence rules (trailing whitespace, blank-line runs, heading-marker spacing,
-  multiple H1, fenced blocks missing a language, missing final newline, broken reference links) shown as
-  inline squiggles with hover messages and listed in a **Markdown Lint** tool window. On by default;
-  toggle with "View: Toggle Markdown Lint".
+- **Markdown lint** — a markdownlint-style rule set (heading-level increment, hard tabs, trailing
+  whitespace, blank-line runs, heading-marker spacing/indent/trailing-punctuation, headings & fenced code
+  surrounded by blank lines, multiple H1, first-line H1, fenced blocks missing a language, bare URLs,
+  missing final newline, broken reference links) shown as inline squiggles with hover messages, a
+  scrollbar **overview stripe** + minimap ticks, and a **Markdown Lint** tool window. Disable individual
+  rules in Settings (or with `<!-- markdownlint-disable MDxxx -->` comments / a `.markdownlint.json`),
+  and **auto-fix** the mechanical issues with "Markdown Lint: Fix Issues". On by default; toggle with
+  "View: Toggle Markdown Lint".
 - **LaTeX math** — render inline `$…$` and display `$$…$$` math in the preview (and block formulas in PDF
   export) via the pure-Java **JLaTeXMath**, with GitHub-style delimiter rules so prose dollar amounts are
   left alone. **On by default** — toggle under *Settings → Editor → Render LaTeX math* or with

--- a/TODO.md
+++ b/TODO.md
@@ -14,7 +14,9 @@ A backlog of planned features and improvements. Unordered within each section.
       timestamp-range filtering, jump-to-next-error navigation*
 - [x] Markdown support improvements — preview **CommonMark extensions** (YAML front matter, footnotes,
       heading anchors, `++inserted++`); **heading outline** in the Structure tool window; **Markdown lint**
-      (squiggles + tool window; `View: Toggle Markdown Lint`, on by default); **image paste & drag-drop**
+      (squiggles + tool window; `View: Toggle Markdown Lint`, on by default — now a wider markdownlint rule
+      set with per-rule config, inline `markdownlint-disable` comments, `.markdownlint.json` discovery,
+      scrollbar/minimap overview stripes, and `Markdown Lint: Fix Issues` auto-fix); **image paste & drag-drop**
       (into a sibling `assets/` folder); **smart link paste** (URL over a selection → `[sel](url)`); **table
       cell navigation** (Tab/Shift-Tab between cells, Enter adds a row, reflow); **LaTeX math** via
       JLaTeXMath (inline `$…$` + display `$$…$$` in the preview and PDF, off by default — `View: Toggle Math

--- a/src/main/java/com/editora/config/Settings.java
+++ b/src/main/java/com/editora/config/Settings.java
@@ -10,7 +10,7 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 public class Settings {
 
     /** Current on-disk schema version of {@code settings.toml}; bump when the format changes (+ a migration). */
-    public static final int SCHEMA_VERSION = 39;
+    public static final int SCHEMA_VERSION = 40;
 
     private int schemaVersion = SCHEMA_VERSION;
 
@@ -93,6 +93,8 @@ public class Settings {
     private java.util.List<com.editora.externaltool.ExternalTool> externalTools = new java.util.ArrayList<>();
     /** Lint Markdown buffers (squiggles + the Markdown Lint tool window). */
     private boolean markdownLint = true;
+    /** Markdown-lint rule codes ({@code MDxxx}) the user has turned off; empty = all rules enabled. */
+    private java.util.List<String> markdownLintDisabledRules = new java.util.ArrayList<>();
     /** Render LaTeX math ({@code $…$} / {@code $$…$$}) in the Markdown preview/PDF. On by default. */
     private boolean mathSupport = true;
 
@@ -533,6 +535,15 @@ public class Settings {
 
     public void setMarkdownLint(boolean markdownLint) {
         this.markdownLint = markdownLint;
+    }
+
+    public java.util.List<String> getMarkdownLintDisabledRules() {
+        return markdownLintDisabledRules;
+    }
+
+    public void setMarkdownLintDisabledRules(java.util.List<String> markdownLintDisabledRules) {
+        this.markdownLintDisabledRules =
+                markdownLintDisabledRules == null ? new java.util.ArrayList<>() : markdownLintDisabledRules;
     }
 
     public boolean isMathSupport() {

--- a/src/main/java/com/editora/config/migration/ConfigSchema.java
+++ b/src/main/java/com/editora/config/migration/ConfigSchema.java
@@ -77,7 +77,8 @@ public enum ConfigSchema {
                     Map.entry(35, (Migration) ConfigMigrations::identity), // v35→36: + externalTools (additive)
                     Map.entry(36, (Migration) ConfigMigrations::identity), // v36→37: + ripgrepSearch/Command
                     Map.entry(37, (Migration) ConfigMigrations::identity), // v37→38: + logViewer (additive)
-                    Map.entry(38, (Migration) ConfigMigrations::identity))), // v38→39: + projectShowHidden
+                    Map.entry(38, (Migration) ConfigMigrations::identity), // v38→39: + projectShowHidden
+                    Map.entry(39, (Migration) ConfigMigrations::identity))), // v39→40: + markdownLintDisabledRules
     WORKSPACE(WorkspaceState.SCHEMA_VERSION, 1, Map.of()),
     BOOKMARKS(BookmarkStore.SCHEMA_VERSION, 1, Map.of()),
     BREAKPOINTS(BreakpointStore.SCHEMA_VERSION, 1, Map.of()),

--- a/src/main/java/com/editora/editor/EditorBuffer.java
+++ b/src/main/java/com/editora/editor/EditorBuffer.java
@@ -289,6 +289,8 @@ public class EditorBuffer implements TabContent {
     private final DiagnosticStripe diagnosticStripe = new DiagnosticStripe(area);
     /** TODO/highlight overview stripe over the scrollbar (beside the diagnostic stripe). */
     private final TodoStripe todoStripe = new TodoStripe(area);
+    /** Markdown-lint overview stripe over the scrollbar (beside the TODO/diagnostic stripes). */
+    private final MarkdownLintStripe mdLintStripe = new MarkdownLintStripe(area);
     /** Files above this size are never scanned for compact-source detection (keeps it off the hot path). */
     private static final int COMPACT_SCAN_LIMIT = 256 * 1024;
     /** Whether the Run affordance is enabled at all (gated by the LSP feature setting). */
@@ -983,6 +985,7 @@ public class EditorBuffer implements TabContent {
                         inlineValues,
                         minimap,
                         diagnosticStripe,
+                        mdLintStripe,
                         todoStripe,
                         columnRuler);
         // searchOverlay / logOverlay / lintOverlay / lspOverlay / aceJump are attached lazily on first
@@ -1043,6 +1046,10 @@ public class EditorBuffer implements TabContent {
         AnchorPane.setBottomAnchor(todoStripe, 0d);
         AnchorPane.setRightAnchor(todoStripe, 0d);
         todoStripe.setOnActivate(this::jumpToLine);
+        AnchorPane.setTopAnchor(mdLintStripe, 0d);
+        AnchorPane.setBottomAnchor(mdLintStripe, 0d);
+        AnchorPane.setRightAnchor(mdLintStripe, 0d);
+        mdLintStripe.setOnActivate(this::jumpToLine);
     }
 
     /** Moves the caret to the start of {@code line} (0-based), scrolls it into view, and focuses the editor. */
@@ -1611,8 +1618,13 @@ public class EditorBuffer implements TabContent {
     public void setMarkdownLintEnabled(boolean on) {
         this.markdownLintEnabled = on && isMarkdown() && !hugeFile;
         mdLintOverlay.setActive(this.markdownLintEnabled);
+        minimap.setLintEnabled(this.markdownLintEnabled);
+        updateMarkdownLintStripe();
         if (this.markdownLintEnabled) {
             scheduleMarkdownLint();
+        } else {
+            mdLintStripe.setDiagnostics(java.util.List.of());
+            minimap.setLintMarks(java.util.List.of());
         }
     }
 
@@ -1620,7 +1632,14 @@ public class EditorBuffer implements TabContent {
         if (!markdownLintEnabled || !isMarkdown() || hugeFile || markdownLintValidator == null) {
             return;
         }
-        markdownLintValidator.accept(area.getText(), mdLintOverlay::setDiagnostics);
+        markdownLintValidator.accept(area.getText(), this::applyMarkdownLintDiagnostics);
+    }
+
+    /** Pushes fresh lint diagnostics to the squiggle overlay + the scrollbar stripe + the minimap ticks. */
+    private void applyMarkdownLintDiagnostics(java.util.List<MarkdownLint.Diagnostic> diags) {
+        mdLintOverlay.setDiagnostics(diags);
+        mdLintStripe.setDiagnostics(diags);
+        minimap.setLintMarks(diags);
     }
 
     /** Shows the lint message(s) in a tooltip when hovering a squiggled span (overlay is mouse-transparent). */
@@ -2022,15 +2041,27 @@ public class EditorBuffer implements TabContent {
         boolean minimapShown = minimapVisible && !largeFile;
         AnchorPane.setRightAnchor(diagnosticStripe, minimapShown ? Minimap.WIDTH : 0d);
         diagnosticStripe.setActive(lspActive);
+        updateMarkdownLintStripe();
+    }
+
+    /** Positions the Markdown-lint overview stripe beside the diagnostic stripe (shifted left by its width
+     *  when LSP is also active — never the case for a Markdown buffer, but kept general). */
+    private void updateMarkdownLintStripe() {
+        boolean minimapShown = minimapVisible && !largeFile;
+        double base = minimapShown ? Minimap.WIDTH : 0d;
+        AnchorPane.setRightAnchor(mdLintStripe, base + (lspActive ? DiagnosticStripe.WIDTH : 0d));
+        mdLintStripe.setActive(markdownLintEnabled && !largeFile);
         updateTodoStripe();
     }
 
     /** Positions the TODO overview stripe over the scrollbar: at the edge (inside the minimap when shown),
-     *  shifted left by the diagnostic stripe's width when that one is also active, so they sit side by side. */
+     *  shifted left by the diagnostic + lint stripes' widths when those are active, so they sit side by side. */
     private void updateTodoStripe() {
         boolean minimapShown = minimapVisible && !largeFile;
         double base = minimapShown ? Minimap.WIDTH : 0d;
-        AnchorPane.setRightAnchor(todoStripe, base + (lspActive ? DiagnosticStripe.WIDTH : 0d));
+        double offset = (lspActive ? DiagnosticStripe.WIDTH : 0d)
+                + (markdownLintEnabled && !largeFile ? MarkdownLintStripe.WIDTH : 0d);
+        AnchorPane.setRightAnchor(todoStripe, base + offset);
         todoStripe.setActive(todoEnabled && !largeFile);
     }
 

--- a/src/main/java/com/editora/editor/MarkdownLint.java
+++ b/src/main/java/com/editora/editor/MarkdownLint.java
@@ -9,10 +9,13 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 /**
- * Pure, high-confidence Markdown linter (a small subset of the markdownlint rule set). Returns
+ * Pure, high-confidence Markdown linter (a curated subset of the markdownlint rule set). Returns
  * 1-based {@link Diagnostic}s in document order, mirroring {@link com.editora.mermaid.MaidOutput}'s
- * shape so the lint overlay/panel can render either. Fenced code blocks (and a leading YAML front
- * matter block) are skipped where it would otherwise produce noise.
+ * shape so the lint overlay/panel/stripe can render either. Fenced code blocks (and a leading YAML
+ * front matter block) are skipped where a rule would otherwise produce noise.
+ *
+ * <p>A {@code disabled} set (rule codes the user turned off in Settings / a {@code .markdownlint.json})
+ * and inline {@link MarkdownLintDirectives} (<!-- markdownlint-disable … -->) both suppress emission.
  *
  * <p>Stateless and toolkit-free — unit-tested directly.
  */
@@ -30,17 +33,51 @@ public final class MarkdownLint {
         }
     }
 
+    /** A lint rule's code + short label (for the Settings checklist / per-rule toggle picker). */
+    public record Rule(String code, String name) {}
+
+    /** Every rule this linter can emit, in code order — the source of truth for the per-rule UI. */
+    public static final List<Rule> RULES = List.of(
+            new Rule("MD001", "Heading levels increment by one"),
+            new Rule("MD009", "Trailing whitespace"),
+            new Rule("MD010", "Hard tabs"),
+            new Rule("MD012", "Multiple consecutive blank lines"),
+            new Rule("MD018", "No space after heading marker"),
+            new Rule("MD019", "Multiple spaces after heading marker"),
+            new Rule("MD022", "Headings surrounded by blank lines"),
+            new Rule("MD023", "Headings start at line beginning"),
+            new Rule("MD025", "Single top-level heading"),
+            new Rule("MD026", "No trailing punctuation in heading"),
+            new Rule("MD031", "Fenced code surrounded by blank lines"),
+            new Rule("MD034", "No bare URLs"),
+            new Rule("MD040", "Fenced code should specify a language"),
+            new Rule("MD041", "First line should be a top-level heading"),
+            new Rule("MD047", "File should end with a single newline"),
+            new Rule("MD052", "Reference links have a definition"));
+
     // Full reference link use: [text][label] with a non-empty label (not an image).
     private static final Pattern FULL_REF = Pattern.compile("\\[[^\\]]*\\]\\[([^\\]]+)\\]");
     // A reference definition: [label]: url
     private static final Pattern REF_DEF = Pattern.compile("^\\s{0,3}\\[([^\\]]+)\\]:\\s*\\S");
+    // A bare URL (no surrounding markdown link / autolink syntax).
+    private static final Pattern BARE_URL = Pattern.compile("https?://[^\\s<>\\[\\]()]+");
+    // Trailing punctuation flagged by MD026 (markdownlint default minus the question mark).
+    private static final String HEADING_PUNCTUATION = ".,;:!";
 
+    /** Lints with no rules disabled. */
     public static List<Diagnostic> lint(String text) {
+        return lint(text, Set.of());
+    }
+
+    /** Lints {@code text}; {@code disabled} rule codes (and inline directives) suppress those diagnostics. */
+    public static List<Diagnostic> lint(String text, Set<String> disabled) {
         List<Diagnostic> out = new ArrayList<>();
         if (text == null || text.isEmpty()) {
             return out;
         }
+        Set<String> off = disabled == null ? Set.of() : disabled;
         String[] lines = text.split("\n", -1);
+        MarkdownLintDirectives directives = MarkdownLintDirectives.compute(lines);
 
         // Collect reference-definition labels (normalized) for the broken-reference check.
         Set<String> defined = new HashSet<>();
@@ -51,9 +88,8 @@ public final class MarkdownLint {
             }
         }
 
-        boolean inFrontMatter = lines.length > 0 && lines[0].strip().equals("---");
         int frontMatterEnd = -1;
-        if (inFrontMatter) {
+        if (lines.length > 0 && lines[0].strip().equals("---")) {
             for (int j = 1; j < lines.length; j++) {
                 if (lines[j].strip().equals("---")) {
                     frontMatterEnd = j;
@@ -62,8 +98,10 @@ public final class MarkdownLint {
             }
         }
 
+        // MD041: the first content line (after front matter, skipping blanks/HTML comments) should be an H1.
+        checkFirstLineHeading(lines, frontMatterEnd, off, directives, out);
+
         String fence = null; // the opening fence run while inside a fenced code block
-        int h1Count = 0;
         for (int i = 0; i < lines.length; i++) {
             String line = stripCr(lines[i]);
             int lineNo = i + 1;
@@ -73,21 +111,52 @@ public final class MarkdownLint {
             if (fence != null) {
                 if (fenceTok != null && fenceTok.charAt(0) == fence.charAt(0) && fenceTok.length() >= fence.length()) {
                     fence = null;
+                    // MD031: a fenced code block should be followed by a blank line.
+                    if (i + 1 < lines.length && !stripCr(lines[i + 1]).isBlank()) {
+                        add(
+                                out,
+                                off,
+                                directives,
+                                new Diagnostic(
+                                        lineNo,
+                                        1,
+                                        fenceTok.length(),
+                                        WARNING,
+                                        "MD031",
+                                        "Fenced code block should be followed by a blank line"));
+                    }
                 }
                 continue; // inside code: no line-level rules
             }
             if (fenceTok != null) {
                 fence = fenceTok;
-                // MD040: opening fence with no language/info string.
                 String info = line.strip().substring(fenceTok.length()).strip();
                 if (info.isEmpty()) {
-                    out.add(new Diagnostic(
-                            lineNo,
-                            1,
-                            fenceTok.length(),
-                            WARNING,
-                            "MD040",
-                            "Fenced code block should specify a language"));
+                    add(
+                            out,
+                            off,
+                            directives,
+                            new Diagnostic(
+                                    lineNo,
+                                    1,
+                                    fenceTok.length(),
+                                    WARNING,
+                                    "MD040",
+                                    "Fenced code block should specify a language"));
+                }
+                // MD031: a fenced code block should be preceded by a blank line.
+                if (i > 0 && !stripCr(lines[i - 1]).isBlank()) {
+                    add(
+                            out,
+                            off,
+                            directives,
+                            new Diagnostic(
+                                    lineNo,
+                                    1,
+                                    fenceTok.length(),
+                                    WARNING,
+                                    "MD031",
+                                    "Fenced code block should be preceded by a blank line"));
                 }
                 continue;
             }
@@ -96,32 +165,59 @@ public final class MarkdownLint {
                 continue; // don't lint inside front matter
             }
 
+            // MD010: hard tabs (outside code blocks).
+            int tab = line.indexOf('\t');
+            if (tab >= 0) {
+                int run = tab;
+                while (run < line.length() && line.charAt(run) == '\t') {
+                    run++;
+                }
+                add(out, off, directives, new Diagnostic(lineNo, tab + 1, run - tab, WARNING, "MD010", "Hard tab"));
+            }
+
             // MD009: trailing whitespace.
             int end = line.length();
             while (end > 0 && (line.charAt(end - 1) == ' ' || line.charAt(end - 1) == '\t')) {
                 end--;
             }
             if (end < line.length()) {
-                out.add(new Diagnostic(lineNo, end + 1, line.length() - end, WARNING, "MD009", "Trailing whitespace"));
+                add(
+                        out,
+                        off,
+                        directives,
+                        new Diagnostic(lineNo, end + 1, line.length() - end, WARNING, "MD009", "Trailing whitespace"));
             }
 
             // MD012: multiple consecutive blank lines.
             if (line.isBlank() && i > 0 && stripCr(lines[i - 1]).isBlank()) {
-                out.add(new Diagnostic(lineNo, 1, 1, WARNING, "MD012", "Multiple consecutive blank lines"));
+                add(
+                        out,
+                        off,
+                        directives,
+                        new Diagnostic(lineNo, 1, 1, WARNING, "MD012", "Multiple consecutive blank lines"));
             }
 
-            // MD018 / MD019: ATX heading hash spacing.
             int hashes = leadingHashes(line);
             if (hashes > 0) {
-                int after = leadingSpaces(line) + hashes;
+                int indent = leadingSpaces(line);
+                // MD023: headings must start at the beginning of the line.
+                if (indent > 0) {
+                    add(
+                            out,
+                            off,
+                            directives,
+                            new Diagnostic(
+                                    lineNo, 1, indent, WARNING, "MD023", "Heading must start at line beginning"));
+                }
+                int after = indent + hashes;
+                // MD018 / MD019: ATX heading hash spacing.
                 if (after < line.length() && line.charAt(after) != ' ' && line.charAt(after) != '\t') {
-                    out.add(new Diagnostic(
-                            lineNo,
-                            leadingSpaces(line) + 1,
-                            hashes,
-                            WARNING,
-                            "MD018",
-                            "No space after heading marker"));
+                    add(
+                            out,
+                            off,
+                            directives,
+                            new Diagnostic(
+                                    lineNo, indent + 1, hashes, WARNING, "MD018", "No space after heading marker"));
                 } else {
                     int spaces = 0;
                     int p = after;
@@ -130,8 +226,69 @@ public final class MarkdownLint {
                         spaces++;
                     }
                     if (spaces > 1 && p < line.length()) {
-                        out.add(new Diagnostic(
-                                lineNo, after + 1, spaces, WARNING, "MD019", "Multiple spaces after heading marker"));
+                        add(
+                                out,
+                                off,
+                                directives,
+                                new Diagnostic(
+                                        lineNo,
+                                        after + 1,
+                                        spaces,
+                                        WARNING,
+                                        "MD019",
+                                        "Multiple spaces after heading marker"));
+                    }
+                }
+                // MD026: trailing punctuation in a heading.
+                int punct = trailingPunctuation(line, after);
+                if (punct >= 0) {
+                    add(
+                            out,
+                            off,
+                            directives,
+                            new Diagnostic(lineNo, punct + 1, 1, WARNING, "MD026", "Trailing punctuation in heading"));
+                }
+                // MD022: a heading should be surrounded by blank lines.
+                if (i > 0 && i - 1 != frontMatterEnd && !stripCr(lines[i - 1]).isBlank()) {
+                    add(
+                            out,
+                            off,
+                            directives,
+                            new Diagnostic(
+                                    lineNo,
+                                    indent + 1,
+                                    hashes,
+                                    WARNING,
+                                    "MD022",
+                                    "Heading should be preceded by a blank line"));
+                }
+                if (i + 1 < lines.length && !stripCr(lines[i + 1]).isBlank()) {
+                    add(
+                            out,
+                            off,
+                            directives,
+                            new Diagnostic(
+                                    lineNo,
+                                    indent + 1,
+                                    hashes,
+                                    WARNING,
+                                    "MD022",
+                                    "Heading should be followed by a blank line"));
+                }
+            }
+
+            // MD034: bare URL used (not inside a link/autolink/ref-def/inline code).
+            if (!REF_DEF.matcher(line).find()) {
+                Matcher url = BARE_URL.matcher(line);
+                while (url.find()) {
+                    int s = url.start();
+                    char before = s > 0 ? line.charAt(s - 1) : ' ';
+                    if (before != '(' && before != '<' && !inInlineCode(line, s)) {
+                        add(
+                                out,
+                                off,
+                                directives,
+                                new Diagnostic(lineNo, s + 1, url.end() - s, WARNING, "MD034", "Bare URL used"));
                     }
                 }
             }
@@ -140,35 +297,64 @@ public final class MarkdownLint {
             Matcher ref = FULL_REF.matcher(line);
             while (ref.find()) {
                 if (!defined.contains(normalizeLabel(ref.group(1)))) {
-                    out.add(new Diagnostic(
-                            lineNo,
-                            ref.start() + 1,
-                            ref.end() - ref.start(),
-                            WARNING,
-                            "MD052",
-                            "Reference link has no matching definition"));
+                    add(
+                            out,
+                            off,
+                            directives,
+                            new Diagnostic(
+                                    lineNo,
+                                    ref.start() + 1,
+                                    ref.end() - ref.start(),
+                                    WARNING,
+                                    "MD052",
+                                    "Reference link has no matching definition"));
                 }
             }
         }
 
-        // MD025: more than one top-level (H1) heading. Reuse the outline (skips code/front matter).
+        // MD001 / MD025: heading structure (the outline skips code + front matter).
+        int h1Count = 0;
+        int prevLevel = 0;
         for (MarkdownOutline.Heading h : MarkdownOutline.headings(text)) {
-            if (h.level() == 1) {
-                h1Count++;
-                if (h1Count > 1) {
-                    out.add(new Diagnostic(h.line() + 1, 1, 1, WARNING, "MD025", "Multiple top-level headings"));
-                }
+            int level = h.level();
+            int lineNo = h.line() + 1;
+            if (level == 1 && ++h1Count > 1) {
+                add(
+                        out,
+                        off,
+                        directives,
+                        new Diagnostic(lineNo, 1, 1, WARNING, "MD025", "Multiple top-level headings"));
             }
+            if (prevLevel > 0 && level > prevLevel + 1) {
+                add(
+                        out,
+                        off,
+                        directives,
+                        new Diagnostic(
+                                lineNo,
+                                1,
+                                1,
+                                WARNING,
+                                "MD001",
+                                "Heading levels should increment by one level at a time"));
+            }
+            prevLevel = level;
         }
 
         // MD047: file should end with a single trailing newline.
-        if (!text.isEmpty()) {
-            int lastLine = lines.length; // split("\n",-1): a trailing "\n" yields a final empty element
-            if (!text.endsWith("\n")) {
-                out.add(new Diagnostic(lastLine, 1, 1, WARNING, "MD047", "File should end with a newline"));
-            } else if (text.endsWith("\n\n")) {
-                out.add(new Diagnostic(lastLine, 1, 1, WARNING, "MD047", "File should end with a single newline"));
-            }
+        int lastLine = lines.length; // split("\n",-1): a trailing "\n" yields a final empty element
+        if (!text.endsWith("\n")) {
+            add(
+                    out,
+                    off,
+                    directives,
+                    new Diagnostic(lastLine, 1, 1, WARNING, "MD047", "File should end with a newline"));
+        } else if (text.endsWith("\n\n")) {
+            add(
+                    out,
+                    off,
+                    directives,
+                    new Diagnostic(lastLine, 1, 1, WARNING, "MD047", "File should end with a single newline"));
         }
 
         out.sort((a, b) ->
@@ -176,12 +362,75 @@ public final class MarkdownLint {
         return out;
     }
 
+    /** Adds {@code d} unless its rule is globally disabled or suppressed by an inline directive on its line. */
+    private static void add(List<Diagnostic> out, Set<String> off, MarkdownLintDirectives dir, Diagnostic d) {
+        if (off.contains(d.code()) || dir.disabled(d.line() - 1, d.code())) {
+            return;
+        }
+        out.add(d);
+    }
+
+    private static void checkFirstLineHeading(
+            String[] lines, int frontMatterEnd, Set<String> off, MarkdownLintDirectives dir, List<Diagnostic> out) {
+        int start = frontMatterEnd >= 0 ? frontMatterEnd + 1 : 0;
+        for (int j = start; j < lines.length; j++) {
+            String s = stripCr(lines[j]).strip();
+            if (s.isEmpty() || s.startsWith("<!--")) {
+                continue;
+            }
+            if (leadingHashes(stripCr(lines[j])) != 1) {
+                add(
+                        out,
+                        off,
+                        dir,
+                        new Diagnostic(
+                                j + 1, 1, 1, WARNING, "MD041", "First line in a file should be a top-level heading"));
+            }
+            return; // only the first content line matters
+        }
+    }
+
+    /** The 0-based index of trailing punctuation in an ATX heading whose marker ends at {@code after}, else -1. */
+    static int trailingPunctuation(String line, int after) {
+        int e = line.length();
+        while (e > after && (line.charAt(e - 1) == ' ' || line.charAt(e - 1) == '\t')) {
+            e--;
+        }
+        // Drop a closing ATX hash run ("## Title ##").
+        int hashEnd = e;
+        while (hashEnd > after && line.charAt(hashEnd - 1) == '#') {
+            hashEnd--;
+        }
+        if (hashEnd < e) { // there was a closing run; trim the space before it
+            e = hashEnd;
+            while (e > after && (line.charAt(e - 1) == ' ' || line.charAt(e - 1) == '\t')) {
+                e--;
+            }
+        }
+        if (e <= after) {
+            return -1; // empty heading text
+        }
+        char last = line.charAt(e - 1);
+        return HEADING_PUNCTUATION.indexOf(last) >= 0 ? e - 1 : -1;
+    }
+
+    /** Whether the character at {@code idx} falls inside an inline-code span (odd number of backticks before). */
+    private static boolean inInlineCode(String line, int idx) {
+        int ticks = 0;
+        for (int i = 0; i < idx && i < line.length(); i++) {
+            if (line.charAt(i) == '`') {
+                ticks++;
+            }
+        }
+        return (ticks & 1) == 1;
+    }
+
     private static String normalizeLabel(String label) {
         return label == null ? "" : label.strip().toLowerCase(Locale.ROOT).replaceAll("\\s+", " ");
     }
 
     /** Count of leading {@code #} (1–6) if {@code line} is an ATX heading marker, else 0. */
-    private static int leadingHashes(String line) {
+    static int leadingHashes(String line) {
         int indent = leadingSpaces(line);
         if (indent > 3) {
             return 0;
@@ -195,7 +444,7 @@ public final class MarkdownLint {
         return n >= 1 && n <= 6 ? n : 0;
     }
 
-    private static String fenceToken(String line) {
+    static String fenceToken(String line) {
         int indent = leadingSpaces(line);
         if (indent > 3) {
             return null;
@@ -213,7 +462,7 @@ public final class MarkdownLint {
         return n >= 3 ? line.substring(indent, indent + n) : null;
     }
 
-    private static int leadingSpaces(String line) {
+    static int leadingSpaces(String line) {
         int n = 0;
         while (n < line.length() && line.charAt(n) == ' ') {
             n++;
@@ -221,7 +470,7 @@ public final class MarkdownLint {
         return n;
     }
 
-    private static String stripCr(String line) {
+    static String stripCr(String line) {
         return !line.isEmpty() && line.charAt(line.length() - 1) == '\r' ? line.substring(0, line.length() - 1) : line;
     }
 }

--- a/src/main/java/com/editora/editor/MarkdownLintConfig.java
+++ b/src/main/java/com/editora/editor/MarkdownLintConfig.java
@@ -1,0 +1,60 @@
+package com.editora.editor;
+
+import java.util.HashSet;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+/**
+ * Parses a project {@code .markdownlint.json} into the set of rule codes it turns <b>off</b>, so the
+ * controller can merge it with the user's Settings before linting. Supports the common markdownlint
+ * config forms: {@code {"MD013": false}} (disable a rule) and {@code {"default": false}} (disable all,
+ * then re-enable the rules explicitly set {@code true}). Rule <em>aliases</em> ("line-length") and
+ * per-rule option objects aren't interpreted — only the {@code MDxxx} on/off booleans (v1).
+ *
+ * <p>Pure (parse-only) and tolerant: any malformed JSON yields an empty set. Unit-tested directly.
+ */
+public final class MarkdownLintConfig {
+
+    private MarkdownLintConfig() {}
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    /** The rule codes disabled by {@code json}; empty on malformed input. */
+    public static Set<String> disabledRules(String json) {
+        Set<String> disabled = new HashSet<>();
+        if (json == null || json.isBlank()) {
+            return disabled;
+        }
+        JsonNode root;
+        try {
+            root = MAPPER.readTree(json);
+        } catch (Exception e) {
+            return disabled; // tolerant: a broken config never crashes linting
+        }
+        if (root == null || !root.isObject()) {
+            return disabled;
+        }
+        JsonNode def = root.get("default");
+        if (def != null && def.isBoolean() && !def.asBoolean()) {
+            for (MarkdownLint.Rule r : MarkdownLint.RULES) {
+                disabled.add(r.code());
+            }
+        }
+        for (Map.Entry<String, JsonNode> e : (Iterable<Map.Entry<String, JsonNode>>) root::fields) {
+            String key = e.getKey().toUpperCase(Locale.ROOT);
+            if (!key.matches("MD\\d+") || !e.getValue().isBoolean()) {
+                continue;
+            }
+            if (e.getValue().asBoolean()) {
+                disabled.remove(key);
+            } else {
+                disabled.add(key);
+            }
+        }
+        return disabled;
+    }
+}

--- a/src/main/java/com/editora/editor/MarkdownLintDirectives.java
+++ b/src/main/java/com/editora/editor/MarkdownLintDirectives.java
@@ -1,0 +1,102 @@
+package com.editora.editor;
+
+import java.util.HashSet;
+import java.util.Locale;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Parses inline {@code markdownlint} control comments and resolves, per line, which rules are
+ * suppressed — so both {@link MarkdownLint} (skip emitting) and {@link MarkdownLintFix} (skip fixing)
+ * honor the same directives. Recognized HTML-comment forms (markdownlint-compatible):
+ *
+ * <ul>
+ *   <li>{@code <!-- markdownlint-disable [MDxxx ...] -->} — from this line onward (all rules, or listed)
+ *   <li>{@code <!-- markdownlint-enable [MDxxx ...] -->} — re-enable (all, or listed)
+ *   <li>{@code <!-- markdownlint-disable-line [MDxxx ...] -->} — this line only
+ *   <li>{@code <!-- markdownlint-disable-next-line [MDxxx ...] -->} — the following line only
+ * </ul>
+ *
+ * <p>Pure and toolkit-free — unit-tested directly. {@link #ALL} is the wildcard token used internally
+ * for a code-less {@code disable}/{@code enable}. Selectively re-enabling a single rule after a
+ * code-less {@code disable} (which sets {@link #ALL}) is a no-op — a documented v1 limitation.
+ */
+final class MarkdownLintDirectives {
+
+    /** Wildcard standing for "every rule" in the per-line disabled sets. */
+    static final String ALL = "*";
+
+    private static final Pattern DIRECTIVE = Pattern.compile(
+            "<!--\\s*markdownlint-(disable-next-line|disable-line|disable|enable)([^>]*?)-->",
+            Pattern.CASE_INSENSITIVE);
+    private static final Pattern CODE = Pattern.compile("MD\\d+", Pattern.CASE_INSENSITIVE);
+
+    private final Set<String>[] perLine;
+
+    @SuppressWarnings("unchecked")
+    private MarkdownLintDirectives(int lineCount) {
+        perLine = new Set[Math.max(0, lineCount)];
+    }
+
+    /** Builds the per-line suppression table for {@code lines} (already CR-stripped is fine; not required). */
+    static MarkdownLintDirectives compute(String[] lines) {
+        MarkdownLintDirectives d = new MarkdownLintDirectives(lines.length);
+        Set<String> region = new HashSet<>(); // active region disables (codes or ALL)
+        Set<String> nextLine = null; // disables queued for the next line by disable-next-line
+        for (int i = 0; i < lines.length; i++) {
+            Set<String> eff = new HashSet<>(region);
+            if (nextLine != null) {
+                eff.addAll(nextLine);
+                nextLine = null;
+            }
+            Matcher m = DIRECTIVE.matcher(lines[i] == null ? "" : lines[i]);
+            while (m.find()) {
+                String kind = m.group(1).toLowerCase(Locale.ROOT);
+                Set<String> codes = codes(m.group(2));
+                switch (kind) {
+                    case "disable" -> {
+                        region.addAll(codes);
+                        eff.addAll(codes);
+                    }
+                    case "enable" -> {
+                        if (codes.contains(ALL)) {
+                            region.clear();
+                            eff.clear();
+                        } else {
+                            region.removeAll(codes);
+                            eff.removeAll(codes);
+                        }
+                    }
+                    case "disable-line" -> eff.addAll(codes);
+                    case "disable-next-line" -> nextLine = codes;
+                    default -> {
+                        // unreachable
+                    }
+                }
+            }
+            d.perLine[i] = eff;
+        }
+        return d;
+    }
+
+    /** Whether {@code code} is suppressed on the 0-based {@code line}. */
+    boolean disabled(int line, String code) {
+        if (line < 0 || line >= perLine.length) {
+            return false;
+        }
+        Set<String> set = perLine[line];
+        return set != null && (set.contains(ALL) || set.contains(code));
+    }
+
+    private static Set<String> codes(String tail) {
+        Set<String> out = new HashSet<>();
+        if (tail != null) {
+            Matcher m = CODE.matcher(tail);
+            while (m.find()) {
+                out.add(m.group().toUpperCase(Locale.ROOT));
+            }
+        }
+        return out.isEmpty() ? Set.of(ALL) : out;
+    }
+}

--- a/src/main/java/com/editora/editor/MarkdownLintFix.java
+++ b/src/main/java/com/editora/editor/MarkdownLintFix.java
@@ -1,0 +1,139 @@
+package com.editora.editor;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Pure auto-fixer for the safely-mechanical {@link MarkdownLint} rules — the markdownlint {@code --fix}
+ * subset that can be applied in place without restructuring the document: MD009 (trailing whitespace),
+ * MD010 (hard tabs → spaces), MD012 (collapse blank-line runs), MD018/MD019 (heading hash spacing),
+ * MD023 (de-indent headings), MD026 (strip heading trailing punctuation), and MD047 (single final
+ * newline). Structural rules (MD001/MD022/MD025/MD031/MD034/MD040/MD041/MD052) are <b>not</b> auto-fixed.
+ *
+ * <p>Honors the global {@code disabled} set and inline {@link MarkdownLintDirectives}, and skips fenced
+ * code blocks + a leading YAML front matter block (as the linter does). Idempotent: a second pass is a
+ * no-op. Stateless and toolkit-free — unit-tested directly.
+ */
+public final class MarkdownLintFix {
+
+    private MarkdownLintFix() {}
+
+    /** Returns {@code text} with the fixable issues corrected (or unchanged when there is nothing to fix). */
+    public static String fix(String text, Set<String> disabled, int spacesPerTab) {
+        if (text == null || text.isEmpty()) {
+            return text;
+        }
+        Set<String> off = disabled == null ? Set.of() : disabled;
+        int tabWidth = Math.max(1, spacesPerTab);
+        String[] lines = text.split("\n", -1);
+        MarkdownLintDirectives dir = MarkdownLintDirectives.compute(lines);
+
+        int frontMatterEnd = -1;
+        if (lines.length > 0 && lines[0].strip().equals("---")) {
+            for (int j = 1; j < lines.length; j++) {
+                if (lines[j].strip().equals("---")) {
+                    frontMatterEnd = j;
+                    break;
+                }
+            }
+        }
+
+        List<String> outLines = new ArrayList<>(lines.length);
+        String fence = null;
+        boolean prevBlank = false;
+        for (int i = 0; i < lines.length; i++) {
+            String raw = lines[i];
+            boolean cr = !raw.isEmpty() && raw.charAt(raw.length() - 1) == '\r';
+            String line = MarkdownLint.stripCr(raw);
+            boolean inFront = frontMatterEnd >= 0 && i <= frontMatterEnd;
+
+            String fenceTok = MarkdownLint.fenceToken(line);
+            boolean inCode = fence != null;
+            if (inCode) {
+                if (fenceTok != null && fenceTok.charAt(0) == fence.charAt(0) && fenceTok.length() >= fence.length()) {
+                    fence = null;
+                }
+            } else if (fenceTok != null) {
+                fence = fenceTok;
+            }
+
+            if (inCode || fenceTok != null || inFront) {
+                outLines.add(raw); // verbatim inside code / front matter
+                prevBlank = line.isBlank();
+                continue;
+            }
+
+            String fixed = line;
+            if (enabled(off, dir, i, "MD010")) {
+                fixed = fixed.replace("\t", " ".repeat(tabWidth));
+            }
+            int hashes = MarkdownLint.leadingHashes(fixed);
+            if (hashes > 0) {
+                int indent = MarkdownLint.leadingSpaces(fixed);
+                if (indent > 0 && enabled(off, dir, i, "MD023")) {
+                    fixed = fixed.substring(indent);
+                    indent = 0;
+                }
+                int after = indent + hashes;
+                if (after < fixed.length()
+                        && fixed.charAt(after) != ' '
+                        && fixed.charAt(after) != '\t'
+                        && enabled(off, dir, i, "MD018")) {
+                    fixed = fixed.substring(0, after) + " " + fixed.substring(after);
+                } else if (enabled(off, dir, i, "MD019")) {
+                    int p = after;
+                    while (p < fixed.length() && fixed.charAt(p) == ' ') {
+                        p++;
+                    }
+                    if (p - after > 1 && p < fixed.length()) {
+                        fixed = fixed.substring(0, after) + " " + fixed.substring(p);
+                    }
+                }
+                if (enabled(off, dir, i, "MD026")) {
+                    int hb = MarkdownLint.leadingSpaces(fixed) + MarkdownLint.leadingHashes(fixed);
+                    int punct = MarkdownLint.trailingPunctuation(fixed, hb);
+                    if (punct >= 0) {
+                        fixed = fixed.substring(0, punct) + fixed.substring(punct + 1);
+                    }
+                }
+            }
+            if (enabled(off, dir, i, "MD009")) {
+                fixed = stripTrailing(fixed);
+            }
+
+            if (fixed.isBlank()) {
+                if (prevBlank && enabled(off, dir, i, "MD012")) {
+                    continue; // collapse the run
+                }
+                outLines.add(cr ? "\r" : "");
+                prevBlank = true;
+                continue;
+            }
+            outLines.add(cr ? fixed + "\r" : fixed);
+            prevBlank = false;
+        }
+
+        String result = String.join("\n", outLines);
+        if (enabled(off, dir, Math.max(0, lines.length - 1), "MD047")) {
+            int e = result.length();
+            while (e > 0 && (result.charAt(e - 1) == '\n' || result.charAt(e - 1) == '\r')) {
+                e--;
+            }
+            result = e == 0 ? "" : result.substring(0, e) + "\n";
+        }
+        return result;
+    }
+
+    private static boolean enabled(Set<String> off, MarkdownLintDirectives dir, int line, String code) {
+        return !off.contains(code) && !dir.disabled(line, code);
+    }
+
+    private static String stripTrailing(String line) {
+        int e = line.length();
+        while (e > 0 && (line.charAt(e - 1) == ' ' || line.charAt(e - 1) == '\t')) {
+            e--;
+        }
+        return e == line.length() ? line : line.substring(0, e);
+    }
+}

--- a/src/main/java/com/editora/editor/MarkdownLintService.java
+++ b/src/main/java/com/editora/editor/MarkdownLintService.java
@@ -26,9 +26,16 @@ public final class MarkdownLintService {
 
     /** Lints {@code source} off-thread; delivers diagnostics on the FX thread (latest request wins). */
     public void validate(String source, Consumer<List<MarkdownLint.Diagnostic>> onResult) {
+        validate(source, java.util.Set.of(), onResult);
+    }
+
+    /** As {@link #validate(String, Consumer)} but with a set of rule codes to suppress. */
+    public void validate(
+            String source, java.util.Set<String> disabled, Consumer<List<MarkdownLint.Diagnostic>> onResult) {
         long mine = gen.incrementAndGet();
+        java.util.Set<String> off = disabled == null ? java.util.Set.of() : java.util.Set.copyOf(disabled);
         exec.submit(() -> {
-            List<MarkdownLint.Diagnostic> diags = MarkdownLint.lint(source);
+            List<MarkdownLint.Diagnostic> diags = MarkdownLint.lint(source, off);
             if (mine == gen.get()) {
                 Platform.runLater(() -> {
                     if (mine == gen.get()) {

--- a/src/main/java/com/editora/editor/MarkdownLintStripe.java
+++ b/src/main/java/com/editora/editor/MarkdownLintStripe.java
@@ -1,0 +1,229 @@
+package com.editora.editor;
+
+import java.util.List;
+import java.util.function.IntConsumer;
+
+import javafx.application.Platform;
+import javafx.scene.Cursor;
+import javafx.scene.canvas.Canvas;
+import javafx.scene.canvas.GraphicsContext;
+import javafx.scene.control.Tooltip;
+import javafx.scene.input.MouseEvent;
+import javafx.scene.layout.Region;
+import javafx.scene.paint.Color;
+
+import org.fxmisc.richtext.CodeArea;
+
+/**
+ * A thin Markdown-lint overview stripe docked over the editor's vertical scrollbar (beside the TODO
+ * {@link TodoStripe} / LSP {@link DiagnosticStripe}), mapping the <em>whole document</em> to its height
+ * so a glance shows where the lint warnings are — IntelliJ-style. Each mark is a single amber warning
+ * tick; hovering shows the rule code + message and clicking jumps the caret there (via an injected
+ * {@code onActivate}). Coalesced redraw + a 1×1 backing texture while inactive — the same
+ * {@link CanvasGuards}/overlay discipline as {@link TodoStripe}. Diagnostics carry 1-based lines.
+ */
+final class MarkdownLintStripe extends Region {
+
+    static final double WIDTH = 6;
+    private static final double HIT_PAD = 3;
+    private static final Color WARNING = Color.web("#e2a03f");
+
+    private final CodeArea area;
+    private final Canvas canvas = new Canvas(1, 1);
+    private List<MarkdownLint.Diagnostic> marks = List.of();
+    private boolean active;
+    private boolean redrawPending;
+    private Tooltip tooltip;
+    private String shownText;
+    private IntConsumer onActivate = line -> {};
+
+    MarkdownLintStripe(CodeArea area) {
+        this.area = area;
+        getStyleClass().add("markdown-lint-stripe");
+        setMouseTransparent(true);
+        setVisible(false);
+        setMinWidth(WIDTH);
+        setPrefWidth(WIDTH);
+        setMaxWidth(WIDTH);
+        getChildren().add(canvas);
+        area.multiPlainChanges().subscribe(ignore -> scheduleRedraw());
+        addEventHandler(MouseEvent.MOUSE_MOVED, this::onHover);
+        addEventHandler(MouseEvent.MOUSE_EXITED, e -> hideTooltip());
+        addEventHandler(MouseEvent.MOUSE_CLICKED, this::onClick);
+    }
+
+    /** Shows/hides the stripe (driven by Markdown-lint-on for this buffer). */
+    void setActive(boolean active) {
+        if (this.active == active) {
+            return;
+        }
+        this.active = active;
+        setVisible(active);
+        setMouseTransparent(!active || marks.isEmpty());
+        if (active) {
+            requestLayout();
+            scheduleRedraw();
+        } else {
+            hideTooltip();
+            clear();
+            releaseTexture();
+        }
+    }
+
+    void setDiagnostics(List<MarkdownLint.Diagnostic> diagnostics) {
+        this.marks = diagnostics == null ? List.of() : diagnostics;
+        setMouseTransparent(!active || marks.isEmpty());
+        requestLayout();
+        scheduleRedraw();
+    }
+
+    void setOnActivate(IntConsumer onActivate) {
+        this.onActivate = onActivate == null ? line -> {} : onActivate;
+    }
+
+    private boolean shouldPaint() {
+        return active && !marks.isEmpty();
+    }
+
+    @Override
+    protected void layoutChildren() {
+        canvas.relocate(0, 0);
+        if (!shouldPaint()) {
+            releaseTexture();
+            return;
+        }
+        double w = CanvasGuards.clampDim(getWidth());
+        double h = CanvasGuards.clampDim(getHeight());
+        if (canvas.getWidth() != w || canvas.getHeight() != h) {
+            canvas.setWidth(w);
+            canvas.setHeight(h);
+        }
+        scheduleRedraw();
+    }
+
+    private void releaseTexture() {
+        if (canvas.getWidth() != 1 || canvas.getHeight() != 1) {
+            canvas.setWidth(1);
+            canvas.setHeight(1);
+        }
+    }
+
+    private void scheduleRedraw() {
+        if (!active || redrawPending) {
+            return;
+        }
+        redrawPending = true;
+        Platform.runLater(() -> {
+            redrawPending = false;
+            redraw();
+        });
+    }
+
+    private void clear() {
+        canvas.getGraphicsContext2D().clearRect(0, 0, canvas.getWidth(), canvas.getHeight());
+    }
+
+    private void redraw() {
+        GraphicsContext g = canvas.getGraphicsContext2D();
+        double w = canvas.getWidth();
+        double h = canvas.getHeight();
+        g.clearRect(0, 0, w, h);
+        if (!shouldPaint() || !CanvasGuards.paintable(getWidth(), getHeight())) {
+            releaseTexture();
+            return;
+        }
+        int total = area.getParagraphs().size();
+        if (total == 0) {
+            return;
+        }
+        double markH = markHeight(h, total);
+        g.setFill(WARNING);
+        for (MarkdownLint.Diagnostic d : marks) {
+            double y = yForLine(d.line() - 1, h, total);
+            g.fillRect(0, Math.min(y, h - markH), w, markH);
+        }
+    }
+
+    private double yForLine(int line, double h, int total) {
+        int clamped = Math.max(0, Math.min(line, total - 1));
+        Double estimate = area.totalHeightEstimateProperty().getValue();
+        double contentH = estimate == null ? 0 : estimate;
+        if (contentH > 0) {
+            double lineH = contentH / total;
+            double scale = h / Math.max(contentH, h);
+            return clamped * lineH * scale;
+        }
+        return (clamped / (double) total) * h;
+    }
+
+    private double markHeight(double h, int total) {
+        Double estimate = area.totalHeightEstimateProperty().getValue();
+        double contentH = estimate == null ? 0 : estimate;
+        if (contentH > 0) {
+            double lineH = contentH / total;
+            double scale = h / Math.max(contentH, h);
+            return Math.max(2.0, lineH * scale);
+        }
+        return Math.max(2.0, h / total);
+    }
+
+    private MarkdownLint.Diagnostic hitAt(double localY) {
+        int total = area.getParagraphs().size();
+        if (total == 0) {
+            return null;
+        }
+        double h = canvas.getHeight();
+        double markH = markHeight(h, total);
+        for (MarkdownLint.Diagnostic d : marks) {
+            double y = Math.min(yForLine(d.line() - 1, h, total), h - markH);
+            if (localY >= y - HIT_PAD && localY <= y + markH + HIT_PAD) {
+                return d;
+            }
+        }
+        return null;
+    }
+
+    private void onHover(MouseEvent e) {
+        if (!active || marks.isEmpty()) {
+            hideTooltip();
+            return;
+        }
+        MarkdownLint.Diagnostic hit = hitAt(e.getY());
+        if (hit == null) {
+            setCursor(Cursor.DEFAULT);
+            hideTooltip();
+            return;
+        }
+        setCursor(Cursor.HAND);
+        String text = hit.code() + ": " + hit.message();
+        if (tooltip != null && tooltip.isShowing() && text.equals(shownText)) {
+            return;
+        }
+        if (tooltip == null) {
+            tooltip = new Tooltip();
+            tooltip.getStyleClass().add("todo-stripe-tooltip");
+            tooltip.setWrapText(true);
+            tooltip.setMaxWidth(480);
+        }
+        tooltip.setText(text);
+        shownText = text;
+        tooltip.show(this, e.getScreenX() - 12 - tooltip.getWidth(), e.getScreenY() + 14);
+    }
+
+    private void onClick(MouseEvent e) {
+        if (!active) {
+            return;
+        }
+        MarkdownLint.Diagnostic hit = hitAt(e.getY());
+        if (hit != null) {
+            onActivate.accept(hit.line() - 1);
+        }
+    }
+
+    private void hideTooltip() {
+        if (tooltip != null) {
+            tooltip.hide();
+        }
+        shownText = null;
+    }
+}

--- a/src/main/java/com/editora/editor/Minimap.java
+++ b/src/main/java/com/editora/editor/Minimap.java
@@ -60,6 +60,12 @@ final class Minimap extends Region {
 
     private boolean todoEnabled;
 
+    /** Markdown-lint warnings drawn as right-edge stripes (Markdown buffers have no LSP diagnostics, so
+     *  the right edge is free); never cached. */
+    private java.util.List<MarkdownLint.Diagnostic> lintMarks = java.util.List.of();
+
+    private boolean lintEnabled;
+
     private static final Color ERROR_STRIPE = Color.web("#e5484d");
     private static final Color WARNING_STRIPE = Color.web("#e2a03f");
     private static final Color INFO_STRIPE = Color.web("#4c8eda");
@@ -128,6 +134,21 @@ final class Minimap extends Region {
             return;
         }
         this.todoEnabled = enabled;
+        repaintStripes();
+    }
+
+    /** Sets the Markdown-lint warnings drawn as right-edge stripes; a cheap stripe-only repaint. */
+    void setLintMarks(java.util.List<MarkdownLint.Diagnostic> marks) {
+        this.lintMarks = marks == null ? java.util.List.of() : marks;
+        repaintStripes();
+    }
+
+    /** Enables/disables the lint stripes (driven by Markdown-lint-on for this buffer); a cheap repaint. */
+    void setLintEnabled(boolean enabled) {
+        if (this.lintEnabled == enabled) {
+            return;
+        }
+        this.lintEnabled = enabled;
         repaintStripes();
     }
 
@@ -227,6 +248,7 @@ final class Minimap extends Region {
         }
         drawViewport(g, w, h, total, rowHeight);
         drawDiagnosticStripes(g, w, h, total, rowHeight);
+        drawLintStripes(g, w, h, total, rowHeight);
         drawTodoStripes(g, h, total, rowHeight);
     }
 
@@ -254,6 +276,7 @@ final class Minimap extends Region {
         double rowHeight = rowHeight(h, total);
         drawViewport(g, w, h, total, rowHeight);
         drawDiagnosticStripes(g, w, h, total, rowHeight);
+        drawLintStripes(g, w, h, total, rowHeight);
         drawTodoStripes(g, h, total, rowHeight);
     }
 
@@ -306,6 +329,20 @@ final class Minimap extends Region {
             case WARNING -> WARNING_STRIPE;
             default -> INFO_STRIPE;
         };
+    }
+
+    /** Draws Markdown-lint warnings as amber stripes on the right edge (no LSP diagnostics on Markdown). */
+    private void drawLintStripes(GraphicsContext g, double w, double h, int total, double rowHeight) {
+        if (!lintEnabled || lintMarks.isEmpty() || total == 0) {
+            return;
+        }
+        double x = w - STRIPE_WIDTH;
+        double markH = Math.max(2.0, rowHeight);
+        g.setFill(WARNING_STRIPE);
+        for (MarkdownLint.Diagnostic d : lintMarks) {
+            double y = clamp(d.line() - 1, total) * rowHeight;
+            g.fillRect(x, Math.min(y, h - markH), STRIPE_WIDTH, markH);
+        }
     }
 
     /** Draws TODO/highlight matches as colored stripes on the LEFT edge (each in its pattern's color). */

--- a/src/main/java/com/editora/ui/MainController.java
+++ b/src/main/java/com/editora/ui/MainController.java
@@ -5240,12 +5240,123 @@ public class MainController implements com.editora.mcp.McpBridge {
             markdownLintPanel.setResults(null, java.util.List.of());
             return;
         }
-        markdownLintService.validate(b.getContent(), diags -> markdownLintPanel.setResults(b.getPath(), diags));
+        markdownLintService.validate(
+                b.getContent(),
+                effectiveMarkdownLintDisabled(b),
+                diags -> markdownLintPanel.setResults(b.getPath(), diags));
     }
 
     /** Toggles the Markdown Lint tool window; opening it auto-scans via {@code focusFirstItem}. */
     private void toggleMarkdownLintWindow() {
         toolWindows.toggle(markdownLintToolWindow);
+    }
+
+    /** A cached parse of one {@code .markdownlint.json} (keyed by path, invalidated by mtime). */
+    private record MarkdownLintConfigEntry(long mtime, java.util.Set<String> disabled) {}
+
+    private final java.util.Map<java.nio.file.Path, MarkdownLintConfigEntry> markdownLintConfigCache =
+            new java.util.HashMap<>();
+
+    /** The rule codes disabled for {@code buffer}: the Settings list ∪ the nearest {@code .markdownlint.json}. */
+    private java.util.Set<String> effectiveMarkdownLintDisabled(EditorBuffer buffer) {
+        java.util.Set<String> off = new java.util.HashSet<>();
+        for (String code : config.getSettings().getMarkdownLintDisabledRules()) {
+            if (code != null && !code.isBlank()) {
+                off.add(code.strip().toUpperCase(java.util.Locale.ROOT));
+            }
+        }
+        java.nio.file.Path path = buffer == null ? null : buffer.getPath();
+        if (path != null && com.editora.vfs.Vfs.isLocal(path)) {
+            off.addAll(markdownLintConfigDisabled(path));
+        }
+        return off;
+    }
+
+    /** Walks up from {@code file} for the nearest {@code .markdownlint.json} and returns the rules it disables. */
+    private java.util.Set<String> markdownLintConfigDisabled(java.nio.file.Path file) {
+        java.nio.file.Path dir = file.getParent();
+        while (dir != null) {
+            java.nio.file.Path cfg = dir.resolve(".markdownlint.json");
+            if (java.nio.file.Files.isRegularFile(cfg)) {
+                try {
+                    long mtime = java.nio.file.Files.getLastModifiedTime(cfg).toMillis();
+                    MarkdownLintConfigEntry cached = markdownLintConfigCache.get(cfg);
+                    if (cached == null || cached.mtime() != mtime) {
+                        java.util.Set<String> rules = com.editora.editor.MarkdownLintConfig.disabledRules(
+                                java.nio.file.Files.readString(cfg));
+                        cached = new MarkdownLintConfigEntry(mtime, rules);
+                        markdownLintConfigCache.put(cfg, cached);
+                    }
+                    return cached.disabled();
+                } catch (java.io.IOException e) {
+                    return java.util.Set.of();
+                }
+            }
+            dir = dir.getParent();
+        }
+        return java.util.Set.of();
+    }
+
+    /** Applies the safe-to-automate Markdown-lint fixes to the active buffer (undoable). */
+    private void fixMarkdownLint() {
+        EditorBuffer b = activeBuffer();
+        if (b == null || !b.isMarkdown()) {
+            setStatus(tr("status.markdownLint.notMarkdown"));
+            return;
+        }
+        if (!markdownLintEnabled()) {
+            setStatus(tr("status.markdownLint.off"));
+            return;
+        }
+        String text = b.getContent();
+        String fixed = com.editora.editor.MarkdownLintFix.fix(
+                text, effectiveMarkdownLintDisabled(b), config.getSettings().getTabSize());
+        if (fixed.equals(text)) {
+            setStatus(tr("status.markdownLint.fixNone"));
+            return;
+        }
+        b.getArea().replaceText(fixed); // whole-document replace (undoable)
+        setStatus(tr("status.markdownLint.fixed"));
+    }
+
+    /** Picker to enable/disable an individual Markdown-lint rule (writes Settings + re-lints live). */
+    private void chooseMarkdownLintRule() {
+        chooseSetting(
+                "markdownLint.toggleRule",
+                () -> com.editora.editor.MarkdownLint.RULES.stream()
+                        .map(com.editora.editor.MarkdownLint.Rule::code)
+                        .toList(),
+                code -> {
+                    boolean on = !markdownLintRuleDisabled(code);
+                    String name = tr("mdlint.rule." + code);
+                    return (on ? "✓ " : "✗ ") + code + " — " + name;
+                },
+                this::toggleMarkdownLintRule);
+    }
+
+    private boolean markdownLintRuleDisabled(String code) {
+        for (String c : config.getSettings().getMarkdownLintDisabledRules()) {
+            if (code.equalsIgnoreCase(c)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private void toggleMarkdownLintRule(String code) {
+        java.util.List<String> list =
+                new java.util.ArrayList<>(config.getSettings().getMarkdownLintDisabledRules());
+        boolean wasDisabled = list.removeIf(c -> code.equalsIgnoreCase(c));
+        if (!wasDisabled) {
+            list.add(code);
+        }
+        config.getSettings().setMarkdownLintDisabledRules(list);
+        requestSave();
+        applyMarkdownLint(); // re-kicks every buffer's validator (new disabled set) + refreshes the panel
+        if (settingsWindow != null) {
+            settingsWindow.syncAll();
+        }
+        setStatus(tr(wasDisabled ? "status.markdownLint.ruleEnabled" : "status.markdownLint.ruleDisabled", code));
     }
 
     /** Quick-add a highlight pattern from the palette (name → regex); full editing is in Settings. */
@@ -6518,14 +6629,15 @@ public class MainController implements com.editora.mcp.McpBridge {
         mermaid.wireBuffer(buffer); // live maid validator + initial lint state
         // Markdown linting: the overlay gets the diagnostics; the Lint tool window mirrors them live when
         // this buffer is the active one and the window is open.
-        buffer.setMarkdownLintValidator((text, cb) -> markdownLintService.validate(text, diags -> {
-            cb.accept(diags);
-            if (activeBuffer() == buffer
-                    && markdownLintToolWindow != null
-                    && toolWindows.isOpen(markdownLintToolWindow)) {
-                markdownLintPanel.setResults(buffer.getPath(), diags);
-            }
-        }));
+        buffer.setMarkdownLintValidator((text, cb) ->
+                markdownLintService.validate(text, effectiveMarkdownLintDisabled(buffer), diags -> {
+                    cb.accept(diags);
+                    if (activeBuffer() == buffer
+                            && markdownLintToolWindow != null
+                            && toolWindows.isOpen(markdownLintToolWindow)) {
+                        markdownLintPanel.setResults(buffer.getPath(), diags);
+                    }
+                }));
         buffer.setMarkdownLintEnabled(markdownLintEnabled());
         buffer.setImageDropHandler(files -> insertDroppedImages(buffer, files)); // drag image → assets/ + ![](…)
         // Hover value tooltip while suspended: evaluate the hovered identifier in the selected frame.
@@ -10503,6 +10615,7 @@ public class MainController implements com.editora.mcp.McpBridge {
                     b.getContent(), title, config.getSettings().isMathSupport());
             java.nio.file.Files.writeString(f.toPath(), html);
             setStatus(tr("status.html.exported", f.toString()));
+            openPath(f.toPath()); // show the generated HTML in a tab
         } catch (Exception ex) {
             setStatus(tr("status.html.exportFailed", String.valueOf(ex.getMessage())));
         }
@@ -12057,6 +12170,8 @@ public class MainController implements com.editora.mcp.McpBridge {
                         () -> config.getSettings().isMarkdownLint(),
                         v -> config.getSettings().setMarkdownLint(v),
                         this::applyMarkdownLint)));
+        registry.register(Command.of("markdownLint.fix", this::fixMarkdownLint));
+        registry.register(Command.of("markdownLint.toggleRule", this::chooseMarkdownLintRule));
         registry.register(Command.of(
                 "view.toggleMath",
                 () -> toggleSetting(

--- a/src/main/java/com/editora/ui/SettingsWindow.java
+++ b/src/main/java/com/editora/ui/SettingsWindow.java
@@ -68,6 +68,7 @@ public class SettingsWindow {
     private enum Category {
         APPEARANCE(tr("settings.cat.appearance"), false),
         EDITOR(tr("settings.cat.editor"), false),
+        MARKDOWN(tr("settings.cat.markdown"), false),
         TOOL_WINDOWS(tr("settings.cat.toolWindows"), false),
         SPELL_CHECK(tr("settings.cat.spellCheck"), false),
         APPLICATION(tr("settings.cat.application"), false),
@@ -156,6 +157,7 @@ public class SettingsWindow {
     private CheckBox logViewerCheck;
     private CheckBox todoHighlightCheck;
     private javafx.scene.layout.VBox todoPatternsBox;
+    private javafx.scene.layout.FlowPane markdownLintRulesBox;
     /** Working copy of the External Tools list, edited live by the master-detail page. */
     private final javafx.collections.ObservableList<com.editora.externaltool.ExternalTool> externalToolItems =
             javafx.collections.FXCollections.observableArrayList();
@@ -900,6 +902,7 @@ public class SettingsWindow {
     private void buildPages() {
         pages.put(Category.APPEARANCE, appearancePage());
         pages.put(Category.EDITOR, editorPage());
+        pages.put(Category.MARKDOWN, markdownPage());
         pages.put(Category.TOOL_WINDOWS, toolWindowsPage());
         pages.put(Category.SPELL_CHECK, spellPage());
         pages.put(Category.APPLICATION, applicationPage());
@@ -1182,15 +1185,6 @@ public class SettingsWindow {
                 completion,
                 semanticHighlightCheck,
                 "semantic highlighting lsp tokens types parameters fields deprecated");
-        Label markdown = section(p, tr("settings.section.markdown"));
-        row(
-                p,
-                Category.EDITOR,
-                markdown,
-                markdownFormatBarCheck,
-                "markdown format bar selection bold italic toolbar floating");
-        row(p, Category.EDITOR, markdown, markdownLintCheck, "markdown lint linting warnings squiggles rules");
-        row(p, Category.EDITOR, markdown, mathSupportCheck, "markdown math latex katex formula equation dollar");
         Label todoHl = section(p, tr("settings.section.todo"));
         row(p, Category.EDITOR, todoHl, todoHighlightCheck, "todo fixme highlight patterns tags comments annotations");
         row(p, Category.EDITOR, todoHl, todoPatternsEditor(), "todo fixme pattern regex color add remove edit");
@@ -1214,6 +1208,67 @@ public class SettingsWindow {
                 labeled(tr("settings.pdf.pageSize"), pdfPageSizeCombo),
                 "pdf export page size letter a4 paper");
         return p;
+    }
+
+    /** The Markdown settings page: editing (format bar), preview/PDF (math), and linting (enable + per-rule). */
+    private Region markdownPage() {
+        VBox p = page(tr("settings.cat.markdown"));
+        Label editing = section(p, tr("settings.section.markdownEditing"));
+        row(
+                p,
+                Category.MARKDOWN,
+                editing,
+                markdownFormatBarCheck,
+                "markdown format bar selection bold italic toolbar floating");
+        Label preview = section(p, tr("settings.section.markdownPreview"));
+        row(p, Category.MARKDOWN, preview, mathSupportCheck, "markdown math latex katex formula equation dollar");
+        Label lint = section(p, tr("settings.section.markdownLint"));
+        row(p, Category.MARKDOWN, lint, markdownLintCheck, "markdown lint linting warnings squiggles rules");
+        row(
+                p,
+                Category.MARKDOWN,
+                lint,
+                markdownLintRulesEditor(),
+                "markdown lint rules MD009 MD040 MD034 disable enable per-rule checklist");
+        return p;
+    }
+
+    /** The Markdown-lint per-rule checklist: one checkbox per rule (checked = enabled). Toggling writes the
+     *  disabled rule codes to {@code Settings.markdownLintDisabledRules} and applies live. */
+    private javafx.scene.Node markdownLintRulesEditor() {
+        markdownLintRulesBox = new javafx.scene.layout.FlowPane(12, 4);
+        rebuildMarkdownLintRules();
+        return markdownLintRulesBox;
+    }
+
+    private void rebuildMarkdownLintRules() {
+        if (markdownLintRulesBox == null) {
+            return;
+        }
+        markdownLintRulesBox.getChildren().clear();
+        java.util.Set<String> disabled = new java.util.HashSet<>();
+        for (String c : config.getSettings().getMarkdownLintDisabledRules()) {
+            if (c != null) {
+                disabled.add(c.strip().toUpperCase(java.util.Locale.ROOT));
+            }
+        }
+        for (com.editora.editor.MarkdownLint.Rule rule : com.editora.editor.MarkdownLint.RULES) {
+            String code = rule.code();
+            CheckBox cb = new CheckBox(code);
+            cb.setSelected(!disabled.contains(code));
+            cb.setTooltip(new Tooltip(tr("mdlint.rule." + code)));
+            cb.selectedProperty().addListener((o, was, on) -> {
+                java.util.List<String> list =
+                        new java.util.ArrayList<>(config.getSettings().getMarkdownLintDisabledRules());
+                list.removeIf(c -> code.equalsIgnoreCase(c));
+                if (!on) {
+                    list.add(code);
+                }
+                config.getSettings().setMarkdownLintDisabledRules(list);
+                apply();
+            });
+            markdownLintRulesBox.getChildren().add(cb);
+        }
     }
 
     /** The TODO/highlight pattern editor: one row per pattern (enabled / name / regex / color / case) plus
@@ -2914,6 +2969,7 @@ public class SettingsWindow {
             logViewerCheck.setSelected(settings.isLogViewer());
             todoHighlightCheck.setSelected(settings.isTodoHighlight());
             rebuildTodoRows();
+            rebuildMarkdownLintRules();
             multiCaretCheck.setSelected(settings.isMultiCaret());
             projectsCheck.setSelected(settings.isProjectSupport());
             updateProjectRowEnabled();
@@ -3408,6 +3464,7 @@ public class SettingsWindow {
             logViewerCheck.setSelected(s.isLogViewer());
             todoHighlightCheck.setSelected(s.isTodoHighlight());
             rebuildTodoRows();
+            rebuildMarkdownLintRules();
             indentStyleCombo.setValue(s.getIndentStyle());
             multiCaretCheck.setSelected(s.isMultiCaret());
             projectsCheck.setSelected(s.isProjectSupport());

--- a/src/main/resources/com/editora/i18n/messages.properties
+++ b/src/main/resources/com/editora/i18n/messages.properties
@@ -2044,3 +2044,37 @@ search.globsTip=Comma-separated globs (gitignore-style)
 settings.projectShowHidden=Show hidden files in the project tree
 command.view.toggleProjectHidden=Toggle Hidden Files in Project Tree
 command.view.toggleProjectHidden.desc=Show or hide hidden (dot) files and folders in the Project tool window
+
+# --- Markdown lint (extensions: rules, per-rule config, fix) ---
+command.markdownLint.fix=Markdown Lint: Fix Issues
+command.markdownLint.fix.desc=Auto-fix the safely-correctable Markdown lint issues (whitespace, headings, blank lines) in the active file.
+command.markdownLint.toggleRule=Markdown Lint: Enable/Disable Rule
+command.markdownLint.toggleRule.desc=Turn an individual Markdown lint rule on or off (persisted in Settings).
+status.markdownLint.notMarkdown=Not a Markdown file
+status.markdownLint.off=Markdown lint is disabled
+status.markdownLint.fixNone=No auto-fixable Markdown lint issues
+status.markdownLint.fixed=Fixed Markdown lint issues
+status.markdownLint.ruleEnabled=Enabled Markdown lint rule {0}
+status.markdownLint.ruleDisabled=Disabled Markdown lint rule {0}
+mdlint.rule.MD001=Heading levels increment by one
+mdlint.rule.MD009=Trailing whitespace
+mdlint.rule.MD010=Hard tabs
+mdlint.rule.MD012=Multiple consecutive blank lines
+mdlint.rule.MD018=No space after heading marker
+mdlint.rule.MD019=Multiple spaces after heading marker
+mdlint.rule.MD022=Headings surrounded by blank lines
+mdlint.rule.MD023=Headings start at line beginning
+mdlint.rule.MD025=Single top-level heading
+mdlint.rule.MD026=No trailing punctuation in heading
+mdlint.rule.MD031=Fenced code surrounded by blank lines
+mdlint.rule.MD034=No bare URLs
+mdlint.rule.MD040=Fenced code should specify a language
+mdlint.rule.MD041=First line should be a top-level heading
+mdlint.rule.MD047=File should end with a single newline
+mdlint.rule.MD052=Reference links have a definition
+
+# --- Markdown settings page ---
+settings.cat.markdown=Markdown
+settings.section.markdownEditing=Editing
+settings.section.markdownPreview=Preview & PDF
+settings.section.markdownLint=Linting

--- a/src/main/resources/com/editora/i18n/messages_de.properties
+++ b/src/main/resources/com/editora/i18n/messages_de.properties
@@ -2036,3 +2036,37 @@ search.globsTip=Kommagetrennte Globs (im .gitignore-Stil)
 settings.projectShowHidden=Versteckte Dateien im Projektbaum anzeigen
 command.view.toggleProjectHidden=Versteckte Dateien im Projektbaum umschalten
 command.view.toggleProjectHidden.desc=Versteckte (Punkt-)Dateien und -Ordner im Projektfenster ein- oder ausblenden
+
+# --- Markdown lint (extensions: rules, per-rule config, fix) ---
+command.markdownLint.fix=Markdown-Lint: Probleme beheben
+command.markdownLint.fix.desc=Behebt automatisch die sicher korrigierbaren Markdown-Lint-Probleme (Leerzeichen, Überschriften, Leerzeilen) in der aktiven Datei.
+command.markdownLint.toggleRule=Markdown-Lint: Regel aktivieren/deaktivieren
+command.markdownLint.toggleRule.desc=Schaltet eine einzelne Markdown-Lint-Regel ein oder aus (in den Einstellungen gespeichert).
+status.markdownLint.notMarkdown=Keine Markdown-Datei
+status.markdownLint.off=Markdown-Lint ist deaktiviert
+status.markdownLint.fixNone=Keine automatisch behebbaren Markdown-Lint-Probleme
+status.markdownLint.fixed=Markdown-Lint-Probleme behoben
+status.markdownLint.ruleEnabled=Markdown-Lint-Regel {0} aktiviert
+status.markdownLint.ruleDisabled=Markdown-Lint-Regel {0} deaktiviert
+mdlint.rule.MD001=Überschriftenebenen steigen um eins
+mdlint.rule.MD009=Nachgestellte Leerzeichen
+mdlint.rule.MD010=Tabulatoren
+mdlint.rule.MD012=Mehrere aufeinanderfolgende Leerzeilen
+mdlint.rule.MD018=Kein Leerzeichen nach Überschriftenmarkierung
+mdlint.rule.MD019=Mehrere Leerzeichen nach Überschriftenmarkierung
+mdlint.rule.MD022=Überschriften von Leerzeilen umgeben
+mdlint.rule.MD023=Überschriften beginnen am Zeilenanfang
+mdlint.rule.MD025=Nur eine Überschrift oberster Ebene
+mdlint.rule.MD026=Keine abschließende Interpunktion in Überschrift
+mdlint.rule.MD031=Codeblöcke von Leerzeilen umgeben
+mdlint.rule.MD034=Keine nackten URLs
+mdlint.rule.MD040=Codeblock sollte eine Sprache angeben
+mdlint.rule.MD041=Erste Zeile sollte eine Überschrift oberster Ebene sein
+mdlint.rule.MD047=Datei sollte mit einer einzelnen Leerzeile enden
+mdlint.rule.MD052=Referenzlinks haben eine Definition
+
+# --- Markdown settings page ---
+settings.cat.markdown=Markdown
+settings.section.markdownEditing=Bearbeitung
+settings.section.markdownPreview=Vorschau & PDF
+settings.section.markdownLint=Linting

--- a/src/main/resources/com/editora/i18n/messages_es.properties
+++ b/src/main/resources/com/editora/i18n/messages_es.properties
@@ -2036,3 +2036,37 @@ search.globsTip=Globs separados por comas (estilo .gitignore)
 settings.projectShowHidden=Mostrar archivos ocultos en el \u00E1rbol del proyecto
 command.view.toggleProjectHidden=Alternar archivos ocultos en el \u00E1rbol del proyecto
 command.view.toggleProjectHidden.desc=Muestra u oculta los archivos y carpetas ocultos (con punto) en la ventana Proyecto
+
+# --- Markdown lint (extensions: rules, per-rule config, fix) ---
+command.markdownLint.fix=Lint Markdown: Corregir problemas
+command.markdownLint.fix.desc=Corrige automáticamente los problemas de lint Markdown corregibles con seguridad (espacios, encabezados, líneas en blanco) en el archivo activo.
+command.markdownLint.toggleRule=Lint Markdown: Activar/Desactivar regla
+command.markdownLint.toggleRule.desc=Activa o desactiva una regla de lint Markdown concreta (guardada en Ajustes).
+status.markdownLint.notMarkdown=No es un archivo Markdown
+status.markdownLint.off=El lint Markdown está desactivado
+status.markdownLint.fixNone=No hay problemas de lint Markdown corregibles
+status.markdownLint.fixed=Problemas de lint Markdown corregidos
+status.markdownLint.ruleEnabled=Regla de lint Markdown {0} activada
+status.markdownLint.ruleDisabled=Regla de lint Markdown {0} desactivada
+mdlint.rule.MD001=Los niveles de encabezado aumentan de uno en uno
+mdlint.rule.MD009=Espacios finales
+mdlint.rule.MD010=Tabulaciones
+mdlint.rule.MD012=Varias líneas en blanco consecutivas
+mdlint.rule.MD018=Sin espacio tras el marcador de encabezado
+mdlint.rule.MD019=Varios espacios tras el marcador de encabezado
+mdlint.rule.MD022=Encabezados rodeados de líneas en blanco
+mdlint.rule.MD023=Los encabezados empiezan al inicio de la línea
+mdlint.rule.MD025=Un único encabezado de nivel superior
+mdlint.rule.MD026=Sin puntuación final en el encabezado
+mdlint.rule.MD031=Bloques de código rodeados de líneas en blanco
+mdlint.rule.MD034=Sin URLs sueltas
+mdlint.rule.MD040=El bloque de código debe especificar un lenguaje
+mdlint.rule.MD041=La primera línea debe ser un encabezado de nivel superior
+mdlint.rule.MD047=El archivo debe terminar con una sola línea nueva
+mdlint.rule.MD052=Los enlaces de referencia tienen definición
+
+# --- Markdown settings page ---
+settings.cat.markdown=Markdown
+settings.section.markdownEditing=Edición
+settings.section.markdownPreview=Vista previa y PDF
+settings.section.markdownLint=Linting

--- a/src/main/resources/com/editora/i18n/messages_fr.properties
+++ b/src/main/resources/com/editora/i18n/messages_fr.properties
@@ -2036,3 +2036,37 @@ search.globsTip=Globs s\u00E9par\u00E9s par des virgules (style .gitignore)
 settings.projectShowHidden=Afficher les fichiers cachés dans l'arborescence du projet
 command.view.toggleProjectHidden=Basculer les fichiers cachés dans l'arborescence du projet
 command.view.toggleProjectHidden.desc=Affiche ou masque les fichiers et dossiers cachés (avec un point) dans la fenêtre Projet
+
+# --- Markdown lint (extensions: rules, per-rule config, fix) ---
+command.markdownLint.fix=Lint Markdown : Corriger les problèmes
+command.markdownLint.fix.desc=Corrige automatiquement les problèmes de lint Markdown corrigeables sans risque (espaces, titres, lignes vides) dans le fichier actif.
+command.markdownLint.toggleRule=Lint Markdown : Activer/Désactiver une règle
+command.markdownLint.toggleRule.desc=Active ou désactive une règle de lint Markdown précise (enregistrée dans les Préférences).
+status.markdownLint.notMarkdown=Pas un fichier Markdown
+status.markdownLint.off=Le lint Markdown est désactivé
+status.markdownLint.fixNone=Aucun problème de lint Markdown corrigeable
+status.markdownLint.fixed=Problèmes de lint Markdown corrigés
+status.markdownLint.ruleEnabled=Règle de lint Markdown {0} activée
+status.markdownLint.ruleDisabled=Règle de lint Markdown {0} désactivée
+mdlint.rule.MD001=Les niveaux de titre augmentent d'un seul
+mdlint.rule.MD009=Espaces en fin de ligne
+mdlint.rule.MD010=Tabulations
+mdlint.rule.MD012=Plusieurs lignes vides consécutives
+mdlint.rule.MD018=Pas d'espace après le marqueur de titre
+mdlint.rule.MD019=Plusieurs espaces après le marqueur de titre
+mdlint.rule.MD022=Titres entourés de lignes vides
+mdlint.rule.MD023=Les titres commencent en début de ligne
+mdlint.rule.MD025=Un seul titre de niveau supérieur
+mdlint.rule.MD026=Pas de ponctuation finale dans le titre
+mdlint.rule.MD031=Blocs de code entourés de lignes vides
+mdlint.rule.MD034=Pas d'URL brute
+mdlint.rule.MD040=Le bloc de code doit indiquer un langage
+mdlint.rule.MD041=La première ligne doit être un titre de niveau supérieur
+mdlint.rule.MD047=Le fichier doit se terminer par une seule nouvelle ligne
+mdlint.rule.MD052=Les liens de référence ont une définition
+
+# --- Markdown settings page ---
+settings.cat.markdown=Markdown
+settings.section.markdownEditing=Édition
+settings.section.markdownPreview=Aperçu et PDF
+settings.section.markdownLint=Analyse (lint)

--- a/src/main/resources/com/editora/i18n/messages_it.properties
+++ b/src/main/resources/com/editora/i18n/messages_it.properties
@@ -2036,3 +2036,37 @@ search.globsTip=Glob separati da virgola (stile .gitignore)
 settings.projectShowHidden=Mostra i file nascosti nell'albero del progetto
 command.view.toggleProjectHidden=Attiva/disattiva i file nascosti nell'albero del progetto
 command.view.toggleProjectHidden.desc=Mostra o nasconde i file e le cartelle nascosti (con punto) nella finestra Progetto
+
+# --- Markdown lint (extensions: rules, per-rule config, fix) ---
+command.markdownLint.fix=Lint Markdown: Correggi problemi
+command.markdownLint.fix.desc=Corregge automaticamente i problemi di lint Markdown correggibili in modo sicuro (spazi, intestazioni, righe vuote) nel file attivo.
+command.markdownLint.toggleRule=Lint Markdown: Abilita/Disabilita regola
+command.markdownLint.toggleRule.desc=Attiva o disattiva una singola regola di lint Markdown (salvata nelle Impostazioni).
+status.markdownLint.notMarkdown=Non è un file Markdown
+status.markdownLint.off=Il lint Markdown è disabilitato
+status.markdownLint.fixNone=Nessun problema di lint Markdown correggibile
+status.markdownLint.fixed=Problemi di lint Markdown corretti
+status.markdownLint.ruleEnabled=Regola di lint Markdown {0} abilitata
+status.markdownLint.ruleDisabled=Regola di lint Markdown {0} disabilitata
+mdlint.rule.MD001=I livelli di intestazione aumentano di uno
+mdlint.rule.MD009=Spazi finali
+mdlint.rule.MD010=Tabulazioni
+mdlint.rule.MD012=Più righe vuote consecutive
+mdlint.rule.MD018=Nessuno spazio dopo il marcatore di intestazione
+mdlint.rule.MD019=Più spazi dopo il marcatore di intestazione
+mdlint.rule.MD022=Intestazioni circondate da righe vuote
+mdlint.rule.MD023=Le intestazioni iniziano a inizio riga
+mdlint.rule.MD025=Una sola intestazione di primo livello
+mdlint.rule.MD026=Nessuna punteggiatura finale nell'intestazione
+mdlint.rule.MD031=Blocchi di codice circondati da righe vuote
+mdlint.rule.MD034=Nessun URL nudo
+mdlint.rule.MD040=Il blocco di codice deve specificare un linguaggio
+mdlint.rule.MD041=La prima riga deve essere un'intestazione di primo livello
+mdlint.rule.MD047=Il file deve terminare con una sola riga vuota
+mdlint.rule.MD052=I link di riferimento hanno una definizione
+
+# --- Markdown settings page ---
+settings.cat.markdown=Markdown
+settings.section.markdownEditing=Modifica
+settings.section.markdownPreview=Anteprima e PDF
+settings.section.markdownLint=Linting

--- a/src/main/resources/com/editora/i18n/messages_pt.properties
+++ b/src/main/resources/com/editora/i18n/messages_pt.properties
@@ -2036,3 +2036,37 @@ search.globsTip=Globs separados por v\u00EDrgula (estilo .gitignore)
 settings.projectShowHidden=Mostrar arquivos ocultos na árvore do projeto
 command.view.toggleProjectHidden=Alternar arquivos ocultos na árvore do projeto
 command.view.toggleProjectHidden.desc=Mostra ou oculta arquivos e pastas ocultos (com ponto) na janela Projeto
+
+# --- Markdown lint (extensions: rules, per-rule config, fix) ---
+command.markdownLint.fix=Lint Markdown: Corrigir problemas
+command.markdownLint.fix.desc=Corrige automaticamente os problemas de lint Markdown corrigíveis com segurança (espaços, títulos, linhas em branco) no ficheiro ativo.
+command.markdownLint.toggleRule=Lint Markdown: Ativar/Desativar regra
+command.markdownLint.toggleRule.desc=Ativa ou desativa uma regra de lint Markdown específica (guardada nas Definições).
+status.markdownLint.notMarkdown=Não é um ficheiro Markdown
+status.markdownLint.off=O lint Markdown está desativado
+status.markdownLint.fixNone=Não há problemas de lint Markdown corrigíveis
+status.markdownLint.fixed=Problemas de lint Markdown corrigidos
+status.markdownLint.ruleEnabled=Regra de lint Markdown {0} ativada
+status.markdownLint.ruleDisabled=Regra de lint Markdown {0} desativada
+mdlint.rule.MD001=Os níveis de título aumentam de um em um
+mdlint.rule.MD009=Espaços no fim da linha
+mdlint.rule.MD010=Tabulações
+mdlint.rule.MD012=Várias linhas em branco consecutivas
+mdlint.rule.MD018=Sem espaço após o marcador de título
+mdlint.rule.MD019=Vários espaços após o marcador de título
+mdlint.rule.MD022=Títulos rodeados por linhas em branco
+mdlint.rule.MD023=Os títulos começam no início da linha
+mdlint.rule.MD025=Um único título de nível superior
+mdlint.rule.MD026=Sem pontuação final no título
+mdlint.rule.MD031=Blocos de código rodeados por linhas em branco
+mdlint.rule.MD034=Sem URLs soltos
+mdlint.rule.MD040=O bloco de código deve especificar uma linguagem
+mdlint.rule.MD041=A primeira linha deve ser um título de nível superior
+mdlint.rule.MD047=O ficheiro deve terminar com uma única nova linha
+mdlint.rule.MD052=As ligações de referência têm definição
+
+# --- Markdown settings page ---
+settings.cat.markdown=Markdown
+settings.section.markdownEditing=Edição
+settings.section.markdownPreview=Pré-visualização e PDF
+settings.section.markdownLint=Linting

--- a/src/test/java/com/editora/editor/MarkdownLintConfigTest.java
+++ b/src/test/java/com/editora/editor/MarkdownLintConfigTest.java
@@ -1,0 +1,39 @@
+package com.editora.editor;
+
+import java.util.Set;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/** Unit tests for the {@code .markdownlint.json} parser. */
+class MarkdownLintConfigTest {
+
+    @Test
+    void disablesAnExplicitFalseRule() {
+        Set<String> off = MarkdownLintConfig.disabledRules("{\"MD013\": false, \"MD009\": true}");
+        assertTrue(off.contains("MD013"));
+        assertFalse(off.contains("MD009"));
+    }
+
+    @Test
+    void defaultFalseDisablesAllThenReEnables() {
+        Set<String> off = MarkdownLintConfig.disabledRules("{\"default\": false, \"MD009\": true}");
+        assertTrue(off.contains("MD040"));
+        assertFalse(off.contains("MD009"));
+    }
+
+    @Test
+    void caseInsensitiveKeys() {
+        assertTrue(MarkdownLintConfig.disabledRules("{\"md040\": false}").contains("MD040"));
+    }
+
+    @Test
+    void toleratesMalformedOrEmpty() {
+        assertTrue(MarkdownLintConfig.disabledRules("not json").isEmpty());
+        assertTrue(MarkdownLintConfig.disabledRules("").isEmpty());
+        assertTrue(MarkdownLintConfig.disabledRules(null).isEmpty());
+        assertTrue(MarkdownLintConfig.disabledRules("[1,2,3]").isEmpty());
+    }
+}

--- a/src/test/java/com/editora/editor/MarkdownLintDirectivesTest.java
+++ b/src/test/java/com/editora/editor/MarkdownLintDirectivesTest.java
@@ -1,0 +1,58 @@
+package com.editora.editor;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/** Unit tests for the inline markdownlint directive parser. */
+class MarkdownLintDirectivesTest {
+
+    private static MarkdownLintDirectives of(String text) {
+        return MarkdownLintDirectives.compute(text.split("\n", -1));
+    }
+
+    @Test
+    void disableRegionForListedRule() {
+        MarkdownLintDirectives d = of("<!-- markdownlint-disable MD009 -->\nline\nline");
+        assertTrue(d.disabled(1, "MD009"));
+        assertTrue(d.disabled(2, "MD009"));
+        assertFalse(d.disabled(1, "MD040"));
+    }
+
+    @Test
+    void enableReopensRegion() {
+        MarkdownLintDirectives d = of("<!-- markdownlint-disable MD009 -->\na\n<!-- markdownlint-enable MD009 -->\nb");
+        assertTrue(d.disabled(1, "MD009"));
+        assertFalse(d.disabled(3, "MD009"));
+    }
+
+    @Test
+    void disableAllWildcard() {
+        MarkdownLintDirectives d = of("<!-- markdownlint-disable -->\nx");
+        assertTrue(d.disabled(1, "MD009"));
+        assertTrue(d.disabled(1, "MD040"));
+    }
+
+    @Test
+    void disableLineIsScopedToTheSameLine() {
+        MarkdownLintDirectives d = of("a <!-- markdownlint-disable-line MD009 -->\nb");
+        assertTrue(d.disabled(0, "MD009"));
+        assertFalse(d.disabled(1, "MD009"));
+    }
+
+    @Test
+    void disableNextLineIsScopedToTheFollowingLine() {
+        MarkdownLintDirectives d = of("<!-- markdownlint-disable-next-line MD009 -->\nb\nc");
+        assertFalse(d.disabled(0, "MD009"));
+        assertTrue(d.disabled(1, "MD009"));
+        assertFalse(d.disabled(2, "MD009"));
+    }
+
+    @Test
+    void outOfRangeLineIsNeverDisabled() {
+        MarkdownLintDirectives d = of("plain");
+        assertFalse(d.disabled(99, "MD009"));
+        assertFalse(d.disabled(-1, "MD009"));
+    }
+}

--- a/src/test/java/com/editora/editor/MarkdownLintFixTest.java
+++ b/src/test/java/com/editora/editor/MarkdownLintFixTest.java
@@ -1,0 +1,76 @@
+package com.editora.editor;
+
+import java.util.Set;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/** Unit tests for the pure Markdown-lint auto-fixer. */
+class MarkdownLintFixTest {
+
+    private static String fix(String md) {
+        return MarkdownLintFix.fix(md, Set.of(), 4);
+    }
+
+    @Test
+    void md009StripsTrailingWhitespace() {
+        assertEquals("a\nb\n", fix("a   \nb\n"));
+    }
+
+    @Test
+    void md010ConvertsTabsToSpaces() {
+        assertEquals("  x\n", MarkdownLintFix.fix("\tx\n", Set.of(), 2));
+    }
+
+    @Test
+    void md012CollapsesBlankRuns() {
+        assertEquals("a\n\nb\n", fix("a\n\n\n\nb\n"));
+    }
+
+    @Test
+    void md018And019FixHeadingSpacing() {
+        assertEquals("# x\n", fix("#x\n"));
+        assertEquals("# x\n", fix("#   x\n"));
+    }
+
+    @Test
+    void md023DeIndentsHeadings() {
+        assertEquals("# x\n", fix("   # x\n"));
+    }
+
+    @Test
+    void md026StripsHeadingTrailingPunctuation() {
+        assertEquals("# Title\n", fix("# Title.\n"));
+    }
+
+    @Test
+    void md047EnsuresSingleFinalNewline() {
+        assertEquals("# T\n", fix("# T"));
+        assertEquals("# T\n", fix("# T\n\n\n"));
+    }
+
+    @Test
+    void idempotent() {
+        String once = fix("#x  \n\n\n##y.\n");
+        assertEquals(once, fix(once));
+    }
+
+    @Test
+    void respectsDisabledRules() {
+        assertEquals("a   \n", MarkdownLintFix.fix("a   \n", Set.of("MD009"), 4));
+    }
+
+    @Test
+    void leavesCodeBlocksUntouched() {
+        String md = "# T\n\n```\n\tcode  \n```\n";
+        // tabs/trailing-ws inside the fence are preserved verbatim.
+        assertEquals(md, fix(md));
+    }
+
+    @Test
+    void emptyAndNull() {
+        assertEquals("", fix(""));
+        assertEquals(null, MarkdownLintFix.fix(null, Set.of(), 4));
+    }
+}

--- a/src/test/java/com/editora/editor/MarkdownLintTest.java
+++ b/src/test/java/com/editora/editor/MarkdownLintTest.java
@@ -81,4 +81,70 @@ class MarkdownLintTest {
         assertTrue(MarkdownLint.lint(null).isEmpty());
         assertTrue(MarkdownLint.lint("").isEmpty());
     }
+
+    @Test
+    void md001HeadingIncrement() {
+        assertTrue(has("# A\n\n### C\n", "MD001"));
+        assertFalse(has("# A\n\n## B\n", "MD001"));
+    }
+
+    @Test
+    void md010HardTabs() {
+        assertTrue(has("text\twith tab\n", "MD010"));
+        assertFalse(has("text with spaces\n", "MD010"));
+    }
+
+    @Test
+    void md022HeadingsSurroundedByBlanks() {
+        assertTrue(has("# A\ntext\n", "MD022")); // heading not followed by a blank line
+        assertFalse(has("# A\n\ntext\n", "MD022"));
+    }
+
+    @Test
+    void md023HeadingIndent() {
+        assertTrue(has("  ## Indented\n", "MD023"));
+        assertFalse(has("## Flush\n", "MD023"));
+    }
+
+    @Test
+    void md026HeadingTrailingPunctuation() {
+        assertTrue(has("# Title.\n", "MD026"));
+        assertTrue(has("## Done! ##\n", "MD026")); // closing-hash form
+        assertFalse(has("# Title\n", "MD026"));
+    }
+
+    @Test
+    void md031FencedCodeSurroundedByBlanks() {
+        assertTrue(has("text\n\n```java\ncode\n```\ntext\n", "MD031")); // no blank after the fence
+        assertFalse(has("text\n\n```java\ncode\n```\n\ntext\n", "MD031"));
+    }
+
+    @Test
+    void md034BareUrl() {
+        assertTrue(has("See https://example.com here.\n", "MD034"));
+        assertFalse(has("See [x](https://example.com) here.\n", "MD034"));
+        assertFalse(has("See <https://example.com> here.\n", "MD034"));
+    }
+
+    @Test
+    void md041FirstLineHeading() {
+        assertTrue(has("Not a heading\n", "MD041"));
+        assertFalse(has("# Heading\n", "MD041"));
+        assertFalse(has("---\ntitle: x\n---\n\n# Heading\n", "MD041")); // front matter is skipped
+    }
+
+    @Test
+    void perRuleDisabledSuppressesEmission() {
+        assertFalse(MarkdownLint.lint("#Heading\n", Set.of("MD018")).stream()
+                .anyMatch(d -> d.code().equals("MD018")));
+    }
+
+    @Test
+    void inlineDisableDirectiveSuppresses() {
+        assertFalse(MarkdownLint.lint("<!-- markdownlint-disable MD018 -->\n#Heading\n").stream()
+                .anyMatch(d -> d.code().equals("MD018")));
+        assertFalse(MarkdownLint.lint("<!-- markdownlint-disable-next-line MD018 -->\n#Heading\n").stream()
+                .anyMatch(d -> d.code().equals("MD018")));
+        assertTrue(has("#Heading\n", "MD018")); // still flagged without the directive
+    }
 }


### PR DESCRIPTION
Extends the (already-shipped) Markdown linter and gives Markdown its own Settings page.

## Linter
- **New rules** — MD001 (heading increment), MD010 (hard tabs), MD022 (headings surrounded by blanks), MD023 (heading indent), MD026 (heading trailing punctuation), MD031 (fenced code surrounded by blanks), MD034 (bare URLs), MD041 (first-line H1) — now **16 rules**.
- **Per-rule config** — `Settings.markdownLintDisabledRules` (schema 39→40), a per-rule checklist in Settings, and the `markdownLint.toggleRule` palette picker.
- **Inline directives** — `<!-- markdownlint-disable/enable/disable-line/disable-next-line MDxxx -->` (new pure `MarkdownLintDirectives`).
- **`.markdownlint.json` discovery** — nearest config file merged into the disabled set (`MarkdownLintConfig`, mtime-cached).
- **Auto-fix** — `markdownLint.fix` corrects the mechanical issues (whitespace, tabs, blank-line runs, heading spacing/indent/punctuation, final newline) as one undoable edit (`MarkdownLintFix`).

## Surfacing
- **Overview stripe + minimap ticks** — dedicated `MarkdownLintStripe` over the scrollbar (click-to-jump, hover for `MDxxx: message`) + minimap ticks, on a channel separate from the LSP diagnostic stripe so a settings-apply can't wipe it.

## Settings
- Markdown options moved out of *Editor* into their own **Settings → Markdown** page (Editing / Preview & PDF / Linting sections).

## Misc
- **Preview: Export to HTML** now opens the generated `.html` in a tab.

## Tests / gates
- 4 new/extended pure suites (rules, directives, fix, config). `mvn verify` green: **1119 tests**, JaCoCo floors met, Spotless clean. i18n in all six catalogs (key-parity enforced).

🤖 Generated with [Claude Code](https://claude.com/claude-code)