### PR TITLE
Linux: also build RPM packages (.deb + .rpm)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,16 +32,16 @@ jobs:
           java-version: '25'
           cache: maven
 
-      # The -Pdist build trains a full-GUI AOT cache (see scripts/aot_build.java + pom.xml). On a
-      # headless Linux runner that needs a virtual X display + JavaFX's GTK/GL runtime libs; the
-      # helper auto-wraps the training run in xvfb-run when DISPLAY is unset. If any of this is
-      # missing the training degrades gracefully (the app just ships without the cache), so this
-      # step is a best-effort enabler, not a hard dependency. macOS/Windows runners need nothing.
-      - name: Install virtual display for AOT training (Linux)
+      # Linux build deps:
+      #  - xvfb + GTK/GL libs: the -Pdist build trains a full-GUI AOT cache (scripts/aot_build.java),
+      #    and on a headless runner JavaFX needs a virtual X display; the helper auto-wraps training in
+      #    xvfb-run when DISPLAY is unset. Best-effort — training degrades gracefully if it's missing.
+      #  - rpm: provides rpmbuild so jpackage can build the .rpm (the Linux leg ships .deb AND .rpm).
+      - name: Install Linux build deps (virtual display + rpmbuild)
         if: runner.os == 'Linux'
         run: |
           sudo apt-get update
-          sudo apt-get install -y --no-install-recommends xvfb libgtk-3-0 libgl1 libxxf86vm1
+          sudo apt-get install -y --no-install-recommends xvfb libgtk-3-0 libgl1 libxxf86vm1 rpm
 
       - name: Build native installer (-Pdist)
         shell: bash

--- a/pom.xml
+++ b/pom.xml
@@ -872,7 +872,11 @@
             <id>os-linux</id>
             <activation><os><name>Linux</name></os></activation>
             <properties>
-                <jpackage.type>DEB</jpackage.type>
+                <!-- Build both Debian and RPM packages from the one trained app image (the aot_build
+                     helper wraps each comma-separated type). RPM needs rpmbuild on the runner — see
+                     release.yml. A per-type wrap failure is non-fatal, so a missing rpmbuild can't
+                     sink the .deb. -->
+                <jpackage.type>DEB,RPM</jpackage.type>
                 <jpackage.icon>${project.basedir}/branding/editora.png</jpackage.icon>
                 <!-- es2 first on Linux (no Metal/Direct3D there); sw fallback. -->
                 <prism.pipeline>es2,sw</prism.pipeline>

--- a/scripts/aot_build.java
+++ b/scripts/aot_build.java
@@ -71,16 +71,33 @@ public class aot_build {
             System.out.println("[aot] stripped runtime bin/: " + imageJava.getParent());
         }
 
-        // --- 3) deliver: copy (APP_IMAGE) or wrap into an installer ---
+        // --- 3) deliver: copy (APP_IMAGE) or wrap into one or more installers ---
+        // `type` may be a comma list (e.g. "DEB,RPM" on Linux) — train once, wrap each. Per-type
+        // failures are non-fatal so a flaky RPM can't sink the DEB; only an all-failed result (or a
+        // single-type platform's failure) fails the build.
         Files.createDirectories(destDir);
         Path imageRoot = imageRoot(imageDir, appName, win); // Editora.app (mac) or Editora dir
-        if ("APP_IMAGE".equalsIgnoreCase(type)) {
+        if ("APP_IMAGE".equalsIgnoreCase(type.trim())) {
             Path out = destDir.resolve(imageRoot.getFileName());
             deleteRecursive(out);
             copyRecursive(imageRoot, out);
             System.out.println("[aot] app image -> " + out);
         } else {
-            wrapInstaller(imageRoot, appName, appVer, type, icon, destDir); // fails the build on error
+            int ok = 0, attempted = 0;
+            for (String one : type.split(",")) {
+                one = one.trim();
+                if (one.isEmpty()) continue;
+                attempted++;
+                if (wrapInstaller(imageRoot, appName, appVer, one, icon, destDir)) ok++;
+            }
+            if (attempted > 0 && ok == 0) {
+                System.err.println("[aot] every installer wrap failed — failing the build");
+                System.exit(1);
+            }
+            if (ok < attempted) {
+                System.out.println("[aot] " + ok + "/" + attempted
+                        + " installers built; the rest failed (see log above)");
+            }
         }
     }
 
@@ -119,8 +136,9 @@ public class aot_build {
         }
     }
 
-    /** jpackage --app-image <image> --type <installer> ... (build JDK's jpackage). Fails on error. */
-    private static void wrapInstaller(Path imageRoot, String appName, String appVer, String type,
+    /** jpackage --app-image <image> --type <installer> ... (build JDK's jpackage). Returns true on
+     *  success; the caller decides whether a failure is fatal (it is for a single-type platform). */
+    private static boolean wrapInstaller(Path imageRoot, String appName, String appVer, String type,
                                       String icon, Path destDir) throws Exception {
         boolean win = System.getProperty("os.name", "").toLowerCase(Locale.ROOT).contains("win");
         Path jpackage = Path.of(System.getProperty("java.home"), "bin", win ? "jpackage.exe" : "jpackage");
@@ -152,10 +170,11 @@ public class aot_build {
         Process p = new ProcessBuilder(cmd).inheritIO().start();
         int code = p.waitFor();
         if (code != 0) {
-            System.err.println("[aot] jpackage installer wrap failed with exit " + code);
-            System.exit(code); // the installer is the real deliverable — fail the build
+            System.err.println("[aot] jpackage " + type + " wrap failed with exit " + code);
+            return false;
         }
-        System.out.println("[aot] installer -> " + destDir);
+        System.out.println("[aot] installer -> " + destDir + " (" + type + ")");
+        return true;
     }
 
     // ---- helpers ----


### PR DESCRIPTION
## Summary
The Linux release leg now ships **both a `.deb` and an `.rpm`**, built from the single trained app image.

- `os-linux` sets `jpackage.type=DEB,RPM`; `aot_build.java` wraps each comma-separated type (train once, wrap each).
- **Resilient:** a per-type wrap failure is non-fatal, so a missing/misconfigured `rpmbuild` can't sink the `.deb`. An all-failed result (or a single-type platform's failure, e.g. macOS DMG / Windows MSI) still fails the build.
- `release.yml` installs `rpm` (provides `rpmbuild`) on the Linux legs.
- The staging step already globs `target/dist/*` by extension, so both artifacts upload as `Editora-<version>-linux-<arch>.deb` / `.rpm`.

## Testing
- macOS DMG build verified locally (the multi-type loop with a single type still wraps + ships).
- `.deb`/`.rpm` can't be built on macOS (needs `dpkg`/`rpmbuild` on Linux) — verify via the next release's Linux legs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)