### PR TITLE
Highlight common project config files (.editorconfig/.gitignore/mvnw/.classpath/.project)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Syntax highlighting for common project config files.** `.editorconfig` (INI), `.gitignore` (and other
+  `.*ignore` files, via a new `ignore` grammar), `mvnw`/`gradlew` (shell), and Eclipse `.classpath`/`.project`
+  (XML) are now recognized by name and highlighted — wired through the shared `ConfigFileType` resolver so the
+  grammar and language registries stay in sync.
+
 - **Local History, closer to IntelliJ.** Three additions to the File History tool window:
   **selective restore** — the snapshot-vs-current diff is now editable on the current side, so the
   apply-chevrons copy individual fragments from a revision back into the file (undoable) instead of only a

--- a/src/main/java/com/editora/editor/ConfigFileType.java
+++ b/src/main/java/com/editora/editor/ConfigFileType.java
@@ -101,6 +101,24 @@ public final class ConfigFileType {
         if ((lower.equals("changelog") && hasAncestor(norm, "debian")) || lower.equals("changelog.debian")) {
             return "debian-changelog";
         }
+        // .editorconfig — INI-style key/value sections.
+        if (lower.equals(".editorconfig")) {
+            return "ini";
+        }
+        // Ignore files share one glob/comment syntax: .gitignore, .dockerignore, .npmignore,
+        // .eslintignore, .prettierignore, .vscodeignore, ... (any dotfile ending in "ignore").
+        if (lower.startsWith(".") && lower.endsWith("ignore")) {
+            return "ignore";
+        }
+        // Maven/Gradle wrapper launchers are POSIX shell scripts (the .cmd/.bat siblings map to batchfile
+        // via their extension).
+        if (lower.equals("mvnw") || lower.equals("gradlew")) {
+            return "shell";
+        }
+        // Eclipse project metadata is XML.
+        if (lower.equals(".classpath") || lower.equals(".project")) {
+            return "xml";
+        }
         return null;
     }
 

--- a/src/main/java/com/editora/editor/GrammarRegistry.java
+++ b/src/main/java/com/editora/editor/GrammarRegistry.java
@@ -192,6 +192,7 @@ public final class GrammarRegistry {
         scopeToResource.put("source.interfaces", "interfaces");
         scopeToResource.put("source.debian-changelog", "debian-changelog");
         scopeToResource.put("source.log", "log");
+        scopeToResource.put("source.ignore", "ignore"); // .gitignore / .dockerignore / .npmignore / …
 
         // file extension -> scope name
         mapExtensions("source.java", "java");

--- a/src/main/resources/com/editora/grammars/ignore.tmLanguage.json
+++ b/src/main/resources/com/editora/grammars/ignore.tmLanguage.json
@@ -1,0 +1,26 @@
+{
+  "name": "ignore",
+  "scopeName": "source.ignore",
+  "patterns": [
+    {
+      "name": "comment.line.number-sign.ignore",
+      "match": "^\\s*#.*$"
+    },
+    {
+      "name": "keyword.operator.negation.ignore",
+      "match": "^\\s*!"
+    },
+    {
+      "name": "keyword.operator.glob.ignore",
+      "match": "\\*\\*|[*?]"
+    },
+    {
+      "name": "constant.character.range.ignore",
+      "match": "\\[[^\\]]*\\]"
+    },
+    {
+      "name": "punctuation.separator.path.ignore",
+      "match": "/"
+    }
+  ]
+}

--- a/src/test/java/com/editora/editor/ConfigFileTypeTest.java
+++ b/src/test/java/com/editora/editor/ConfigFileTypeTest.java
@@ -94,6 +94,25 @@ class ConfigFileTypeTest {
     }
 
     @Test
+    void projectConfigFilesMapToReusableGrammars() {
+        // .editorconfig is INI-style.
+        assertEquals("ini", ConfigFileType.resolve(".editorconfig"));
+        assertEquals("ini", ConfigFileType.resolve("/proj/.editorconfig"));
+        // Ignore files share one syntax (any dotfile ending in "ignore").
+        assertEquals("ignore", ConfigFileType.resolve(".gitignore"));
+        assertEquals("ignore", ConfigFileType.resolve(".dockerignore"));
+        assertEquals("ignore", ConfigFileType.resolve("/proj/sub/.npmignore"));
+        // Maven/Gradle wrapper scripts are POSIX shell.
+        assertEquals("shell", ConfigFileType.resolve("mvnw"));
+        assertEquals("shell", ConfigFileType.resolve("/proj/gradlew"));
+        // Eclipse project metadata is XML.
+        assertEquals("xml", ConfigFileType.resolve(".classpath"));
+        assertEquals("xml", ConfigFileType.resolve("/proj/.project"));
+        // mvnw.cmd stays a batch file (matched by extension elsewhere, not special here).
+        assertNull(ConfigFileType.resolve("mvnw.cmd"));
+    }
+
+    @Test
     void nullAndOrdinaryFilesAreNotSpecial() {
         assertNull(ConfigFileType.resolve(null));
         assertNull(ConfigFileType.resolve(""));

--- a/src/test/java/com/editora/editor/GrammarRegistryTest.java
+++ b/src/test/java/com/editora/editor/GrammarRegistryTest.java
@@ -85,6 +85,19 @@ class GrammarRegistryTest {
     }
 
     @Test
+    void projectConfigFilesResolveToGrammars() {
+        // .editorconfig -> INI grammar; .gitignore -> the in-house ignore grammar; mvnw -> shell;
+        // .classpath/.project -> XML. Each resolves to a loadable grammar (parse + Oniguruma compile).
+        assertNotNull(GrammarRegistry.shared().forFileName(".editorconfig"));
+        assertNotNull(GrammarRegistry.shared().forLanguageName("ignore"));
+        assertNotNull(GrammarRegistry.shared().forFileName(".gitignore"));
+        assertNotNull(GrammarRegistry.shared().forFileName(".dockerignore"));
+        assertNotNull(GrammarRegistry.shared().forFileName("mvnw"));
+        assertNotNull(GrammarRegistry.shared().forFileName(".classpath"));
+        assertNotNull(GrammarRegistry.shared().forFileName(".project"));
+    }
+
+    @Test
     void debianGrammarsLoad() {
         // In-house deb822 / apt-sources / interfaces / debian-changelog grammars load end-to-end.
         assertNotNull(GrammarRegistry.shared().forLanguageName("deb822"));


### PR DESCRIPTION
Adds syntax highlighting for common project config files, recognized by **filename** through the shared `ConfigFileType` resolver (keeps `GrammarRegistry` + `LanguageRegistry` in sync).

| File | Language | Grammar |
|---|---|---|
| `.editorconfig` | `ini` | existing INI |
| `.gitignore` (+ any `.*ignore`: `.dockerignore`, `.npmignore`, …) | `ignore` | **new** `ignore.tmLanguage.json` (comments, `!` negation, `*`/`**`/`?` globs, `[…]`, `/`) |
| `mvnw`, `gradlew` | `shell` | existing shell |
| `.classpath`, `.project` | `xml` | existing XML |

Notes:
- `mvnw.cmd` / `gradlew.bat` already highlight as batch via their extension (unchanged).
- Only new asset is the small `ignore` grammar (rides the existing `opens com.editora.grammars`); no new dependency / `module-info` change.

## Verification
`./mvnw verify` green: **1130 tests** (new cases in `ConfigFileTypeTest` + `GrammarRegistryTest` confirm the mappings resolve and the grammars load), Spotless, JaCoCo. CHANGELOG updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)