### PR TITLE
deb: correct StartupWMClass to com.editora.App

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -81,9 +81,11 @@ packaging/linux` **in the DEB wrap of `scripts/aot_build.java`** — DEB-only; t
 installed into `/usr/share/applications` and the app shows the generic Java icon.** So `postinst`
 (`configure`): (1) symlinks `/usr/bin/editora` → the launcher (found via the `/opt/*/bin/Editora` glob,
 since jpackage lowercases the install dir); (2) **copies the bundled `.desktop` into
-`/usr/share/applications/editora-Editora.desktop`, injecting `StartupWMClass=Editora`** (jpackage's
-generated entry omits it, so the *running* window can't be matched to the entry — the menu icon comes
-from the `.desktop`'s already-absolute `Icon=/opt/editora/lib/Editora.png`); then `update-desktop-database`.
+`/usr/share/applications/editora-Editora.desktop`, injecting `StartupWMClass=com.editora.App`** (the
+real `WM_CLASS`, verified via `wmctrl -lx` — JavaFX derives it from the module main `com.editora.App`,
+*not* the app name; jpackage's generated entry omits it, so the *running* window can't be matched to the
+entry — the menu icon itself comes from the `.desktop`'s already-absolute
+`Icon=/opt/editora/lib/Editora.png`); then `update-desktop-database`.
 `postrm` (remove/purge) removes both. **Device-test on Linux** (install the `.deb`: `which editora`
 works + the app shows our icon in the menu and dock; then remove: both are gone) — the macOS dev box and
 the `os-linux` profile can't exercise this. *(If a terminal-launched window's dock icon is still generic,

--- a/packaging/linux/postinst
+++ b/packaging/linux/postinst
@@ -33,8 +33,10 @@ case "$1" in
             if grep -q '^StartupWMClass=' "$src"; then
                 cp -f "$src" /usr/share/applications/editora-Editora.desktop
             else
+                # WM_CLASS is com.editora.App (JavaFX derives it from the module main); must match
+                # exactly or GNOME won't bind the running window to this entry (verified via wmctrl -lx).
                 awk '{ print }
-                     /^\[Desktop Entry\]/ && !added { print "StartupWMClass=Editora"; added = 1 }' \
+                     /^\[Desktop Entry\]/ && !added { print "StartupWMClass=com.editora.App"; added = 1 }' \
                     "$src" > /usr/share/applications/editora-Editora.desktop
             fi
             chmod 0644 /usr/share/applications/editora-Editora.desktop


### PR DESCRIPTION
Follow-up to #172. The injected `StartupWMClass=Editora` was a guess; the app's real `WM_CLASS` on Debian (verified via `wmctrl -lx`) is `com.editora.App` (instance + class), which JavaFX derives from the module main `com.editora.App` — not the app name. GNOME matches `StartupWMClass` against `WM_CLASS` exactly, so the guess never bound the running window to our menu entry and a terminal-launched window kept the generic dock icon. This sets the correct value so the dock icon resolves. postinst one-liner + CLAUDE.md note; shellcheck clean. Verify on the rebuilt .deb (terminal-launch dock icon).