### PR TITLE
Don't materialize the whole document per keystroke for dirty tracking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Performance
+
+- **Dirty-state tracking no longer allocates the whole document on every keystroke.** The editor's modified-flag listener was bound to RichTextFX's `textProperty()`, which forces the full document `String` to be materialized on each change — an O(n) allocation per character on a very large single buffer (e.g. minified JS/CSS or a one-line JSON/log that slips past the line-count heavy-file tier). It now runs off `plainTextChanges` with a cheap `getLength()` gate, so the full text is only built in the rare near-clean state, never while typing. Behavior is unchanged (reverting an edit still clears the marker).
+
 ### Internal
 
 - **Broadened the headless-FX harness over the Run + External-Tool console panels.** New `RunPanelFxTest` and `ExternalToolPanelFxTest` exercise the console lifecycle (started → appendOutput stdout/stderr → finished/failed, Stop-button enablement) and the one-shot tool console (command header + stdout + stderr + status line, clear).

--- a/src/main/java/com/editora/editor/EditorBuffer.java
+++ b/src/main/java/com/editora/editor/EditorBuffer.java
@@ -613,11 +613,14 @@ public class EditorBuffer implements TabContent {
             }
         });
         // Dirty only when the content differs from the last saved/loaded text, so reverting an edit
-        // (undo or manual) clears the marker. The length check short-circuits the O(n) compare —
-        // it runs only when the length matches the saved length (i.e. near the original state).
-        area.textProperty()
-                .addListener(
-                        (obs, old, now) -> dirty.set(now.length() != cleanText.length() || !now.equals(cleanText)));
+        // (undo or manual) clears the marker. Driven off plainTextChanges (not textProperty): subscribing
+        // to textProperty would force RichTextFX to materialize the whole document String on every
+        // keystroke — O(n) allocation per char on a very large single buffer (e.g. minified JS on one
+        // line, past the line-count heavy-file tier). The cheap getLength() check gates the full-text
+        // compare so area.getText() is only built in the rare near-clean state, never while typing.
+        area.plainTextChanges()
+                .subscribe(c -> dirty.set(area.getLength() != cleanText.length()
+                        || !area.getText().equals(cleanText)));
         area.caretPositionProperty().addListener((obs, old, now) -> {
             resetGoalColumn();
             scheduleBraceMatch();

--- a/src/test/java/com/editora/ui/EditorBufferFxTest.java
+++ b/src/test/java/com/editora/ui/EditorBufferFxTest.java
@@ -174,4 +174,24 @@ class EditorBufferFxTest {
         assertEquals("CRLF", EditorBuffer.detectLineEnding("a\r\nb"));
         assertEquals("LF", EditorBuffer.detectLineEnding("a\nb"));
     }
+
+    @Test
+    void revertingToSavedContentClearsDirty() throws Exception {
+        EditorBuffer b = FxTestSupport.callOnFx(() -> {
+            EditorBuffer buf = new EditorBuffer();
+            buf.setContent("abc");
+            buf.markClean();
+            return buf;
+        });
+        org.fxmisc.richtext.CodeArea area = FxTestSupport.field(b, "area");
+        assertFalse(FxTestSupport.callOnFx(b::isDirty), "clean after markClean");
+
+        // An edit of different length hits the cheap getLength() path ⇒ dirty.
+        FxTestSupport.runOnFx(() -> area.appendText("X"));
+        assertTrue(FxTestSupport.callOnFx(b::isDirty), "an edit marks dirty");
+
+        // Reverting to the exact saved text (lengths match again) clears dirty via the getText compare.
+        FxTestSupport.runOnFx(() -> area.replaceText("abc"));
+        assertFalse(FxTestSupport.callOnFx(b::isDirty), "reverting to saved content clears dirty");
+    }
 }


### PR DESCRIPTION
The editor's dirty-flag listener was bound to RichTextFX's `textProperty()`, which forces the full document `String` to be materialized on **every** change — an O(n) allocation per character on a very large single buffer (minified JS/CSS, or a one-line JSON/log that slips past the line-count heavy-file tier).

Now driven off `plainTextChanges` with a cheap `getLength()` gate:
```java
area.plainTextChanges().subscribe(c ->
    dirty.set(area.getLength() != cleanText.length() || !area.getText().equals(cleanText)));
```
`area.getText()` is only built in the rare near-clean state (lengths match), never while actively typing. Behavior is unchanged — reverting an edit still clears the marker — and a new `EditorBufferFxTest.revertingToSavedContentClearsDirty` locks that in (covers both the cheap length-differs path and the getText compare path).

Found during a hot-path performance audit; everything else audited (debounced edit pulses, coalesced overlays, bounded image caches, snapshot guards) was already in good shape. `./mvnw verify` green (1254 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)