### PR TITLE
Add a session-log link to Settings → Advanced

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Open the session log from Settings → Advanced.** Added a "Session log" link next to the settings-file path that opens `editora-session.log` (the captured logging + uncaught exceptions for the current session) in the editor — handy for grabbing diagnostics for a bug report.
+
 - **Open the dictionary files from Settings → Spell Check.** Two links (grouped near the top of the page): **"Open the technical.txt dictionary"** opens the built-in technical dictionary read-only in a new tab so you can browse what it covers, and **"Open dictionary.txt…"** opens your personal dictionary file in the editor (created empty if you haven't added a word yet).
 
 - **Large source files stay responsive (intermediate large-file tier).** A very long single file (e.g. a 13k-line source) below the 5 MB hard cutoff used to get the full treatment — syntax highlighting *plus* the minimap (which redraws every line) *plus* a language server churning over a huge AST — which made it slow to load and scroll. There's now an intermediate tier: above a configurable **line count** (Settings → Editor → Performance → "Disable minimap & LSP above", default **10000 lines**, `0` = never), the **minimap and language server auto-disable** while syntax highlighting and full editing stay on. A status note reports it on open, and you can flip it per file from the palette (**Toggle Large-File Mode**). Palette `editor.setLargeFileThreshold` changes the threshold; `view.toggleLargeFileMode` overrides per buffer.

--- a/src/main/java/com/editora/ui/SettingsWindow.java
+++ b/src/main/java/com/editora/ui/SettingsWindow.java
@@ -4170,6 +4170,23 @@ public class SettingsWindow {
         fileRow.setAlignment(Pos.CENTER_LEFT);
         row(p, Category.ADVANCED, fileSection, fileRow, "settings file path toml config location");
 
+        Path sessionLog = DebugLog.sessionFile(config.getConfigDir());
+        Hyperlink sessionLink = new Hyperlink(displaySettingsPath(sessionLog));
+        sessionLink.setTooltip(new Tooltip(tr("settings.openFileTip")));
+        sessionLink.setOnAction(e -> {
+            if (onOpenFile != null && sessionLog != null) {
+                onOpenFile.accept(sessionLog);
+            }
+        });
+        HBox sessionRow = new HBox(6, new Label(tr("settings.sessionLog")), sessionLink);
+        sessionRow.setAlignment(Pos.CENTER_LEFT);
+        row(
+                p,
+                Category.ADVANCED,
+                fileSection,
+                sessionRow,
+                "session log debug crash report editora-session.log diagnostics");
+
         Label resetSection = section(p, tr("settings.section.reset"));
         Button reset = new Button(tr("settings.resetDefaults"));
         reset.setOnAction(e -> resetAll());

--- a/src/main/resources/com/editora/i18n/messages.properties
+++ b/src/main/resources/com/editora/i18n/messages.properties
@@ -487,6 +487,7 @@ settings.section.features=Features
 settings.section.file=Settings file
 settings.openFileTip=Open the settings file in Editora
 settings.path=Path:
+settings.sessionLog=Session log
 settings.section.reset=Reset
 settings.resetDefaults=Reset to Defaults
 settings.section.io=Import / Export

--- a/src/main/resources/com/editora/i18n/messages_de.properties
+++ b/src/main/resources/com/editora/i18n/messages_de.properties
@@ -483,6 +483,7 @@ settings.section.features=Funktionen
 settings.section.file=Konfigurationsdatei
 settings.openFileTip=Die Konfigurationsdatei in Editora öffnen
 settings.path=Pfad:
+settings.sessionLog=Sitzungsprotokoll
 settings.section.reset=Zurücksetzen
 settings.resetDefaults=Auf Standard zurücksetzen
 settings.section.io=Import / Export

--- a/src/main/resources/com/editora/i18n/messages_es.properties
+++ b/src/main/resources/com/editora/i18n/messages_es.properties
@@ -483,6 +483,7 @@ settings.section.features=Funciones
 settings.section.file=Archivo de configuración
 settings.openFileTip=Abrir el archivo de configuración en Editora
 settings.path=Ruta:
+settings.sessionLog=Registro de sesión
 settings.section.reset=Restablecer
 settings.resetDefaults=Restablecer valores predeterminados
 settings.section.io=Importar / Exportar

--- a/src/main/resources/com/editora/i18n/messages_fr.properties
+++ b/src/main/resources/com/editora/i18n/messages_fr.properties
@@ -483,6 +483,7 @@ settings.section.features=Fonctionnalités
 settings.section.file=Fichier de configuration
 settings.openFileTip=Ouvrir le fichier de configuration dans Editora
 settings.path=Chemin :
+settings.sessionLog=Journal de session
 settings.section.reset=Réinitialiser
 settings.resetDefaults=Réinitialiser aux valeurs par défaut
 settings.section.io=Importer / Exporter

--- a/src/main/resources/com/editora/i18n/messages_it.properties
+++ b/src/main/resources/com/editora/i18n/messages_it.properties
@@ -483,6 +483,7 @@ settings.section.features=Funzionalità
 settings.section.file=File di configurazione
 settings.openFileTip=Apri il file di configurazione in Editora
 settings.path=Percorso:
+settings.sessionLog=Registro di sessione
 settings.section.reset=Ripristina
 settings.resetDefaults=Ripristina valori predefiniti
 settings.section.io=Importa / Esporta

--- a/src/main/resources/com/editora/i18n/messages_pt.properties
+++ b/src/main/resources/com/editora/i18n/messages_pt.properties
@@ -483,6 +483,7 @@ settings.section.features=Recursos
 settings.section.file=Arquivo de configuração
 settings.openFileTip=Abrir o arquivo de configuração no Editora
 settings.path=Caminho:
+settings.sessionLog=Registo de sessão
 settings.section.reset=Redefinir
 settings.resetDefaults=Restaurar padrões
 settings.section.io=Importar / Exportar


### PR DESCRIPTION
Adds a **"Session log"** row in Settings → Advanced, directly under the settings-file path link. It shows the path to `editora-session.log` (the captured logging + uncaught exceptions for the current session, written by `DebugLog.attachFile`) and opens it in the editor on click — handy for grabbing diagnostics for a bug report.

Reuses the existing `onOpenFile`/`openPath` mechanism and `DebugLog.sessionFile(config.getConfigDir())`. New `settings.sessionLog` i18n key in all six catalogs; CHANGELOG updated. No schema/dependency change.

## Verification
`./mvnw verify` green — 1176 tests, Spotless + JaCoCo gates + i18n key-parity pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)