### PR TITLE
Open version-matched command docs (/docs/v-<appVersion>/commands/<id>)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Command docs now open the version-matched page.** The command palette's "open docs" (C-h) now links to
+  `…/docs/v-<appVersion>/commands/<command-id>`, matching the website's new versioned docs layout, so each
+  build opens the docs for the version that's actually running.
+
 - **De-duplicated the plugin examples.** The full plugin catalog lives canonically in the
   [adriandeleon/editora-plugins](https://github.com/adriandeleon/editora-plugins) repo (source +
   signed registry index), so the editor repo no longer keeps copies under `examples/` — those had

--- a/src/main/java/com/editora/ui/CommandPalette.java
+++ b/src/main/java/com/editora/ui/CommandPalette.java
@@ -43,8 +43,13 @@ public class CommandPalette {
     private static final boolean IS_MAC =
             System.getProperty("os.name", "").toLowerCase(Locale.ROOT).contains("mac");
 
-    /** Base URL for per-command documentation on the website; the command id is appended. */
-    private static final String DOCS_BASE = "https://editora-project.dev/docs/commands/";
+    /**
+     * Base URL for per-command documentation on the website; the command id is appended. The docs are
+     * versioned per app release ({@code /docs/v-<appVersion>/commands/<command-id>}), so the running
+     * version's docs are opened.
+     */
+    private static final String DOCS_BASE =
+            com.editora.AppInfo.HOMEPAGE + "/docs/v-" + com.editora.AppInfo.VERSION + "/commands/";
 
     private final CommandRegistry registry;
     private final KeymapManager keymap;


### PR DESCRIPTION
The website moved to versioned docs: `https://editora-project.dev/docs/v-<appVersion>/commands/<command-id>`.

## Change
`CommandPalette.DOCS_BASE` now builds the URL from `AppInfo` instead of a hardcoded path:

```java
private static final String DOCS_BASE =
        AppInfo.HOMEPAGE + "/docs/v-" + AppInfo.VERSION + "/commands/";
```

So C-h ("open docs") on a command opens the page for the version that's actually running (e.g. `…/docs/v-1.0.0/commands/file.save`); the `v-<appVersion>` segment updates automatically on each release bump. Also reuses `AppInfo.HOMEPAGE` so the host isn't duplicated.

## Verification
`./mvnw verify` green (1128 tests, Spotless). CHANGELOG updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)