### PR TITLE
Use per-type file icons in the breadcrumb folder dropdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Breadcrumb dropdown uses the same file icons as the Project tool window.** The folder dropdown on a
+  breadcrumb crumb now shows per-type file glyphs (and the boxed folder icon) via `FileIcons`, instead of a
+  single generic file icon — matching the Project tree.
+
 - **The Git Log tool window refreshes when opened.** Opening it — via the stripe icon (which toggles the
   window directly) or a command — now reloads the commit history, so it no longer shows stale commits from a
   previous open. (Opening via the stripe button previously bypassed the load entirely.)

--- a/src/main/java/com/editora/ui/FileBreadcrumb.java
+++ b/src/main/java/com/editora/ui/FileBreadcrumb.java
@@ -214,12 +214,15 @@ public class FileBreadcrumb extends StackPane {
             }
         }
         for (Path d : dirs) {
-            MenuItem mi = new MenuItem(d.getFileName().toString(), Icons.project());
+            // Match the Project tool window's icons (FileIcons.boxed folder + per-type file glyphs).
+            MenuItem mi = new MenuItem(d.getFileName().toString(), FileIcons.boxed(Icons.project()));
             mi.setOnAction(e -> navigateInto(d, anchor));
             menu.getItems().add(mi);
         }
         for (Path f : files) {
-            MenuItem mi = new MenuItem(f.getFileName().toString(), Icons.fileSheet());
+            MenuItem mi = new MenuItem(
+                    f.getFileName().toString(),
+                    FileIcons.forFileName(f.getFileName().toString()));
             mi.setOnAction(e -> onOpenFile.accept(f));
             menu.getItems().add(mi);
         }


### PR DESCRIPTION
The breadcrumb crumb dropdown (folder contents listing) used a single generic file icon (`Icons.fileSheet`) and a bare folder icon, while the Project tool window uses per-type `FileIcons`. They now match.

## Change
In `FileBreadcrumb.showCrumbMenu`:
- files → `FileIcons.forFileName(name)` (per-type glyphs)
- folders → `FileIcons.boxed(Icons.project())`

Same as the Project tree's cells. The crumb *bar* segments stay text-only (unchanged by design).

## Verification
`./mvnw verify` green (1130 tests, Spotless). CHANGELOG updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)