### PR TITLE
Structure: stop the editor jumping back while navigating the outline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Structure tool window no longer jumps the editor back while navigating.** A language server that
+  re-announces readiness repeatedly (jdtls re-sends `language/status` "ServiceReady" on workspace events)
+  re-pushed the same document symbols, rebuilding the outline tree, resetting the selection to the first
+  row, and snapping the editor back to the top of the file as you clicked around. Re-pushing an unchanged
+  outline is now a no-op, and a genuine rebuild preserves the symbol you had selected.
 - **Java LSP (jdtls) now initializes reliably; completion works.** jdtls was launched without a `-data`
   workspace, so every project shared one default Eclipse workspace and deadlocked on its `.lock` (contending
   with a leaked previous run or another editor) — the server never finished `initialize`, leaving the

--- a/src/main/java/com/editora/ui/StructurePanel.java
+++ b/src/main/java/com/editora/ui/StructurePanel.java
@@ -386,13 +386,48 @@ public class StructurePanel extends VBox implements ToolWindowContent {
         }
         sortNodes(roots);
         rebuildKindFilter();
-        // A rebuild reselects the first row; that must not move the editor caret.
+        // A rebuild rebuilds the tree (applyFilter selects row 0); that must not move the editor caret,
+        // and it should keep the user on the symbol they had selected rather than snapping to the top.
+        StructureNode prevSelection = selectedNodeValue();
         suppressNavigation = true;
         try {
             applyFilter(filterField.getText());
+            reselect(prevSelection);
         } finally {
             suppressNavigation = false;
         }
+    }
+
+    /** The {@link StructureNode} currently selected in the tree (a real symbol with a line), or {@code null}. */
+    private StructureNode selectedNodeValue() {
+        TreeItem<StructureNode> sel = tree.getSelectionModel().getSelectedItem();
+        StructureNode v = sel == null ? null : sel.getValue();
+        return v != null && v.line() >= 0 ? v : null;
+    }
+
+    /** Re-selects the tree row matching {@code target} (by line + label) after a rebuild; no-op if absent. */
+    private void reselect(StructureNode target) {
+        if (target == null || tree.getRoot() == null) {
+            return;
+        }
+        TreeItem<StructureNode> match = findItem(tree.getRoot(), target);
+        if (match != null) {
+            tree.getSelectionModel().select(match);
+        }
+    }
+
+    private static TreeItem<StructureNode> findItem(TreeItem<StructureNode> node, StructureNode target) {
+        StructureNode v = node.getValue();
+        if (v != null && v.line() == target.line() && java.util.Objects.equals(v.label(), target.label())) {
+            return node;
+        }
+        for (TreeItem<StructureNode> child : node.getChildren()) {
+            TreeItem<StructureNode> found = findItem(child, target);
+            if (found != null) {
+                return found;
+            }
+        }
+        return null;
     }
 
     /**
@@ -401,6 +436,14 @@ public class StructurePanel extends VBox implements ToolWindowContent {
      */
     public void setLspSymbols(EditorBuffer forBuffer, List<SymbolNode> symbols) {
         if (forBuffer != buffer) {
+            return;
+        }
+        // Skip the rebuild when the outline is unchanged. A server can re-announce readiness repeatedly
+        // (jdtls re-sends language/status "ServiceReady" on indexing/workspace events), and each one
+        // re-fetches the same document symbols — rebuilding would reset the selection to row 0 and can
+        // jump the editor back to the top while the user is navigating. SymbolNode is a record, so this
+        // is deep value equality. (attach() already built the initial tree, so this never skips first paint.)
+        if (java.util.Objects.equals(symbols, lspSymbols)) {
             return;
         }
         this.lspSymbols = symbols;

--- a/src/test/java/com/editora/ui/StructureNavFxTest.java
+++ b/src/test/java/com/editora/ui/StructureNavFxTest.java
@@ -1,0 +1,107 @@
+package com.editora.ui;
+
+import java.util.List;
+
+import javafx.scene.control.TreeItem;
+import javafx.scene.control.TreeView;
+
+import com.editora.editor.EditorBuffer;
+import com.editora.lsp.SymbolNode;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+/**
+ * Regression guard for "Structure navigation keeps jumping back": a chatty LSP server (jdtls re-sends
+ * {@code language/status} "ServiceReady" repeatedly) re-pushes the same document symbols, which used to
+ * rebuild the tree, reset the selection to row 0, and jump the editor to the top while the user navigated.
+ * {@link StructurePanel#setLspSymbols} now no-ops when the outline is unchanged, and a genuine rebuild
+ * preserves the selected symbol instead of snapping to the first row.
+ */
+@Tag("fx")
+class StructureNavFxTest {
+
+    @BeforeAll
+    static void boot() throws Exception {
+        FxTestSupport.bootToolkit();
+    }
+
+    private static EditorBuffer tenLineBuffer() throws Exception {
+        return FxTestSupport.callOnFx(() -> {
+            EditorBuffer b = new EditorBuffer();
+            b.setContent("line0\nline1\nline2\nline3\nline4\nline5\nline6\nline7\nline8\nline9\n");
+            return b;
+        });
+    }
+
+    private static List<SymbolNode> threeSymbols() {
+        return List.of(
+                new SymbolNode("Alpha", null, "class", 0, 9, List.of()),
+                new SymbolNode("beta", null, "method", 3, 4, List.of()),
+                new SymbolNode("gamma", null, "method", 6, 7, List.of()));
+    }
+
+    /** Reads the line of the tree's currently-selected StructureNode (package-private) via its accessor. */
+    private static int selectedLine(TreeView<?> tree) throws Exception {
+        return FxTestSupport.callOnFx(() -> {
+            TreeItem<?> sel = tree.getSelectionModel().getSelectedItem();
+            return sel == null || sel.getValue() == null
+                    ? -1
+                    : (int) FxTestSupport.call(sel.getValue(), "line", new Class<?>[] {});
+        });
+    }
+
+    @Test
+    void unchangedSymbolsKeepSelectionAndDoNotRebuild() throws Exception {
+        StructurePanel panel = FxTestSupport.callOnFx(StructurePanel::new);
+        EditorBuffer buffer = tenLineBuffer();
+        FxTestSupport.runOnFx(() -> {
+            panel.attach(buffer);
+            panel.setLspSymbols(buffer, threeSymbols());
+        });
+
+        TreeView<?> tree = FxTestSupport.field(panel, "tree");
+        // Select the third symbol ("gamma"), mimicking the user navigating away from the top.
+        TreeItem<?> selectedBefore = FxTestSupport.callOnFx(() -> {
+            tree.getSelectionModel().select(2);
+            return tree.getSelectionModel().getSelectedItem();
+        });
+        assertEquals(6, selectedLine(tree));
+
+        // The server re-announces the SAME outline (a fresh but value-equal list).
+        FxTestSupport.runOnFx(() -> panel.setLspSymbols(buffer, threeSymbols()));
+
+        // No rebuild happened: the very same TreeItem instance is still selected (not reset to row 0).
+        TreeItem<?> selectedAfter =
+                FxTestSupport.callOnFx(() -> tree.getSelectionModel().getSelectedItem());
+        assertSame(
+                selectedBefore, selectedAfter, "an unchanged outline must not rebuild the tree or move the selection");
+    }
+
+    @Test
+    void changedSymbolsRebuildButPreserveTheSelectedSymbol() throws Exception {
+        StructurePanel panel = FxTestSupport.callOnFx(StructurePanel::new);
+        EditorBuffer buffer = tenLineBuffer();
+        FxTestSupport.runOnFx(() -> {
+            panel.attach(buffer);
+            panel.setLspSymbols(buffer, threeSymbols());
+        });
+
+        TreeView<?> tree = FxTestSupport.field(panel, "tree");
+        FxTestSupport.runOnFx(() -> tree.getSelectionModel().select(2)); // "gamma" at line 6
+
+        // A genuine change (a 4th symbol appended) forces a rebuild — the user's selected symbol must survive.
+        List<SymbolNode> grown = List.of(
+                new SymbolNode("Alpha", null, "class", 0, 9, List.of()),
+                new SymbolNode("beta", null, "method", 3, 4, List.of()),
+                new SymbolNode("gamma", null, "method", 6, 7, List.of()),
+                new SymbolNode("delta", null, "method", 8, 9, List.of()));
+        FxTestSupport.runOnFx(() -> panel.setLspSymbols(buffer, grown));
+
+        // The selection should still be "gamma" (line 6), re-selected by line+label, not snapped to row 0.
+        assertEquals(6, selectedLine(tree), "a rebuild must preserve the user's selected symbol");
+    }
+}


### PR DESCRIPTION
Structure tool window navigation in a Java file kept jumping the editor back (to the top) while clicking around the outline.

## Root cause
Now that jdtls actually initializes (PR #123), it re-sends `language/status` "ServiceReady" repeatedly on workspace/indexing events, and the LSP-status handler re-fetches document symbols on **each** one. Every `setLspSymbols` push rebuilt the Structure tree, reset the selection to row 0, and — because TreeView's root-change selection adjustment can fire on a later pulse, escaping the synchronous `suppressNavigation` guard — snapped the editor back to the top.

## Fix (`StructurePanel`)
1. **No-op on unchanged outline** — `setLspSymbols` returns early when the symbols are value-equal to the current ones (`SymbolNode` is a record → deep equality). jdtls's repeated identical pushes no longer rebuild the tree or disturb the selection/caret during navigation.
2. **Preserve selection across a genuine rebuild** — re-selects the symbol the user had (by line + label) instead of forcing row 0.

## Verification
`./mvnw verify` green: **1135 tests** including two new FX regression tests in `StructureNavFxTest` (one asserts the same `TreeItem` survives an identical push; one asserts the selected symbol survives a real change). Spotless + JaCoCo pass. CHANGELOG updated.

**Perf:** net improvement — an O(symbols) equality compare now *skips* whole rebuilds on the chatty LSP-status path; the selection-restore is one O(tree) walk only on genuine changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)