### PR TITLE
Refresh the Git Log tool window when it's opened

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **The Git Log tool window refreshes when opened.** Opening it — via the stripe icon (which toggles the
+  window directly) or a command — now reloads the commit history, so it no longer shows stale commits from a
+  previous open. (Opening via the stripe button previously bypassed the load entirely.)
+
 - **Tool windows that act on the active file now hide on non-buffer tabs.** The **Git Commit** and **Git Log**
   stripe buttons — and **plugin** tool windows (e.g. GnuPG, the Regex tester) — only appear when there's an
   open editor buffer to act on; on the Welcome tab (or any non-buffer tab) they're hidden, matching how the

--- a/src/main/java/com/editora/ui/MainController.java
+++ b/src/main/java/com/editora/ui/MainController.java
@@ -2457,6 +2457,14 @@ public class MainController implements com.editora.mcp.McpBridge {
         // Detect a *user* open/close of the HTTP window (vs. our own auto show/hide, guarded by
         // httpAutoMutating) so a manual close is remembered per .http buffer and a manual open clears it.
         toolWindows.setStateListener((tw, opened) -> {
+            if (tw == gitLogToolWindow) {
+                // Refresh the log whenever the window is opened — via the stripe button (which toggles
+                // directly, bypassing showGitLog) or a command. open() only fires this on a real open.
+                if (opened && git.isEnabled()) {
+                    loadGitLog(gitLogFilter);
+                }
+                return;
+            }
             if (tw != httpToolWindow || httpAutoMutating) {
                 return;
             }
@@ -5075,10 +5083,23 @@ public class MainController implements com.editora.mcp.McpBridge {
         };
     }
 
+    /**
+     * Opens the Git Log tool window with the given filter (null = whole repo). A fresh open triggers the
+     * load via the tool-window state listener; if the window is already open (no state change, so no
+     * listener), the log is refreshed explicitly — so opening always shows current history.
+     */
+    private void openGitLog(Path filter) {
+        gitLogFilter = filter;
+        boolean wasOpen = toolWindows.isOpen(gitLogToolWindow);
+        toolWindows.open(gitLogToolWindow);
+        if (wasOpen) {
+            loadGitLog(filter);
+        }
+    }
+
     /** Opens the Git Log tool window showing the whole-repo history. */
     private void showGitLog() {
-        loadGitLog(null);
-        toolWindows.open(gitLogToolWindow);
+        openGitLog(null);
     }
 
     /** Opens the Git Log filtered to the active file's history. */
@@ -5088,8 +5109,7 @@ public class MainController implements com.editora.mcp.McpBridge {
             setStatus(tr("status.diff.noFile"));
             return;
         }
-        loadGitLog(b.getPath());
-        toolWindows.open(gitLogToolWindow);
+        openGitLog(b.getPath());
     }
 
     /** Loads up to 200 commits (whole-repo when {@code file} is null, else that file's history). */
@@ -5534,8 +5554,7 @@ public class MainController implements com.editora.mcp.McpBridge {
             setStatus(tr("status.diff.noFile"));
             return;
         }
-        loadGitLog(file);
-        toolWindows.open(gitLogToolWindow);
+        openGitLog(file);
     }
 
     /** Project-tree Git ▸ Stage File for {@code file}: {@code git add -- <relpath>}. */


### PR DESCRIPTION
The Git Log stripe icon toggles the tool window directly (it bypasses `showGitLog`, which was the only thing loading the log), so opening it via the icon showed **stale commits** from a previous open.

## Fix
- Reload the log whenever the window opens, via the existing tool-window **state listener** (`tw == gitLogToolWindow && opened → loadGitLog(gitLogFilter)`). Covers the stripe icon, the `tool.gitLog` command (`M-g h`), and file history.
- Routed `showGitLog` / `showFileHistory` / `gitFileHistoryForPath` through a small `openGitLog(filter)` helper: a fresh open loads via the listener; an already-open window refreshes explicitly — **no redundant double-load**, and the current filter (whole-repo vs file history) is preserved.

## Perf
One `git log` (200 commits, off-thread, generation-guarded) per open — an explicit user action, not a hot path.

## Verification
`./mvnw verify` green: **1119 tests**, Spotless, JaCoCo. CHANGELOG updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)