### PR TITLE
Add a left margin to the editor when the gutter is hidden (Simple UI mode)

### DIFF
--- a/src/main/java/com/editora/editor/EditorBuffer.java
+++ b/src/main/java/com/editora/editor/EditorBuffer.java
@@ -3261,8 +3261,20 @@ public class EditorBuffer implements TabContent {
     public void refreshGutter() {
         noteOverlay.refresh();
         area.setParagraphGraphicFactory(gutterVisible ? folds.gutterFactory(lineNumbersVisible) : null);
+        applyNoGutterStyle(area);
         if (area2 != null) {
             area2.setParagraphGraphicFactory(gutterVisible ? LineNumberFactory.get(area2) : null);
+            applyNoGutterStyle(area2);
+        }
+    }
+
+    /** With no gutter (Simple UI mode) the text would sit flush against the editor's left edge; the
+     *  {@code .no-gutter} class adds a small left padding so it doesn't. The gutter itself supplies that
+     *  inset when present, so the class is removed then. */
+    private void applyNoGutterStyle(CodeArea a) {
+        a.getStyleClass().remove("no-gutter");
+        if (!gutterVisible) {
+            a.getStyleClass().add("no-gutter");
         }
     }
 

--- a/src/main/resources/com/editora/styles/app.css
+++ b/src/main/resources/com/editora/styles/app.css
@@ -7,6 +7,11 @@
     -fx-font-family: "JetBrains Mono", "monospace";
     -fx-font-size: 14px;
 }
+/* Simple UI mode removes the gutter entirely; without it the text sits flush against the editor's
+   left edge, so add a small left padding (the gutter supplies this inset when it is present). */
+.editor-area.no-gutter {
+    -fx-padding: 0 0 0 6px;
+}
 
 .editor-area .text {
     -fx-fill: #24292f;


### PR DESCRIPTION
In **Simple UI mode** the gutter is removed entirely (null paragraph-graphic factory), so the editor text had no left offset and sat **flush against the left edge** of the window.

## Fix
- `EditorBuffer.refreshGutter()` toggles a `no-gutter` style class on the editor area(s): added when the gutter is hidden, removed when it's present (the gutter itself supplies the left inset normally).
- `app.css`: `.editor-area.no-gutter { -fx-padding: 0 0 0 6px; }` — a small left margin only when there's no gutter.

Scoped precisely to the no-gutter case (`!gutterVisible`, i.e. Simple mode), so the normal gutter layout is untouched; applies to the split secondary view too. Perf-neutral (rides the existing `refreshGutter` path — just a style-class toggle).

## Verification
`./mvnw verify` green — 1169 tests, Spotless check + JaCoCo gates pass. (Visual padding to be confirmed in the running app — `-fx-padding` on the RichTextFX area is the standard content inset.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)