### PR TITLE
Fix multi-second UI freeze when opening a large source file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Opening a large source file no longer freezes the UI.** Computing fold regions on open recreated a gutter
+  graphic for *every* fold header in the file (thousands, for a big file like a 12k-line Java source) on the
+  JavaFX thread, blocking it for several seconds. The fold recompute now only refreshes the chevrons of
+  currently-visible rows — offscreen rows get the correct fold state when the gutter factory builds them on
+  scroll — cutting the per-open cost from seconds to a few milliseconds.
+
 - **Breadcrumb dropdown uses the same file icons as the Project tool window.** The folder dropdown on a
   breadcrumb crumb now shows per-type file glyphs (and the boxed folder icon) via `FileIcons`, instead of a
   single generic file icon — matching the Project tree.

--- a/src/main/java/com/editora/editor/FoldManager.java
+++ b/src/main/java/com/editora/editor/FoldManager.java
@@ -237,8 +237,20 @@ public final class FoldManager {
         changed.removeIf(line -> oldStarts.contains(line) && map.containsKey(line));
         byStart = map;
         int total = area.getParagraphs().size();
+        // Only recreate the gutter graphics for changed fold-start lines that are *currently visible*; the
+        // graphic factory reads the (now-updated) byStart when it lazily builds offscreen rows on scroll,
+        // so recreating them eagerly is wasted work — and recreating thousands at once (e.g. the initial
+        // recompute of a large file, which marks every fold header changed) froze the FX thread for seconds.
+        int first = 0;
+        int last = -1;
+        try {
+            first = Math.max(0, area.firstVisibleParToAllParIndex());
+            last = Math.min(total - 1, area.lastVisibleParToAllParIndex());
+        } catch (RuntimeException notLaidOutYet) {
+            last = -1; // no viewport yet (e.g. during open) — the factory builds correct graphics on layout
+        }
         for (int line : changed) {
-            if (line >= 0 && line < total) {
+            if (line >= first && line <= last) {
                 area.recreateParagraphGraphic(line);
             }
         }

--- a/src/test/java/com/editora/ui/LargeFileOpenPerfFxTest.java
+++ b/src/test/java/com/editora/ui/LargeFileOpenPerfFxTest.java
@@ -1,0 +1,49 @@
+package com.editora.ui;
+
+import com.editora.editor.EditorBuffer;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Regression guard for the large-file open freeze: setting the language on a large, fold-heavy buffer that
+ * isn't laid out yet must not synchronously recreate a gutter graphic per fold region. Before the fix,
+ * {@code FoldManager.recompute()} recreated every fold-start line's graphic (thousands of them) on the first
+ * recompute, freezing the FX thread for seconds; now it only touches currently-visible rows.
+ */
+@Tag("fx")
+class LargeFileOpenPerfFxTest {
+
+    @BeforeAll
+    static void boot() throws Exception {
+        FxTestSupport.bootToolkit();
+    }
+
+    @Test
+    void settingLanguageOnLargeFoldHeavyBufferIsFast() throws Exception {
+        // ~16k lines with a fold region every ~3 lines → thousands of fold headers.
+        StringBuilder sb = new StringBuilder(600_000);
+        for (int i = 0; i < 4000; i++) {
+            sb.append("class C").append(i).append(" {\n");
+            sb.append("    int f() {\n");
+            sb.append("        return ").append(i).append(";\n");
+            sb.append("    }\n");
+        }
+        String text = sb.toString();
+
+        long ms = FxTestSupport.callOnFx(() -> {
+            EditorBuffer buf = new EditorBuffer();
+            buf.setContent(text);
+            long s = System.nanoTime();
+            buf.setLanguageOverride("java"); // first fold recompute over the whole document
+            return (System.nanoTime() - s) / 1_000_000;
+        });
+
+        System.out.println("setLanguageOverride on " + (text.length() / 1024) + " KB fold-heavy buffer: " + ms + " ms");
+        // Pre-fix this was multiple seconds (one recreateParagraphGraphic per fold header). The visible-only
+        // fix makes it a few ms; a generous bound catches a regression to O(folds) graphic recreation.
+        assertTrue(ms < 2000, "setLanguageOverride took " + ms + " ms (expected < 2000 ms — fold-graphic regression?)");
+    }
+}


### PR DESCRIPTION
Opening a large source file (reported: `MainController.java`, 565 KB / 12.7k lines) froze the JavaFX thread for ~5 seconds.

## Diagnosis (measured via a headless FX probe)
Timed each phase of the real open path on the buffer:

| Phase | Before |
|---|---|
| Fold *detection* (`FoldRegions.detect`) | 8 ms |
| Grammar compile (Oniguruma) | 86 ms |
| Tokenization | 1.8 s (off-thread — not a UI block) |
| `setStyleSpans` whole document | 24 ms |
| **`setPath` / first language-set** | **~5–7 s ⟵ the freeze** |

Cause: `FoldManager.recompute()` recreates a gutter graphic for every *changed* fold header. On the first recompute of a freshly-opened file, **all** fold headers count as changed (~1837 for this file), so it issued ~1837 synchronous `recreateParagraphGraphic` calls on the FX thread.

## Fix
`recompute()` now recreates chevrons only for **currently-visible** rows (same `try/catch` viewport idiom as the neighbouring `repadVisibleLineNumbers`). Offscreen rows get the correct fold state when the gutter factory lazily builds them on scroll — so this is purely less FX-thread work, no behavior change.

- `setPath`: **~5000 ms → 23 ms**; first `setLanguageOverride`: 7020 ms → 5 ms.

## Test
`LargeFileOpenPerfFxTest` (headless FX): setting the language on a synthetic fold-heavy buffer must complete < 2 s — runs in ~140 ms now; would be multiple seconds if the per-fold-header recreation regressed.

`./mvnw verify` green: **1131 tests**, Spotless, JaCoCo. CHANGELOG updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)