### PR TITLE
Plugin API: needsBuffer opt-out for tool windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Plugin API: `needsBuffer` opt-out for tool windows.** Plugin tool windows are gated on an open editor
+  buffer by default (they act on the active editor), but a new `registerToolWindow(…, icon, needsBuffer)`
+  overload lets a self-contained tool window (scratchpad, calculator, color picker, …) pass
+  `needsBuffer = false` so its stripe button stays available on every tab, including Welcome. The existing
+  overloads are unchanged (they default to `needsBuffer = true`).
+
 - **Markdown lint, substantially expanded.** The Markdown linter now covers more of the markdownlint rule
   set — MD001 (heading-level increment), MD010 (hard tabs), MD022 (headings surrounded by blank lines),
   MD023 (heading indent), MD026 (heading trailing punctuation), MD031 (fenced code surrounded by blank

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -212,8 +212,11 @@ icon (`Icons.findInFiles()`, `onFindInFiles → openSearchInFiles`) sits beside 
   tracked in `MainController.pluginToolWindows` and its stripe button is gated on an open editor buffer
   (`toolWindows.setAvailable(tw, activeBuffer() != null)` at registration + in `updateBufferToolWindows()`,
   alongside the built-in Structure/File-Info/TODO windows) — plugins act on the active editor, so they're
-  hidden on a non-buffer tab (e.g. Welcome). (A buffer-less plugin tool window, like a scratchpad, is also
-  hidden there; there's no per-plugin "needs no buffer" opt-out yet.) Declarative **assets**: `SnippetManager.addExtraSourceDir`/
+  hidden on a non-buffer tab (e.g. Welcome). **Opt-out:** the full
+  `registerToolWindow(id,title,side,content,commandId,icon,needsBuffer)` overload takes a `needsBuffer` flag
+  (the icon/no-icon overloads are `default`s delegating with `true`); a plugin passes `false` for a
+  self-contained tool window (scratchpad/calculator/…) so it's **not** added to `pluginToolWindows` and stays
+  available on every tab. Declarative **assets**: `SnippetManager.addExtraSourceDir`/
   `TemplateRegistry.addExtraSourceDir` (generalized extra-source-dir lists, cache-clearing) merge a plugin's
   `snippets/`/`templates/` into the registries (`reload()`d once after applying). **Enabled set** lives in
   `<configDir>/plugins.json` (`config/PluginStore`, schema-versioned via `ConfigSchema.PLUGINS`, owned by

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -91,8 +91,9 @@ public class HelloPlugin implements Plugin {
 | --- | --- |
 | `registerCommand(id, title, action)` | A palette command (id namespaced to the plugin). |
 | `bindKey(chord, commandId)` | A keybinding. |
-| `registerToolWindow(id, title, side, content, commandId)` | A dockable tool window (`LEFT`/`RIGHT`/`BOTTOM`), using the default plugin (jigsaw) stripe icon. |
-| `registerToolWindow(id, title, side, content, commandId, icon)` | Same, with a custom stripe icon: `icon` is a `Supplier<javafx.scene.Node>` (e.g. an `SVGPath` with the `toolbar-icon` style class, themed for light/dark). Called per window/repaint, so it must return a fresh node each time; `null` (or a null result) falls back to the jigsaw. |
+| `registerToolWindow(id, title, side, content, commandId)` | A dockable tool window (`LEFT`/`RIGHT`/`BOTTOM`), using the default plugin (jigsaw) stripe icon. Its stripe is gated on an open editor buffer (hidden on a non-buffer tab like Welcome). |
+| `registerToolWindow(id, title, side, content, commandId, icon)` | Same, with a custom stripe icon: `icon` is a `Supplier<javafx.scene.Node>` (e.g. an `SVGPath` with the `toolbar-icon` style class, themed for light/dark). Called per window/repaint, so it must return a fresh node each time; `null` (or a null result) falls back to the jigsaw. Also buffer-gated. |
+| `registerToolWindow(id, title, side, content, commandId, icon, needsBuffer)` | Full form. `needsBuffer = true` (the default of the other overloads) gates the stripe on an open editor buffer — for a tool window that acts on the active editor. Pass `false` for a self-contained tool window (scratchpad, calculator, color picker, …) that should stay available regardless of the active tab. |
 | `addEditorMenuItem(label, action)` | An editor right-click item; the action gets an `ActiveEditor`. |
 | `addStatusBarSegment(label, commandId)` | A clickable status-bar segment. |
 | `activeEditor()` | The live active-buffer facade (`filePath`/`text`/`selectedText`/`replaceSelection`/`insertAtCaret`/`setText`/`openPath`). `setText` replaces the whole buffer (undoable) — for whole-file transforms like formatting. |

--- a/src/main/java/com/editora/plugin/PluginContext.java
+++ b/src/main/java/com/editora/plugin/PluginContext.java
@@ -26,7 +26,9 @@ public interface PluginContext {
     /**
      * Registers a dockable tool window with the given content node + a toggle command id, using the default
      * plugin (jigsaw) stripe icon. Equivalent to {@link #registerToolWindow(String, String, ToolWindowSide,
-     * Region, String, Supplier)} with a {@code null} icon.
+     * Region, String, Supplier)} with a {@code null} icon. The stripe is gated on an open editor buffer
+     * ({@code needsBuffer = true}); use {@link #registerToolWindow(String, String, ToolWindowSide, Region,
+     * String, Supplier, boolean)} to opt out.
      */
     default void registerToolWindow(String id, String title, ToolWindowSide side, Region content, String commandId) {
         registerToolWindow(id, title, side, content, commandId, null);
@@ -38,9 +40,34 @@ public interface PluginContext {
      * {@code toolbar-icon} style class (which the app theme colors for light/dark). It is invoked per window
      * and per repaint, so it <em>must</em> return a new node each call (a node can have only one parent). A
      * {@code null} supplier, or one that returns {@code null}, falls back to the default plugin (jigsaw) icon.
+     * The stripe is gated on an open editor buffer ({@code needsBuffer = true}); use
+     * {@link #registerToolWindow(String, String, ToolWindowSide, Region, String, Supplier, boolean)} to opt out.
+     */
+    default void registerToolWindow(
+            String id, String title, ToolWindowSide side, Region content, String commandId, Supplier<Node> icon) {
+        registerToolWindow(id, title, side, content, commandId, icon, true);
+    }
+
+    /**
+     * Full form. {@code needsBuffer} controls whether the tool window's stripe button is gated on an open
+     * editor buffer:
+     *
+     * <ul>
+     *   <li>{@code true} (the default of the other overloads) — the tool window acts on the active editor, so
+     *       its stripe is hidden on a non-buffer tab (e.g. the Welcome page), matching the built-in
+     *       Structure / File-Info / TODO windows.
+     *   <li>{@code false} — a self-contained tool window (a scratchpad, a calculator, a color picker, …) that
+     *       should stay available regardless of the active tab.
+     * </ul>
      */
     void registerToolWindow(
-            String id, String title, ToolWindowSide side, Region content, String commandId, Supplier<Node> icon);
+            String id,
+            String title,
+            ToolWindowSide side,
+            Region content,
+            String commandId,
+            Supplier<Node> icon,
+            boolean needsBuffer);
 
     /** Adds an item to the editor's right-click menu; the action receives the {@link ActiveEditor}. */
     void addEditorMenuItem(String label, Consumer<ActiveEditor> action);

--- a/src/main/java/com/editora/ui/MainController.java
+++ b/src/main/java/com/editora/ui/MainController.java
@@ -976,7 +976,8 @@ public class MainController implements com.editora.mcp.McpBridge {
                 com.editora.plugin.ToolWindowSide side,
                 javafx.scene.layout.Region content,
                 String commandId,
-                java.util.function.Supplier<javafx.scene.Node> icon) {
+                java.util.function.Supplier<javafx.scene.Node> icon,
+                boolean needsBuffer) {
             String twId = fullId(id);
             String cmd = commandId == null || commandId.isBlank() ? twId : fullId(commandId);
             ToolWindow.Side s =
@@ -995,8 +996,13 @@ public class MainController implements com.editora.mcp.McpBridge {
                     };
             ToolWindow tw = new ToolWindow(twId, title == null ? twId : title, s, iconFactory, content, cmd);
             toolWindows.register(tw);
-            pluginToolWindows.add(tw);
-            toolWindows.setAvailable(tw, activeBuffer() != null); // gate on an open buffer to act on
+            if (needsBuffer) {
+                // Acts on the active editor — track it so updateBufferToolWindows() keeps its stripe gated on
+                // an open buffer (hidden on a non-buffer tab like Welcome).
+                pluginToolWindows.add(tw);
+                toolWindows.setAvailable(tw, activeBuffer() != null);
+            }
+            // needsBuffer == false: a self-contained tool window (scratchpad, calculator, …) — never gated.
             registry.register(
                     com.editora.command.Command.of(cmd, title == null ? twId : title, () -> toolWindows.toggle(tw)));
         }


### PR DESCRIPTION
Adds an opt-out so a plugin tool window can declare it doesn't need an open buffer (follow-up to #115, which buffer-gated all plugin tool windows).

## What
- **`PluginContext`** — new full overload `registerToolWindow(id, title, side, content, commandId, icon, needsBuffer)`. The existing 5-arg and 6-arg(+icon) methods become `default`s delegating with `needsBuffer = true`, so **existing plugins compile and behave unchanged** (still buffer-gated).
- **`PluginContextImpl`** — only adds the window to `pluginToolWindows` and applies the initial gate when `needsBuffer == true`; with `false` the window is registered untouched and stays available on every tab (Welcome included).
- Docs: `docs/plugins.md` API table, `CLAUDE.md` plugin note, CHANGELOG.

A buffer-acting plugin (GnuPG, Regex tester) keeps the default and hides on non-buffer tabs; a self-contained one (scratchpad, calculator, color picker) passes `false`.

Purely additive to the exported `com.editora.plugin` API — no new dependency, no schema/Settings change.

## Verification
`./mvnw verify` green: **1119 tests**, Spotless, JaCoCo, MessagesTest parity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)