### PR TITLE
Linux .deb: add an editora command on PATH

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Linux `.deb`: an `editora` command on `PATH`.** The Debian package now creates a `/usr/bin/editora` symlink to the installed launcher (jpackage otherwise installs it only at `/opt/editora/bin/Editora`, off `PATH`), so you can start Editora from a terminal with arguments — e.g. `editora some/file.java:42`. It's removed on uninstall. Implemented via custom DEB maintainer scripts (`packaging/linux/postinst`/`postrm`) passed through `jpackage --resource-dir` in the installer-wrap step; `.rpm` is unaffected (run `/opt/editora/bin/Editora`).
+
 ### Changed
 
 - **Internal: extracted `DebugCoordinator` from `MainController`.** The whole DAP debugging integration (the `DebugPanel`, breakpoint persistence + gutter gating, the DAP event sink + panel actions, the inline-values / hover / execution-line editor surfaces, the start/attach/step/run-to-cursor/jump flows, and the `debug.toggleAdapter`/`debug.setAdapterPath` pickers) moved into its own `CoordinatorHost`-style coordinator. The `DapManager` stays a `MainController` field (it's built on the LSP `lspManager`, and `SettingsWindow` + window-dispose reach it) and is passed to the coordinator, mirroring the LSP split; Java debugging layers on the jdtls session, so the coordinator also takes the `lspManager` + `LspCoordinator`. `MainController` shed ~565 lines (11,057 → ~10,492). This completes the `MainController` decomposition campaign (13,017 → ~10,492). No behavior change.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,6 +70,18 @@ hands them to **JReleaser** (`jreleaser.yml`, via `jreleaser/release-action`) wh
 GitHub release with all installers + fat jars + `checksums.txt` + a changelog. JReleaser only *orchestrates the release* — it does not
 build (the `dist` profile is reused as-is) and there is **no `pom.xml`/Maven change**, so the normal
 build is unaffected. Installers are currently **unsigned** (signing/notarization is a follow-up).
+**Linux `editora` command on PATH:** jpackage installs the launcher only at `/opt/editora/bin/Editora`
+(not on `PATH`), so the **`.deb`** ships custom Debian maintainer scripts — `packaging/linux/postinst`
+(symlinks `/usr/bin/editora` → the installed launcher, found via the `/opt/*/bin/Editora` glob since
+jpackage lowercases the install dir) and `packaging/linux/postrm` (removes it on remove/purge, only if
+it still points into `/opt/*/bin/Editora`). They're passed via `jpackage --resource-dir packaging/linux`
+**in the DEB wrap of `scripts/aot_build.java`** (the AOT helper builds the actual installer), DEB-only —
+the RPM bundler uses a `.spec` and ignores `postinst`/`postrm`, so `.rpm` users run `/opt/editora/bin/Editora`
+or add their own symlink. Because the override replaces jpackage's generated `postinst`/`postrm`, both
+scripts also re-run the freedesktop database refresh (`update-desktop-database`/`xdg-desktop-menu
+forceupdate`) that jpackage's default scripts did for the `--linux-shortcut` menu entry. **Device-test on
+Linux** (install the `.deb`: `which editora` + the app appears in the menu; then remove: the symlink is gone)
+— the macOS dev box and the `os-linux` profile can't exercise this.
 Uses the BellSoft **Liberica** JDK 25 in CI for full arch coverage (incl. linux aarch64).
 
 ## Architecture

--- a/README.md
+++ b/README.md
@@ -374,6 +374,12 @@ java -jar target/Editora-<version>.jar
 
 The `dist` profile produces a platform installer under `target/dist/`.
 
+On **Linux**, the `.deb` installs the app under `/opt/editora/` and adds an **`editora` command on
+`PATH`** (a `/usr/bin/editora` symlink created by the package's maintainer scripts), so you can launch
+it from a terminal with arguments — e.g. `editora some/file.java:42` or `editora --new-file=notes.md`.
+The command is removed when you uninstall the package. (The `.rpm` installs under `/opt/editora/`
+too; run `/opt/editora/bin/Editora` or add your own symlink.)
+
 The `fatjar` profile produces a self-contained, runnable `target/Editora-<version>.jar` (no separate
 JavaFX install needed — `java -jar` is enough, on a JDK 25 runtime). It bundles JavaFX's classes and
 native libraries **for the build host's platform only**: a single jar can't be portable because

--- a/packaging/linux/postinst
+++ b/packaging/linux/postinst
@@ -1,0 +1,33 @@
+#!/bin/sh
+#
+# Editora .deb postinst — OVERRIDES jpackage's generated DEB postinst (jpackage picks up any file
+# named "postinst" in --resource-dir). jpackage installs the launcher only at
+# /opt/<package>/bin/Editora, which is not on PATH, so add an `editora` command via a symlink in
+# /usr/bin (policy-correct location for a package-provided command; postrm removes it).
+#
+# Because this replaces jpackage's default postinst, it also re-runs the desktop-database refresh
+# that jpackage's script would have done for the --linux-shortcut menu entry.
+#
+set -e
+
+case "$1" in
+    configure)
+        # Install dir is /opt/<package-name> (jpackage lowercases it); the launcher keeps its case.
+        for launcher in /opt/*/bin/Editora; do
+            if [ -x "$launcher" ]; then
+                ln -sf "$launcher" /usr/bin/editora
+                break
+            fi
+        done
+        ;;
+esac
+
+# Refresh desktop integration for the bundled .desktop entry (harmless if the tools are absent).
+if command -v update-desktop-database >/dev/null 2>&1; then
+    update-desktop-database -q 2>/dev/null || true
+fi
+if command -v xdg-desktop-menu >/dev/null 2>&1; then
+    xdg-desktop-menu forceupdate 2>/dev/null || true
+fi
+
+exit 0

--- a/packaging/linux/postrm
+++ b/packaging/linux/postrm
@@ -1,0 +1,23 @@
+#!/bin/sh
+#
+# Editora .deb postrm — OVERRIDES jpackage's generated DEB postrm. Removes the `editora` PATH
+# symlink that postinst created (only if it still points into our install tree, so a foreign
+# /usr/bin/editora is never touched) on remove/purge.
+#
+set -e
+
+case "$1" in
+    remove|purge)
+        if [ -L /usr/bin/editora ]; then
+            case "$(readlink /usr/bin/editora 2>/dev/null || true)" in
+                /opt/*/bin/Editora) rm -f /usr/bin/editora ;;
+            esac
+        fi
+        ;;
+esac
+
+if command -v update-desktop-database >/dev/null 2>&1; then
+    update-desktop-database -q 2>/dev/null || true
+fi
+
+exit 0

--- a/scripts/aot_build.java
+++ b/scripts/aot_build.java
@@ -165,6 +165,16 @@ public class aot_build {
                     "--win-shortcut", "--win-dir-chooser"));
         } else if (t.equals("DEB") || t.equals("RPM")) {
             cmd.add("--linux-shortcut");
+            // DEB: ship an `editora` command on PATH via custom maintainer scripts (postinst/postrm in
+            // packaging/linux). jpackage installs only /opt/<pkg>/bin/Editora, which isn't on PATH. The
+            // RPM bundler uses a .spec (it ignores postinst/postrm), so the resource dir is DEB-only.
+            if (t.equals("DEB")) {
+                Path resDir = Path.of(System.getProperty("user.dir"), "packaging", "linux");
+                if (Files.isDirectory(resDir)) {
+                    cmd.add("--resource-dir");
+                    cmd.add(resDir.toString());
+                }
+            }
         }
         System.out.println("[aot] wrapping installer: " + String.join(" ", cmd));
         Process p = new ProcessBuilder(cmd).inheritIO().start();


### PR DESCRIPTION
After installing the `.deb`, jpackage only places the launcher at `/opt/editora/bin/Editora` — **not on `PATH`** — so there's no `editora` terminal command. This adds one.

## What it does
The Debian package now creates a **`/usr/bin/editora`** symlink to the installed launcher, so you can start Editora from a terminal with arguments:
```bash
editora some/file.java:42
editora --new-file=notes.md --project ~/code/proj
```
The command is removed when you uninstall the package.

## How
jpackage has no "add to PATH" option, so it's done with custom Debian maintainer scripts passed via `jpackage --resource-dir packaging/linux` (which overrides jpackage's generated scripts):
- **`packaging/linux/postinst`** — symlinks `/usr/bin/editora` → the launcher (found via the `/opt/*/bin/Editora` glob, since jpackage lowercases the install dir); also re-runs `update-desktop-database` / `xdg-desktop-menu forceupdate` (the override replaces jpackage's desktop-refresh).
- **`packaging/linux/postrm`** — removes the symlink on remove/purge, only if it still points into `/opt/*/bin/Editora` (never touches a foreign `/usr/bin/editora`).
- **`scripts/aot_build.java`** — adds `--resource-dir packaging/linux` on the **DEB** wrap only; the RPM bundler uses a `.spec` and ignores `postinst`/`postrm`, so `.rpm` is unchanged (run `/opt/editora/bin/Editora`).

Chose `/usr/bin` (not `/usr/local/bin`) as the policy-correct location for a package-provided command, guaranteed on `PATH`.

## Verification
Linux-only packaging — the `os-linux` jpackage profile can't run on the macOS dev box, so this is **not buildable/testable here**. Verified what's possible: `sh -n` + `shellcheck` clean on both scripts, `aot_build.java` compiles, scripts tracked `100755`.

**Needs a Linux device-test before relying on it** (do it off the release-CI `.deb` artifact or a local Linux build):
1. Install the `.deb` → `which editora` resolves, `editora --version` runs, and Editora still appears in the application menu.
2. `sudo apt remove editora` → `/usr/bin/editora` is gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)