### PR TITLE
Fix Markdown preview: hide HTML comments + hide minimap when preview is shown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Markdown preview no longer renders HTML comments.** `<!-- … -->` blocks (and inline comments) were shown as visible text/code in the preview (and PDF/print export); they're now hidden, matching GitHub and every other Markdown renderer.
+- **Markdown preview hides the editor minimap.** In Split/Preview mode the minimap was wedged between the editor and the preview; it's now hidden while the preview is shown (the preview is the overview) and restored when you return to the plain editor view.
+
 - **The "install language support?" banner no longer shows when the language server is actually installed and running.** It was reading the server-availability flag before startup detection finished (and never re-checking), so it could falsely claim e.g. Java support was missing while jdtls was serving the file. The banner now only appears once a server is *confirmed* absent (not merely "not probed yet"), never when a live session is already serving the file, and re-evaluates as soon as detection settles. Also fixed the banner text dropping its apostrophe ("isnt") — the message runs through `MessageFormat`, where `'` must be doubled.
 
 ### Added

--- a/src/main/java/com/editora/editor/EditorBuffer.java
+++ b/src/main/java/com/editora/editor/EditorBuffer.java
@@ -2544,6 +2544,7 @@ public class EditorBuffer implements TabContent {
             scheduleRenderPreview();
         }
         rebuildViewHost();
+        setMinimapVisible(minimapVisible); // re-apply: the minimap is hidden while the preview is shown
         if (target == MarkdownViewMode.PREVIEW) {
             // Focus the preview so the paging keys (Space/PageDown/Backspace/PageUp) work without a click.
             Platform.runLater(previewPane()::requestFocus);
@@ -3679,8 +3680,10 @@ public class EditorBuffer implements TabContent {
     public void setMinimapVisible(boolean visible) {
         this.minimapVisible = visible;
         // Large files (and the intermediate large-source tier) force the minimap off regardless of the
-        // user's setting (see setLargeFile / setHeavyFile).
-        boolean effective = visible && !largeFile && !heavyFile;
+        // user's setting (see setLargeFile / setHeavyFile). The Markdown preview (SPLIT/PREVIEW) also hides
+        // it — a minimap squeezed between the editor and the preview is redundant clutter (the preview is
+        // the overview), so it only shows in the plain EDITOR view.
+        boolean effective = visible && !largeFile && !heavyFile && markdownViewMode == MarkdownViewMode.EDITOR;
         applyMinimap(scrollPane, minimap, effective);
         AnchorPane.setRightAnchor(whitespace, effective ? Minimap.WIDTH : 0d);
         if (minimap2 != null) {

--- a/src/main/java/com/editora/editor/MarkdownRenderer.java
+++ b/src/main/java/com/editora/editor/MarkdownRenderer.java
@@ -189,7 +189,10 @@ public final class MarkdownRenderer {
             return s;
         }
         if (node instanceof HtmlBlock hb) {
-            return codeBlock(hb.getLiteral()); // raw HTML shown as text (no interpretation)
+            if (isHtmlComment(hb.getLiteral())) {
+                return null; // HTML comments are invisible (as in GitHub / every Markdown renderer)
+            }
+            return codeBlock(hb.getLiteral()); // other raw HTML shown as text (no interpretation)
         }
         if (node instanceof TableBlock tb) {
             return renderTable(tb, baseDir);
@@ -204,6 +207,11 @@ public final class MarkdownRenderer {
         VBox box = new VBox();
         appendBlocks(node, box, baseDir);
         return box.getChildren().isEmpty() ? null : box;
+    }
+
+    /** Whether a raw-HTML literal is an HTML comment ({@code <!-- … -->}) — rendered invisibly. Pure. */
+    public static boolean isHtmlComment(String literal) {
+        return literal != null && literal.strip().startsWith("<!--");
     }
 
     private static Node renderList(org.commonmark.node.Node list, Path baseDir, boolean ordered, int start) {
@@ -418,7 +426,9 @@ public final class MarkdownRenderer {
         } else if (n instanceof HardLineBreak) {
             flow.getChildren().add(new Text("\n"));
         } else if (n instanceof HtmlInline h) {
-            flow.getChildren().add(inlineCode(h.getLiteral()));
+            if (!isHtmlComment(h.getLiteral())) {
+                flow.getChildren().add(inlineCode(h.getLiteral())); // skip inline HTML comments
+            }
         } else if (n instanceof TaskListItemMarker) {
             // rendered as a CheckBox by renderList — skip here
         } else {

--- a/src/main/java/com/editora/pdf/MarkdownPdfWriter.java
+++ b/src/main/java/com/editora/pdf/MarkdownPdfWriter.java
@@ -182,8 +182,11 @@ public final class MarkdownPdfWriter {
                 rule(left);
             } else if (n instanceof TableBlock t) {
                 table(t, left);
+            } else if (n instanceof org.commonmark.node.HtmlBlock hb
+                    && com.editora.editor.MarkdownRenderer.isHtmlComment(hb.getLiteral())) {
+                // HTML comments are invisible — skip (matches the on-screen preview).
             } else {
-                // HtmlBlock / unknown: render its textual content as a paragraph if any.
+                // HtmlBlock(non-comment) / unknown: render its textual content as a paragraph if any.
                 String text = plain(n);
                 if (!text.isBlank()) {
                     flow(

--- a/src/test/java/com/editora/editor/MarkdownRendererTest.java
+++ b/src/test/java/com/editora/editor/MarkdownRendererTest.java
@@ -19,6 +19,15 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  */
 class MarkdownRendererTest {
 
+    @Test
+    void htmlCommentsAreRecognizedAsInvisible() {
+        assertTrue(MarkdownRenderer.isHtmlComment("<!-- hidden -->"));
+        assertTrue(MarkdownRenderer.isHtmlComment("   <!--\nmulti\nline\n-->"));
+        assertFalse(MarkdownRenderer.isHtmlComment("<div>shown</div>"));
+        assertFalse(MarkdownRenderer.isHtmlComment(""));
+        assertFalse(MarkdownRenderer.isHtmlComment(null));
+    }
+
     private static final String SAMPLE = """
             # Heading
 


### PR DESCRIPTION
Two Markdown-preview rendering bugs (reported via screenshot):

**1. HTML comments rendered as visible text.** `MarkdownRenderer` rendered every `HtmlBlock` (and inline HTML) as a code block, so `<!-- … -->` comments — and any Markdown inside them — appeared literally in the preview and in PDF/print export. They're now skipped (invisible), matching GitHub and every other Markdown renderer. Non-comment raw HTML still renders as text. A shared `MarkdownRenderer.isHtmlComment` helper (pure, unit-tested) is reused by `MarkdownPdfWriter`.

**2. Minimap wedged between editor and preview.** In Split/Preview the editor's minimap sat cramped in the middle. It's now hidden whenever the Markdown preview is showing (the preview is the overview) and restored when returning to the plain editor view — folded into `setMinimapVisible`'s effective gate and re-applied on view-mode change, so the user's minimap setting is preserved.

`./mvnw verify` green (1203 tests). No new dependency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)