### PR TITLE
Fix review-found bugs: BOM truncation, auto-close-over-selection, regex replace-all, javac hang

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   files deleted in Editora or that already had edit history — not files deleted by an external tool that were
   never opened.)
 
+### Fixed
+
+- **EditorConfig BOM charset no longer truncates files on open.** When a project's `.editorconfig` declared `charset = utf-8-bom` (or `utf-16le`/`utf-16be`) but a file on disk had no actual byte-order mark, the first 2–3 content bytes were silently dropped on open — and saving re-added a BOM, corrupting the file. `EditorConfigCharset.decode` now strips the BOM only when the bytes really start with it.
+- **Typing a closing bracket over a selection no longer silently deletes it.** With text selected, typing `)`/`]`/`}` where the next character was that same bracket "typed over" it and discarded the selection without inserting anything. It now replaces the selection like normal typing. (`AutoClose.decide` gates skip-over on having no selection.)
+- **Regex "Replace All" now respects the whole-word toggle.** With both *Regex* and *Whole word* enabled, Replace All replaced every unbounded occurrence instead of the `\b`-bounded matches it had highlighted and counted. It now uses the same `SearchMatcher.compileRegex` as the search/highlight path.
+- **A hung `javac` can no longer freeze debugging.** The loose-Java compile-and-debug fallback now runs the compile through `ProcessRunner` with a 60-second timeout (and concurrent pipe draining), so a stuck compiler can't pin the single-threaded debug-adapter executor and block every later debug start.
+
 ### Changed
 
 - **Headless FX tests now use JavaFX 26's built-in headless platform.** The `@Tag("fx")` harness boots over

--- a/src/main/java/com/editora/dap/DapManager.java
+++ b/src/main/java/com/editora/dap/DapManager.java
@@ -434,15 +434,15 @@ public final class DapManager implements DapClient.Host {
             try {
                 Path out = java.nio.file.Files.createTempDirectory("editora-dap-");
                 out.toFile().deleteOnExit();
-                List<String> cmd =
-                        ProcessRunner.resolveExecutable(List.of("javac", "-g", "-d", out.toString(), file.toString()));
-                ProcessBuilder pb = new ProcessBuilder(cmd);
-                ProcessRunner.applyStandardEnv(pb);
-                pb.redirectErrorStream(true);
-                Process p = pb.start();
-                String log = new String(p.getInputStream().readAllBytes(), java.nio.charset.StandardCharsets.UTF_8);
-                if (p.waitFor() != 0) {
-                    fail("Compilation failed:\n" + log.strip());
+                // Route through ProcessRunner.run so the compile is bounded by a hard timeout (a hung javac
+                // would otherwise pin the single-threaded `io` executor and block every later DAP start/detect)
+                // and both pipes are drained concurrently (no fill-the-buffer deadlock).
+                ProcessRunner.Result r = ProcessRunner.run(
+                        null,
+                        java.time.Duration.ofSeconds(60),
+                        List.of("javac", "-g", "-d", out.toString(), file.toString()));
+                if (!r.ok()) {
+                    fail("Compilation failed:\n" + (r.out() + "\n" + r.err()).strip());
                     return;
                 }
                 String javaExec = firstOrNull(ProcessRunner.resolveExecutable(List.of("java")));

--- a/src/main/java/com/editora/editor/AutoClose.java
+++ b/src/main/java/com/editora/editor/AutoClose.java
@@ -61,7 +61,7 @@ public final class AutoClose {
         if (hasSelection && (isOpener(typed) || isQuote(typed))) {
             return new Decision(Action.WRAP_SELECTION, closerFor(typed));
         }
-        if ((isCloser(typed) || isQuote(typed)) && next == typed) {
+        if (!hasSelection && (isCloser(typed) || isQuote(typed)) && next == typed) {
             return new Decision(Action.SKIP_OVER, typed); // type over the existing closer/quote
         }
         if (isOpener(typed)) {

--- a/src/main/java/com/editora/editorconfig/EditorConfigCharset.java
+++ b/src/main/java/com/editora/editorconfig/EditorConfigCharset.java
@@ -66,10 +66,15 @@ public final class EditorConfigCharset {
         return null;
     }
 
-    /** Decodes {@code bytes} as {@code name}, dropping a leading BOM for BOM charsets. */
+    /**
+     * Decodes {@code bytes} as {@code name}, dropping a leading BOM only when the bytes <em>actually</em>
+     * begin with this charset's BOM. A BOM charset (e.g. {@code utf-8-bom}) declared in {@code .editorconfig}
+     * does not guarantee the on-disk file has a BOM, so skipping unconditionally would silently drop the
+     * first 2-3 real content bytes of a BOM-less file.
+     */
     public static String decode(byte[] bytes, String name) {
-        int skip = writesBom(name) ? bomFor(name).length : 0;
-        skip = Math.min(skip, bytes.length);
+        byte[] bom = bomFor(name);
+        int skip = bom.length > 0 && startsWith(bytes, bom) ? bom.length : 0;
         return new String(bytes, skip, bytes.length - skip, charsetFor(name));
     }
 

--- a/src/main/java/com/editora/ui/FindReplaceBar.java
+++ b/src/main/java/com/editora/ui/FindReplaceBar.java
@@ -4,7 +4,6 @@ import java.util.List;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
 import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 import javafx.animation.PauseTransition;
 import javafx.geometry.Pos;
@@ -354,7 +353,9 @@ public class FindReplaceBar extends HBox {
                 status.accept(tr("find.badRegex", err));
                 return;
             }
-            Matcher m = Pattern.compile(query, caseSensitive.isSelected() ? 0 : Pattern.CASE_INSENSITIVE)
+            // Reuse the shared compiler so case + whole-word match the highlighted/counted matches
+            // (it wraps whole-word as \b(?:…)\b with a non-capturing group, preserving user group numbers).
+            Matcher m = SearchMatcher.compileRegex(query, caseSensitive.isSelected(), wholeWord.isSelected())
                     .matcher(text);
             StringBuffer sb = new StringBuffer();
             count = 0;

--- a/src/test/java/com/editora/editor/AutoCloseTest.java
+++ b/src/test/java/com/editora/editor/AutoCloseTest.java
@@ -46,6 +46,16 @@ class AutoCloseTest {
     }
 
     @Test
+    void closerDoesNotSkipOverWithSelection() {
+        // With a selection, a typed closer must NOT skip-over (that silently dropped the selection);
+        // it falls through to NONE so RichTextFX replaces the selection normally.
+        assertEquals(Action.NONE, act('}', 'b', '}', true));
+        assertEquals(Action.NONE, act(')', 'x', ')', true));
+        // A quote with a selection still wraps it (the wrap branch runs before skip-over).
+        assertEquals(Action.WRAP_SELECTION, act('"', 'b', '"', true));
+    }
+
+    @Test
     void quotePairingHeuristics() {
         assertEquals(Action.INSERT_PAIR, act('"', ' ', ' ', false)); // open space → pair
         assertEquals(Action.INSERT_PAIR, act('"', '(', (char) 0, false));

--- a/src/test/java/com/editora/editorconfig/EditorConfigCharsetTest.java
+++ b/src/test/java/com/editora/editorconfig/EditorConfigCharsetTest.java
@@ -44,6 +44,17 @@ class EditorConfigCharsetTest {
     }
 
     @Test
+    void decodeKeepsContentWhenBomCharsetButNoBomOnDisk() {
+        // .editorconfig may declare charset=utf-8-bom for a file that doesn't actually have a BOM yet.
+        // decode must NOT strip the first 3 bytes in that case (that silently truncated real content).
+        byte[] noBom = "héllo".getBytes(java.nio.charset.StandardCharsets.UTF_8);
+        assertEquals("héllo", EditorConfigCharset.decode(noBom, "utf-8-bom"));
+        // utf-16 declared but bytes are bare (no FF FE / FE FF) — first char must survive.
+        byte[] le = "A".getBytes(java.nio.charset.StandardCharsets.UTF_16LE);
+        assertEquals("A", EditorConfigCharset.decode(le, "utf-16le"));
+    }
+
+    @Test
     void displayNames() {
         assertEquals("UTF-8", EditorConfigCharset.displayName("utf-8"));
         assertEquals("UTF-8 BOM", EditorConfigCharset.displayName("utf-8-bom"));


### PR DESCRIPTION
An external-review pass over the codebase (fan-out reviewers + manual verification, including an NPE sweep of the two largest files) surfaced four confirmed bugs. Each is fixed here with a regression test where it's unit-testable.

## Fixed

| Sev | Bug | Fix |
|---|---|---|
| 🔴 HIGH | `EditorConfigCharset.decode` stripped the BOM length by charset **name**, so a file declared `charset = utf-8-bom` / `utf-16*` but lacking an on-disk BOM lost its first 2–3 content bytes on open — and save re-added a BOM, corrupting the file. | Strip the BOM only when the bytes actually start with it. |
| 🟠 MED | `AutoClose.decide` returned `SKIP_OVER` for a typed closer even with a live selection, so typing `)`/`]`/`}` over a selection (when the next char matched) silently discarded it without inserting. | Gate skip-over on `!hasSelection`; the selection is replaced normally. |
| 🟠 MED | `FindReplaceBar` regex **Replace All** compiled the pattern raw, ignoring the *Whole word* toggle — replacing unbounded occurrences that differed from the highlighted/counted matches. | Route through `SearchMatcher.compileRegex` (same path as search/highlight; preserves user capture-group numbers). |
| 🟡 LOW | `DapManager.compileAndLaunch` ran `javac` with an unbounded read + `waitFor` on the single-threaded debug executor; a hung compiler would pin every later DAP start/detect. | Route through `ProcessRunner.run` with a 60 s timeout + concurrent pipe draining. |

## Regression tests
- `AutoCloseTest.closerDoesNotSkipOverWithSelection` — closer+selection → `NONE`, quote+selection → `WRAP_SELECTION`.
- `EditorConfigCharsetTest.decodeKeepsContentWhenBomCharsetButNoBomOnDisk` — BOM-less bytes declared `utf-8-bom`/`utf-16le` keep all content.
- The regex Replace-All fix delegates to the already-tested `SearchMatcher.compileRegex`; the javac fix to the already-tested `ProcessRunner.run`.

## Not changed (deliberate)
- `ProjectManager.idFor` 32-bit hashCode collision — changing the id format would orphan existing `projects/<id>.json` sessions; needs a migration, not a quick fix.
- Two convention nits (`replaceCurrent` on an arbitrary selection; `Filler`'s `*`/`>` prefix) — behavior conventions, not bugs.
- Two agent claims were **withdrawn** after verification: `LivePreviewServer.stop()` "hang" (`stop(0)` returns immediately; the parked poll is interrupted) and `RunService` "leak" (`runService.stop()` is called on dispose).

## NPE sweep
`MainController` and `EditorBuffer` were swept specifically for NPEs and came back clean — only LOW/theoretical, non-reachable fragilities (the `focusedArea` invariant and the `viewModeBar` field trio), not worth a change.

## Verification
`./mvnw verify` green — **1162 tests** (2 new), Spotless check + JaCoCo gates pass. No schema / `module-info` / dependency change; perf-neutral (the javac fix removes a potential FX-executor stall).

🤖 Generated with [Claude Code](https://claude.com/claude-code)