### PR TITLE
Align the External Tools editor buttons on one bottom row

### DIFF
--- a/src/main/java/com/editora/ui/SettingsWindow.java
+++ b/src/main/java/com/editora/ui/SettingsWindow.java
@@ -2998,25 +2998,28 @@ public class SettingsWindow {
                 persistExternalTools();
             }
         });
-        HBox buttons = new HBox(6, add, remove);
-        VBox left = new VBox(6, list, buttons);
-
         // Explicit Save (edits also auto-save on Enter / focus-loss + combo/checkbox change).
         Button save = new Button(tr("settings.save"));
         save.disableProperty().bind(form.disabledProperty());
         save.setOnAction(e -> commit.run());
-        HBox saveRow = new HBox(save);
-        saveRow.setAlignment(Pos.CENTER_RIGHT);
-        VBox right = new VBox(8, form, saveRow);
+
+        VBox left = new VBox(6, list);
+        VBox.setVgrow(list, Priority.ALWAYS);
+        VBox right = new VBox(8, form);
         VBox.setVgrow(form, Priority.ALWAYS);
         HBox.setHgrow(right, Priority.ALWAYS);
 
         if (!externalToolItems.isEmpty()) {
             list.getSelectionModel().select(0);
         }
-        HBox box = new HBox(12, left, right);
-        box.setAlignment(Pos.TOP_LEFT);
-        return box;
+        HBox top = new HBox(12, left, right);
+        top.setAlignment(Pos.TOP_LEFT);
+        VBox.setVgrow(top, Priority.ALWAYS);
+
+        // One bottom bar below the whole editor: Add / Remove on the left, Save aligned on the right.
+        HBox buttons = new HBox(6, add, remove, spacer(), save);
+        buttons.setAlignment(Pos.CENTER_LEFT);
+        return new VBox(8, top, buttons);
     }
 
     /** Deep-copies the persisted tools so the working list edits independently until persisted. */


### PR DESCRIPTION
On **Settings → External Tools**, the **Save** button lived in the right column's own right-aligned sub-row (under the form), while **Add/Remove** sat under the left list — two different columns, so the three buttons didn't line up. The right-aligned save row was also crammed under the form and overlapped the "Enabled" checkbox.

## Fix
All three buttons now share **one bottom bar spanning the whole editor**: `Add  Remove  … spacer … Save` (Add/Remove left, Save right). The master-detail list + form sit above it, so the Enabled checkbox no longer collides with the buttons.

Layout-only change in `externalToolsEditor()`. No schema / settings / i18n change.

## Verification
`./mvnw verify` green — 1176 tests, Spotless + JaCoCo gates pass. Visual alignment to be confirmed in the running app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)