### PR TITLE
Markdown settings: lint rules as a vertical list with descriptions

### DIFF
--- a/src/main/java/com/editora/ui/SettingsWindow.java
+++ b/src/main/java/com/editora/ui/SettingsWindow.java
@@ -187,7 +187,7 @@ public class SettingsWindow {
     private CheckBox logViewerCheck;
     private CheckBox todoHighlightCheck;
     private javafx.scene.layout.VBox todoPatternsBox;
-    private javafx.scene.layout.FlowPane markdownLintRulesBox;
+    private VBox markdownLintRulesBox;
     /** Working copy of the External Tools list, edited live by the master-detail page. */
     private final javafx.collections.ObservableList<com.editora.externaltool.ExternalTool> externalToolItems =
             javafx.collections.FXCollections.observableArrayList();
@@ -1636,7 +1636,7 @@ public class SettingsWindow {
     /** The Markdown-lint per-rule checklist: one checkbox per rule (checked = enabled). Toggling writes the
      *  disabled rule codes to {@code Settings.markdownLintDisabledRules} and applies live. */
     private javafx.scene.Node markdownLintRulesEditor() {
-        markdownLintRulesBox = new javafx.scene.layout.FlowPane(12, 4);
+        markdownLintRulesBox = new VBox(4);
         rebuildMarkdownLintRules();
         return markdownLintRulesBox;
     }
@@ -1652,11 +1652,21 @@ public class SettingsWindow {
                 disabled.add(c.strip().toUpperCase(java.util.Locale.ROOT));
             }
         }
+        // One row per rule: a checkbox whose label is the rule code (fixed-width so codes align) followed by
+        // a muted one-line description — a readable vertical list instead of a wrapping grid of bare codes.
         for (com.editora.editor.MarkdownLint.Rule rule : com.editora.editor.MarkdownLint.RULES) {
             String code = rule.code();
-            CheckBox cb = new CheckBox(code);
+            Label codeLabel = new Label(code);
+            codeLabel.getStyleClass().add("md-lint-code");
+            codeLabel.setMinWidth(58);
+            Label desc = new Label(tr("mdlint.rule." + code));
+            desc.getStyleClass().add("settings-hint");
+            HBox label = new HBox(8, codeLabel, desc);
+            label.setAlignment(Pos.CENTER_LEFT);
+
+            CheckBox cb = new CheckBox();
+            cb.setGraphic(label);
             cb.setSelected(!disabled.contains(code));
-            cb.setTooltip(new Tooltip(tr("mdlint.rule." + code)));
             cb.selectedProperty().addListener((o, was, on) -> {
                 java.util.List<String> list =
                         new java.util.ArrayList<>(config.getSettings().getMarkdownLintDisabledRules());

--- a/src/main/resources/com/editora/styles/app.css
+++ b/src/main/resources/com/editora/styles/app.css
@@ -1244,6 +1244,11 @@
     -fx-text-fill: -color-fg-muted;
     -fx-padding: 8 0 0 0;
 }
+/* Markdown-lint per-rule list: the rule code (e.g. MD009) beside its muted description. */
+.md-lint-code {
+    -fx-font-weight: bold;
+    -fx-font-family: monospace;
+}
 .settings-coming-soon {
     -fx-text-fill: -color-fg-muted;
     -fx-font-style: italic;


### PR DESCRIPTION
Cleans up the **Settings → Markdown → Linting** rule checklist. It was a wrapping grid of bare rule codes (`MD001  MD009  MD010 …`) whose meaning was hidden behind a tooltip. It's now a **vertical list, one rule per line**, each row showing the rule **code** (bold monospace, column-aligned) followed by its **description** inline:

```
☑ MD001   Heading levels increment by one
☑ MD009   Trailing whitespace
☑ MD010   Hard tabs
   …
```

## How
- `markdownLintRulesBox`: `FlowPane` → `VBox`; each `CheckBox`'s graphic is an `HBox(codeLabel, descLabel)`.
- The description reuses the existing `tr("mdlint.rule.<code>")` — **no new i18n** (the text that was a tooltip is now an inline muted label).
- One small CSS class `.md-lint-code` (bold + monospace) added to `app.css`.
- Toggle/persist (`Settings.markdownLintDisabledRules`) and live-apply are unchanged; the whole row stays clickable.

## Verification
`./mvnw verify` green — **1162 tests**, Spotless check + JaCoCo gates pass. No schema / `module-info` / dependency change; perf-neutral (built once per Settings open).

🤖 Generated with [Claude Code](https://claude.com/claude-code)