### PR TITLE
docs: upgrade developer docs (diagrams, ADRs, glossary, gotchas, deep-dives)

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -8,12 +8,15 @@ are the readable distillation of it — when they disagree with the code, the co
 
 ## Start here
 
-- [architecture.md](architecture.md) — module map, boot path, the multi-window model, the
-  `EditorBuffer`/`TabContent` abstraction, and the recurring patterns.
+- [architecture.md](architecture.md) — module map (with diagrams), boot path, the multi-window
+  model, the `EditorBuffer`/`TabContent` abstraction, and the recurring patterns.
 - [conventions.md](conventions.md) — the rules a change must follow (commands, settings, i18n,
   schema, formatting, worktrees). See also [`../CONTRIBUTING.md`](../CONTRIBUTING.md).
 - [performance.md](performance.md) — the hot paths and the discipline that keeps the editor
   responsive. Read before touching highlighting, overlays, the gutter, or scrolling.
+- [glossary.md](glossary.md) — the recurring Editora-specific terms in one place.
+- [gotchas.md](gotchas.md) — the non-obvious traps (JPMS opens, macOS classloader, the
+  headless-AWT guard, the texture-pool black window, …) with symptom and fix.
 
 ## How-to
 
@@ -23,11 +26,28 @@ are the readable distillation of it — when they disagree with the code, the co
   packaging, and the registry. The full plugin catalog lives in the
   [editora-plugins](https://github.com/adriandeleon/editora-plugins) repo.
 
+## Subsystem deep-dives
+
+- [subsystems/command-system.md](subsystems/command-system.md) — `Command`/`CommandRegistry`,
+  the five keymaps + per-OS variants, `KeyDispatcher`, the keybinding editor.
+- [subsystems/config-and-migrations.md](subsystems/config-and-migrations.md) — the config dir,
+  `SharedConfig`/`ConfigManager`, `ConfigWriter`, and schema versioning + migrations.
+- [subsystems/lsp-and-dap.md](subsystems/lsp-and-dap.md) — Language Server + Debug Adapter
+  integration, and the `process/ProcessRegistry` lifecycle that owns spawned servers.
+
+## Decisions
+
+- [decisions/](decisions/README.md) — architecture decision records: the *why* behind the
+  unusual choices (the RichTextFX fork, native-CLI git, TOML settings, TextMate highlighting,
+  in-scene overlays, the headless-AWT guard, multi-window config, feature coordinators, the
+  plugin classloader, the headless test platform).
+
 ## Build, test, ship
 
 - [building-and-packaging.md](building-and-packaging.md) — run, dist/jpackage, the AOT cache,
   fat jar, the per-OS Prism pipeline.
-- [dependencies.md](dependencies.md) — the vendored/forked/repackaged deps (RichTextFX fork,
-  Monocle, tm4e) and the moditect story.
-- [testing.md](testing.md) — pure tests, the headless-FX Monocle harness, the JaCoCo floors.
+- [dependencies.md](dependencies.md) — the vendored/forked/repackaged deps (the RichTextFX fork,
+  tm4e) and the moditect story.
+- [testing.md](testing.md) — pure tests, the headless-FX harness (JavaFX 26's built-in Headless
+  platform), the JaCoCo floors.
 - [release.md](release.md) — cutting a release and the CI matrix.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -11,7 +11,7 @@ the deeper conventions live in [conventions.md](conventions.md) and
 
 ## What it is
 
-A keyboard-driven, cross-platform programmer's text editor: **JDK 25 + JavaFX 25**, Maven,
+A keyboard-driven, cross-platform programmer's text editor: **JDK 25 + JavaFX 26**, Maven,
 a single JPMS module `com.editora` (see [`src/main/java/module-info.java`](../src/main/java/module-info.java)).
 The editor surface is a [RichTextFX](dependencies.md) `CodeArea`; standard controls are
 themed by AtlantaFX.
@@ -34,6 +34,25 @@ themed by AtlantaFX.
    is the per-window hub: toolbar, the tabbed `EditorBuffer`s, the status bar, tool windows,
    and the wiring for every feature. It is large by design — most features are wired here and
    delegate into their own packages.
+
+```mermaid
+sequenceDiagram
+    participant main as App.main
+    participant start as App.start
+    participant WM as WindowManager
+    participant MC as MainController (per window)
+    main->>main: java.awt.headless=true  (first statement)
+    main->>main: DebugLog.install() + uncaught handler
+    main->>start: launch()
+    start->>start: config.load(), Messages.init(), pin classloader
+    start->>start: ProcessRegistry.reapOrphans()
+    start->>WM: launch()  (restore previously-open windows)
+    loop each window to open
+        WM->>MC: buildWindow()
+        MC->>MC: registerCommands, KeyDispatcher, theme, load main.fxml
+        MC->>MC: setWindowContext(project) + startup(...)
+    end
+```
 
 ### The headless-AWT guard (don't move it)
 
@@ -60,7 +79,28 @@ Config is split:
 So a `config.save()` from any window writes `settings.toml` + that window's session file
 without clobbering another window's in-memory copy. A settings change in one window
 broadcasts to all via `WindowManager.broadcastSettingsApplied()`. See
-[config-and-schema](conventions.md#config-and-schema) for the storage details.
+[config-and-schema](conventions.md#config-and-schema) for the storage details, and the
+[config subsystem deep-dive](subsystems/config-and-migrations.md) for the full model.
+
+```mermaid
+flowchart LR
+    subgraph shared["SharedConfig — one instance, shared by reference"]
+        direction TB
+        S["Settings (settings.toml)"]
+        ST["bookmark / note / breakpoint /<br/>connection / macro stores"]
+        PM["ProjectManager index"]
+    end
+    subgraph w1["Window A — own MainController + ConfigManager"]
+        WS1["WorkspaceState"]
+    end
+    subgraph w2["Window B — own MainController + ConfigManager"]
+        WS2["WorkspaceState"]
+    end
+    w1 -->|delegates shared| shared
+    w2 -->|delegates shared| shared
+    WS1 -.->|workspace-state.json| F1[(session A)]
+    WS2 -.->|projects/&lt;id&gt;.json| F2[(session B)]
+```
 
 ## The editor buffer
 
@@ -72,6 +112,25 @@ completion, snippets). Features are injected rather than imported so the `editor
 stays free of `ui`, `config`, and the feature packages — e.g. `setSnippetProvider`,
 `setCompletionProvider`, `setMarkdownLintValidator`, `setLspCompletionProvider`. When you add
 an editor feature, follow that injection pattern.
+
+A buffer's lifecycle, and why `dispose()` matters (it shuts the per-buffer daemon executors so
+they don't accumulate one pair per opened file):
+
+```mermaid
+stateDiagram-v2
+    [*] --> Opened: addBuffer / loadInto
+    Opened --> Editing: user edits
+    Editing --> Editing: debounced highlight + coalesced overlays
+    Editing --> Saved: save → writeBuffer
+    Saved --> Editing: further edits
+    Editing --> Disposed: tab closed
+    Saved --> Disposed: tab closed
+    Disposed --> [*]: dispose() — shutdownNow() executors + unsubscribe
+    note right of Disposed
+        Runs on every real close path,
+        never on a tab switch.
+    end note
+```
 
 ### Tabs are `TabContent`, not always buffers
 
@@ -95,6 +154,33 @@ Welcome tab. Tab-switch consumers (status bar, Structure, git, …) must be null
 | `git/` `diff/` | Native-CLI git, the diff/merge viewer. |
 | `search/` `todo/` `snippet/` `template/` `completion/` `pdf/` `print/` `mermaid/` `http/` `web/` `macro/` `externaltool/` `logviewer/` `editorconfig/` `vfs/` `plugin/` `run/` | Feature packages, each largely self-contained and wired in `MainController`. |
 | `process/` | `ProcessRunner` (the only place a subprocess is spawned) + `ProcessRegistry` (lifecycle of spawned servers). |
+
+Dependency direction (arrows point at what a package depends on). The key invariants: `ui`
+depends on everything and wires it together; `editor` and `completion` depend on **neither** `ui`
+nor the feature packages — features reach the editor through injected hooks; every subprocess
+goes through `process`.
+
+```mermaid
+flowchart TD
+    ui["ui<br/>(MainController, coordinators)"]
+    editor["editor"]
+    command["command"]
+    config["config (+ migration)"]
+    i18n["i18n"]
+    features["feature packages<br/>lsp · dap · git · diff · search · todo ·<br/>snippet · template · pdf · mermaid · http ·<br/>web · macro · run · plugin · vfs · …"]
+    process["process<br/>(ProcessRunner / ProcessRegistry)"]
+
+    ui --> editor
+    ui --> command
+    ui --> config
+    ui --> features
+    ui --> i18n
+    features --> process
+    features --> config
+    editor -. "feature hooks injected by ui<br/>(setXxxProvider) — no compile dep" .-> features
+    editor --> command
+    editor --> i18n
+```
 
 ## Recurring patterns
 

--- a/docs/decisions/0001-richtextfx-fork.md
+++ b/docs/decisions/0001-richtextfx-fork.md
@@ -1,0 +1,31 @@
+# 0001 — Fork RichTextFX for multiple cursors, vendor it in `m2-repo/`
+
+**Status:** Accepted
+
+## Context
+
+The editor surface is a RichTextFX `CodeArea`. RichTextFX has no built-in support for VS
+Code–style multiple cursors / Alt+drag column selection, and upstream has not added it. We want
+that feature, and we want it without rewriting the editor surface on a different toolkit.
+
+## Decision
+
+Maintain a personal fork, `io.github.adriandeleon:richtextfx`, **vendored in the in-project
+`m2-repo/`** (source at github.com/adriandeleon/RichTextFX). The fork adds a self-contained
+`org.fxmisc.richtext.multi.MultiCaretController.install(area)` add-on — a layered, well-behaved
+`InputMap` gated on `MultiCaretManager.hasExtras()`, so it is transparent when there is one caret.
+
+## Consequences
+
+- `EditorBuffer` installs it via `setMultiCaretEnabled(...)`; the area-level KEY filters
+  early-return (no consume) via `multiCaretActiveOn(a)` when an area has extra carets, so edits
+  fan out to all carets.
+- Updating the fork is a manual ritual: rebuild it, copy `richtextfx-<version>.{jar,pom}` into
+  `m2-repo/`, bump `<richtextfx.version>`. Use 0.11.7+ (earlier breaks on JavaFX 25+).
+- RichTextFX and its transitive deps (`reactfx`, `flowless`, `undofx`, `wellbehavedfx`) are
+  automatic modules, so the dist build's moditect step injects `module-info` descriptors for the
+  jlink image — bumping the fork may require adjusting their `requires`.
+- **Known limitation:** Emacs movement chords are resolved by the scene-level `KeyDispatcher` on
+  the primary caret and don't fan out; arrows do.
+
+See [dependencies.md](../dependencies.md#richtextfx--a-personal-fork-m2-repo).

--- a/docs/decisions/0002-native-cli-git.md
+++ b/docs/decisions/0002-native-cli-git.md
@@ -1,0 +1,29 @@
+# 0002 — Native-CLI git, not JGit
+
+**Status:** Accepted
+
+## Context
+
+Editora has a full git integration: status, diff, gutter change bars, branch switching, log,
+blame, stash, commit, clone. The two ways to do this in a JVM app are an embedded library (JGit)
+or shelling out to the user's installed `git`.
+
+## Decision
+
+Shell out to the user's `git` binary. There is no JGit dependency. All git work goes through one
+subprocess chokepoint, `process/ProcessRunner`, behind the `git/GitService` facade (a single
+daemon executor + a generation guard, posting results to the FX thread).
+
+## Consequences
+
+- **No new dependency, no `module-info` change** — the integration is pure CLI.
+- We get exactly the user's git: their version, config, credential helpers, hooks, and any
+  `includeIf`/conditional config. `LC_ALL=C` + `GIT_OPTIONAL_LOCKS=0` are set for stable parsing
+  and lock-free status.
+- Parsing is our responsibility: pure, unit-tested parsers (`StatusParser` for porcelain-v2,
+  `DiffParser`, `BlameParser`, `StashParser`, …) turn git output into model records.
+- A Finder-launched `.app` inherits a stripped `PATH` without Homebrew's git; `ProcessRunner`'s
+  augmented-PATH / login-shell-PATH resolution handles that (see [gotchas.md](../gotchas.md)).
+- Git is **self-gating**: inert until `git` is on `PATH`; remote (SFTP) buffers report no repo.
+
+The diff/merge viewer reuses the same facade (`GitService.show`/`log`/`diff`).

--- a/docs/decisions/0003-toml-settings-json-session.md
+++ b/docs/decisions/0003-toml-settings-json-session.md
@@ -1,0 +1,29 @@
+# 0003 — TOML for settings, JSON for session + stores
+
+**Status:** Accepted
+
+## Context
+
+Editora persists several kinds of state: user **preferences** (font, theme, keymap, toggles,
+keybindings), per-window **session** state (open files, folds, tool-window layout), and a set of
+**stores** (bookmarks, notes, breakpoints, connections, macros, recent files, projects).
+Preferences are meant to be hand-editable; session/stores are machine-managed.
+
+## Decision
+
+- **Preferences** live in `settings.toml`, read/written with a Jackson `TomlMapper`
+  (jackson-dataformat-toml). TOML is comfortable to hand-edit, with comments and clear sections.
+- **Session state** stays JSON in `workspace-state.json`, and the stores stay JSON in their own
+  files. These are machine-managed, so editability doesn't matter and JSON is the lighter choice.
+
+## Consequences
+
+- The switch to TOML for settings was a clean cut — a pre-existing `settings.json` is **not**
+  migrated.
+- Both POJOs (`Settings`, `WorkspaceState`) are `@JsonIgnoreProperties(ignoreUnknown = true)`, so
+  a save rewrites with only modeled fields.
+- Every structured file carries a `schemaVersion` and goes through the same migration path
+  (`ConfigMigrations.readVersioned`), which is mapper-agnostic — it works for TOML and JSON alike
+  because `TomlMapper` yields ordinary Jackson nodes. See
+  [config-and-migrations.md](../subsystems/config-and-migrations.md).
+- Bundled keymaps and TextMate grammars stay JSON — they are app resources, not user config.

--- a/docs/decisions/0004-textmate-grammars.md
+++ b/docs/decisions/0004-textmate-grammars.md
@@ -1,0 +1,31 @@
+# 0004 — TextMate grammars via tm4e, not a hand-written highlighter
+
+**Status:** Accepted
+
+## Context
+
+Syntax highlighting needs to cover many languages and stay maintainable. The options are a
+hand-written tokenizer per language, a parser-generator approach, or reusing the TextMate grammar
+ecosystem (the `.tmLanguage.json` grammars that VS Code and many editors use).
+
+## Decision
+
+Use **TextMate grammars** via **tm4e** (`org.eclipse.tm4e.core`). `GrammarRegistry` maps a file
+extension to a bundled grammar under `resources/com/editora/grammars/`; `TextMateHighlighter`
+tokenizes the document line-by-line (carrying grammar state across lines) and maps each token's
+scope to a CSS class themed in `styles/syntax.css`.
+
+## Consequences
+
+- Adding a language is mostly **data**: drop a `.tmLanguage.json`, register a scope→resource and
+  extension→scope mapping, add fold/indent/comment entries. See
+  [extending.md](../extending.md#add-a-language--textmate-grammar).
+- We inherit a large, battle-tested grammar corpus (vendored from VS Code / shiki / authored;
+  attributed in `NOTICE`).
+- tm4e is not on Maven Central — it ships as the NetBeans repackaging, which is **code-signed**,
+  so the dist build strips the jar signature before jlink (jlink rejects signed modular jars).
+- **JPMS trap:** the grammar package must `opens com.editora.grammars to org.eclipse.tm4e.core`,
+  or tm4e's `getResourceAsStream` returns null at runtime on the module path (classpath tests
+  still pass). See [gotchas.md](../gotchas.md).
+- `LanguageRegistry` is now only an extension→language-name resolver (folding + File Info); it no
+  longer does highlighting.

--- a/docs/decisions/0005-in-scene-overlays.md
+++ b/docs/decisions/0005-in-scene-overlays.md
@@ -1,0 +1,34 @@
+# 0005 — In-scene overlays (`OverlayHost`), not `javafx.stage.Popup`
+
+**Status:** Accepted
+
+## Context
+
+The command palette and every keyboard picker (file finder, switcher, quick-open lists, branch
+dropdown, message log, input prompts) need a focused, modal-ish surface that takes keyboard input.
+The obvious JavaFX primitive is `javafx.stage.Popup` — a separate native window.
+
+## Decision
+
+Render all of them as **in-scene overlays** over a single shared `ui/OverlayHost` installed into
+the scene-root `StackPane`, not as `Popup`s. The host draws one "card" at a time over a dim,
+click-to-dismiss backdrop and owns focus capture/restore, `Esc`/`C-g` dismissal, and a
+`justHidden()` toggle guard.
+
+## Context behind it
+
+A `Popup` is a separate native window. On Windows it doesn't reliably take OS keyboard focus, so
+calling `input.requestFocus()` orphaned focus between the popup's scene and the main window and
+the keyboard went dead app-wide (mouse still worked). In-scene overlays share the main window's
+scene, so focus never leaves it.
+
+## Consequences
+
+- Every picker supplies a card node (which sets `editora.ownsKeys` so its `C-n`/`C-p`/arrow nav
+  isn't hijacked by the global `KeyDispatcher`), an `onShown` hook (`requestFocus`), and an
+  `onHidden` hook. `MainController.wireOverlayHost()` injects the host into all of them.
+- Input dialogs use the same mechanism via `ui/OverlayInput` (callback-driven; `onAccept` runs
+  after the card hides, so focus is already back in the editor — no blocking `showAndWait`).
+- The one exception is `editor/CompletionPopup`, which stays a `Popup` — it never calls
+  `requestFocus()`, so it's safe.
+- Deliberately left native: simple `Alert` confirmations and `ChoiceDialog` selectors.

--- a/docs/decisions/0006-headless-awt-guard.md
+++ b/docs/decisions/0006-headless-awt-guard.md
@@ -1,0 +1,28 @@
+# 0006 — Force `java.awt.headless=true` before anything else
+
+**Status:** Accepted
+
+## Context
+
+The Markdown preview rasterizes SVG (shields.io / GitHub badges via JSVG) and LaTeX math (via
+JLaTeXMath). Both touch `java.awt`/Java2D. On macOS the AWT/Java2D native pipeline (AppKit/Metal)
+contends with JavaFX's Glass/Prism for the single AppKit run loop — an intermittent
+deadlock/hang that grows likelier the more badges/formulas are rasterized.
+
+## Decision
+
+`App.main`'s **very first statement** is `System.setProperty("java.awt.headless", "true")`.
+Headless Java2D rasterizes to a `BufferedImage` purely in software (no AppKit), so badges and math
+still render while the conflict disappears.
+
+## Consequences
+
+- It must run **before any AWT class loads**, hence first in `main`. Keep it there.
+- It covers every entry point — `javafx:run`, the fat-jar `Launcher`, and the jpackage module all
+  route through `App.main`.
+- A corollary: features that would otherwise use AWT must avoid it. Printing uses `javafx.print`,
+  not `java.awt.print` (which would throw `HeadlessException` under this guard).
+- SVG/math rasterization copies the `BufferedImage` into a JavaFX `WritableImage` via a
+  `PixelWriter` — no `javafx.swing` is pulled in.
+
+See [gotchas.md](../gotchas.md).

--- a/docs/decisions/0007-multi-window-shared-config.md
+++ b/docs/decisions/0007-multi-window-shared-config.md
@@ -1,0 +1,35 @@
+# 0007 — One window per project + a `SharedConfig`/`ConfigManager` split
+
+**Status:** Accepted
+
+## Context
+
+Editora is project-aware and multi-window: a user can have several projects (and several
+no-project "New Window"s) open at once. Early on, a single `ConfigManager` held everything,
+which made "the active project" a global — switching a project in one place affected all windows,
+and parallel windows clobbered each other's open-files/layout.
+
+## Decision
+
+Each project (and each New Window) opens in its **own top-level window** with its own
+`MainController`, `Stage`, `CommandRegistry`, `KeyDispatcher`, and per-window services. Config is
+split in two:
+
+- **`SharedConfig`** — app-wide state held by reference across every window (`Settings`, the
+  bookmark/note/breakpoint/connection/macro stores, the user dictionary, the `ProjectManager`
+  index).
+- **`ConfigManager`** — per-window, owning only that window's session (`WorkspaceState` + its
+  `workspaceStateFile`) and delegating everything shared to `SharedConfig`.
+
+## Consequences
+
+- A `config.save()` from any window writes `settings.toml` + that window's session file without
+  clobbering another window's in-memory copy. A settings change broadcasts via
+  `WindowManager.broadcastSettingsApplied()`.
+- `config.getBookmarks()/getNotes()/getBreakpoints()` return the bucket for *this* window's
+  project, keyed off its session file (`currentBookmarkKey()`).
+- The open-window set is tracked in `ProjectManager.Index.openProjectIds` and restored next launch
+  (a debounced reconcile distinguishes a single-window close from a quit, so a quit reopens
+  everything).
+- Per-window services must all be per-instance (no static per-window state) and disposed on window
+  close. See the [config subsystem deep-dive](../subsystems/config-and-migrations.md).

--- a/docs/decisions/0008-feature-coordinators.md
+++ b/docs/decisions/0008-feature-coordinators.md
@@ -1,0 +1,32 @@
+# 0008 — Decompose `MainController` into feature coordinators
+
+**Status:** Accepted (ongoing)
+
+## Context
+
+`MainController` is the per-window hub and grew to ~12k lines as features accreted. A class that
+large is hard to hold in your head, hard to test (it needs a real window), and a magnet for more
+code. But the features genuinely need access to window-level state (the active buffer, tool
+windows, the status bar, settings), so they can't just move to their own packages wholesale.
+
+## Decision
+
+Pull each feature's logic into a **coordinator** in `ui` that reaches the window only through a
+narrow shared interface, `ui/CoordinatorHost` (plus a small per-feature `Ops`/`WindowOps`
+extension for the few extra capabilities it needs). `MainController` constructs the coordinator
+with an anonymous `Host` adapter and keeps **one-line delegations** at each call site.
+
+## Consequences
+
+- A coordinator is **unit-testable** with a fake `Host`, without a real window (see the
+  `*CoordinatorFxTest`s).
+- New features should be their own coordinator (or pure package) from the start, **never** bolted
+  onto `MainController`.
+- The decomposition is incremental — External Tools, Macros, TODO, Search, Run, Log Viewer,
+  Mermaid, HTML Preview, LSP, Debug, Git, Diff, History, Notes, Bookmarks, Remote, Plugins, and
+  others now live in coordinators; `MainController` keeps the tool-window registrations, the
+  shared helpers, and the command registrations that delegate in.
+- Give a coordinator only the capabilities it needs on `CoordinatorHost`; don't hand it the whole
+  `MainController`.
+
+See [extending.md](../extending.md#extract-a-feature-coordinator).

--- a/docs/decisions/0009-plugins-no-modulelayer.md
+++ b/docs/decisions/0009-plugins-no-modulelayer.md
@@ -1,0 +1,34 @@
+# 0009 — Plugins via a child `URLClassLoader`, no `ModuleLayer`
+
+**Status:** Accepted
+
+## Context
+
+Editora supports third-party plugins (a `plugin.json` manifest + optional Java jar). The modern
+JPMS way to load isolated code would be a `ModuleLayer` with its own module path. But the
+shipped app is a **sealed jlink image with no module path at runtime**, and there is no
+`ServiceLoader` infrastructure baked in.
+
+## Decision
+
+Discover plugins by **manifest**, and load a Java plugin's classes via a child
+`URLClassLoader(jarUrls, appClassLoader)` — no `ModuleLayer`, no `ServiceLoader`. The parent is
+the app module's loader, so a plugin can use Editora's **exported** packages
+(`com.editora.plugin`/`command`/`ui`/`editor`/`config`) and the baked JDK/JavaFX modules via
+normal parent delegation.
+
+## Consequences
+
+- A plugin is compiled on a plain **classpath**, not the module path.
+- The API surface is the exported `com.editora.plugin` package: `Plugin`/`PluginContext`/
+  `ActiveEditor` — a narrow editor facade that never exposes `MainController`.
+- Classes load **once** (a shared `PluginManager` owned by `WindowManager`), but a `Plugin`
+  instance + its tool-window content node are built **per window** (a node can't live in two
+  scenes).
+- Plugins load at **startup only**; enable/disable takes effect next launch (no hot
+  classloader/UI unload). Per-window `stop()` on close is the only teardown.
+- Security is consent + integrity + authenticity (capability disclosure, HTTPS-only capped
+  downloads, an Ed25519-signed registry index), **not** a sandbox — a plugin runs with full
+  trust, like VS Code / IntelliJ.
+
+See [plugins.md](../plugins.md).

--- a/docs/decisions/0010-builtin-headless-test-platform.md
+++ b/docs/decisions/0010-builtin-headless-test-platform.md
@@ -1,0 +1,33 @@
+# 0010 — JavaFX 26 built-in Headless test platform, drop self-built Monocle
+
+**Status:** Accepted (supersedes the previous self-built-Monocle approach)
+
+## Context
+
+The FX test harness needs a headless Glass backend so `@Tag("fx")` tests run on CI with no
+display. The long-standing option was **Monocle**, but there is no upstream Monocle build for
+current JavaFX (`org.testfx:openjfx-monocle` stops at 21), so it had to be **self-built from the
+OpenJFX sources and vendored in `m2-repo/`, and rebuilt on every JavaFX bump** — a stale-version
+jar fails to link against the internal `com.sun.glass.ui` APIs.
+
+## Decision
+
+Use **JavaFX 26's built-in Headless Glass platform** (`-Dglass.platform=Headless`, part of
+`javafx.graphics` since 26, set in the surefire `<systemPropertyVariables>`). Remove the vendored
+Monocle artifact and the `<monocle.version>` property.
+
+## Consequences
+
+- **Nothing is vendored** — no jar, no native libs, no rebuild ritual. The backend ships inside
+  the JavaFX runtime, so it can never go stale on a JavaFX bump.
+- The built-in platform is officially a **prototype** in 26. That's fine here because the harness
+  only uses TestFX's `FxToolkit` to **boot the toolkit** — it never drives the robot (input/clicks)
+  or renders/snapshots in tests, so the prototype's limitations don't apply (and TestFX needs no
+  changes despite not yet adopting it).
+- If a future need ever requires real headless rendering or robot input under the prototype,
+  Monocle could be re-vendored — but as of 26 it isn't needed.
+- Surefire still needs `<useModulePath>false</useModulePath>`, `prism.order=sw`, and the
+  `<argLine>@{argLine}</argLine>` token (so JaCoCo's agent survives).
+
+See [testing.md](../testing.md) and
+[dependencies.md](../dependencies.md#the-headless-test-backend-no-vendored-dependency).

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -1,0 +1,27 @@
+# Architecture decision records
+
+Short records of the non-obvious choices in Editora — the ones where the "why" isn't visible in
+the code and a future contributor (or your future self) would otherwise re-litigate them.
+
+Format is lightweight: **Status / Context / Decision / Consequences**. A record is a snapshot of
+the reasoning at the time; if a decision is later reversed, add a new record that supersedes it
+rather than rewriting history.
+
+| # | Decision | Status |
+| --- | --- | --- |
+| [0001](0001-richtextfx-fork.md) | Fork RichTextFX for multiple cursors, vendor it in `m2-repo/` | Accepted |
+| [0002](0002-native-cli-git.md) | Native-CLI git (shell out), not JGit | Accepted |
+| [0003](0003-toml-settings-json-session.md) | TOML for settings, JSON for session + stores | Accepted |
+| [0004](0004-textmate-grammars.md) | TextMate grammars via tm4e, not a hand-written highlighter | Accepted |
+| [0005](0005-in-scene-overlays.md) | In-scene overlays (`OverlayHost`), not `javafx.stage.Popup` | Accepted |
+| [0006](0006-headless-awt-guard.md) | Force `java.awt.headless=true` before anything else | Accepted |
+| [0007](0007-multi-window-shared-config.md) | One window per project + a `SharedConfig`/`ConfigManager` split | Accepted |
+| [0008](0008-feature-coordinators.md) | Decompose `MainController` into feature coordinators | Accepted (ongoing) |
+| [0009](0009-plugins-no-modulelayer.md) | Plugins via a child `URLClassLoader`, no `ModuleLayer` | Accepted |
+| [0010](0010-builtin-headless-test-platform.md) | JavaFX 26 built-in Headless test platform, drop self-built Monocle | Accepted |
+
+## Writing a new one
+
+Copy the format of an existing record, take the next number, and add a row above. Keep it to the
+reasoning — the *what* belongs in the code and the other [docs](../README.md); the ADR captures
+the *why* and the alternatives considered.

--- a/docs/dependencies.md
+++ b/docs/dependencies.md
@@ -39,20 +39,19 @@ automatic module, so moditect injects a `module-info` for it too.
 The NetBeans jar is **code-signed**, and `jlink` rejects signed modular jars — the `dist`
 profile's antrun step strips `META-INF/*.SF,*.RSA,*.DSA,*.EC` before linking.
 
-## Monocle — self-built headless backend (`m2-repo/`, test scope only)
+## The headless test backend (no vendored dependency)
 
-`io.github.adriandeleon:openjfx-monocle` is the headless Glass backend for the FX test harness,
-**vendored in `m2-repo/`, test scope, never shipped**. There is no upstream build for current
-JavaFX (`org.testfx:openjfx-monocle` stops at 21, `one.jpro` at jfx-21), and Monocle is tightly
-coupled to internal `com.sun.glass.ui` APIs, so it is **self-built and must be rebuilt on every
-JavaFX bump** (a stale-version jar fails to link, breaking the `@Tag("fx")` tests).
+The `@Tag("fx")` harness runs over **JavaFX 26's built-in Headless Glass platform**
+(`-Dglass.platform=Headless`, part of `javafx.graphics` since 26 — set in the surefire
+`<systemPropertyVariables>`). Nothing is vendored: no jar, no native libs, no rebuild on a
+JavaFX bump.
 
-To rebuild: sparse-checkout the `com/sun/glass/ui/monocle` sources (+ resources) from the
-matching `openjdk/jfx` tag, `javac --release <ver>` against the **platform-classified** JavaFX
-jars (the no-classifier ones are stubs), `jar` with manifest
-`Automatic-Module-Name: org.testfx.monocle`, drop under
-`m2-repo/io/github/adriandeleon/openjfx-monocle/<ver>/`, and bump `<monocle.version>`. No
-`module-info`/jlink impact — it's never on the runtime path. See [testing.md](testing.md).
+This **replaced** a previously self-built **Monocle** backend
+(`io.github.adriandeleon:openjfx-monocle`, once vendored in `m2-repo/`), which had to be rebuilt
+from the OpenJFX sources on every JavaFX bump. That whole ritual and its artifacts are gone. The
+built-in platform is officially a *prototype* in 26, but the harness only boots the toolkit and
+never drives the robot or renders/snapshots, so the prototype's limitations don't apply. It's
+test-scope only and never on the runtime path. See [testing.md](testing.md).
 
 ## Automatic modules + moditect (general)
 

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -1,0 +1,218 @@
+# Glossary
+
+The recurring Editora-specific terms a new contributor will hit, with one place each to go read
+more. Back to [the docs index](README.md). When a definition here disagrees with the code, the
+code wins — see the root [`CLAUDE.md`](../CLAUDE.md) for the exhaustive reference.
+
+---
+
+### automatic module
+
+a jar with no `module-info` (a `Automatic-Module-Name`, or a name derived
+from the filename). `jlink` cannot link one, so the `dist` profile's [moditect](#moditect) step
+injects a generated descriptor. See [dependencies.md](dependencies.md#automatic-modules--moditect-general).
+
+### Canvas overlay
+
+the discipline every document overlay follows (whitespace, spell-check,
+search-highlight, TODO, Markdown-lint, LSP diagnostics, …): a mouse-transparent `Canvas` sized to
+the viewport, [coalesced](#debounce--coalesce) redraw, drawing only the [visible paragraphs](#hot-path),
+clamped via [`CanvasGuards`](../src/main/java/com/editora/editor/CanvasGuards.java) and released to
+a 1×1 backing texture when inactive. References:
+[`SpellCheckOverlay`](../src/main/java/com/editora/editor/SpellCheckOverlay.java),
+[`MarkdownLintOverlay`](../src/main/java/com/editora/editor/MarkdownLintOverlay.java); recipe in
+[extending.md](extending.md#add-a-canvas-overlay).
+
+### chord
+
+a single key combination token (e.g. `C-x`, `Cmd-S`) built by
+[`KeyDispatcher.chord(KeyEvent)`](../src/main/java/com/editora/command/KeyDispatcher.java), with
+modifiers in canonical order `C- M- Cmd- S-`. A multi-key Emacs binding (`C-x C-s`) is a
+space-joined sequence of chords. The recorder in the keybinding editor captures the same tokens.
+
+### ConfigManager
+
+the per-window config object
+([`config/ConfigManager.java`](../src/main/java/com/editora/config/ConfigManager.java)). It owns
+only that window's session ([`WorkspaceState`](#workspacestate) + its `workspaceStateFile`) and
+delegates everything app-wide to [`SharedConfig`](#sharedconfig). Contrast with `SharedConfig`.
+
+### CoordinatorHost
+
+the narrow interface
+([`ui/CoordinatorHost.java`](../src/main/java/com/editora/ui/CoordinatorHost.java)) a
+[feature coordinator](#feature-coordinator) reaches the window through (settings, active/all
+buffers, status, prompts, the overlay host, …). A fake `Host` in a test makes the coordinator
+unit-testable without a real window. Recipe in
+[extending.md](extending.md#extract-a-feature-coordinator).
+
+### debounce / coalesce
+
+the two ways work is kept off the [hot path](#hot-path). *Debounce*: wait
+for a quiet interval before doing expensive text-driven work
+(`multiPlainChanges().successionEnds(Duration.ofMillis(250))`). *Coalesce*: collapse many redraw
+requests in a pulse to one via a `pending` flag + `Platform.runLater`. See
+[performance.md](performance.md#2-debounce-and-coalesce).
+
+### EditorBuffer
+
+the per-file hub
+([`editor/EditorBuffer.java`](../src/main/java/com/editora/editor/EditorBuffer.java)): it wraps the
+RichTextFX `CodeArea` and owns highlighting, the gutter/fold chevrons, the minimap, every overlay,
+bookmarks, notes, and the per-feature [injected hooks](#injected-hooks-setxxxprovider). It is a
+[`TabContent`](#tabcontent), so a tab's buffer is reached via `MainController.bufferOf(Tab)`, never
+a raw cast.
+
+### `editora.ownsKeys`
+
+a node property
+(`getProperties().put("editora.ownsKeys", Boolean.TRUE)`) that tells the scene-level
+[`KeyDispatcher`](#keydispatcher) to leave a focused node's own navigation keys (`C-n`/`C-p`/arrows)
+alone instead of resolving them as commands. Set on in-scene overlay cards and the completion popup
+so their list navigation works. See `ui/ProjectPanel`, `ui/OverlayHost`.
+
+### feature coordinator
+
+a `final class …Coordinator` in `ui` that pulls a feature's logic out of
+the large `MainController` and owns its service(s) + state, reaching the window only through
+[`CoordinatorHost`](#coordinatorhost). `MainController` keeps one-line delegations. References:
+`LogViewerCoordinator`, `MermaidCoordinator`, `HtmlPreviewCoordinator`. New features should be their
+own coordinator, not bolted onto `MainController`.
+
+### generation guard
+
+the `AtomicLong` counter that drops a stale [off-thread](#off-thread-service-idiom)
+result: a request bumps the counter, captures its value, and the result is applied only if the
+counter is still equal when it returns. Prevents an old highlight/search/diagnostic from landing
+after a newer one. See [performance.md](performance.md#1-never-block-the-javafx-application-thread).
+
+### highlightExecutor idiom
+
+the canonical [off-thread service](#off-thread-service-idiom) shape,
+named for the `editor-highlighter` daemon executor in `EditorBuffer`: tokenize/parse off the FX
+thread, then apply on the FX thread under a [generation guard](#generation-guard). Reused by every
+service and overlay.
+
+### hot path
+
+code that runs on every keystroke or scroll pulse: typing/editing, scrolling, syntax
+highlighting, the document overlays, the line-number gutter. The FX thread is sacred on these paths;
+work must be [off-thread](#off-thread-service-idiom), [debounced/coalesced](#debounce--coalesce),
+incremental, and visible-only. See [performance.md](performance.md#the-hot-paths).
+
+### huge / large / heavy file tiers
+
+three size guards in `EditorBuffer`. *huge* (≥ 50 MB): the
+file is read-only with a capped load. *large* (≥ 5 MB): highlighting + minimap are disabled. *heavy*
+(`setHeavyFile`, line-count ≥ `Settings.largeFileThreshold`, default 10000): minimap + LSP are
+disabled but highlighting + editing stay. Overlays check these flags and no-op. See
+[performance.md](performance.md#5-preserve-the-largehuge-file-guards).
+
+### injected hooks (`setXxxProvider`)
+
+the pattern that keeps the `editor` and `completion`
+packages free of `ui`/`config`/feature packages. Instead of importing a feature, `EditorBuffer`
+exposes setters (`setSnippetProvider`, `setCompletionProvider`, `setMarkdownLintValidator`,
+`setLspCompletionProvider`, …) and `MainController` injects a `Supplier`/`Consumer`/small interface.
+Add an editor feature this way; don't add a `ui` import to `editor`. See
+[architecture.md](architecture.md#the-editor-buffer).
+
+### KeyDispatcher
+
+the scene-level `KEY_PRESSED` filter
+([`command/KeyDispatcher.java`](../src/main/java/com/editora/command/KeyDispatcher.java)) that builds
+[chord](#chord) tokens, holds a pending-prefix buffer for multi-key Emacs chords, and resolves them
+to command ids via the [keymap](#keymap). A lone unbound key is not consumed, so normal typing works.
+
+### keymap
+
+the [chord](#chord)→command-id map managed by
+[`KeymapManager`](../src/main/java/com/editora/command/KeymapManager.java). Five are bundled (the
+ordered `KeymapManager.AVAILABLE`): **emacs** (default), **cua**, **sublime**, **vscode**,
+**intellij**. The four non-Emacs maps are non-modal (different accelerators over the same command
+ids). Each GUI keymap ships a base `<name>.json` (Ctrl) and a `<name>.mac.json` (Cmd); Emacs is
+single-file. User overrides layer on top via `applyOverrides`.
+
+### moditect
+
+the `moditect-maven-plugin` (`dist` profile) that injects a generated `module-info`
+into an [automatic module](#automatic-module) so `jlink` can link it (RichTextFX & friends, tm4e
+core, PDFBox, lsp4j, java-diff-utils, …). A few need hand-written descriptors. See
+[dependencies.md](dependencies.md#automatic-modules--moditect-general).
+
+### off-thread service idiom
+
+a feature's impure engine: a single daemon `ExecutorService` + a
+[generation guard](#generation-guard), running heavy work off the FX thread and posting results back
+via `Platform.runLater`. References: `GitService`, `SearchService`, `MarkdownLintService`,
+`MermaidService`. See [performance.md](performance.md#1-never-block-the-javafx-application-thread).
+
+### OverlayHost (in-scene overlays)
+
+the single shared host
+([`ui/OverlayHost.java`](../src/main/java/com/editora/ui/OverlayHost.java)) that renders the command
+palette and every keyboard picker/popup as one "card" over a dim, click-to-dismiss backdrop inside
+the scene — **not** as a `javafx.stage.Popup`. A Popup is a separate native window that on Windows
+doesn't reliably take OS keyboard focus, which orphaned focus and killed typing app-wide; the
+in-scene host owns focus capture/restore and `Esc`/`C-g` dismissal. `OverlayInput` builds form
+cards over the same host.
+
+### the palette
+
+the command palette (`M-x`), populated from `CommandRegistry.all()`. Every
+user-facing action is a registered `command/Command`, so it is discoverable for free; a setting also
+needs a palette command, not just a Settings-window control. See
+[conventions.md](conventions.md#every-feature-is-a-command).
+
+### schema version / migration
+
+every structured config file carries an integer `schemaVersion`
+(the owning POJO's `SCHEMA_VERSION`), enumerated in
+[`config/migration/ConfigSchema.java`](../src/main/java/com/editora/config/migration/ConfigSchema.java)
+with an ordered map of `v→v+1` step migrations. Reads go through
+`ConfigMigrations.readVersioned(...)`, which applies the chain; a file newer than the build is
+backed up and defaults loaded (`NewerThanSupportedException`). See
+[conventions.md](conventions.md#config-and-schema).
+
+### SharedConfig
+
+the app-wide config
+([`config/SharedConfig.java`](../src/main/java/com/editora/config/SharedConfig.java)) held by
+reference across every window: the `Settings` object, the bookmark/note/breakpoint/connection
+stores, the user dictionary, the macro store, and the `ProjectManager` index. Contrast with the
+per-window [`ConfigManager`](#configmanager). See
+[architecture.md](architecture.md#multi-window-model).
+
+### TabContent
+
+the tab-content interface
+([`editor/TabContent.java`](../src/main/java/com/editora/editor/TabContent.java)):
+`node()`/`title()`/`icon()`/`closeable()`. A tab's `userData` is a `TabContent`, not always an
+[`EditorBuffer`](#editorbuffer) — `EditorBuffer` and `WelcomePane` both implement it. Read it via
+`MainController.bufferOf(Tab)` (returns the buffer or `null`); a raw cast `ClassCastException`s on
+the Welcome tab. See [architecture.md](architecture.md#tabs-are-tabcontent-not-always-buffers).
+
+### tool window
+
+a dockable side/bottom panel (Project, Search, Problems, Git, Debug, …) managed by
+`ToolWindowManager` and built from a `ToolWindowContent`. `register(ToolWindow)` adds it to a stripe
++ toggle command; `setAvailable(tw, condition)` is a *transient* hide (e.g. "only in a git repo"),
+distinct from the persisted `setVisible` preference. Recipe in
+[extending.md](extending.md#add-a-tool-window).
+
+### `Vfs.isLocal` (local-only gating)
+
+the single predicate
+([`vfs/Vfs.java`](../src/main/java/com/editora/vfs/Vfs.java)) that decides whether a buffer's `Path`
+is on the default filesystem versus a remote (SFTP) `SftpFileSystem`. Every local-process feature
+(LSP, DAP, run, git, external-change polling) gates on it, because those reach the file via
+`path.toFile()`, which a remote path can't honor. A null/untitled path counts as local.
+
+### WorkspaceState
+
+the per-window session POJO
+([`config/WorkspaceState.java`](../src/main/java/com/editora/config/WorkspaceState.java)), stored as
+JSON in `workspace-state.json` (or `projects/<id>.json`): collapsed fold regions, tool-window
+layout/visibility, per-file Markdown/read-only modes, program args, debug watches, etc. Owned by the
+per-window [`ConfigManager`](#configmanager). Bookmarks/notes are deliberately *not* here — they live
+in their own stores.

--- a/docs/gotchas.md
+++ b/docs/gotchas.md
@@ -1,0 +1,155 @@
+# Gotchas and known traps
+
+The non-obvious failures that have bitten Editora before. Each is a symptom + the fix and why.
+Back to [the docs index](README.md). Terms in **bold** are defined in the [glossary](glossary.md).
+When this disagrees with the code, the code wins.
+
+---
+
+## The headless-AWT guard must be `App.main`'s first statement
+
+**Symptom:** an intermittent deadlock/hang on macOS, more likely the more Markdown previews (SVG
+badges, math) are open — the app freezes, mouse still works, restart required.
+
+**Why/fix:** SVG and math rasterization touches `java.awt`/Java2D. On macOS the AWT/Java2D native
+pipeline contends with JavaFX's Glass/Prism for the single AppKit run loop. So `App.main`'s very
+first line is `System.setProperty("java.awt.headless", "true")` — headless Java2D rasterizes to a
+`BufferedImage` in software with no AppKit, and the conflict disappears. It must run before any AWT
+class loads, so keep it first in `main`. See
+[`App.java`](../src/main/java/com/editora/App.java) and
+[architecture.md](architecture.md#the-headless-awt-guard-dont-move-it).
+
+## macOS FXMLLoader null context classloader → NPE
+
+**Symptom:** an NPE inside `FXMLLoader.load()` when a window is built at runtime on macOS (the
+FX/AppKit thread's context classloader is null).
+
+**Why/fix:** `App` pins a classloader before building any window —
+`FXMLLoader.setDefaultClassLoader(...)` + `Thread.currentThread().setContextClassLoader(...)` (see
+[`App.java`](../src/main/java/com/editora/App.java) lines ~44). Without it, lazy class loading on
+that thread also breaks. Don't remove the pin.
+
+## JPMS `opens` pitfalls
+
+JPMS encapsulation silently breaks reflection-based resource and field access at runtime on the
+module path, even when classpath tests pass. Three to remember (all in
+[`module-info.java`](../src/main/java/module-info.java)):
+
+- **Grammar package.** `com.editora.grammars` must `opens ... to org.eclipse.tm4e.core`. Without it,
+  tm4e's `Class.getResourceAsStream` returns null at runtime (module path) and grammars silently
+  fail to load — but classpath tests pass, so it's invisible in CI. See
+  [extending.md](extending.md#add-a-language--textmate-grammar).
+- **Jackson-serialized config/DTO types.** Any TOML/JSON-serialized POJO needs
+  `opens com.editora.<pkg> to com.fasterxml.jackson.databind;` (e.g. `opens com.editora.config to …`).
+  Add the `opens` when you add a serialized type. See
+  [conventions.md](conventions.md#config-and-schema).
+- **The LSP DTO needs an *unqualified* `opens`.** `module-info` has `opens com.editora.lsp;` (not
+  qualified to lsp4j.jsonrpc). Gson reflectively reads the `@JsonNotification` param DTO, and under
+  `mvn javafx:run` it runs in the *unnamed* module — a qualified opens leaves it unable to set the
+  DTO fields accessible.
+
+## Prism texture pool exhaustion → black window (packaged build only)
+
+**Symptom:** a black/garbled window, seen only in the packaged build (not `javafx:run`), as more
+files open.
+
+**Why/fix:** JavaFX's Prism texture pool has a fixed ceiling; exhausting it makes the render thread
+NPE on a null texture. Don't let GPU-backed resources grow with the number of open files: a
+background tab drops its minimap snapshot via `EditorBuffer.setRenderingActive(false)`; image caches
+(`PreviewImageLoader`, `MermaidImages`) are LRU-bounded; a **Canvas overlay** releases its canvas to
+1×1 when inactive. When you add any per-buffer `Canvas`/`Image`, make sure it's released or bounded.
+See [performance.md](performance.md#6-bound-retained-gpu-textures).
+
+## Signed modular jar → `jlink` rejects it
+
+**Symptom:** the `dist` jlink step fails on the tm4e NetBeans jar (it is code-signed, and `jlink`
+rejects signed modular jars).
+
+**Why/fix:** the `dist` profile's antrun step strips `META-INF/*.SF,*.RSA,*.DSA,*.EC` from the jar
+before linking (see the unsigned-jar repackaging in [`pom.xml`](../pom.xml)). If you add another
+signed modular dependency, it needs the same strip. See
+[dependencies.md](dependencies.md#tm4e--netbeans-repackaging-signed-jar).
+
+## The headless FX test backend is JavaFX 26's built-in Headless platform (no Monocle)
+
+**Symptom (historical):** the self-built **Monocle** Glass backend had to be rebuilt on every JavaFX
+bump or the `@Tag("fx")` tests failed to link (a stale-version jar can't link against internal
+`com.sun.glass.ui` APIs).
+
+**Current state:** as of JavaFX 26 the harness uses the **built-in Headless Glass platform** that
+ships inside `javafx.graphics` (`-Dglass.platform=Headless` in the surefire config — see
+[`pom.xml`](../pom.xml)). No Monocle jar, no native libs, nothing to rebuild on a JavaFX bump. If you
+ever need real headless *rendering* or robot input (the built-in platform is a prototype), Monocle
+could be re-vendored, but it isn't needed now. See [testing.md](testing.md) and
+[dependencies.md](dependencies.md#the-headless-test-backend-no-vendored-dependency).
+
+## The surefire `@{argLine}` token must be preserved
+
+**Symptom:** JaCoCo reports zero coverage after someone edits the surefire `<argLine>`.
+
+**Why/fix:** JaCoCo injects its coverage agent by *setting the `argLine` property*. Surefire's
+`<argLine>@{argLine}</argLine>` expands that property; a plain `<argLine>` with literal flags clobbers
+it and the agent never loads. Keep the `@{argLine}` token (first). See
+[testing.md](testing.md#the-surefire-config-that-makes-it-work) and [`pom.xml`](../pom.xml).
+
+## `tab.getUserData()` is a `TabContent`, not always an `EditorBuffer`
+
+**Symptom:** a `ClassCastException` on the Welcome tab when code casts `tab.getUserData()` to
+`EditorBuffer`.
+
+**Why/fix:** a tab's `userData` is a **`TabContent`** ([`TabContent.java`](../src/main/java/com/editora/editor/TabContent.java));
+`EditorBuffer` and `WelcomePane` both implement it. Always read it through
+`MainController.bufferOf(Tab)` (returns the buffer or `null`), and make tab-switch consumers
+null-safe. See [architecture.md](architecture.md#tabs-are-tabcontent-not-always-buffers).
+
+## The `NO_ROOT` sentinel `Path` must not contain a NUL
+
+**Symptom:** a corrupt/throwing static initializer if the git repo-root cache sentinel were built
+from a string with a NUL byte.
+
+**Why/fix:** `GitService` caches "directory has no repo root" with a static sentinel
+`Path.of("")` ([`GitService.java`](../src/main/java/com/editora/git/GitService.java) ~line 63), an
+empty path that `rev-parse` never returns, compared by *identity*. Keep it the empty path — a `Path`
+with a NUL throws on construction, and any non-empty value risks colliding with a real result.
+
+## LSP/DAP server stderr must be drained; dispose must `killTree`
+
+**Symptom (stderr):** a chatty server (jdtls logs heavily) deadlocks mid-startup — no diagnostics,
+the loading bar spins forever.
+
+**Why/fix (stderr):** an undrained child-process stderr PIPE fills its ~64 KB OS buffer and the
+server blocks writing (LSP traffic is on stdout).
+[`LanguageServerSession`](../src/main/java/com/editora/lsp/LanguageServerSession.java) drains it on a
+daemon thread (capped, into the Debug Log so a failed launch is diagnosable); the DAP adapters use
+`Redirect.DISCARD`. Either way, the stream must be consumed, never left a live unread PIPE.
+
+**Symptom (dispose):** after closing a window, the next LSP session for the same root hangs — the old
+server JVM is still running and holds its workspace `.lock`.
+
+**Why/fix (dispose):** `jdtls` (and others) is a wrapper script (Homebrew `jdtls` → python → java);
+destroying only the wrapper orphans the real server. `dispose()` calls
+`ProcessRegistry.killTree(process)` ([`ProcessRegistry.java`](../src/main/java/com/editora/process/ProcessRegistry.java))
+to kill the whole descendant tree (children first, escalating to a force-kill) and untrack it.
+
+## Don't call `getCharacterBoundsOnScreen` synchronously inside a layout/viewport event
+
+**Symptom:** layout thrash / re-entrancy when positioning an overlay or popup from a viewport
+listener.
+
+**Why/fix:** querying `getCharacterBoundsOnScreen` synchronously inside a layout/viewport event
+forces work the [hot path](glossary.md#hot-path) can't afford. Defer it (e.g. read it on the next
+pulse) rather than mid-event. See [performance.md](performance.md#3-work-incrementally-and-only-on-whats-visible).
+
+## GUI-launched `.app` inherits a stripped PATH
+
+**Symptom:** `mmdc`/`npx`/`git`/an LSP server "not found" only when Editora is launched from Finder
+(a `.app`) or a `.desktop`, but found when launched from a terminal.
+
+**Why/fix:** a Finder-launched app inherits a stripped `PATH` (`/usr/bin:/bin:…`) without
+Homebrew/npm/Node/version-manager dirs. `ProcessRunner` builds an **augmented PATH** — the inherited
+PATH plus the user's *login-shell* PATH (`$SHELL -l -i -c …`, which recovers version-specific bins
+like nvm's `~/.nvm/versions/node/<ver>/bin`) plus the hardcoded `EXTRA_PATH_DIRS` — and rewrites a
+bare command to its absolute path against it (Java's `ProcessBuilder` resolves the executable against
+the JVM's own PATH, not the child env). Always spawn subprocesses through `ProcessRunner`
+([`ProcessRunner.java`](../src/main/java/com/editora/process/ProcessRunner.java)); don't call
+`ProcessBuilder` directly.

--- a/docs/release.md
+++ b/docs/release.md
@@ -53,8 +53,10 @@ CI uses the BellSoft **Liberica** JDK 25 for full arch coverage (incl. linux aar
 ## Notes
 
 - Installers are currently **unsigned** (signing/notarization is a follow-up).
-- Bumping the JavaFX version means rebuilding the vendored **Monocle** backend, or the
-  `@Tag("fx")` tests stop linking — see [dependencies.md](dependencies.md#monocle--self-built-headless-backend-m2-repo-test-scope-only).
+- A JavaFX bump no longer needs any test-harness work — the headless backend ships inside JavaFX
+  26 (the old vendored Monocle rebuild is gone; see
+  [dependencies.md](dependencies.md#the-headless-test-backend-no-vendored-dependency)). Do
+  re-run the device tests, since the per-OS Prism pipeline matters.
 - The AOT cache adds ~60 MB to the installed image (compressed in the DMG/MSI/DEB); it's
   failure-tolerant, so a runner without a usable display still ships, just without the cache —
   see [building-and-packaging.md](building-and-packaging.md#aot-cache-jdk-25-leyden).

--- a/docs/subsystems/command-system.md
+++ b/docs/subsystems/command-system.md
@@ -1,0 +1,278 @@
+# Command & keymap subsystem
+
+How keyboard input becomes an action in Editora. Back to [the docs index](../README.md).
+
+Editora is command-driven: every user action is a registered `Command`, dispatched
+either from a keybinding or the command palette. The `command/` package is the core,
+and `ui/MainController` wires it into a window. The pieces:
+
+- [`command/Command.java`](../../src/main/java/com/editora/command/Command.java) — the unit of action.
+- [`command/CommandRegistry.java`](../../src/main/java/com/editora/command/CommandRegistry.java) — the registry every action is looked up in.
+- [`command/KeymapManager.java`](../../src/main/java/com/editora/command/KeymapManager.java) — chord sequence → command id.
+- [`command/KeyDispatcher.java`](../../src/main/java/com/editora/command/KeyDispatcher.java) — the scene-level key filter that builds chords and dispatches.
+- [`command/KeybindingEdits.java`](../../src/main/java/com/editora/command/KeybindingEdits.java) — pure logic behind the keybinding editor.
+
+## Command
+
+A `Command` is an `id`, a `title`, and a `run()`. Prefer the title-less factory; it
+resolves the title and description from the message catalog lazily, so they follow the
+active UI language:
+
+```java
+registry.register(Command.of("edit.myThing", this::myThing));
+```
+
+`Command.of(id, runnable)` reads `command.<id>` for the title via `Messages.tr`. The
+default `description()` reads `command.<id>.desc` and returns `""` when the key is absent
+(`tr` returns the key itself on a miss), so dynamically-registered commands without a
+catalog entry degrade gracefully. There is also an explicit-title overload
+`Command.of(id, title, runnable)`, used for synthetic commands whose title is data rather
+than a catalog string (e.g. a saved macro's `macro.run.<slug>`).
+
+## CommandRegistry
+
+A `LinkedHashMap<String, Command>` keyed by id; insertion order is preserved so the palette
+lists commands in registration order. `register(command)` adds, `remove(id)` drops (used to
+clear stale `macro.run.*` commands on rename/delete), `get(id)` looks up, and `all()` returns
+every command (the palette and keybinding editor populate from this).
+
+`run(id)` executes the command and then notifies the **execution listener** — a single
+`Consumer<String>` installed via `setExecutionListener`. It fires *after* the command runs, so
+a control command like `macro.startRecording` has already flipped state before the notification
+arrives. `MainController.setKeyDispatcher` wires it to the macro coordinator:
+
+```java
+registry.setExecutionListener(macroCoordinator::onCommand);
+```
+
+`MacroService.onCommand` ignores `macro.*` ids and `palette.show` (so recording the act of
+recording, or opening the palette to invoke a command, isn't captured), and short-circuits when
+not recording or while replaying — see
+[`macro/MacroService.java`](../../src/main/java/com/editora/macro/MacroService.java).
+
+## KeymapManager
+
+Maps chord sequences to command ids. A named keymap loads from a bundled JSON resource;
+user (and plugin) overrides layer on top.
+
+### The five bundled keymaps
+
+The static `AVAILABLE` map (insertion-ordered) is the source of truth for which keymaps exist:
+
+| id | display name |
+| --- | --- |
+| `emacs` | Emacs (default) |
+| `cua` | CUA |
+| `sublime` | Sublime Text |
+| `vscode` | Visual Studio Code |
+| `intellij` | IntelliJ IDEA |
+
+`displayName(id)` returns the display string, or the id itself if unknown. The four non-Emacs
+keymaps are non-modal: they only remap chords onto the same command ids, so they fit the flat
+resolver and never strand functionality (every command is palette-reachable).
+
+### Per-OS `.mac` variants
+
+Each GUI keymap ships a base `<name>.json` (Ctrl-based, Win/Linux) **and** a complete
+`<name>.mac.json` (Cmd-based). `loadNamed(name)` prefers the `.mac` variant on macOS when the
+resource exists, falling back to the base:
+
+```java
+String resource = mac && KeymapManager.class.getResource(macResource) != null
+        ? macResource : baseResource;
+```
+
+It is a **full replacement**, not a merge, so there's no Ctrl-shadowing or modifier-token-order
+bug. Emacs is single-file (`emacs.json`; Control on every platform — no `.mac`). A
+package-visible `loadNamed(name, mac)` overload takes an explicit platform flag so tests don't
+depend on the host OS.
+
+### Overrides and the UNBIND sentinel
+
+`applyOverrides(Map<String,String>)` layers a chord → id map on top of the loaded keymap. A
+blank value is the `KeymapManager.UNBIND` sentinel (`= ""`): instead of binding, it **removes**
+that chord, so a user override can suppress a base-keymap default. This is what the keybinding
+editor's clear/rebind uses.
+
+### Resolving chords
+
+- `commandFor(sequence)` — the command id bound exactly to a chord sequence, or null.
+- `isPrefix(sequence)` — true if some binding starts with `sequence + " "`, i.e. more keys are
+  expected (e.g. `C-x` is a prefix of `C-x C-s`).
+- `bindings()` — an immutable copy of the current map.
+
+### Chord token format
+
+A keymap JSON value is the command id; the key is a chord sequence built from one or more chord
+tokens joined by spaces. A token is produced by `KeyDispatcher.chord()`: modifier prefixes in the
+canonical order `C- M- Cmd- S-` followed by the key name. Examples from the bundled keymaps:
+
+```json
+"C-x C-s": "file.save",
+"C-space":  "edit.setMark",
+"Cmd-S-s":  "file.saveAs"
+```
+
+Letter keys lowercase; digits as-is; named keys like `space`, `enter`, `tab`, `backspace`,
+`left`, `pageup`. Function keys fall through `keyName`'s default branch (`KeyCode.F5` → `"f5"`),
+so VSCode/IntelliJ F-key bindings work with no engine change.
+
+### Live switching
+
+There is a **single shared** `KeymapManager` per launch, owned by `WindowManager` and read by
+every window's `KeyDispatcher`. Switching the keymap (Settings → Keymaps picker or the
+`keymap.select` palette command) sets `Settings.keymap`, persists, then calls
+`WindowManager.reloadSharedKeymap()`, which rebuilds the one instance and re-applies overrides:
+
+```java
+keymap.loadNamed(settings.getKeymap());
+keymap.applyOverrides(settings.getKeybindings());
+// then, if plugins are on, each enabled plugin's manifest.keymap
+broadcastSettingsApplied();
+```
+
+Because every dispatcher reads the same instance, the switch is instant with no restart; a stale
+mid-chord prefix in any dispatcher self-cancels on the next key. The broadcast lets each window
+refresh chord-derived hints (toolbar tooltips, palette bindings via `CommandPalette.refreshBindings()`,
+tool-window tooltips, Welcome shortcut labels) so nothing stays frozen to the old keymap.
+
+## KeyDispatcher
+
+A per-window object installed on the scene as a `KEY_PRESSED` event filter (plus a `KEY_TYPED`
+filter, and a `KEY_RELEASED` filter on non-macOS — see the Alt fix below). It translates each key
+press into a chord token and resolves it against the shared `KeymapManager`.
+
+### The dispatch loop
+
+`handle(KeyEvent)` builds the token with `chord(event)` (null for a modifier-only press), then
+forms the sequence (`pending + " " + token` when a prefix is buffered). With `commandFor`/`isPrefix`:
+
+- a bound chord → consume the event, reset, `registry.run(commandId)`;
+- a prefix → consume, buffer it in `pending`, echo `"<seq> -"` via the status listener;
+- mid-chord with no continuation → consume, echo `"<seq> is undefined"`, reset;
+- a lone unbound key → fall through (so normal typing works).
+
+`pending` is the **multi-key chord buffer** for Emacs-style sequences (`C-x C-s`).
+
+When a press is consumed, `consumedPress` is set so the paired `KEY_TYPED` is swallowed in
+`handleTyped` — this matters when a command opens a modal dialog, whose deferred `KEY_TYPED`
+would otherwise reach the editor after the dialog closes. On macOS, `handleTyped` also swallows
+any Option-produced character (Option is the Meta key).
+
+### `chord()` is public
+
+`KeyDispatcher.chord(KeyEvent)` is `public static` because the keybinding-editor recorder reuses
+it to capture a chord in the Settings scene (which has no global dispatcher). It returns tokens in
+the canonical `C- M- Cmd- S-` order.
+
+### The typed-char listener
+
+`setTypedListener(Consumer<Character>)` installs a hook fed each genuine, non-consumed typed
+character. The macro recorder uses it to capture typed text interleaved with command invocations.
+`isRecordableChar` filters to printable characters plus tab/newline/carriage-return.
+
+### `editora.ownsKeys` and the editor-context carve-out
+
+A focused component (e.g. a tool window) can opt out of global dispatch by setting the
+`editora.ownsKeys` node property. The dispatcher walks the target's ancestor chain
+(`ownsKeys(target)`) and, for such a window, leaves only the **editor-context** chords to it — the
+caret/text chords it repurposes for local navigation, identified by id prefix in `isEditorContext`
+(`nav.*` and `edit.*`). Jump/window/view commands (`M-x`, `M-1`, `M-g`, …) and prefixes (`C-x …`)
+stay global so they work even while a tool window is focused. The completion popup uses the same
+property so its `C-n`/`C-p`/arrows aren't hijacked.
+
+### `setPreDispatch` hook
+
+`setPreDispatch(BiPredicate<String, EventTarget>)` is a first-look hook consulted only when no
+prefix is pending: given the chord token + target, returning true means it handled the key (the
+event is consumed and dispatch stops). `MainController` uses it so `M-g` closes a focused tool
+window:
+
+```java
+dispatcher.setPreDispatch((token, target) -> {
+    if (!"M-g".equals(token)) return false;
+    ToolWindow tw = toolWindows.toolWindowOf(target);
+    if (tw == null) return false;
+    toolWindows.close(tw);
+    // refocus the editor
+    return true;
+});
+```
+
+### Windows/Linux Alt menu-mode fix
+
+On Windows a bare `Alt` — or an *unbound* `Alt+<key>` — is treated by the OS as menu/mnemonic
+activation, which puts the native window into "menu mode": that freezes `KEY_TYPED` app-wide and
+breaks the many `M-` chords (`M-x`, `M-g`, `M-1`…`M-9`, …) until restart. So on non-macOS,
+`handle()` consumes a bare `Alt` press and any unbound key pressed while plain Alt is held, and
+`install()` adds a `KEY_RELEASED` filter that consumes the bare `Alt` release.
+
+The plain-vs-AltGr decision is the pure, unit-tested predicate:
+
+```java
+static boolean plainAltActive(boolean isMac, boolean altDown, boolean controlDown) {
+    return !isMac && altDown && !controlDown;
+}
+```
+
+AltGr is reported as Ctrl+Alt, so requiring Alt-down **and** Ctrl-up excludes it — international
+AltGr typing and explicit Ctrl+Alt chords keep working. macOS is never affected (Option = Meta),
+and a *bound* `M-` chord still runs and consumes normally.
+
+## The keybinding editor
+
+Settings → Keymaps lists every command (from `CommandRegistry.all()`) with its current chord and
+lets the user rebind, reset, or reset-all. The mutation logic is the pure, toolkit-free
+`KeybindingEdits`, operating over the base bindings + the current user-overrides map:
+
+- `rebind(base, overrides, commandId, newSeq)` — drop the command's prior user entries, suppress
+  each base default chord that isn't the new one (via the `UNBIND` sentinel), then bind the new
+  chord. A blank `newSeq` falls back to `clear`.
+- `clear(base, overrides, commandId)` — drop user entries and suppress every base default.
+- `reset(base, overrides, commandId)` — drop user entries and remove the command's
+  default-suppressors so the base default reappears.
+
+`defaultChords(base, commandId)` lists every base chord bound to a command.
+
+`MainController` wires it through the `SettingsWindow.ShortcutActions`/`Shortcut` interface:
+
+- `shortcutRows()` builds the rows from `registry.all()` + `invertBindings()` (the current
+  effective chord per command).
+- `baseBindings()` is a fresh `KeymapManager.loadNamed` of the active keymap with **no** overrides
+  — the defaults to rebind/reset against.
+- `rebindShortcut`/`resetShortcut`/`resetAllShortcuts` call the `KeybindingEdits` helpers, persist
+  the result to `Settings.keybindings`, and call `reloadKeymap()` so the change is live across all
+  windows (overrides are global and layer on the active keymap).
+
+The **recorder** turns a row into a live capture field that calls `KeyDispatcher.chord(e)`
+(space-joining a multi-key sequence; Esc cancels) — it runs in the Settings window's own scene, so
+there's no global dispatcher to interfere. The **conflict check** lives in
+`SettingsWindow.rebindWithConflictCheck`: before binding, `ShortcutActions.commandUsing(seq)` (→
+`KeymapManager.commandFor`) reports whether the chord is already taken, and a confirmation dialog
+warns before stealing it. The same path serves the inline Macros keybinding row.
+
+User overrides persist in `Settings.keybindings` (a `Map<String,String>` of chord → id, with blank
+values meaning UNBIND), serialized with the rest of `settings.toml`.
+
+## Adding a command
+
+See [extending.md → Add a command](../extending.md#add-a-command). In short: register in
+`MainController.registerCommands()`, add `command.<id>` + `command.<id>.desc` to all six i18n
+catalogs, and (optionally) add a chord → id mapping in the bundled keymap JSON (and the `.mac`
+variant for GUI keymaps). The palette and keybinding editor populate from the registry, so a
+properly registered command appears automatically — never wire a user-facing action that bypasses
+the registry.
+
+## What `KeymapsTest` guarantees
+
+[`KeymapsTest`](../../src/test/java/com/editora/command/KeymapsTest.java) guards every bundled
+keymap without a GUI:
+
+- **Parse + valid ids** — each keymap (including `.mac` variants) parses, and every value is a real
+  `command.*` i18n key (the registry-independent source of truth).
+- **Canonical token order** — every chord token uses modifiers in the exact `C- M- Cmd- S-` order
+  `KeyDispatcher.chord()` emits.
+- **Base ↔ `.mac` parity** — for each GUI keymap, the base and `.mac` files bind the **same set of
+  command ids** (only the accelerators differ).
+- **UNBIND behavior** — a blank override value removes a base chord (`applyOverrides`).
+- **Registry resolves** — every `AVAILABLE` id loads non-empty on both the base and `.mac` paths.

--- a/docs/subsystems/config-and-migrations.md
+++ b/docs/subsystems/config-and-migrations.md
@@ -1,0 +1,125 @@
+# Config and schema migrations
+
+How Editora finds, reads, writes, and version-migrates its on-disk configuration. Back to [the docs index](../README.md).
+
+The `config/` package (plus `config/migration/`) owns everything the editor persists between launches: preferences, per-window session state, recent files, and a handful of standalone stores (bookmarks, notes, breakpoints, SFTP connections, macros, plugin enable-state, projects). It is multi-window-aware, writes off the FX thread, and carries a per-file schema version so an upgrade or downgrade never loses or corrupts data.
+
+## Config directory
+
+Everything lives under one config directory. It is resolved by precedence, with the CLI flag winning over the environment, the environment over `--dev`, and `--dev` over the production default:
+
+1. `--config-dir <path>` — the CLI arg, parsed by `App.configDirArg` (pure, unit-tested).
+2. `EDITORA_CONFIG_DIR` — used verbatim as the config folder when set and non-blank.
+3. `--dev` → `~/.editora-dev/` (the `App.devFlag`), so a development instance can't disturb production config.
+4. `~/.editora/` (the default).
+
+The env/default fallback is the pure resolver [`ConfigManager.resolveConfigDir(editoraHome, userHome, dev)`](../../src/main/java/com/editora/config/ConfigManager.java) — `editoraHome` (trimmed) when non-blank, else `userHome/.editora` or `userHome/.editora-dev`. `user.home` is the user profile on every OS, so this works on macOS, Linux, and Windows. The `--config-dir` precedence step is applied above this by the caller in `App`. Malformed input falls back to `.` (the current directory).
+
+## File formats and layout
+
+Two serialization formats, chosen per file:
+
+| File | Format | POJO / store | Notes |
+| --- | --- | --- | --- |
+| `settings.toml` | TOML (Jackson `TomlMapper`) | `Settings` | App-wide preferences. |
+| `workspace-state.json` | JSON | `WorkspaceState` | The no-project window's session. |
+| `projects/<id>.json` | JSON | `WorkspaceState` | One project window's session. |
+| `windows/<uuid>.json` | JSON | `WorkspaceState` | An untitled "New Window" session. |
+| `recent-files.json` | JSON | `RecentFiles.Stored` | Was a bare array (v0). |
+| `bookmarks.json` | JSON | `BookmarkStore` | Per-project buckets. |
+| `notes.json` | JSON | `NoteStore` | Per-project buckets. |
+| `breakpoints.json` | JSON | `BreakpointStore` | Per-project buckets. |
+| `history/index.json` + `history/blobs/` | JSON | `HistoryStore` | Local File History; blobs gzip'd. |
+| `connections.json` | JSON | `ConnectionStore` | SFTP connection metadata, no secrets. |
+| `macros.json` | JSON | `MacroStore` | App-global keyboard macros. |
+| `plugins.json` | JSON | `PluginStore` | Plugin enable-state. |
+| `projects.json` | JSON | `ProjectManager.Index` | Projects index + open-window set. |
+| `search-history.json` | JSON | `SearchHistory` | Find-in-Files history. |
+| `dictionary.txt` | plain text | (in-memory `Set<String>`) | User spell-check words, one per line. |
+
+`settings.toml` was a clean cut from a pre-existing `settings.json` — there is no JSON→TOML migration. The bundled keymap and TextMate grammars stay JSON but are app *resources*, not user config, so they are out of scope here.
+
+## SharedConfig vs ConfigManager
+
+The config is split in two so that multiple windows can run over the same preferences without clobbering each other:
+
+- [`SharedConfig`](../../src/main/java/com/editora/config/SharedConfig.java) — the **app-wide** half: the `Settings` object, the bucketed stores (`BookmarkStore`/`NoteStore`/`BreakpointStore`/`HistoryStore`), `ConnectionStore`, `MacroStore`, `PluginStore`, the user spell dictionary, and the `ProjectManager` index. A single instance is created once at startup and held **by reference** across every window. It owns the `ConfigWriter` (below) and the file-location getters (`getSettingsFile()`, `getBookmarksFile()`, …).
+- [`ConfigManager`](../../src/main/java/com/editora/config/ConfigManager.java) — the **per-window** half: it owns only that window's `WorkspaceState` and the `workspaceStateFile` it lives in, and delegates everything shared to its `SharedConfig`. In single-window/test use a `ConfigManager` constructs its own `SharedConfig`.
+
+So a `save()` from any window writes `settings.toml` plus that window's session file without touching another window's in-memory copy.
+
+### Per-window session and per-project buckets
+
+`ConfigManager.setWorkspaceStateFile(Path)` points a window at its session file (default `workspace-state.json` for the no-project window) and reloads it; `useDefaultWorkspaceStateFile()` returns to the default. The bucketed stores are keyed by a **project key** derived from the session file by the private `ConfigManager.currentBookmarkKey()`:
+
+- `workspace-state.json` → `""` (the no-project / global bucket).
+- `windows/<uuid>.json` (an untitled "New Window") → also `""` — every no-project window shares the global bucket.
+- `projects/<id>.json` → `<id>`. **Only** a file directly under `projects/` gets its own bucket.
+
+`getBookmarks()`/`getNotes()`/`getBreakpoints()`/`getHistory()` each return the bucket for *this* window's key, so switching the session file automatically swaps which bookmarks/notes/breakpoints are visible. `SharedConfig.deleteBookmarksForProject(key)` (and the note/breakpoint/history twins) drop a whole project bucket when a project is deleted.
+
+Bookmarks were deliberately moved out of `WorkspaceState` into their own `bookmarks.json`. `SharedConfig.loadBookmarks()` runs a one-time migration on first launch (`migrateLegacyBookmarks` / `extractAndStripBookmarks`): it pulls the legacy `bookmarks` node out of `workspace-state.json` (→ `""`) and each `projects/<id>.json` (→ that id), strips the node, and writes `bookmarks.json` so the migration never runs again. This is field-level back-compat that runs *before* the versioned read path below, not a registered schema migration.
+
+## ConfigWriter: off-FX-thread atomic writes
+
+[`ConfigWriter`](../../src/main/java/com/editora/config/ConfigWriter.java) performs all `settings.toml` and session writes off the JavaFX thread on a single `config-writer` daemon thread.
+
+The contract: callers serialize a **consistent snapshot to bytes on their own thread** (the FX thread is single-threaded, so reading the config POJOs needs no locking) and hand the immutable bytes to the writer. Each write is a **temp-file + atomic move** (`writeAtomic`), so a crash mid-write never leaves a half-written config.
+
+Two paths:
+
+- `enqueue(file, bytes)` — non-blocking and **coalesced per file** (latest bytes win), via `ConfigManager.saveAsync()` → `SharedConfig.enqueueSettings()`. This backs the frequent in-session save (`MainController.requestSave`).
+- `flush()` — blocks until everything queued has landed, via `ConfigManager.save()` → `SharedConfig.flushWrites()`. This is the durable form used by quit (`persistSession`), one-off actions, and `exportConfig()`. `App.start` registers a JVM-shutdown flush.
+
+`settings.toml` and `workspace-state.json` are the only files with both an async and a sync writer, and **both funnel through the one writer queue**. Because a single thread keeps writes ordered, a stale async write can never land *after* and clobber a later durable one. The other stores (`bookmarks.json`, `notes.json`, …) keep their own direct synchronous `json.writeValue` calls in `SharedConfig` and don't go through the queue.
+
+## Schema versioning and migrations
+
+Every structured config file carries an integer `schemaVersion` field, and its owning POJO declares a `SCHEMA_VERSION` constant (the baseline is **1**). The [`config/migration/`](../../src/main/java/com/editora/config/migration) package drives reads through one engine.
+
+### The registry: `ConfigSchema`
+
+[`ConfigSchema`](../../src/main/java/com/editora/config/migration/ConfigSchema.java) is an enum, one constant per versioned file. Each carries three things:
+
+1. The **current** version (the POJO's `SCHEMA_VERSION`).
+2. The version to **assume when the file has no `schemaVersion` marker** — `1`, the pre-versioning baseline (a bare JSON array is detected as `0` instead, by `ConfigMigrations.versionOf`).
+3. An ordered map of **step `Migration`s** keyed by the version they upgrade *from* (`v → v+1`).
+
+For example `SETTINGS` is currently at `Settings.SCHEMA_VERSION` (45) with identity steps for every bump from 1 through 44; `PROJECTS` registers `1 → 2` as `seedOpenProjectIds`; `RECENT` registers `0 → 1` as `wrapRecentFilesArray`.
+
+### The engine: `ConfigMigrations.readVersioned`
+
+[`ConfigMigrations.readVersioned(file, mapper, defaults, schema)`](../../src/main/java/com/editora/config/migration/ConfigMigrations.java) is the single read path (mapper-agnostic, so it works for both `TomlMapper` and the JSON `ObjectMapper` — `TomlMapper` produces ordinary Jackson nodes):
+
+1. Missing/unreadable/empty → return `defaults`.
+2. Parse to a Jackson tree.
+3. `upgrade(schema, tree, mapper)` — read the stored version (`versionOf`), then `applySteps` runs the `from → to` chain in order (one registered step per version, throwing `IllegalStateException` if a step is missing), and stamps `schemaVersion` to the current version.
+4. Merge the migrated object **onto `defaults`** via `mapper.readerForUpdating(defaults)`. So a purely additive new field just defaults when an old file is read.
+5. Malformed content or a misconfigured migration → fall back to `defaults` rather than crash.
+
+A [`Migration`](../../src/main/java/com/editora/config/migration/Migration.java) is a `@FunctionalInterface` over the in-memory tree (`JsonNode apply(JsonNode)`). Keep steps pure and total: never throw on unexpected-but-harmless input, return the best tree you can.
+
+### Downgrade safety
+
+If a file's stored `schemaVersion` is **newer** than this build supports (the user downgraded the app), `upgrade` throws [`NewerThanSupportedException`](../../src/main/java/com/editora/config/migration/NewerThanSupportedException.java). `readVersioned` then backs the file up to `<name>.v<n>.bak` (`ConfigMigrations.backup`, preserving any existing backup) and returns `defaults`. An older Editora never overwrites — and silently drops fields from — a newer config.
+
+### Worked examples
+
+- **RECENT 0 → 1** — `recent-files.json` was a bare JSON array. `versionOf` reports a bare array as `0`; `wrapRecentFilesArray` wraps it into `{ "files": [ … ] }` (the `RecentFiles.Stored` shape), and `readVersioned` stamps `schemaVersion: 1`.
+- **PROJECTS 1 → 2** — `seedOpenProjectIds` adds the multi-window `openProjectIds` set (when absent), seeding it from the single `activeProjectId` a pre-multi-window install tracked, so the previously-active project reopens as its own window. No active project → an empty set (the global window opens by default).
+
+## How to add a migration
+
+The short version is in [conventions.md → Config and schema](../conventions.md#config-and-schema). The full steps:
+
+1. **Bump the POJO's `SCHEMA_VERSION`** (`Settings`, `WorkspaceState`, `BookmarkStore`, `ProjectManager.Index`, `RecentFiles`, …).
+2. **Add one `v → v+1` entry** to that file's `steps` map in `ConfigSchema`. For a purely additive field (new field with a default), use `ConfigMigrations::identity` — the read path merges onto defaults, so the old file needs no transform; it just gets re-stamped. For a structural change, write a small pure `Migration` and register it (see `wrapRecentFilesArray` / `seedOpenProjectIds`).
+3. Done. The read path, version stamping, and downgrade backup are automatic once the step is registered.
+
+If the change adds a **new Jackson-serialized type**, also add `opens com.editora.<pkg> to com.fasterxml.jackson.databind;` in `module-info.java`. The config package already has `opens com.editora.config to com.fasterxml.jackson.databind` (and `com.editora.vfs`/`macro`/`todo`/`externaltool` for the types those packages serialize through this engine).
+
+## Projects
+
+[`ProjectManager`](../../src/main/java/com/editora/config/ProjectManager.java) holds the projects index, persisted as JSON in `projects.json` (the inner `ProjectManager.Index`, schema **2**). A project is a named single folder; each project's session is a separate `WorkspaceState` JSON under `projects/<id>.json` (`ProjectManager.stateFile(project)`).
+
+The index tracks the **open-window set** in `openProjectIds` (`""` = the global no-project window; an untitled window's `untitled:<uuid>` key also collapses to `""` for bucketing but is tracked here by its key) plus `activeProjectId` as the last-focused window. `markOpen`/`markClosed`/`setOpenWindows` mutate the set; it's restored on the next launch by `WindowManager.launch`. The `1 → 2` migration (`seedOpenProjectIds`) is what bridges pre-multi-window installs into this model.

--- a/docs/subsystems/lsp-and-dap.md
+++ b/docs/subsystems/lsp-and-dap.md
@@ -1,0 +1,283 @@
+# LSP & DAP integration
+
+How Editora talks to external language servers (LSP) and debug adapters (DAP). Part of [the docs index](../README.md).
+
+Both protocols ride on lsp4j, both spawn external processes, and both route every external
+process through one lifecycle owner (`process/ProcessRegistry`) so nothing outlives the app. The
+two are also coupled at one point: Java debugging is hosted *inside* the running jdtls language
+server, so the DAP layer reaches back through the LSP layer to start it. To add a new server or
+adapter, follow the recipes in [extending.md](../extending.md) rather than the internals below.
+
+## Dependency
+
+LSP uses lsp4j (`org.eclipse.lsp4j` + `.jsonrpc`); DAP uses lsp4j.debug (`org.eclipse.lsp4j.debug`,
+same version). Both are automatic modules that `jlink` can't link, so the `dist` profile's moditect
+step injects descriptors — see [dependencies.md](../dependencies.md). jsonrpc reuses the existing
+gson, and `module-info` carries `opens com.editora.lsp;` (unqualified — gson reflectively reads the
+`@JsonNotification("language/status")` DTO, which under `mvn javafx:run` runs in the unnamed module)
+and `opens com.editora.dap` (gson parses jdtls's untyped `executeCommand` results).
+
+The neutral value types ([`lsp/LspDiagnostic`](../../src/main/java/com/editora/editor/LspDiagnostic.java)
+lives in `editor`; `dap/DapModels`) keep `editor`/`ui` free of any lsp4j wire type.
+
+---
+
+## LSP
+
+### Server-centric registry
+
+[`lsp/LspServerRegistry`](../../src/main/java/com/editora/lsp/LspServerRegistry.java) is the static,
+pure source of truth: an editor **language id** (resolved by `editor.LanguageRegistry.forFileName`)
+maps to a **server** — its id, default launch command (tokenized via `tokenize`, honoring quotes),
+and project-root markers. The registry is server-centric, not language-centric: one server can serve
+several language ids, so the `typescript` server's `languageIds` is
+`{javascript, javascriptreact, typescript, typescriptreact}` and `clangd` serves `{c, cpp}`.
+
+It ships **twenty-one** servers (the `ServerDef` enum). A few examples:
+
+| Server id | Default command | Root markers (nearest-first) |
+| --- | --- | --- |
+| `java` | `jdtls` | `pom.xml`, `build.gradle`, …, `.git` |
+| `typescript` | `typescript-language-server --stdio` | `tsconfig.json`, `jsconfig.json`, `package.json`, `.git` |
+| `python` | `pyright-langserver --stdio` | `pyproject.toml`, `setup.py`, …, `.git` |
+| `go` | `gopls` | `go.mod`, `go.work`, `.git` |
+| `rust` | `rust-analyzer` | `Cargo.toml`, `.git` |
+| `clangd` | `clangd` | `compile_commands.json`, `CMakeLists.txt`, …, `.git` |
+
+The rest cover XML (lemminx), JSON, Bash, YAML, PHP, Ruby, HTML, CSS, Kotlin, Lua, Dockerfile, SQL,
+Terraform, TOML, and C#. Commands are user-configurable (Settings) and **never bundled** — servers
+are auto-detected on the augmented PATH or installed in-app.
+
+Useful pure methods: `serverIdFor(languageId)`, `isSupported(languageId)`, `rootMarkersFor(...)`,
+`specFor(languageId, commands)` → a `ServerSpec`. The served language ids are mirrored (kept in sync
+by hand) in [`EditorBuffer.LSP_LANGUAGES`](../../src/main/java/com/editora/editor/EditorBuffer.java),
+which `isLspLanguage()` checks so `editor` imports nothing from `lsp`.
+
+### One session per `(serverId, root)`
+
+[`lsp/RootResolver`](../../src/main/java/com/editora/lsp/RootResolver.java) computes the workspace
+root: the active Editora project folder (only when the file actually lives under it), else the
+nearest ancestor containing a root marker, else the file's directory. One root → one server process,
+shared by every file beneath it.
+
+[`lsp/LspManager`](../../src/main/java/com/editora/lsp/LspManager.java) is the UI-facing facade
+(mirrors `MermaidService`). It keys sessions by `serverId + " " + root.toUri()` — **not** by
+language id — so js/ts/jsx/tsx in one project share a single `tsserver`. It owns:
+
+- `sessionsByRoot` (`computeIfAbsent` starts a server on first open) and `sessionByDocUri` (routing).
+- An async, per-server availability probe (`detect(serverId, cb)` → cached in `availableCache`,
+  invalidated when that server's command changes or after an in-app install via `invalidateDetection()`).
+- The document lifecycle (`openDocument`/`changeDocument`/`saveDocument`/`closeDocument`) and the
+  request methods, each returning **neutral** results (`Target(file, line, character)` for
+  definition/references) marshaled to the FX thread via `Platform.runLater`.
+
+`LspManager` warms the augmented PATH off-thread in its constructor (`ProcessRunner::augmentedPath`),
+since both detection and the FX-thread session start read it. Remote (SFTP) files are never managed —
+`isManaged` bails on `!Vfs.isLocal` before `toUri()`, which would throw for such paths.
+
+### `LanguageServerSession`: one process over stdio
+
+[`lsp/LanguageServerSession`](../../src/main/java/com/editora/lsp/LanguageServerSession.java) drives
+one external server process for a single root over stdio, via an lsp4j `LSPLauncher` on a daemon
+executor. It implements `LanguageClient`, so it receives `publishDiagnostics`/log/show-message.
+
+- **Launch** reuses `ProcessRunner.resolveExecutable`/`applyStandardEnv` (the GUI-launch PATH fix, so
+  a Finder-launched `.app` finds `jdtls`), then registers the process with `ProcessRegistry.track`.
+- **Handshake**: `initialize` (client capabilities + workspace folder + optional
+  `initializationOptions`) → on success cache the server `ServerCapabilities`, send `initialized`,
+  push default configuration (enables Pyright auto-imports), then flush queued requests.
+- **Queue-until-initialized**: `whenReady(action)` runs an action now if initialized, else parks it in
+  `pending` to flush when `initialize` resolves. So a document open issued before the handshake
+  completes is held rather than dropped.
+- **Document sync** is full-text (`didOpen`/`didChange`/`didSave`/`didClose`), with per-uri versions.
+  `didChange` is skipped entirely when the server explicitly negotiated `TextDocumentSyncKind.None`.
+- **Requests** are a subset: completion (+ `resolveCompletionItem` for auto-import additional edits),
+  hover, definition, references, document/range formatting, document symbols, pull diagnostics,
+  semantic tokens (range or full), and `executeCommand` (used by the DAP layer to drive jdtls).
+- **stderr must be drained.** A daemon thread (`drainStderr`) reads the server's stderr to EOF and
+  logs the first 200 lines to the Debug Log. An undrained PIPE fills its ~64 KB OS buffer on a chatty
+  server (jdtls logs heavily) and the server blocks mid-startup, deadlocking the handshake. Capturing
+  it (rather than `Redirect.DISCARD`ing) surfaces *why* a launch failed — missing JDK, a lock, a bad
+  command — which would otherwise be invisible in a packaged build.
+- **Dispose** sends `shutdown`+`exit` (best-effort) then `ProcessRegistry.killTree(process)`. Killing
+  only the launcher would orphan the real server: jdtls is a wrapper script (Homebrew `jdtls` → python
+  → java), and the orphaned JVM keeps its Eclipse workspace `.lock`, blocking the next session for that
+  root.
+
+### Per-jdtls workspace
+
+jdtls deadlocks on its single shared default workspace's `.lock` when two roots — or a leaked previous
+run — contend for it, so `initialize` never resolves (loading bar spins forever, dead completion).
+`LspManager` gives each root a dedicated Eclipse workspace by appending `-data <dir>` to the launch
+command. The dir is `jdtlsWorkspaceBase / workspaceDirName(root)`, where `workspaceDirName` is a stable
+truncated SHA-256 of the root's absolute path (pure, unit-tested). `withDataDir` is a no-op if the
+user's configured command already specifies `-data`. The workspace persists across sessions so jdtls's
+index is reused.
+
+### Diagnostics → overlay, stripe, minimap, Problems
+
+A server's diagnostics (pushed via `publishDiagnostics`, or *pulled* via `textDocument/diagnostic` for
+servers with a `diagnosticProvider` such as vscode-html/css/json) are mapped by
+[`lsp/DiagnosticMapper`](../../src/main/java/com/editora/lsp/DiagnosticMapper.java) into flat
+`LspDiagnostic` records and routed through one callback. `mapReport` returns `null` for an "unchanged"
+pull report (the caller keeps the current diagnostics). They surface in four places, all gated on the
+buffer being LSP-active:
+
+- `editor/LspDiagnosticOverlay` — squiggles (the Canvas-overlay idiom, visible paragraphs only).
+- `editor/DiagnosticStripe` — marks docked over the scrollbar, click-to-jump.
+- the minimap edge stripes.
+- `ui/ProblemsPanel` (the `problems` tool window), grouped language → file → diagnostic.
+
+The Problems map is **scoped to open files**: a server publishes diagnostics project-wide (jdtls
+especially), so the controller drops any file without an open tab. The open-tab lookup matches by
+**canonical (symlink-resolved) path** (`MainController.canonicalPath` via `Path.toRealPath`) — a server
+reports diagnostics under the file's real URI (`/private/tmp/…` for a `/tmp/…` symlink on macOS), so
+plain `normalize()` matching silently dropped every diagnostic.
+
+### Completion, symbols, and the loading bar
+
+- **Completion** fires on the server's advertised trigger characters, not just `.` — `triggerCharsOf`
+  reads `completionProvider.triggerCharacters` from the cached capabilities (so `<` triggers HTML, `:`
+  triggers CSS). [`lsp/CompletionMapper`](../../src/main/java/com/editora/lsp/CompletionMapper.java) is
+  the only place that touches lsp4j's `CompletionItemKind`/tags, mapping items into the editor's
+  `Completion` popup entries (icon, detail, sort/preselect, deprecated flag, and the raw item as an
+  opaque resolve token for the doc popup).
+- **Structure outline** comes from `textDocument/documentSymbol`, mapped by
+  [`lsp/DocumentSymbolMapper`](../../src/main/java/com/editora/lsp/DocumentSymbolMapper.java) into the
+  neutral `SymbolNode` tree (handling both the hierarchical `DocumentSymbol` and legacy flat
+  `SymbolInformation` forms).
+- **Loading bar**: the status bar shows an indeterminate bar while a server starts. It is cleared when
+  `initialize` resolves — `LanguageServerSession` emits a synthetic `onStatus("ServiceReady", null)` on
+  success / `("Error", null)` on failure. This is universal across every server (and a clean file that
+  never publishes a diagnostic); earlier the bar only stopped on an incoming diagnostic or jdtls's
+  vendor-specific `language/status` notification, leaving non-jdtls servers spinning forever.
+
+Capability gating throughout reads the cached `ServerCapabilities` through pure, null-safe predicates
+(`formattingProvider`, `rangeFormattingProvider`, `documentSymbolProvider`, `semanticTokensProvider`,
+`triggerCharsOf`), so a feature is offered only when the server advertises it.
+
+### LspCoordinator
+
+The whole integration lives in [`ui/LspCoordinator`](../../src/main/java/com/editora/ui/LspCoordinator.java)
+(the `CoordinatorHost` feature-coordinator pattern). It owns the nav/format flows, the diagnostics
+routing, and the configure/detect/gating + per-buffer lifecycle. `applySupport()` (init + every
+settings apply) sets the jdtls workspace base, calls `lspManager.configure(...)`, then runs per-server
+detection (the package-private `SERVER_IDS` array) and gating. `wireBuffer` installs the per-buffer
+hooks (didChange, pull diagnostics, semantic tokens, completion, nav actions). `LspManager` itself
+stays a `MainController` field (the DAP layer and the MCP bridge read it) and is passed in.
+
+---
+
+## ProcessRegistry & ProcessRunner
+
+Every long-lived spawned server — LSP **and** DAP — is owned by
+[`process/ProcessRegistry`](../../src/main/java/com/editora/process/ProcessRegistry.java) so it never
+outlives the app. `LanguageServerSession.start`, `DapClient.connectStdio`, and `DapClient.setAdapterProcess`
+all call `ProcessRegistry.track(process)`. Three mechanisms:
+
+1. **`killTree(process)`** — destroy the descendant tree (SIGTERM, children first so a wrapper script
+   can't reparent-orphan its real child), then schedule a force-kill of any survivor after `GRACE_MS`
+   (1500 ms). **Non-blocking** (a daemon scheduler), so it's safe to call on the FX thread during a
+   window close.
+2. **JVM shutdown hook** (`installShutdownHook`, from `App.main`) force-kills every tracked tree on
+   exit — covering a normal quit *and* SIGTERM/`kill`/OS-quit/most crashes, the paths that bypass the
+   window-close teardown.
+3. **On-disk ledger** (`<configDir>/spawned-servers.txt`) + **`reapOrphans()`** (once from `App.start`,
+   before any window builds): kills any server leaked by a previous run that died too hard for the hook
+   (SIGKILL / power loss). The pure `LedgerEntry` parse/format + the `shouldReap` decision (reap only
+   when pid **and** start-instant **and** executable all match, so a reused PID is never killed) are
+   unit-tested.
+
+[`process/ProcessRunner`](../../src/main/java/com/editora/process/ProcessRunner.java) is the only
+subprocess chokepoint. For servers, `applyStandardEnv` is the relevant part: it sets `LC_ALL=C` and the
+**augmented PATH**. A Finder-launched `.app` (or a `.desktop`) inherits a stripped PATH without
+Homebrew/npm/Node dirs, so `jdtls`/`node`/`pyright` wouldn't be found. `augmentedPath()` =
+inherited PATH + the user's **login-shell PATH** (`$SHELL -l -i -c` once, fenced by markers — the
+`extractMarked` parse is unit-tested) + the hardcoded `EXTRA_PATH_DIRS`. The login-shell step recovers
+version-manager bin dirs that can't be hardcoded (nvm's `~/.nvm/versions/node/<ver>/bin`, fnm, asdf,
+volta). `resolveExecutable` then rewrites a bare command name to its absolute path against that PATH,
+because Java's Unix `ProcessBuilder` resolves the executable against the JVM's own stripped PATH, not
+the child env. The result is cached after the first call.
+
+---
+
+## DAP
+
+### Three transports
+
+Editora debugs Java, Python, and JavaScript (Node), off by default
+(`Settings.debugSupport`). [`dap/DapServerRegistry`](../../src/main/java/com/editora/dap/DapServerRegistry.java)
+is the pure language → adapter spec (a `Kind` transport, the DAP `launch` type, the `initialize`
+adapter id, and the default interpreter + adapter args). `languageIdsForDebug()` =
+`{java, python, javascript}`.
+
+| Language | `Kind` | How |
+| --- | --- | --- |
+| `java` | `JDTLS` | The Microsoft java-debug adapter is started *inside* jdtls via `workspace/executeCommand` (`vscode.java.startDebugSession` returns a port), then `DapClient.connect(port, "java")` opens a socket. |
+| `python` | `STDIO` | `<python> -m debugpy.adapter`; `DapClient.connectStdio(proc, "python")` wires DAP to the process's stdin/stdout. |
+| `javascript` | `SOCKET` | `node <dapDebugServer.js> <port>`; `DapClient.connect(port, "pwa-node")`. |
+
+[`dap/DapClient`](../../src/main/java/com/editora/dap/DapClient.java) (mirrors `LanguageServerSession`)
+runs the handshake over an lsp4j.debug `DSPLauncher`: `initialize` → on the `initialized` event send
+`setBreakpoints`/`setExceptionBreakpoints` then `configurationDone`, **without** `.join()` — that
+callback runs on the reader thread, and lsp4j serializes outgoing messages, so blocking would deadlock
+on a response delivered by the same thread. Events arrive on the launcher thread; the `Host`
+(`DapManager`) marshals them to FX. `dispose()` disconnects, closes the socket, and
+`ProcessRegistry.killTree`s the adapter subprocess tree (same wrapper-orphan reasoning as LSP). The
+standalone adapters' stderr is `Redirect.DISCARD`ed by `DapManager` (an undrained PIPE deadlocks, like
+the LSP servers; DAP traffic is on stdin/stdout or the socket).
+
+### DapManager & the java-debug bundle
+
+[`dap/DapManager`](../../src/main/java/com/editora/dap/DapManager.java) is the UI facade (mirrors
+`LspManager`+`RunService`). It owns the single active session (one debug session at a time, like Run)
+and dispatches `startLaunch(file, language, picker)`:
+
+- **java** → resolve main class (`vscode.java.resolveMainClass`, with a `javac -g` `compileAndLaunch`
+  fallback for a loose file with no project) → `resolveClasspath` → `resolveJavaExecutable` →
+  `startDebugSession` → connect the socket → `launch`.
+- **python/javascript** → `startProgram`: snapshot breakpoints on the FX thread, then off-thread spawn
+  the adapter + connect + `launch`.
+
+The Java path is hosted on jdtls: that's why the DAP layer takes the `LspManager`. jdtls is started
+with the java-debug plugin jar in `initialize.initializationOptions.bundles`
+(`LspManager.setDebugBundles` → the `{"bundles":[…]}` option), which registers the `vscode.java.*`
+debug commands. Toggling debug on **restarts jdtls** so it reloads with the bundle.
+
+[`dap/DebugAdapterLocator`](../../src/main/java/com/editora/dap/DebugAdapterLocator.java) finds each
+adapter (pure name-match + version comparison + filesystem scan): the java-debug jar
+(`com.microsoft.java.debug.plugin-*.jar`, newest wins, from a configured path / VS Code / mason /
+Editora's plugin dir), `dapDebugServer.js`, and a `debugpy` package dir for `PYTHONPATH`.
+[`dap/LaunchConfig`](../../src/main/java/com/editora/dap/LaunchConfig.java) shapes the DAP `launch`/
+`attach`/`program` argument maps (pure, unit-tested; attach stays Java-only). The neutral records
+exposed to the UI are in [`dap/DapModels`](../../src/main/java/com/editora/dap/DapModels.java)
+(`ThreadInfo`, `StackFrameInfo`, `ScopeInfo`, `VariableInfo`, `EvalResult`, `LineBreakpoint`,
+`FileBreakpoints`).
+
+### Breakpoints
+
+Breakpoints are persisted per-project in `breakpoints.json` (`config/Breakpoint` +
+`config/BreakpointStore`), tracked through edits by `editor/BreakpointManager` (mirrors
+`BookmarkManager`; the pure `shift`/`reanchor` are unit-tested), and shown in a leftmost gutter strip
+that toggles a breakpoint on click. They are snapshotted on the FX thread at session start and sent to
+the adapter on its `initialized` event (DAP is 1-based; the model is 0-based).
+
+### DebugCoordinator
+
+The integration lives in [`ui/DebugCoordinator`](../../src/main/java/com/editora/ui/DebugCoordinator.java)
+(`CoordinatorHost`). It owns the `DebugPanel`, breakpoint persistence + gutter gating, the DAP event
+sink, the inline-values/hover/execution-line editor surfaces, the start/step/run-to-cursor/jump flows,
+and `wireBuffer`. `applySupport()` configures all three adapters, pushes the java-debug bundle into
+LSP (restarting jdtls when it changed), async-detects python/js, and gates each buffer's breakpoint
+gutter. `debugEffectiveFor(language)` gates start (java = the jdtls server enabled + available + plugin
+found, via `lspCoordinator.isServerAvailable("java")`; python/js = their enable + detected adapter).
+`DapManager` stays a `MainController` field (built on `lspManager`) and is passed in, mirroring the
+`lspManager`/`LspCoordinator` split.
+
+---
+
+## Adding a server or adapter
+
+See [extending.md](../extending.md) — adding an LSP server is one `ServerDef` entry plus its id in the
+coordinator's `SERVER_IDS` and the served language ids in `EditorBuffer.LSP_LANGUAGES`, plus a Settings
+command/enable pair; adding a DAP adapter is one `Def` entry in `DapServerRegistry`.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -21,13 +21,17 @@ JavaFX code so it can be tested directly.
 ## The headless-FX harness
 
 Real controller behavior (Zen toggling chrome, Simple-mode stripping, tab/window lifecycle, the
-coordinators) is covered end-to-end by a **TestFX** harness running over a self-built JavaFX
-**Monocle** Glass backend, so FX tests run headless on CI with **no display/xvfb**.
+coordinators) is covered end-to-end by a **TestFX** harness running over **JavaFX 26's built-in
+Headless Glass platform** (`-Dglass.platform=Headless`, part of `javafx.graphics` since 26), so
+FX tests run headless on CI with **no display/xvfb** — no Monocle jar, no native libs, nothing
+vendored. The harness only uses `FxToolkit` to boot the toolkit; it never drives the TestFX robot
+(no `clickOn`/key simulation — everything goes through `runOnFx`/`callOnFx` + reflection), so the
+prototype platform's input/rendering limitations don't apply.
 
 - All FX tests are tagged `@Tag("fx")`. Run the pure suite alone with
   `mvn test -DexcludedGroups=fx`.
-- **`FxTestSupport`** boots the toolkit once (Monocle Headless + `Fonts.load`/`Messages.init` +
-  the AtlantaFX UA sheet + the classloader pin) and exposes `runOnFx`/`callOnFx` + reflection
+- **`FxTestSupport`** boots the toolkit once (the Headless platform + `Fonts.load`/`Messages.init`
+  + the AtlantaFX UA sheet + the classloader pin) and exposes `runOnFx`/`callOnFx` + reflection
   helpers (`field`/`invoke`/`call`) to read private `@FXML` nodes and call private methods. Tests
   run on the **classpath** as the unnamed module, so `setAccessible` is unrestricted.
 - **`FxWindowFixture`** builds a real window via `WindowManager.buildWindowForTest()` — a
@@ -39,13 +43,13 @@ coordinators) is covered end-to-end by a **TestFX** harness running over a self-
 In `pom.xml`:
 
 - `<useModulePath>false</useModulePath>` — classpath mode.
-- headless system properties: `glass.platform=Monocle`, `monocle.platform=Headless`,
-  `prism.order=sw`, `testfx.headless=true`.
+- headless system properties: `glass.platform=Headless`, `prism.order=sw`.
 - `<argLine>@{argLine}</argLine>` — **the `@{argLine}` token is mandatory** so JaCoCo's injected
   coverage agent (set via the `argLine` property) survives. A plain `<argLine>` would clobber it.
 
-Monocle is vendored, test-scope, and must be rebuilt on every JavaFX bump — see
-[dependencies.md](dependencies.md#monocle--self-built-headless-backend-m2-repo-test-scope-only).
+Because the backend ships inside JavaFX, it can never go stale on a JavaFX bump — unlike the
+previously self-built Monocle backend it replaced (see
+[dependencies.md](dependencies.md#the-headless-test-backend-no-vendored-dependency)).
 
 ## Coverage
 


### PR DESCRIPTION
Second pass on the `docs/` developer guides, expanding depth and fixing staleness.

## Added
- **Diagrams** — four Mermaid diagrams in `architecture.md` (boot sequence, multi-window `SharedConfig`/`ConfigManager` split, buffer lifecycle, module dependency direction). GitHub renders them inline.
- **Decision records** — `docs/decisions/` index + 10 ADRs for the non-obvious choices: RichTextFX fork, native-CLI git, TOML settings, TextMate highlighting, in-scene overlays, the headless-AWT guard, multi-window config, feature coordinators, the plugin classloader, and the headless test platform.
- **Glossary** — `docs/glossary.md`, ~30 recurring terms, a heading per term so cross-references anchor.
- **Gotchas** — `docs/gotchas.md`, 12 known traps with symptom + fix (JPMS `opens`, macOS classloader, texture-pool black window, signed-jar strip, the `@{argLine}` token, the NUL `Path` sentinel, stderr drain / `killTree`, GUI-launch PATH, …).
- **Subsystem deep-dives** — `docs/subsystems/` for the command/keymap system, config + schema migrations, and LSP/DAP.

## Corrected (staleness from the prior docs PR)
The FX test harness is **JavaFX 26's built-in Headless platform**, not the self-built Monocle backend — Monocle is no longer vendored (`m2-repo/` has only richtextfx). Fixed `testing.md`, `dependencies.md`, `release.md`, and the `JavaFX 25`→`26` line in `architecture.md`.

## Verification
All relative file links and **all heading anchors** verified to resolve (incl. GitHub's `--` double-hyphen slug rule); a sample of **25 cited identifiers** grep-verified against source. The drafting was parallelized across subagents, each grounded in `CLAUDE.md` + source and told to verify identifiers; I reviewed and corrected. No code change.

> Heads-up: `CLAUDE.md` itself is slightly stale in two spots the agents surfaced — its top line says JavaFX 25 (pom is 26.0.1), and it describes LSP stderr as `Redirect.DISCARD` though the code now drains it to the Debug Log. The docs follow the code. Not touched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)