### PR TITLE
Fix Linux .deb generic-Java icon (register .desktop + icon)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- **Linux `.deb`: an `editora` command on `PATH`.** The Debian package now creates a `/usr/bin/editora` symlink to the installed launcher (jpackage otherwise installs it only at `/opt/editora/bin/Editora`, off `PATH`), so you can start Editora from a terminal with arguments — e.g. `editora some/file.java:42`. It's removed on uninstall. Implemented via custom DEB maintainer scripts (`packaging/linux/postinst`/`postrm`) passed through `jpackage --resource-dir` in the installer-wrap step; `.rpm` is unaffected (run `/opt/editora/bin/Editora`).
+- **Linux `.deb`: an `editora` command on `PATH`, plus a proper menu entry + app icon.** The Debian package now (1) creates a `/usr/bin/editora` symlink to the installed launcher (jpackage otherwise installs it only at `/opt/editora/bin/Editora`, off `PATH`), so you can start Editora from a terminal with arguments — e.g. `editora some/file.java:42`; and (2) registers the bundled `.desktop` into `/usr/share/applications` (injecting `StartupWMClass` so the running window matches it), so the application menu and dock show the Editora icon instead of the generic Java icon. Both are removed on uninstall. Implemented via custom DEB maintainer scripts (`packaging/linux/postinst`/`postrm`) passed through `jpackage --resource-dir` in the installer-wrap step — these *replace* jpackage's generated scripts, so they reproduce jpackage's menu/icon registration in addition to the new symlink. `.rpm` is unaffected (run `/opt/editora/bin/Editora`).
 
 ### Changed
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,18 +70,24 @@ hands them to **JReleaser** (`jreleaser.yml`, via `jreleaser/release-action`) wh
 GitHub release with all installers + fat jars + `checksums.txt` + a changelog. JReleaser only *orchestrates the release* — it does not
 build (the `dist` profile is reused as-is) and there is **no `pom.xml`/Maven change**, so the normal
 build is unaffected. Installers are currently **unsigned** (signing/notarization is a follow-up).
-**Linux `editora` command on PATH:** jpackage installs the launcher only at `/opt/editora/bin/Editora`
-(not on `PATH`), so the **`.deb`** ships custom Debian maintainer scripts — `packaging/linux/postinst`
-(symlinks `/usr/bin/editora` → the installed launcher, found via the `/opt/*/bin/Editora` glob since
-jpackage lowercases the install dir) and `packaging/linux/postrm` (removes it on remove/purge, only if
-it still points into `/opt/*/bin/Editora`). They're passed via `jpackage --resource-dir packaging/linux`
-**in the DEB wrap of `scripts/aot_build.java`** (the AOT helper builds the actual installer), DEB-only —
-the RPM bundler uses a `.spec` and ignores `postinst`/`postrm`, so `.rpm` users run `/opt/editora/bin/Editora`
-or add their own symlink. Because the override replaces jpackage's generated `postinst`/`postrm`, both
-scripts also re-run the freedesktop database refresh (`update-desktop-database`/`xdg-desktop-menu
-forceupdate`) that jpackage's default scripts did for the `--linux-shortcut` menu entry. **Device-test on
-Linux** (install the `.deb`: `which editora` + the app appears in the menu; then remove: the symlink is gone)
-— the macOS dev box and the `os-linux` profile can't exercise this.
+**Linux `.deb` PATH command + menu/icon registration:** jpackage installs everything under
+`/opt/editora/` (launcher at `bin/Editora`, the `.desktop` + the 512×512 `Editora.png` at
+`lib/editora-Editora.desktop`/`lib/Editora.png`) and relies on its **own generated `postinst`** to
+register the `.desktop`/icon system-wide (via `xdg-desktop-menu`). The **`.deb`** ships custom Debian
+maintainer scripts (`packaging/linux/postinst`/`postrm`, passed via `jpackage --resource-dir
+packaging/linux` **in the DEB wrap of `scripts/aot_build.java`** — DEB-only; the RPM bundler uses a
+`.spec` and ignores them, so `.rpm` users run `/opt/editora/bin/Editora`). **Because the override
+*replaces* jpackage's generated scripts, it must reproduce that registration or the launcher is never
+installed into `/usr/share/applications` and the app shows the generic Java icon.** So `postinst`
+(`configure`): (1) symlinks `/usr/bin/editora` → the launcher (found via the `/opt/*/bin/Editora` glob,
+since jpackage lowercases the install dir); (2) **copies the bundled `.desktop` into
+`/usr/share/applications/editora-Editora.desktop`, injecting `StartupWMClass=Editora`** (jpackage's
+generated entry omits it, so the *running* window can't be matched to the entry — the menu icon comes
+from the `.desktop`'s already-absolute `Icon=/opt/editora/lib/Editora.png`); then `update-desktop-database`.
+`postrm` (remove/purge) removes both. **Device-test on Linux** (install the `.deb`: `which editora`
+works + the app shows our icon in the menu and dock; then remove: both are gone) — the macOS dev box and
+the `os-linux` profile can't exercise this. *(If a terminal-launched window's dock icon is still generic,
+the real `WM_CLASS` differs from `Editora` — check `xprop WM_CLASS` and fix the injected value.)*
 Uses the BellSoft **Liberica** JDK 25 in CI for full arch coverage (incl. linux aarch64).
 
 ## Architecture

--- a/README.md
+++ b/README.md
@@ -374,11 +374,12 @@ java -jar target/Editora-<version>.jar
 
 The `dist` profile produces a platform installer under `target/dist/`.
 
-On **Linux**, the `.deb` installs the app under `/opt/editora/` and adds an **`editora` command on
-`PATH`** (a `/usr/bin/editora` symlink created by the package's maintainer scripts), so you can launch
-it from a terminal with arguments — e.g. `editora some/file.java:42` or `editora --new-file=notes.md`.
-The command is removed when you uninstall the package. (The `.rpm` installs under `/opt/editora/`
-too; run `/opt/editora/bin/Editora` or add your own symlink.)
+On **Linux**, the `.deb` installs the app under `/opt/editora/`, registers it in the application menu
+(with the Editora icon), and adds an **`editora` command on `PATH`** (a `/usr/bin/editora` symlink
+created by the package's maintainer scripts), so you can launch it from the menu or from a terminal
+with arguments — e.g. `editora some/file.java:42` or `editora --new-file=notes.md`. The menu entry and
+command are removed when you uninstall the package. (The `.rpm` installs under `/opt/editora/` too; run
+`/opt/editora/bin/Editora` or add your own symlink.)
 
 The `fatjar` profile produces a self-contained, runnable `target/Editora-<version>.jar` (no separate
 JavaFX install needed — `java -jar` is enough, on a JDK 25 runtime). It bundles JavaFX's classes and

--- a/packaging/linux/postinst
+++ b/packaging/linux/postinst
@@ -1,33 +1,51 @@
 #!/bin/sh
 #
 # Editora .deb postinst — OVERRIDES jpackage's generated DEB postinst (jpackage picks up any file
-# named "postinst" in --resource-dir). jpackage installs the launcher only at
-# /opt/<package>/bin/Editora, which is not on PATH, so add an `editora` command via a symlink in
-# /usr/bin (policy-correct location for a package-provided command; postrm removes it).
+# named "postinst" in --resource-dir).
 #
-# Because this replaces jpackage's default postinst, it also re-runs the desktop-database refresh
-# that jpackage's script would have done for the --linux-shortcut menu entry.
+# It does what jpackage's default script did (register the menu entry) PLUS two extras:
+#   1. an `editora` command on PATH (jpackage installs the launcher only at /opt/<pkg>/bin/Editora);
+#   2. a StartupWMClass on the menu entry so the *running* window also picks up our icon.
+#
+# Background: jpackage installs the .desktop + icon only under /opt/<pkg>/lib/ and relies on its
+# postinst to register them system-wide. Since we replace postinst we must do that here, or the
+# launcher is never installed into /usr/share/applications and the app shows the generic Java icon.
+# The bundled .desktop's Icon= is already an absolute path to our PNG, so once it's registered the
+# menu shows our icon — we just copy it into /usr/share/applications, injecting StartupWMClass
+# (jpackage's generated entry omits it, so the running window can't be matched to the entry).
 #
 set -e
 
 case "$1" in
     configure)
-        # Install dir is /opt/<package-name> (jpackage lowercases it); the launcher keeps its case.
+        # 1) PATH command — install dir is /opt/<package-name> (jpackage lowercases it).
         for launcher in /opt/*/bin/Editora; do
             if [ -x "$launcher" ]; then
                 ln -sf "$launcher" /usr/bin/editora
                 break
             fi
         done
+
+        # 2) Register the menu entry system-wide, injecting StartupWMClass if the source lacks it.
+        for src in /opt/*/lib/editora-Editora.desktop; do
+            [ -f "$src" ] || continue
+            mkdir -p /usr/share/applications
+            if grep -q '^StartupWMClass=' "$src"; then
+                cp -f "$src" /usr/share/applications/editora-Editora.desktop
+            else
+                awk '{ print }
+                     /^\[Desktop Entry\]/ && !added { print "StartupWMClass=Editora"; added = 1 }' \
+                    "$src" > /usr/share/applications/editora-Editora.desktop
+            fi
+            chmod 0644 /usr/share/applications/editora-Editora.desktop
+            break
+        done
         ;;
 esac
 
-# Refresh desktop integration for the bundled .desktop entry (harmless if the tools are absent).
+# Refresh the desktop database so the launcher + icon show up without a re-login.
 if command -v update-desktop-database >/dev/null 2>&1; then
-    update-desktop-database -q 2>/dev/null || true
-fi
-if command -v xdg-desktop-menu >/dev/null 2>&1; then
-    xdg-desktop-menu forceupdate 2>/dev/null || true
+    update-desktop-database -q /usr/share/applications 2>/dev/null || true
 fi
 
 exit 0

--- a/packaging/linux/postrm
+++ b/packaging/linux/postrm
@@ -1,8 +1,8 @@
 #!/bin/sh
 #
-# Editora .deb postrm — OVERRIDES jpackage's generated DEB postrm. Removes the `editora` PATH
-# symlink that postinst created (only if it still points into our install tree, so a foreign
-# /usr/bin/editora is never touched) on remove/purge.
+# Editora .deb postrm — OVERRIDES jpackage's generated DEB postrm. Undoes what postinst created:
+# the `editora` PATH symlink (only if it still points into our install tree, so a foreign
+# /usr/bin/editora is never touched) and the registered menu entry — on remove/purge.
 #
 set -e
 
@@ -13,11 +13,12 @@ case "$1" in
                 /opt/*/bin/Editora) rm -f /usr/bin/editora ;;
             esac
         fi
+        rm -f /usr/share/applications/editora-Editora.desktop
         ;;
 esac
 
 if command -v update-desktop-database >/dev/null 2>&1; then
-    update-desktop-database -q 2>/dev/null || true
+    update-desktop-database -q /usr/share/applications 2>/dev/null || true
 fi
 
 exit 0


### PR DESCRIPTION
Fixes the generic-Java icon on Debian after installing the .deb. Root cause: PR #170's custom postinst/postrm (for the editora PATH symlink) replaced jpackage's generated maintainer scripts and dropped jpackage's xdg-desktop-menu registration, so the bundled .desktop + icon stayed only under /opt/editora/lib/ (never in /usr/share/applications/). The bundled .desktop Icon= is already an absolute path to our 512x512 PNG, so registering the entry is enough. Fix: postinst now copies the .desktop into /usr/share/applications, injecting StartupWMClass=Editora, plus update-desktop-database; postrm removes both on remove/purge; the editora symlink is kept. DEB-only. shellcheck/sh -n clean; needs a Linux device-test on the rebuilt .deb.