### PR TITLE
Fix the Snippet/Template body editor (framed look + Emacs keys)

### DIFF
--- a/src/main/java/com/editora/ui/SettingsWindow.java
+++ b/src/main/java/com/editora/ui/SettingsWindow.java
@@ -3020,6 +3020,10 @@ public class SettingsWindow {
         if (field instanceof javafx.scene.layout.Region r) {
             r.setMinWidth(220);
         }
+        // A tall multi-line body would otherwise centre its label; align it to the top of the field instead.
+        if (field instanceof CodeArea) {
+            javafx.scene.layout.GridPane.setValignment(l, javafx.geometry.VPos.TOP);
+        }
     }
 
     /** Re-highlights a snippet/template body {@link CodeArea} for {@code languageName} (plain for global/unknown). */
@@ -3046,33 +3050,54 @@ public class SettingsWindow {
         }
     }
 
-    /** Installs basic Emacs caret movement on a settings-scene {@link CodeArea} (no global KeyDispatcher there). */
+    /** Installs basic Emacs caret movement on a settings-scene {@link CodeArea} (no global KeyDispatcher there).
+     *  Uses absolute-offset {@code moveTo}/{@code deleteText} (robust across RichTextFX versions); each action is
+     *  guarded so the key is always consumed (no fall-through to the default behaviour) even at a boundary. */
     private static void installEmacsKeys(CodeArea area) {
-        var clear = org.fxmisc.richtext.NavigationActions.SelectionPolicy.CLEAR;
         area.addEventFilter(javafx.scene.input.KeyEvent.KEY_PRESSED, e -> {
             boolean ctrl = e.isControlDown() && !e.isAltDown() && !e.isMetaDown() && !e.isShiftDown();
             boolean alt = e.isAltDown() && !e.isControlDown() && !e.isMetaDown() && !e.isShiftDown();
+            if (!ctrl && !alt) {
+                return;
+            }
+            int caret = area.getCaretPosition();
+            int len = area.getLength();
+            String text = area.getText();
             if (ctrl) {
                 switch (e.getCode()) {
-                    case A -> consume(e, () -> area.lineStart(clear));
-                    case E -> consume(e, () -> area.lineEnd(clear));
-                    case F -> consume(e, () -> area.nextChar(clear));
-                    case B -> consume(e, () -> area.previousChar(clear));
+                    case A -> consume(e, () -> area.moveTo(area.getCurrentParagraph(), 0));
+                    case E ->
+                        consume(e, () -> {
+                            int par = area.getCurrentParagraph();
+                            area.moveTo(par, area.getParagraphLength(par));
+                        });
+                    case F ->
+                        consume(e, () -> {
+                            if (caret < len) {
+                                area.moveTo(caret + 1);
+                            }
+                        });
+                    case B ->
+                        consume(e, () -> {
+                            if (caret > 0) {
+                                area.moveTo(caret - 1);
+                            }
+                        });
                     case N -> consume(e, () -> emacsMoveLine(area, 1));
                     case P -> consume(e, () -> emacsMoveLine(area, -1));
                     case D ->
                         consume(e, () -> {
-                            if (area.getCaretPosition() < area.getLength()) {
-                                area.deleteNextChar();
+                            if (caret < len) {
+                                area.deleteText(caret, caret + 1);
                             }
                         });
                     case K -> consume(e, () -> emacsKillLine(area));
                     default -> {}
                 }
-            } else if (alt) {
+            } else {
                 switch (e.getCode()) {
-                    case F -> consume(e, () -> area.wordBreaksForwards(1, clear));
-                    case B -> consume(e, () -> area.wordBreaksBackwards(1, clear));
+                    case F -> consume(e, () -> area.moveTo(nextWordBoundary(text, caret)));
+                    case B -> consume(e, () -> area.moveTo(prevWordBoundary(text, caret)));
                     default -> {}
                 }
             }
@@ -3080,7 +3105,11 @@ public class SettingsWindow {
     }
 
     private static void consume(javafx.scene.input.KeyEvent e, Runnable action) {
-        action.run();
+        try {
+            action.run();
+        } catch (RuntimeException ignored) {
+            // A move/delete at a boundary must not crash key handling.
+        }
         e.consume();
     }
 
@@ -3093,13 +3122,36 @@ public class SettingsWindow {
     }
 
     private static void emacsKillLine(CodeArea area) {
-        int par = area.getCurrentParagraph();
-        if (area.getCaretColumn() < area.getParagraphLength(par)) {
-            area.lineEnd(org.fxmisc.richtext.NavigationActions.SelectionPolicy.EXTEND);
-            area.replaceSelection("");
-        } else if (area.getCaretPosition() < area.getLength()) {
-            area.deleteNextChar(); // at end-of-line: join the next line up
+        int caret = area.getCaretPosition();
+        int rest = area.getParagraphLength(area.getCurrentParagraph()) - area.getCaretColumn();
+        if (rest > 0) {
+            area.deleteText(caret, caret + rest); // kill to end of line
+        } else if (caret < area.getLength()) {
+            area.deleteText(caret, caret + 1); // at end-of-line: join the next line up
         }
+    }
+
+    /** Offset of the end of the next word at/after {@code i} (Emacs M-f). Pure. */
+    private static int nextWordBoundary(String s, int i) {
+        int n = s.length();
+        while (i < n && !Character.isLetterOrDigit(s.charAt(i))) {
+            i++;
+        }
+        while (i < n && Character.isLetterOrDigit(s.charAt(i))) {
+            i++;
+        }
+        return i;
+    }
+
+    /** Offset of the start of the previous word at/before {@code i} (Emacs M-b). Pure. */
+    private static int prevWordBoundary(String s, int i) {
+        while (i > 0 && !Character.isLetterOrDigit(s.charAt(i - 1))) {
+            i--;
+        }
+        while (i > 0 && Character.isLetterOrDigit(s.charAt(i - 1))) {
+            i--;
+        }
+        return i;
     }
 
     private VBox mcpPage() {

--- a/src/main/resources/com/editora/styles/app.css
+++ b/src/main/resources/com/editora/styles/app.css
@@ -1737,3 +1737,12 @@
 .settings-sidebar .list-cell.settings-sidebar-item {
     -fx-padding: 6 12 6 24;
 }
+
+/* Snippet/Template body code editor in Settings: frame it like the form's text fields. */
+.snippet-body {
+    -fx-border-color: -color-border-default;
+    -fx-border-width: 1;
+    -fx-border-radius: 4;
+    -fx-background-radius: 4;
+    -fx-padding: 2;
+}


### PR DESCRIPTION
## Summary
Follow-up fixes for the Snippets/Templates body code editor added in the Settings reorg:

- **Look:** the body `CodeArea` had no frame (bare highlighted text on white) and the **Body** label centered against the tall field. Added a `.snippet-body` border/radius/padding so it reads like the form's text inputs, and top-aligned the form label for `CodeArea` fields.
- **Emacs keys didn't work:** the handler ran the navigation method *before* `e.consume()`, so a RichTextFX nav method throwing at a boundary skipped the consume and the key fell through to the default behavior. Now each action is `try/catch`-guarded (so `consume` always runs) and uses absolute-offset `moveTo`/`deleteText` (+ pure word-boundary scans for `M-f`/`M-b`) which can't throw. Bindings: `C-a/C-e/C-f/C-b/C-n/C-p/M-f/M-b/C-d/C-k`.

## Verify
`./mvnw verify` green — **1160 tests**. The event filter runs in the capturing phase (before RichTextFX's own key handlers), so it sees the key first.

Couldn't drive the live GUI here — please confirm in `mvn javafx:run --dev` → Settings → Snippets/Templates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)