### PR TITLE
Space the checkbox from the MDxxx code in the Markdown lint list

### DIFF
--- a/src/main/resources/com/editora/styles/app.css
+++ b/src/main/resources/com/editora/styles/app.css
@@ -1255,6 +1255,7 @@
 .md-lint-code {
     -fx-font-weight: bold;
     -fx-font-family: monospace;
+    -fx-padding: 0 0 0 6; /* breathing room between the checkbox and the "MDxxx" code */
 }
 .settings-coming-soon {
     -fx-text-fill: -color-fg-muted;


### PR DESCRIPTION
On **Settings → Markdown → Linting**, each per-rule checkbox had its `MDxxx` code label sitting flush against the checkbox. Added 6px left padding to `.md-lint-code` so the code clears the box.

CSS-only, one line. `./mvnw verify` green (1176 tests). Visual spacing to be confirmed in the running app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)