### PR TITLE
Spell: persist Add to Dictionary to dictionary.txt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **"Add to Dictionary" now persists to `dictionary.txt`.** The added word was applied for the current
+  session but never written to disk, so it reappeared as misspelled after a restart. The buffer added the
+  word to the shared dictionary set before calling the persist callback, and `addUserWord` only writes the
+  file when the word is newly added to that (same) set — so the write was always skipped. The word is now
+  persisted on the first add.
 - **Structure tool window no longer jumps the editor back while navigating.** A language server that
   re-announces readiness repeatedly (jdtls re-sends `language/status` "ServiceReady" on workspace events)
   re-pushed the same document symbols, rebuilding the outline tree, resetting the selection to the first

--- a/src/main/java/com/editora/editor/EditorBuffer.java
+++ b/src/main/java/com/editora/editor/EditorBuffer.java
@@ -1333,8 +1333,14 @@ public class EditorBuffer implements TabContent {
             return;
         }
         String lower = word.toLowerCase(java.util.Locale.ROOT);
-        spellUserWords.add(lower);
+        // Persist FIRST. The callback (ConfigManager.addUserWord) adds the word to the shared dictionary set
+        // and writes dictionary.txt — but it only writes when the word is newly added to that set, and
+        // spellUserWords *is* that shared set. Adding here first would make the callback see the word as
+        // already present and silently skip the file write (the word then works this session but never
+        // persists). Let the callback add + persist; the local add below is a no-op when shared, and only
+        // matters when no persist callback is wired.
         onAddToDictionary.accept(lower);
+        spellUserWords.add(lower);
         spellOverlay.refresh();
     }
 

--- a/src/test/java/com/editora/ui/SpellDictionaryFxTest.java
+++ b/src/test/java/com/editora/ui/SpellDictionaryFxTest.java
@@ -1,0 +1,52 @@
+package com.editora.ui;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import com.editora.config.ConfigManager;
+import com.editora.editor.EditorBuffer;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Regression guard for "Add to Dictionary is ignored and no file is written": the buffer's spell user-word
+ * set is the very same set as {@code SharedConfig.userDictionary}, and {@code addUserWord} only writes
+ * {@code dictionary.txt} when the word is newly added to that set. The buffer used to add the word to the
+ * shared set *before* invoking the persist callback, so the callback saw it as already present and skipped
+ * the file write entirely — the word applied for the session but never persisted. The callback now runs
+ * first.
+ */
+@Tag("fx")
+class SpellDictionaryFxTest {
+
+    @BeforeAll
+    static void boot() throws Exception {
+        FxTestSupport.bootToolkit();
+    }
+
+    @Test
+    void addToDictionaryPersistsToDiskWhenWiredToTheSharedSet(@TempDir Path dir) throws Exception {
+        ConfigManager config = new ConfigManager(dir);
+        EditorBuffer buffer = FxTestSupport.callOnFx(EditorBuffer::new);
+
+        // Wire exactly as MainController.addBuffer does: the buffer's user-word set IS the shared dictionary,
+        // and "Add to Dictionary" persists through ConfigManager.addUserWord.
+        FxTestSupport.runOnFx(() -> {
+            buffer.setSpellUserWords(config.getUserDictionary());
+            buffer.setOnAddToDictionary(config::addUserWord);
+        });
+
+        FxTestSupport.runOnFx(
+                () -> FxTestSupport.call(buffer, "addToDictionary", new Class<?>[] {String.class}, "zzqqx"));
+
+        Path dictionary = config.getUserDictionaryFile();
+        assertTrue(Files.isReadable(dictionary), "dictionary.txt should be created on the first add");
+        assertTrue(
+                Files.readString(dictionary).contains("zzqqx"), "the added word should be written to dictionary.txt");
+        assertTrue(config.getUserDictionary().contains("zzqqx"), "the added word should be in the in-memory set");
+    }
+}


### PR DESCRIPTION
"Add to Dictionary" appeared to be ignored and never wrote a file to disk.

## Root cause
`MainController.addBuffer` wires the buffer's spell user-word set to be the **same object** as `SharedConfig.userDictionary`. `ConfigManager.addUserWord` only writes `dictionary.txt` when the word is newly added to that set (`if (!userDictionary.add(w)) return;`). But `EditorBuffer.addToDictionary` added the word to the shared set **first**, then called the persist callback — so `addUserWord` saw it as already present and returned before the file write. The word applied for the session but never persisted, reappearing as misspelled after a restart.

## Fix
Reorder `addToDictionary` to invoke the persist callback **before** the local set add. `addUserWord` now adds the word to the shared set *and* writes `dictionary.txt`; the subsequent local add is a harmless no-op (it only matters when no persist callback is wired).

## Verification
`./mvnw verify` green: **1136 tests** including a new `SpellDictionaryFxTest` that wires a real `ConfigManager` exactly like `addBuffer`, invokes the add, and asserts the word lands in `dictionary.txt` (fails on the old order). CHANGELOG updated. No perf impact (same two calls, swapped order).

🤖 Generated with [Claude Code](https://claude.com/claude-code)