### PR TITLE
docs: developer/contributor documentation under docs/

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,49 @@
+# Contributing to Editora
+
+Thanks for hacking on Editora. This is the short version; the full developer documentation is
+in [`docs/`](docs/README.md).
+
+## Setup
+
+- **JDK 25** and Maven (the bundled `./mvnw` wrapper works).
+- Run the app: `mvn javafx:run`
+- Run tests: `mvn test`
+- Format + verify before pushing: `mvn spotless:apply && mvn verify`
+
+See [`docs/building-and-packaging.md`](docs/building-and-packaging.md) for the dist build,
+fat jar, and packaging.
+
+## Workflow
+
+1. **Branch in a worktree** — `scripts/worktree.sh new feat/my-thing` (off `origin/master`),
+   then work in `../Editora-V2-worktrees/<slug>`. Don't `git checkout` another branch in the
+   main checkout. ([why](docs/conventions.md#worktrees-one-per-task))
+2. **Make the change**, following the conventions below.
+3. **`mvn spotless:apply`**, then **`mvn verify`** (runs all tests + the Spotless check + the
+   JaCoCo coverage floors).
+4. **Update docs in the same PR**: `CHANGELOG.md`, `README.md`, `TODO.md`.
+5. Open a PR against `master`.
+
+## The conventions that get PRs bounced
+
+Read [`docs/conventions.md`](docs/conventions.md) in full once. The high points:
+
+- **Every feature is a `Command`**, registered and palette-discoverable.
+- **Every setting also needs a palette command** that flips the same `Settings` field.
+- **Localize every user-facing string** — add the key to **all six** `messages*.properties`
+  catalogs (key-parity is enforced by `MessagesTest`); every `command.<id>` needs a `.desc`.
+- **Bump `SCHEMA_VERSION` + add a migration step** for any config-schema change.
+- **Performance is a first-class constraint** — never block the FX thread; debounce and
+  coalesce; only do work on what's visible. See [`docs/performance.md`](docs/performance.md),
+  and state the hot-path cost of your change in the PR.
+
+## Finding your way
+
+- New here? Start with [`docs/architecture.md`](docs/architecture.md).
+- Adding a command / LSP server / grammar / tool window / overlay? The recipes are in
+  [`docs/extending.md`](docs/extending.md).
+- Writing tests (incl. the headless-FX harness): [`docs/testing.md`](docs/testing.md).
+- Building a plugin (the public extension API): [`docs/plugins.md`](docs/plugins.md).
+
+The exhaustive subsystem reference is [`CLAUDE.md`](CLAUDE.md); the `docs/` guides are the
+readable distillation of it.

--- a/README.md
+++ b/README.md
@@ -378,6 +378,11 @@ show it.
 
 ## Contributing
 
+See [`CONTRIBUTING.md`](CONTRIBUTING.md) for the workflow, and the **developer documentation** in
+[`docs/`](docs/README.md) — architecture, the conventions a change must follow, performance rules, an
+extension cookbook (add a command / LSP server / grammar / tool window / overlay), and build/test/release
+guides. (User-facing docs live in the separate website repo; `docs/` is for contributors.)
+
 All Java is auto-formatted with [Palantir Java Format](https://github.com/palantir/palantir-java-format)
 (a lambda-friendly, 120-column fork of google-java-format), enforced by the
 [Spotless](https://github.com/diffplug/spotless) Maven plugin. **Run `./mvnw spotless:apply` before
@@ -395,8 +400,10 @@ Two conventions the build checks for:
 - **Every action is a command.** User-facing features are registered in the command registry so they
   appear in the command palette (`M-x`); toolbar buttons and keybindings dispatch through commands too.
 
-Tests cover pure logic only (`./mvnw test`) — there is no GUI/toolkit test harness, so verify
-interactive behavior by running the app (`./mvnw javafx:run`).
+Tests are mostly pure logic, plus a headless-FX (TestFX + Monocle) harness for toolkit-bound behavior —
+run all with `./mvnw test`, or the pure suite alone with `./mvnw test -DexcludedGroups=fx`. `./mvnw verify`
+also enforces the Spotless check and the JaCoCo per-package coverage floors. See
+[`docs/testing.md`](docs/testing.md).
 
 ## Releases
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,33 @@
+# Developer documentation
+
+Guides for working **on** Editora. User-facing documentation lives in the separate website
+repository; this folder is for contributors.
+
+The exhaustive, terse subsystem reference is the root [`CLAUDE.md`](../CLAUDE.md). These guides
+are the readable distillation of it — when they disagree with the code, the code wins.
+
+## Start here
+
+- [architecture.md](architecture.md) — module map, boot path, the multi-window model, the
+  `EditorBuffer`/`TabContent` abstraction, and the recurring patterns.
+- [conventions.md](conventions.md) — the rules a change must follow (commands, settings, i18n,
+  schema, formatting, worktrees). See also [`../CONTRIBUTING.md`](../CONTRIBUTING.md).
+- [performance.md](performance.md) — the hot paths and the discipline that keeps the editor
+  responsive. Read before touching highlighting, overlays, the gutter, or scrolling.
+
+## How-to
+
+- [extending.md](extending.md) — recipes: add a command, a setting, an LSP server, a DAP
+  adapter, a language/grammar, a tool window, a Canvas overlay, a feature coordinator.
+- [plugins.md](plugins.md) — the public plugin API (SPI + declarative manifest), building,
+  packaging, and the registry. The full plugin catalog lives in the
+  [editora-plugins](https://github.com/adriandeleon/editora-plugins) repo.
+
+## Build, test, ship
+
+- [building-and-packaging.md](building-and-packaging.md) — run, dist/jpackage, the AOT cache,
+  fat jar, the per-OS Prism pipeline.
+- [dependencies.md](dependencies.md) — the vendored/forked/repackaged deps (RichTextFX fork,
+  Monocle, tm4e) and the moditect story.
+- [testing.md](testing.md) — pure tests, the headless-FX Monocle harness, the JaCoCo floors.
+- [release.md](release.md) — cutting a release and the CI matrix.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,120 @@
+# Architecture
+
+A map of how Editora is put together, for contributors. This is the orientation doc;
+the deeper conventions live in [conventions.md](conventions.md) and
+[performance.md](performance.md), and the step-by-step "add an X" recipes in
+[extending.md](extending.md).
+
+> The authoritative, exhaustive description of every subsystem is in the root
+> [`CLAUDE.md`](../CLAUDE.md). These docs are the human-readable distillation; when they
+> disagree with the code, the code wins.
+
+## What it is
+
+A keyboard-driven, cross-platform programmer's text editor: **JDK 25 + JavaFX 25**, Maven,
+a single JPMS module `com.editora` (see [`src/main/java/module-info.java`](../src/main/java/module-info.java)).
+The editor surface is a [RichTextFX](dependencies.md) `CodeArea`; standard controls are
+themed by AtlantaFX.
+
+## Boot path
+
+1. **`App.main`** ([`App.java`](../src/main/java/com/editora/App.java)) sets
+   `java.awt.headless=true` as its very first statement (the SVG-rasterization guard — see
+   the note below), installs the debug-log handler + uncaught-exception handler, and handles
+   `--version`/`--help` before the toolkit starts.
+2. **`App.start`** loads the shared config, initializes i18n (`Messages.init`), pins a
+   classloader (the macOS FXML null-context-classloader fix), reaps orphaned LSP/DAP servers
+   from a previous run, then hands off to **`WindowManager`**.
+3. **`WindowManager`** ([`ui/WindowManager.java`](../src/main/java/com/editora/ui/WindowManager.java))
+   owns the set of open windows and restores the previously-open window set.
+   `buildWindow(...)` is the per-window construction: it loads config, builds the command +
+   keymap system, installs the `KeyDispatcher` on the scene, applies the theme, and loads
+   `ui/main.fxml` into a **`MainController`**.
+4. **`MainController`** ([`ui/MainController.java`](../src/main/java/com/editora/ui/MainController.java))
+   is the per-window hub: toolbar, the tabbed `EditorBuffer`s, the status bar, tool windows,
+   and the wiring for every feature. It is large by design — most features are wired here and
+   delegate into their own packages.
+
+### The headless-AWT guard (don't move it)
+
+`App.main`'s first line is `System.setProperty("java.awt.headless", "true")`. SVG
+rasterization (badges in the Markdown preview, math via JLaTeXMath) touches Java2D; on macOS
+the AWT/Java2D native pipeline contends with JavaFX's Glass/Prism for the single AppKit run
+loop, an intermittent deadlock. Headless Java2D rasterizes in software, so it must be set
+before any AWT class loads. Keep it first in `main`.
+
+## Multi-window model
+
+Each project (and each "New Window") opens in its own top-level window with its own
+`MainController`, `Stage`, `CommandRegistry`, `KeyDispatcher`, and per-window services.
+Config is split:
+
+- **`SharedConfig`** ([`config/SharedConfig.java`](../src/main/java/com/editora/config/SharedConfig.java))
+  holds app-wide state by reference across every window: the `Settings` object, the
+  bookmark/note/breakpoint/connection stores, the user dictionary, the macro store, and the
+  `ProjectManager` index.
+- **`ConfigManager`** ([`config/ConfigManager.java`](../src/main/java/com/editora/config/ConfigManager.java))
+  is per-window and owns only that window's session (`WorkspaceState` + its
+  `workspaceStateFile`), delegating everything shared to `SharedConfig`.
+
+So a `config.save()` from any window writes `settings.toml` + that window's session file
+without clobbering another window's in-memory copy. A settings change in one window
+broadcasts to all via `WindowManager.broadcastSettingsApplied()`. See
+[config-and-schema](conventions.md#config-and-schema) for the storage details.
+
+## The editor buffer
+
+**`EditorBuffer`** ([`editor/EditorBuffer.java`](../src/main/java/com/editora/editor/EditorBuffer.java))
+wraps the `CodeArea` and owns everything per-file: highlighting, the line-number gutter and
+fold chevrons (`FoldManager`), the minimap, the overlays (whitespace, spell-check, search,
+TODO, lint, diagnostics, …), bookmarks, notes, and the per-feature hooks (LSP, DAP, Mermaid,
+completion, snippets). Features are injected rather than imported so the `editor` package
+stays free of `ui`, `config`, and the feature packages — e.g. `setSnippetProvider`,
+`setCompletionProvider`, `setMarkdownLintValidator`, `setLspCompletionProvider`. When you add
+an editor feature, follow that injection pattern.
+
+### Tabs are `TabContent`, not always buffers
+
+A tab's `userData` is a **`editor/TabContent`** (`node()`/`title()`/`icon()`/`closeable()`),
+not necessarily an `EditorBuffer`. `EditorBuffer` and `WelcomePane` both implement it, so the
+Welcome page is a real tab (and future diff/image/help views can be too). **Every**
+`tab.getUserData()` read must go through `MainController.bufferOf(Tab)`, which returns the
+`EditorBuffer` or `null` for a non-buffer tab — a raw cast `ClassCastException`s on the
+Welcome tab. Tab-switch consumers (status bar, Structure, git, …) must be null-safe.
+
+## Package map
+
+| Package | Responsibility |
+| --- | --- |
+| `command/` | The keyboard core: `Command`/`CommandRegistry`, `KeymapManager`, `KeyDispatcher`. Every action is a registered command. |
+| `editor/` | `EditorBuffer` + the editor surface: highlighting, gutter, minimap, overlays, indentation, brackets, snippets/completion, the pure editing helpers (`Indenter`, `Commenter`, `Transposer`, `MarkdownLint`, …). |
+| `ui/` | `MainController`, `WindowManager`, `SettingsWindow`, tool-window panels, the in-scene overlays (`OverlayHost`), status bar. |
+| `config/` | `ConfigManager`/`SharedConfig`, `Settings` (TOML), `WorkspaceState` (JSON), the stores, and `config/migration/` (schema versioning). |
+| `i18n/` | `Messages` — the localized catalog (six languages). |
+| `lsp/` `dap/` | Language Server / Debug Adapter Protocol integration (lsp4j). |
+| `git/` `diff/` | Native-CLI git, the diff/merge viewer. |
+| `search/` `todo/` `snippet/` `template/` `completion/` `pdf/` `print/` `mermaid/` `http/` `web/` `macro/` `externaltool/` `logviewer/` `editorconfig/` `vfs/` `plugin/` `run/` | Feature packages, each largely self-contained and wired in `MainController`. |
+| `process/` | `ProcessRunner` (the only place a subprocess is spawned) + `ProcessRegistry` (lifecycle of spawned servers). |
+
+## Recurring patterns
+
+You will see these everywhere; learn them once:
+
+- **The off-thread service idiom** (`GitService`/`SearchService`/`MarkdownLintService`/…): a
+  single daemon executor + a generation guard, posting results back via `Platform.runLater`.
+  See [performance.md](performance.md).
+- **The Canvas overlay idiom** (`SpellCheckOverlay`/`MarkdownLintOverlay`/…): a
+  mouse-transparent `Canvas`, coalesced redraw, visible-paragraphs only, released to 1×1 when
+  inactive. Recipe in [extending.md](extending.md#add-a-canvas-overlay).
+- **The feature-coordinator pattern** (`LogViewerCoordinator`/`MermaidCoordinator`/…): pull a
+  feature's logic out of `MainController` behind a `CoordinatorHost` interface so it is
+  unit-testable. Recipe in [extending.md](extending.md#extract-a-feature-coordinator).
+- **Injected hooks** keep `editor`/`completion` free of `ui`. Don't add a `ui` import to
+  `editor`; inject a `Supplier`/`Consumer`/small interface instead.
+
+## Where to start reading
+
+- A feature end-to-end: pick one in `MainController` (e.g. `applyMarkdownLint`), follow it
+  into its package's pure core + its `EditorBuffer` hooks + its overlay/panel.
+- The command system: `command/Command`, `CommandRegistry`, `KeymapManager`, `KeyDispatcher`.
+- The build: [building-and-packaging.md](building-and-packaging.md).

--- a/docs/building-and-packaging.md
+++ b/docs/building-and-packaging.md
@@ -1,0 +1,89 @@
+# Building & packaging
+
+Run Maven from the project root. The bundled `./mvnw` wrapper is fine.
+
+## Everyday
+
+| Command | What it does |
+| --- | --- |
+| `mvn javafx:run` | Run the app from the classpath. |
+| `mvn test` | Run the test suite (pure + the headless-FX harness — see [testing.md](testing.md)). |
+| `mvn spotless:apply` | Auto-format (run before committing). |
+| `mvn verify` | Full gate: tests + `spotless:check` + the JaCoCo coverage floors. |
+
+The `javafx:run`/`compile` dev loop deliberately skips the Spotless check (it runs only at
+`verify`/`package`), so iterating is fast.
+
+## Native installer (`-Pdist`)
+
+```
+mvn -Pdist package
+```
+
+Produces `target/dist/Editora.app` on macOS; the OS profiles auto-select DMG/MSI/DEB. There is
+**no cross-building** — jpackage + JavaFX are host-specific, so each platform builds for itself.
+
+Quick unpackaged bundle (skips the installer):
+
+```
+mvn -Pdist -DskipTests -Djpackage.type=APP_IMAGE package    # → target/dist/Editora.app
+```
+
+### What the dist profile does
+
+- **moditect** injects `module-info` descriptors into the automatic-module dependencies so
+  `jlink` can link them (see [dependencies.md](dependencies.md)).
+- an antrun step strips `META-INF/*.SF,*.RSA,*.DSA,*.EC` from the **code-signed** tm4e jar —
+  `jlink` rejects signed modular jars.
+- `jlink` builds a stripped runtime (`--strip-debug --no-man-pages --no-header-files
+  --compress=zip-6`). `--strip-native-commands` is deliberately **omitted** so `bin/java`
+  survives for the AOT training step; the helper deletes `bin/` afterward.
+- jpackage `<javaOptions>` (mirrored into `javafx:run` so dev == prod) set the heap/GC caps,
+  the texture-pool safety net, and the per-OS Prism pipeline.
+
+### AOT cache (JDK 25 Leyden)
+
+The build is **two-phase**: phase 1 jlinks an `APP_IMAGE` with `-XX:AOTCache=$APPDIR/editora.aot`
+baked into the launcher `.cfg`; then [`scripts/aot_build.java`](../scripts/aot_build.java) trains
+a full-GUI cache against the image's own runtime (a real window renders, settles ~2.5 s, then
+`System.exit` via `-Deditora.aotTrainExit`), writes `editora.aot`, strips `bin/`, and either
+copies the image or wraps it into the installer.
+
+It is **failure-tolerant** — on a display-less machine training is skipped and the build ships
+without the cache (a missing `-XX:AOTCache` just starts normally under `AOTMode=auto`). On Linux
+CI the helper auto-wraps training in `xvfb-run`. The win is ~28% / ≈300–480 ms faster cold start
+(it's JavaFX scene/control/CSS class loading, which is why a *headless* trainer gives ≈0). Cost:
+the cache is ~60 MB.
+
+### Per-OS Prism pipeline
+
+Set via the `${prism.pipeline}` property in the `os-mac`/`os-windows`/`os-linux` profiles and
+passed as `-Dprism.order`:
+
+- **macOS** = `mtl,es2,sw` — the **Metal** pipeline (JavaFX 26) fixes render-to-texture glitches
+  on Apple silicon; es2/sw are fallbacks.
+- **Windows** = `d3d,es2,sw` — must keep Direct3D.
+- **Linux** = `es2,sw`.
+
+JavaFX 26 runs on JDK 24+, so the JDK stays 25.
+
+## Runnable fat jar (`-Pfatjar`)
+
+```
+mvn -Pfatjar package      # → target/Editora-<version>.jar, run with java -jar
+```
+
+Bundles JavaFX (classes + natives) for **the build host's platform only** and runs from the
+classpath via the non-`Application` `com.editora.Launcher` main class. A single all-platforms jar
+is impossible (JavaFX's macOS/Linux x64 and arm64 natives share filenames and collide), so the
+release CI builds one fat jar per runner.
+
+## App icon / branding
+
+The source logo is `branding/editora-icon.svg`. Window-icon PNGs live in
+`resources/com/editora/icons/`; native-installer icons `branding/editora.{icns,ico,png}` are
+generated from the SVG and passed to jpackage via `${jpackage.icon}` (set per-OS in the
+profiles). Regenerate after editing the SVG.
+
+See also: [dependencies.md](dependencies.md) for the vendored/forked deps, and
+[release.md](release.md) for cutting a release.

--- a/docs/conventions.md
+++ b/docs/conventions.md
@@ -1,0 +1,110 @@
+# Conventions
+
+The rules a change must follow to be mergeable. Most PR review comments come back to one of
+these. (See also [performance.md](performance.md), which is a convention important enough to
+get its own page.)
+
+## Every feature is a Command
+
+Editora is command-driven. Every user-facing action is a registered
+`command/Command` (id + title + runnable) in `MainController.registerCommands()`. The command
+palette, the keybinding editor, and toolbar buttons all dispatch through the registry, so a
+properly registered command is discoverable for free.
+
+- **Never wire a UI handler straight to logic** when a command fits — register the command and
+  have the button/menu run it by id.
+- If it needs a key, add a binding to the bundled keymap(s) (see
+  [extending.md](extending.md#add-a-command)). A keymap only changes accelerators; a command
+  must work from the palette without one.
+
+## Every setting also needs a palette command
+
+A Settings-window control is not enough on its own. Add a command that flips/prompts the
+**same** `Settings` field, persists (`requestSave()`), re-applies the feature (e.g.
+`applyMarkdownLint()`), and keeps an open Settings window in step (`SettingsWindow.syncAll()`).
+
+- Toggles → `view.toggle*` (or `appearance.`/`debug.` prefixes so the palette's feature-gating
+  filter never hides the master toggle).
+- Values → a `promptText` prompt or a `QuickOpen` picker; group many per-item settings under
+  one picker command.
+- Reuse the generic helpers: `toggleSetting` / `promptStringSetting` / `promptIntSetting` /
+  `chooseSetting`.
+
+## Localize every user-facing string
+
+Never hand a raw English literal to a JavaFX control. Use
+`import static com.editora.i18n.Messages.tr;` then `tr("some.key")` (or `tr("key", args…)` for
+`MessageFormat` parameters like `Saved {0}`).
+
+- **Add the key to all six** `resources/com/editora/i18n/messages[_<lang>].properties` files
+  (English base + `it/es/fr/pt/de`) with a real translation in each. `MessagesTest`'s
+  key-parity check fails the build if any locale is missing a key.
+- A new `Command` gets its title for free from `command.<id>`, and its palette description from
+  `command.<id>.desc` — **every** `command.<id>` must have a matching `.desc` (enforced by
+  `MessagesTest`).
+- The only deliberately-untranslated tokens are technical identifiers (`UTF-8`, `LF`/`CRLF`,
+  `Ln`/`Col`, git verbs, language names, example URLs) and the pre-GUI `--help`/`--version`
+  text.
+
+## Config and schema
+
+Preferences live in `settings.toml` (`Settings`, a Jackson POJO); session state in
+`workspace-state.json` (`WorkspaceState`); other stores in their own JSON files. See
+[architecture.md](architecture.md#multi-window-model) for the `SharedConfig`/`ConfigManager`
+split.
+
+**When you change a config schema** (add/rename/restructure a field in any versioned file):
+
+1. Bump that POJO's `SCHEMA_VERSION` constant (`Settings`, `WorkspaceState`, `BookmarkStore`,
+   `ProjectManager.Index`, `RecentFiles`, …).
+2. Add a `v→v+1` entry to that file's `steps` map in
+   [`config/migration/ConfigSchema.java`](../src/main/java/com/editora/config/migration/ConfigSchema.java).
+   A purely additive field uses `ConfigMigrations::identity` (additive-identity); the new field
+   just defaults.
+3. A file newer than the running build is backed up to `<name>.v<n>.bak` and defaults are
+   loaded — an older Editora never clobbers a newer config. The read path, version stamping,
+   and downgrade backup are automatic once the step is registered.
+
+If you add a Jackson-serialized type, remember the `opens com.editora.<pkg> to
+com.fasterxml.jackson.databind;` in `module-info.java`.
+
+## Code style: Palantir Java Format via Spotless
+
+All Java is auto-formatted with [Palantir Java Format](https://github.com/palantir/palantir-java-format)
+(a 120-col google-java-format fork) through the `spotless-maven-plugin`.
+
+- **Run `mvn spotless:apply` before committing.** `spotless:check` runs at the `verify` phase,
+  so `mvn verify`/`package`/CI fail on unformatted code. The `mvn javafx:run`/`compile` dev
+  loop is left untouched.
+- Import order: JDK (`java`/`javax`) → `javafx` → third-party + `com.editora` → static last.
+  Longest-prefix wins, so `javafx` is not swallowed by `java`.
+- Escape hatch for hand-aligned code: wrap it in `// spotless:off` … `// spotless:on`.
+
+## Worktrees: one per task
+
+This repo is worked on by multiple sessions in parallel. **Each task gets its own
+`git worktree`** so sessions don't share a working tree:
+
+```
+scripts/worktree.sh new <branch>     # creates ../Editora-V2-worktrees/<slug> off origin/master
+scripts/worktree.sh list
+scripts/worktree.sh rm <branch>      # after merge
+```
+
+**Never `git checkout` a different branch in the main checkout** while other sessions may be
+active — keep it on `master` and operate on a worktree by path. Spawn subagents with
+`isolation: "worktree"` for the same reason.
+
+## Tests
+
+Prefer extracting a **pure decision helper** and unit-testing it (fast, no toolkit) over
+testing through the UI. Real controller behavior is covered by the headless-FX harness. See
+[testing.md](testing.md). `mvn verify` enforces JaCoCo per-package line-coverage floors on the
+well-covered pure packages — when you raise a package's coverage, ratchet its floor up.
+
+## Docs in the same PR
+
+A feature PR updates `CHANGELOG.md`, `README.md`, and `TODO.md` in the same change, not as a
+follow-up. User-facing documentation lives in the separate website repo; **this `docs/` folder
+is for developers**. Keep `CLAUDE.md` (the dense, exhaustive reference) accurate too — but
+prefer linking these docs from it over re-explaining.

--- a/docs/dependencies.md
+++ b/docs/dependencies.md
@@ -1,0 +1,78 @@
+# Dependencies (the tricky ones)
+
+Most dependencies are ordinary. A few are vendored, forked, or repackaged in ways that will
+confuse you the first time — this is the "why is this dep weird" reference. Versions live in
+`pom.xml` properties.
+
+## RichTextFX — a personal fork (`m2-repo/`)
+
+The editor uses a fork of RichTextFX, `io.github.adriandeleon:richtextfx`, **vendored in the
+in-project `m2-repo/`** (source: github.com/adriandeleon/RichTextFX). It adds VS Code–style
+**multiple cursors + Alt+drag column/box selection** via a self-contained
+`org.fxmisc.richtext.multi.MultiCaretController.install(area)` add-on (a layered
+`InputMap`, gated on `MultiCaretManager.hasExtras()` so it's transparent with one caret).
+
+- `EditorBuffer` installs it on `area`/`area2` via `setMultiCaretEnabled(...)`
+  (`Settings.multiCaret`, default on).
+- Editora's area-level KEY filters (auto-indent/close, snippets, completion, view paging) are
+  capture-phase filters that early-return (no consume) via `multiCaretActiveOn(a)` when an area
+  has extra carets, so editing fans out to all carets.
+- **Known limitation:** Emacs movement chords (`C-f`/`C-n`/…) are resolved by the scene-level
+  `KeyDispatcher` on the primary caret and don't fan out — use arrows for multi-caret movement.
+
+**To update the fork:** rebuild it, copy the new `richtextfx-<version>.{jar,pom}` into `m2-repo/`,
+bump `<richtextfx.version>`. Use **0.11.7+** (earlier is incompatible with JavaFX 25).
+
+RichTextFX and its transitive deps (`reactfx`, `flowless`, `undofx`, `wellbehavedfx`) are
+**automatic modules**, which `jlink` cannot link — the `moditect-maven-plugin` in the `dist`
+profile injects explicit `module-info` descriptors. If you bump RichTextFX or add a dep it uses,
+you may need to adjust those descriptors' `requires` (several need `javafx.controls` for
+`IndexRange`).
+
+## tm4e — NetBeans repackaging (signed jar)
+
+The syntax engine ships as `org.netbeans.external:org.eclipse.tm4e.core-0.14.0:RELEASE260`
+(tm4e is not on Maven Central). Its Oniguruma backend (`org.jruby.joni:joni`,
+`org.jruby.jcodings:jcodings`) and `gson` are already proper modules, but tm4e core is an
+automatic module, so moditect injects a `module-info` for it too.
+
+The NetBeans jar is **code-signed**, and `jlink` rejects signed modular jars — the `dist`
+profile's antrun step strips `META-INF/*.SF,*.RSA,*.DSA,*.EC` before linking.
+
+## Monocle — self-built headless backend (`m2-repo/`, test scope only)
+
+`io.github.adriandeleon:openjfx-monocle` is the headless Glass backend for the FX test harness,
+**vendored in `m2-repo/`, test scope, never shipped**. There is no upstream build for current
+JavaFX (`org.testfx:openjfx-monocle` stops at 21, `one.jpro` at jfx-21), and Monocle is tightly
+coupled to internal `com.sun.glass.ui` APIs, so it is **self-built and must be rebuilt on every
+JavaFX bump** (a stale-version jar fails to link, breaking the `@Tag("fx")` tests).
+
+To rebuild: sparse-checkout the `com/sun/glass/ui/monocle` sources (+ resources) from the
+matching `openjdk/jfx` tag, `javac --release <ver>` against the **platform-classified** JavaFX
+jars (the no-classifier ones are stubs), `jar` with manifest
+`Automatic-Module-Name: org.testfx.monocle`, drop under
+`m2-repo/io/github/adriandeleon/openjfx-monocle/<ver>/`, and bump `<monocle.version>`. No
+`module-info`/jlink impact — it's never on the runtime path. See [testing.md](testing.md).
+
+## Automatic modules + moditect (general)
+
+Several real dependencies are automatic modules that `jlink` can't link, so the `dist` profile's
+moditect step injects jdeps-generated `module-info` descriptors (with `--ignore-missing-deps`
+where needed): RichTextFX & friends, tm4e core, **PDFBox** (`pdfbox`/`pdfbox-io`/`fontbox`),
+**lsp4j** + **lsp4j.debug**, and **java-diff-utils**. A couple need hand-maintained descriptors:
+
+- **sshd-osgi** (SFTP) uses a hand-written `src/moditect/module-info-sshd-osgi.java` (jdeps drops
+  a `requires org.slf4j` that every SSHD class needs). The combined `sshd-osgi` bundle is used
+  instead of `sshd-common`+`sshd-core`, which split a package across two automatic modules
+  (illegal under JPMS). `sshd-sftp` excludes `jcl-over-slf4j` (collides with PDFBox's
+  commons-logging under jlink) and slf4j-api is forced to 2.0.17 (a real module).
+
+If you add a dependency that turns out to be an automatic module, expect to add a moditect entry.
+
+## Bundled fonts & grammars
+
+Plain resources, no `module-info`/moditect change, picked up by the dist build automatically:
+five monospace families + **Inter** (Markdown preview / PDF prose) under
+`resources/com/editora/fonts/`, and the TextMate grammars under `resources/com/editora/grammars/`
+(the grammar package needs the `opens … to org.eclipse.tm4e.core` — see
+[extending.md](extending.md#add-a-language--textmate-grammar)). All are attributed in `NOTICE`.

--- a/docs/extending.md
+++ b/docs/extending.md
@@ -1,0 +1,156 @@
+# Extension cookbook
+
+Step-by-step recipes for the things you'll add most often. Each follows the same spirit:
+register through the right system, keep the `editor`/`completion` packages free of `ui`, add
+i18n in all six catalogs, and don't regress the [hot paths](performance.md).
+
+Identifiers (class names, field names) are accurate at the time of writing — grep to confirm
+against the current code.
+
+- [Add a command](#add-a-command)
+- [Add a setting](#add-a-setting)
+- [Add an LSP server](#add-an-lsp-server)
+- [Add a DAP adapter](#add-a-dap-adapter)
+- [Add a language / TextMate grammar](#add-a-language--textmate-grammar)
+- [Add a tool window](#add-a-tool-window)
+- [Add a Canvas overlay](#add-a-canvas-overlay)
+- [Extract a feature coordinator](#extract-a-feature-coordinator)
+
+---
+
+## Add a command
+
+1. **Register** in `MainController.registerCommands()`:
+   ```java
+   registry.register(Command.of("edit.myThing", this::myThing));
+   ```
+   `Command.of(id, runnable)` resolves its title lazily from `command.<id>` and its palette
+   description from `command.<id>.desc`.
+2. **i18n** — add `command.edit.myThing` and `command.edit.myThing.desc` to **all six**
+   `messages*.properties` catalogs.
+3. **Keybinding (optional)** — add a chord → id mapping in the bundled keymap JSON under
+   `resources/com/editora/keymaps/`. Emacs is single-file (`emacs.json`); the GUI keymaps ship
+   a base `<name>.json` (Ctrl) **and** a `<name>.mac.json` (Cmd). Chord tokens are exactly what
+   `KeyDispatcher.chord()` emits, modifiers in canonical order `C- M- Cmd- S-`. `KeymapsTest`
+   guards parse, valid command ids, token order, and base↔`.mac` parity.
+
+The palette and the keybinding editor populate from `CommandRegistry.all()`, so a registered
+command appears automatically. Never add a user-facing action that bypasses the registry.
+
+## Add a setting
+
+A setting is a `Settings` field **plus** a Settings-window control **plus** a palette command.
+
+1. **Field** in `config/Settings.java` with getter/setter; bump `Settings.SCHEMA_VERSION` and
+   add an additive-identity step in `ConfigSchema` (see
+   [conventions.md](conventions.md#config-and-schema)).
+2. **Settings UI** — a control on the relevant page in `SettingsWindow`, wired through the
+   live-apply path (each control writes the field then `apply()`).
+3. **Palette command** — a `view.toggle*` (for a flag) or a prompt/picker (for a value) that
+   flips the same field, `requestSave()`s, re-applies the feature, and calls
+   `SettingsWindow.syncAll()`. Reuse `toggleSetting`/`promptIntSetting`/`chooseSetting`.
+4. **i18n** for the command + the Settings label.
+
+## Add an LSP server
+
+The registry is server-centric — one session per `(serverId, root)`. Adding a server is data,
+not new logic:
+
+1. A `ServerDef` in [`lsp/LspServerRegistry.java`](../src/main/java/com/editora/lsp/LspServerRegistry.java):
+   the command tokenization, the language ids it serves, and its root markers.
+2. The server id in `MainController.LSP_SERVER_IDS`.
+3. The served language id(s) in `EditorBuffer.LSP_LANGUAGES` (kept in sync with the registry;
+   `isLspLanguage()` reads it).
+4. A `Settings.lspSupport`-style per-server `…LspCommand` + `…LspEnabled` pair, and an entry in
+   `SettingsWindow.lspServerUis()` (the LSP page is data-driven over that descriptor list).
+
+`LspManager.configure(enabled, Map<serverId, command>)` is map-based, so it never needs a
+signature change. If the language has no bundled grammar, also do
+[Add a language](#add-a-language--textmate-grammar).
+
+## Add a DAP adapter
+
+Mirrors the LSP recipe. The language→adapter spec is
+[`dap/DapServerRegistry.java`](../src/main/java/com/editora/dap/DapServerRegistry.java)
+(`Kind` = `JDTLS` / `STDIO` / `SOCKET`), `languageIdsForDebug()` gates the breakpoint gutter +
+debug commands, and the Settings → Debugging page is data-driven over
+`SettingsWindow.debugAdapterUis()`. Java rides the jdtls session; Python (debugpy) is stdio;
+JavaScript (vscode-js-debug) is a socket. Adapters are never bundled — they're located by
+`dap/DebugAdapterLocator` and installed by the `scripts/install-*.sh` helpers.
+
+## Add a language / TextMate grammar
+
+1. Drop the `<name>.tmLanguage.json` under
+   [`resources/com/editora/grammars/`](../src/main/resources/com/editora/grammars/) (vendor
+   from a permissive source; attribute it in `NOTICE`).
+2. Register it in `GrammarRegistry`: a `scopeToResource` entry (scope → resource base name) and
+   a `mapExtensions(...)` entry (file extension → scope). Filename-only matches (like
+   `Dockerfile`) get a special case in `scopeForFileName`.
+3. Add the extension to `LanguageRegistry` (language-name resolver used by folding + File
+   Information), and to `FoldRegions`/`Indenter`/`Commenter` if it needs folding/indent/comment
+   support.
+
+> **JPMS gotcha:** grammar resources live in the `com.editora.grammars` package, which
+> `module-info.java` must `opens ... to org.eclipse.tm4e.core`. Without that, tm4e's
+> `Class.getResourceAsStream` returns null at runtime (module path) and grammars silently fail
+> to load even though classpath tests pass.
+
+`TextMateHighlighter` tokenizes line-by-line and maps each scope to a `.text.<class>` CSS class
+themed in [`styles/syntax.css`](../src/main/resources/com/editora/styles/syntax.css).
+
+## Add a tool window
+
+1. Build a panel that `extends` a JavaFX `Region` (usually `VBox`) and `implements`
+   `editor/TabContent`-style `ToolWindowContent`. Keep it in `ui`; route actions back to the
+   controller via a small `Actions` callback interface (see `MarkdownLintPanel`, `SearchPanel`).
+2. Construct a `ToolWindow` and register it:
+   ```java
+   myPanel = new MyPanel(actions);
+   myToolWindow = new ToolWindow(
+           "myId", tr("toolwindow.myId"), ToolWindow.Side.BOTTOM, Icons::myGlyph, myPanel, "tool.myId");
+   toolWindows.register(myToolWindow);
+   ```
+3. Add the `tool.myId` toggle command + a keybinding, and the `toolwindow.myId` i18n key.
+4. Use `ToolWindowManager.setAvailable(tw, condition)` for a **transient** hide (e.g. "only in a
+   git repo") — distinct from the persisted `setVisible` show/hide preference.
+
+The default `Side` is a default only; each window restores its persisted
+`WorkspaceState.toolWindowSides`.
+
+## Add a Canvas overlay
+
+The discipline that keeps overlays off the hot path (see
+[performance.md](performance.md#canvas-overlays)). Mirror `MermaidLintOverlay` /
+`SpellCheckOverlay`:
+
+- a `final class MyOverlay extends Region` in `editor`, holding a `Canvas`, mouse-transparent,
+  `setVisible(false)` until activated;
+- subscribe to `area.viewportDirtyEvents()`, `multiPlainChanges()`, and the scroll properties to
+  `scheduleRedraw()` (coalesced with a `redrawPending` flag + `Platform.runLater`);
+- `redraw()` clears, then iterates only `firstVisibleParToAllParIndex … lastVisibleParToAllParIndex`,
+  using `CanvasGuards` for dimension/paintability checks;
+- `setActive(false)` clears and **releases the canvas to 1×1** so it holds no full-viewport
+  texture;
+- the data (diagnostics/marks) is **pushed in** by `EditorBuffer`; the overlay only renders.
+
+Attach it in `EditorBuffer.installOverlays()` (eagerly for a common feature, or lazily via
+`attachLazyOverlay` for a rare one), anchor it inside `Minimap.WIDTH`, and add an
+`EditorBuffer.setXxxEnabled`/`setXxxData` pair injected from `MainController`. If it should also
+show on the scrollbar/minimap, feed a stripe (`DiagnosticStripe`-style) + a `Minimap` channel.
+
+## Extract a feature coordinator
+
+When a feature's logic bloats `MainController`, pull it into a coordinator behind
+[`ui/CoordinatorHost`](../src/main/java/com/editora/ui/CoordinatorHost.java) (the
+`LogViewerCoordinator` / `MermaidCoordinator` / `HtmlPreviewCoordinator` pattern):
+
+- a `final class MyCoordinator` in `ui` that owns the feature's service(s) + state and reaches
+  the window only through the shared `CoordinatorHost` interface (settings, active/all buffers,
+  status, prompts, the overlay host, …);
+- `MainController` constructs it with an anonymous `Host` adapter and keeps **one-line
+  delegations** at each call site;
+- a fake `Host` in a test makes the coordinator unit-testable without a real window (see the
+  `*CoordinatorFxTest`s).
+
+Add to `CoordinatorHost` only the narrow capabilities your coordinator needs; don't hand it the
+whole `MainController`.

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -1,0 +1,126 @@
+# Performance
+
+Performance is a first-class constraint in Editora, not an afterthought. The editor must stay
+responsive on large files, and the UI thread is sacred. This page is the contract every change
+on a hot path must honor.
+
+**Assess and report the cost of every change.** For any implementation or fix, evaluate its
+effect on the hot paths (allocation per keystroke/scroll, added FX-thread work, extra
+layout/CSS passes, memory) and say so in the PR — even if it's "negligible". If a change risks
+a regression, measure it (e.g. temporary `System.nanoTime` instrumentation) rather than guess.
+
+## The hot paths
+
+Treat these as sacred — they run on every keystroke or scroll pulse:
+
+- typing / editing
+- scrolling
+- syntax highlighting
+- the document overlays (whitespace, minimap, the 80-column ruler, spell-check, search,
+  TODO, lint, diagnostics)
+- the line-number gutter
+
+## The rules
+
+### 1. Never block the JavaFX Application Thread
+
+Tokenize/parse/search **off-thread**, then apply results back on the FX thread under a
+**generation guard** so a stale result is dropped. The canonical shape — used by
+`GitService`, `SearchService`, `MarkdownLintService`, the `highlightExecutor` in
+`EditorBuffer`, and every other service:
+
+```java
+private final ExecutorService exec = Executors.newSingleThreadExecutor(daemon("my-feature"));
+private final AtomicLong gen = new AtomicLong();
+
+void request(String input, Consumer<Result> onResult) {
+    long mine = gen.incrementAndGet();
+    exec.submit(() -> {
+        Result r = computeOffThread(input);          // heavy work, off the FX thread
+        if (mine == gen.get()) {                       // superseded? drop it
+            Platform.runLater(() -> {
+                if (mine == gen.get()) onResult.accept(r);
+            });
+        }
+    });
+}
+```
+
+### 2. Debounce and coalesce
+
+Re-highlighting is debounced; overlay/ruler/minimap redraws coalesce to **one per pulse** with
+a `pending` flag + `Platform.runLater`. Don't add per-keystroke or per-scroll-pulse work that
+isn't coalesced. The coalescing shape:
+
+```java
+private boolean redrawPending;
+private void scheduleRedraw() {
+    if (!active || redrawPending) return;
+    redrawPending = true;
+    Platform.runLater(() -> { redrawPending = false; redraw(); });
+}
+```
+
+For text-driven work, debounce on the RichTextFX stream rather than per-change:
+`area.multiPlainChanges().successionEnds(Duration.ofMillis(250)).subscribe(...)`.
+
+### 3. Work incrementally, and only on what's visible
+
+- Highlighting re-tokenizes only from the **changed line**, carrying grammar state across lines.
+- Overlays iterate just the **visible paragraphs**
+  (`firstVisibleParToAllParIndex … lastVisibleParToAllParIndex`) and skip folded lines.
+- Avoid O(document) work on an edit or a scroll.
+- **Never** call `getCharacterBoundsOnScreen` synchronously inside a layout/viewport event.
+
+### 4. Don't defeat the per-node CSS style cache
+
+- Keep token rules as the compound `.text.<class>` selector (see
+  [`styles/syntax.css`](../src/main/resources/com/editora/styles/syntax.css)).
+- Coalesce adjacent same-style spans (`SpanMerger`) before `setStyleSpans`.
+
+### 5. Preserve the large/huge-file guards
+
+Highlighting + minimap are disabled at **≥ 5 MB**; the file goes read-only with a capped load
+at **≥ 50 MB**. Many overlays check `largeFile`/`hugeFile` and no-op. Keep these guards when
+touching that code, and bound memory (undo history is capped; loads are capped).
+
+### 6. Bound retained GPU textures
+
+JavaFX's Prism texture pool has a fixed ceiling (default 512 MB); exhausting it makes the
+render thread NPE on a null texture — a black window, seen only in the packaged build. So don't
+let GPU-backed resources grow with the number of open files:
+
+- A background (non-selected) tab drops its minimap snapshot via
+  `EditorBuffer.setRenderingActive(false)`.
+- Image caches (`PreviewImageLoader`, `MermaidImages`) are LRU-bounded, not unbounded maps —
+  each pins an `Image` (a texture).
+- A Canvas overlay releases its backing canvas to **1×1** when it has nothing to draw.
+
+When you add any per-buffer `Canvas`/`Image`, make sure it is released or bounded. The dist
+build (and `mvn javafx:run`) also raise the caps as a safety net
+(`-Dprism.maxvram=2G -Dprism.maxTextureSize=16384`).
+
+## Canvas overlays
+
+Every document overlay (whitespace, spell-check, search-highlight, TODO, Markdown-lint, LSP
+diagnostics, …) follows one discipline:
+
+- a **mouse-transparent** `Canvas` sized to the viewport
+- coalesced redraw (one per pulse) on scroll / edit / resize
+- draws **only the visible paragraphs**
+- `CanvasGuards` for dimension clamping + paintability checks
+- released to a 1×1 backing texture while inactive (the common case is a buffer that doesn't
+  use the feature)
+- often **lazily attached** on first activation so an off-feature buffer never builds the
+  `Canvas`/subscriptions at all
+
+See the recipe in [extending.md](extending.md#add-a-canvas-overlay), and `SpellCheckOverlay` /
+`MarkdownLintOverlay` as references.
+
+## Packaged-runtime tuning
+
+The dist `<javaOptions>` (mirrored into `javafx:run` so dev == prod) cap heap and GC: `-Xmx2g`
+(predictable across the release matrix), `-XX:+UseSerialGC` (lowest idle RSS for a mostly-idle
+single-user editor on a small heap). The jlinked runtime is stripped for size. An AOT cache
+(JDK 25 Leyden) shaves ~300–480 ms off cold start. None of this changes behavior — but if you
+touch startup or large-file handling, measure against these settings, since they're what ships.

--- a/docs/release.md
+++ b/docs/release.md
@@ -1,0 +1,60 @@
+# Releasing
+
+## Cutting a release
+
+1. Bump `<version>` in `pom.xml`.
+2. Update `CHANGELOG.md` (move `[Unreleased]` into a versioned section).
+3. Push a `vX.Y.Z` tag. A `-rcN` suffix (`vX.Y.Z-rcN`) marks a pre-release.
+
+```
+git tag vX.Y.Z
+git push origin vX.Y.Z
+```
+
+The tag triggers [`.github/workflows/release.yml`](../.github/workflows/release.yml). (Manual
+dispatch is available for a dry run.)
+
+## The pipeline
+
+A **5-way matrix**, each on its own GitHub-hosted runner (no cross-building — jpackage + JavaFX
+are host-specific, so each runner builds for itself):
+
+| Target | Runner | Notes |
+| --- | --- | --- |
+| linux x64 | ubuntu | |
+| linux arm64 | ubuntu arm | |
+| macOS x64 | `macos-15-intel` | the last Intel x86_64 image (good through ~Aug 2027). |
+| macOS arm64 | macos | |
+| windows x64 | windows | |
+
+**Windows arm64 is omitted:** a hosted runner exists, but OpenJFX 25 publishes no `win-aarch64`
+native jar on Maven Central ([JDK-8314064]), so a native ARM64 build can't link —
+Windows-on-ARM users run the x64 installer under emulation. Revisit when JavaFX ships
+`win-aarch64` natives.
+
+Each runner:
+
+- builds the native installer via the existing `-Pdist` profile (DMG/MSI/DEB);
+- builds a per-platform runnable fat jar via `-Pfatjar`;
+- runs the AOT-cache training step (Linux legs wrap it in `xvfb`; the workflow installs
+  `xvfb` + GTK/GL libs there).
+
+Installers and fat jars are renamed to a consistent `Editora-<version>-<target>.<ext>` prefix
+(the version comes from a `Resolve version` step — the tag minus `v`, else the pom version) and
+uploaded as artifacts.
+
+A final job hands everything to **JReleaser** (`jreleaser.yml`, via `jreleaser/release-action`),
+which creates the GitHub release with all installers + fat jars + `checksums.txt` + a changelog.
+JReleaser only *orchestrates the release* — it does not build (the `dist` profile is reused
+as-is), and there is **no `pom.xml`/Maven change**, so the normal build is unaffected.
+
+CI uses the BellSoft **Liberica** JDK 25 for full arch coverage (incl. linux aarch64).
+
+## Notes
+
+- Installers are currently **unsigned** (signing/notarization is a follow-up).
+- Bumping the JavaFX version means rebuilding the vendored **Monocle** backend, or the
+  `@Tag("fx")` tests stop linking — see [dependencies.md](dependencies.md#monocle--self-built-headless-backend-m2-repo-test-scope-only).
+- The AOT cache adds ~60 MB to the installed image (compressed in the DMG/MSI/DEB); it's
+  failure-tolerant, so a runner without a usable display still ships, just without the cache —
+  see [building-and-packaging.md](building-and-packaging.md#aot-cache-jdk-25-leyden).

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,0 +1,76 @@
+# Testing
+
+```
+mvn test                          # everything (pure + FX harness)
+mvn test -DexcludedGroups=fx      # pure suite only (fast, no toolkit)
+mvn verify                        # tests + Spotless check + JaCoCo coverage floors
+```
+
+## Prefer pure logic
+
+The bulk of the suite is **pure logic** — keymap resolution, config merge, highlighting spans,
+the editing helpers (`Indenter`, `Commenter`, `MarkdownLint`, `MarkdownLintFix`, …), parsers
+(`StatusParser`, `DiffParser`, `MaidOutput`, …). These are fast and need no toolkit.
+
+The cheapest way to cover the toolkit-bound packages (`ui`, `editor`) is to **extract a pure
+decision helper and unit-test that** rather than drive the UI: effective-visibility/gating
+predicates, caret-navigation math, path keying, and the like. See `ui/Chrome`, `editor/TextNav`,
+`config/PathKeys` for the pattern. When you write a feature, factor the decision out of the
+JavaFX code so it can be tested directly.
+
+## The headless-FX harness
+
+Real controller behavior (Zen toggling chrome, Simple-mode stripping, tab/window lifecycle, the
+coordinators) is covered end-to-end by a **TestFX** harness running over a self-built JavaFX
+**Monocle** Glass backend, so FX tests run headless on CI with **no display/xvfb**.
+
+- All FX tests are tagged `@Tag("fx")`. Run the pure suite alone with
+  `mvn test -DexcludedGroups=fx`.
+- **`FxTestSupport`** boots the toolkit once (Monocle Headless + `Fonts.load`/`Messages.init` +
+  the AtlantaFX UA sheet + the classloader pin) and exposes `runOnFx`/`callOnFx` + reflection
+  helpers (`field`/`invoke`/`call`) to read private `@FXML` nodes and call private methods. Tests
+  run on the **classpath** as the unnamed module, so `setAccessible` is unrestricted.
+- **`FxWindowFixture`** builds a real window via `WindowManager.buildWindowForTest()` — a
+  package-private seam mirroring `buildWindow` — against a temp config dir. **If that boot path
+  changes, the fixture/seam must track it.**
+
+### The surefire config that makes it work
+
+In `pom.xml`:
+
+- `<useModulePath>false</useModulePath>` — classpath mode.
+- headless system properties: `glass.platform=Monocle`, `monocle.platform=Headless`,
+  `prism.order=sw`, `testfx.headless=true`.
+- `<argLine>@{argLine}</argLine>` — **the `@{argLine}` token is mandatory** so JaCoCo's injected
+  coverage agent (set via the `argLine` property) survives. A plain `<argLine>` would clobber it.
+
+Monocle is vendored, test-scope, and must be rebuilt on every JavaFX bump — see
+[dependencies.md](dependencies.md#monocle--self-built-headless-backend-m2-repo-test-scope-only).
+
+## Coverage
+
+`mvn test` runs the JaCoCo agent and writes `target/site/jacoco/index.html` (+ `jacoco.xml`).
+`mvn verify` additionally runs a JaCoCo **`check`** that enforces a per-package **line-coverage
+floor** on the well-covered pure packages (e.g. `config`/`migration`/`diff` ≥ 0.85/0.80,
+`template`/`editorconfig` ≥ 0.80, `completion`/`http`/`pdf` ≥ 0.68 — see the `jacoco-check`
+execution in `pom.xml`).
+
+- The floors sit **below** current levels — they're a regression net, not a target. **When you
+  raise a package's coverage, ratchet its floor up.**
+- `ui`/`editor` are deliberately **ungated** (the FX harness covers only a few percent of `ui`
+  so far). Add a floor for them only once coverage is meaningful — and the cheapest way to get
+  there is still to extract pure helpers.
+
+The dev loop (`mvn javafx:run`/`compile`) is unaffected; the check runs only at
+`verify`/`package`.
+
+## What to test for a typical change
+
+- A pure helper → a dedicated `*Test` with positive/negative/edge cases (front matter, empty,
+  null, multi-byte, …).
+- A config-schema change → a migration test if it's not additive-identity; otherwise the
+  round-trip is covered by the read path.
+- New i18n keys → `MessagesTest` already enforces six-catalog parity and command/desc pairing;
+  just keep the catalogs complete.
+- Controller-visible behavior → a `@Tag("fx")` test via `FxWindowFixture` if it can't be reduced
+  to a pure helper.


### PR DESCRIPTION
Establishes docs/ as the developer/contributor documentation home (user-facing docs live in the separate website repo). Distilled from CLAUDE.md into navigable, cross-linked guides; every linked source path and cited class verified to exist.

New: docs/README.md (index), architecture.md, conventions.md, performance.md, extending.md (recipes: command, setting, LSP server, DAP adapter, grammar, tool window, Canvas overlay, coordinator), building-and-packaging.md, dependencies.md (RichTextFX fork, Monocle, tm4e, moditect), release.md, testing.md (headless-FX Monocle harness, JaCoCo floors), and a root CONTRIBUTING.md.

Changed: README Contributing section corrected the stale 'no GUI test harness' claim and points at CONTRIBUTING.md + docs/. No code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)