### PR TITLE
Guard Bookmarks drag-reorder against a null parent (defensive)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Hardened the Bookmarks drag-reorder against a theoretical NPE.** `handleDrop` dereferenced a dragged mark row's `getParent()` directly; it's always non-null today (a mark is always under a file group), but a defensive guard now returns early if a detached row is ever dropped, so a future tree-shape change can't turn it into a crash.
+
 - **Markdown preview no longer renders HTML comments.** `<!-- … -->` blocks (and inline comments) were shown as visible text/code in the preview (and PDF/print export); they're now hidden, matching GitHub and every other Markdown renderer.
 - **Markdown preview hides the editor minimap.** In Split/Preview mode the minimap was wedged between the editor and the preview; it's now hidden while the preview is shown (the preview is the overview) and restored when you return to the plain editor view.
 

--- a/src/main/java/com/editora/ui/BookmarksPanel.java
+++ b/src/main/java/com/editora/ui/BookmarksPanel.java
@@ -381,7 +381,11 @@ public class BookmarksPanel extends VBox implements ToolWindowContent {
             return;
         }
         if (src.getValue() instanceof MarkRow sm) {
-            var siblings = src.getParent().getChildren();
+            TreeItem<Row> parent = src.getParent();
+            if (parent == null) {
+                return; // a detached/root mark row has no file group to reorder within (defensive)
+            }
+            var siblings = parent.getChildren();
             int from = siblings.indexOf(src);
             moveMark(
                     sm.file(),


### PR DESCRIPTION
`BookmarksPanel.handleDrop` dereferenced a dragged mark row's `getParent()` directly. It's structurally non-null today (a `MarkRow` is always a child of a `FileRow`), but nothing enforces it — a future tree-shape refactor could turn it into an NPE. Added a defensive early-return.

Found during an NPE audit; the rest of the codebase guards nullable returns consistently (every `.orElse(null)` is null-checked, `getParent()` chains use `== null ?` ternaries), so this was the one technically-unguarded deref.

`./mvnw verify` green (1254 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)