### PR TITLE
Remote tool window: off by default, opens on the right

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **The Remote Sites tool window is off by default and opens on the right.** Its stripe button is now hidden until you enable it (Settings → Tool Windows, or the `tool.remote` command / `M-g r`), and when shown it docks on the right. The remote (SFTP) functionality is unchanged — only the tool window's default visibility and side moved. Existing layouts (if you'd already shown or moved it) are preserved.
+
 ### Added
 
 - **Open the session log from Settings → Advanced.** Added a "Session log" link next to the settings-file path that opens `editora-session.log` (the captured logging + uncaught exceptions for the current session) in the editor — handy for grabbing diagnostics for a bug report.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -157,8 +157,10 @@ icon (`Icons.findInFiles()`, `onFindInFiles → openSearchInFiles`) sits beside 
   over saved connections → re-opens the form pre-filled), `remote.openFile` (an `sftp://` URI →
   `Vfs.parseStorable` → `openPath`), `remote.disconnect` (restores the local project root). **Saved sites get
   three visible surfaces** (all over the same `connections.json` most-recent-first list — no schema/secret
-  change): a **Remote Sites tool window** (`ui/RemoteConnectionsPanel`, id `remote`, `Side.LEFT`, `Icons::remote`,
-  `tool.remote`/`M-g r`, *not* buffer-gated — a flat `ListView` of saved sites; double-click/Enter or the
+  change): a **Remote Sites tool window** (`ui/RemoteConnectionsPanel`, id `remote`, `Side.RIGHT`, `Icons::remote`,
+  `tool.remote`/`M-g r`, *not* buffer-gated, **registered default-hidden** via `toolWindows.register(tw, false)` —
+  the stripe button is off until the user enables it (Settings → Tool Windows or `tool.remote`), and it opens on the
+  right; the remote *functionality* is unaffected — a flat `ListView` of saved sites; double-click/Enter or the
   New/Connect/Remove bar → `connectRemote(c)`/`removeConnection`/`connectRemote()`, refreshed on open + after a
   mount); a **Settings → Remote master-detail page** (`SettingsWindow.remoteConnectionsEditor`, mirroring the
   External Tools page — list + label/host/port/user/auth/key-path form editing the immutable `RemoteConnection`

--- a/src/main/java/com/editora/ui/MainController.java
+++ b/src/main/java/com/editora/ui/MainController.java
@@ -2476,7 +2476,7 @@ public class MainController implements com.editora.mcp.McpBridge {
         remoteToolWindow = new ToolWindow(
                 "remote",
                 tr("toolwindow.remote"),
-                ToolWindow.Side.LEFT,
+                ToolWindow.Side.RIGHT,
                 Icons::remote,
                 remoteConnectionsPanel,
                 "tool.remote");
@@ -2503,7 +2503,7 @@ public class MainController implements com.editora.mcp.McpBridge {
         toolWindows.register(httpToolWindow);
         toolWindows.setAvailable(httpToolWindow, false); // shown only for a .http file with the feature on
         toolWindows.register(externalToolToolWindow);
-        toolWindows.register(remoteToolWindow); // always available — saved connections don't need a buffer
+        toolWindows.register(remoteToolWindow, false); // off by default (niche); always available — no buffer needed
         updateBufferToolWindows(); // hide buffer-only windows until there's an actionable buffer (no Welcome flash)
         // Detect a *user* open/close of the HTTP window (vs. our own auto show/hide, guarded by
         // httpAutoMutating) so a manual close is remembered per .http buffer and a manual open clears it.

--- a/src/main/java/com/editora/ui/ToolWindowManager.java
+++ b/src/main/java/com/editora/ui/ToolWindowManager.java
@@ -5,9 +5,11 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import javafx.application.Platform;
 import javafx.css.PseudoClass;
@@ -56,6 +58,10 @@ public class ToolWindowManager {
     private final SplitPane vSplit = new SplitPane();
 
     private final Map<String, ToolWindow> byId = new LinkedHashMap<>();
+    /** Tool windows whose stripe button is hidden by default (until the user shows them), absent any saved
+     *  visibility preference — e.g. Remote, which is niche so it stays off until enabled. */
+    private final Set<String> defaultHidden = new HashSet<>();
+
     private final Map<ToolWindow.Side, ToolWindow> openBySide = new HashMap<>();
     private final Map<ToolWindow, Button> stripeButtons = new HashMap<>();
     private final Map<ToolWindow, Region> panels = new HashMap<>();
@@ -128,6 +134,15 @@ public class ToolWindowManager {
     /** Registers an observer notified after any tool window opens (true) / closes (false). */
     public void setStateListener(java.util.function.BiConsumer<ToolWindow, Boolean> listener) {
         this.stateListener = listener;
+    }
+
+    /** Registers a tool window that defaults to hidden (no stripe button until the user enables it),
+     *  unless a saved visibility preference says otherwise. */
+    public void register(ToolWindow tw, boolean defaultVisible) {
+        if (!defaultVisible) {
+            defaultHidden.add(tw.getId());
+        }
+        register(tw);
     }
 
     public void register(ToolWindow tw) {
@@ -221,7 +236,10 @@ public class ToolWindowManager {
     /** True if this tool window's stripe button should be shown. Defaults to visible. */
     public boolean isVisible(ToolWindow tw) {
         Boolean v = config.getWorkspaceState().getToolWindowVisible().get(tw.getId());
-        return v == null || v;
+        if (v != null) {
+            return v;
+        }
+        return !defaultHidden.contains(tw.getId()); // default-hidden windows stay off until enabled
     }
 
     /**


### PR DESCRIPTION
The Remote Sites tool window was shown by default and docked on the **left**. It's now **hidden by default** (until enabled via Settings → Tool Windows or the `tool.remote` command / `M-g r`) and docks on the **right** when shown. The remote (SFTP) functionality is unchanged — only the tool window's default visibility + side.

## How
- `ToolWindowManager`: a new `register(tw, defaultVisible)` overload + a `defaultHidden` set; `isVisible()` returns the default-hidden state when there's no saved visibility preference (so existing/explicit prefs still win).
- `MainController`: register the remote window default-hidden, `Side.RIGHT`.

Docs updated (CHANGELOG "Changed" + CLAUDE.md). No schema/dependency change.

## Verification
`./mvnw verify` green — 1176 tests, Spotless + JaCoCo gates pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)