### PR TITLE
Harden against NPEs from corrupted config + non-conforming servers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Hardened several spots against NullPointerExceptions from corrupted config or non-conforming servers** (found via a full-codebase null-flow audit). `Macro` now defaults a missing `name` to `""`, so a hand-edited/corrupted `macros.json` entry without a name can't NPE macro lookups (find/save/delete). `SnippetManager` skips a snippet file whose content is the literal `null` instead of throwing. `LspManager` go-to-definition / find-references guard a `Location`/`LocationLink` range that a non-conforming language server leaves null. `DapClient.evaluate` tolerates a null adapter response like `evaluateFull` already did. (The wider audit found the `ui`/`editor`/`MainController` packages already guard nullable returns consistently.)
+
 - **Hardened the Bookmarks drag-reorder against a theoretical NPE.** `handleDrop` dereferenced a dragged mark row's `getParent()` directly; it's always non-null today (a mark is always under a file group), but a defensive guard now returns early if a detached row is ever dropped, so a future tree-shape change can't turn it into a crash.
 
 - **Markdown preview no longer renders HTML comments.** `<!-- … -->` blocks (and inline comments) were shown as visible text/code in the preview (and PDF/print export); they're now hidden, matching GitHub and every other Markdown renderer.

--- a/src/main/java/com/editora/dap/DapClient.java
+++ b/src/main/java/com/editora/dap/DapClient.java
@@ -19,7 +19,6 @@ import org.eclipse.lsp4j.debug.ContinueArguments;
 import org.eclipse.lsp4j.debug.ContinuedEventArguments;
 import org.eclipse.lsp4j.debug.DisconnectArguments;
 import org.eclipse.lsp4j.debug.EvaluateArguments;
-import org.eclipse.lsp4j.debug.EvaluateResponse;
 import org.eclipse.lsp4j.debug.InitializeRequestArguments;
 import org.eclipse.lsp4j.debug.NextArguments;
 import org.eclipse.lsp4j.debug.OutputEventArguments;
@@ -349,7 +348,7 @@ public final class DapClient implements IDebugProtocolClient {
         a.setExpression(expression);
         a.setFrameId(frameId);
         a.setContext(context);
-        return server.evaluate(a).thenApply(EvaluateResponse::getResult);
+        return server.evaluate(a).thenApply(r -> r == null ? null : r.getResult()); // adapter may null the body
     }
 
     /** Like {@link #evaluate} but keeps the full response: result + expandable children reference + type

--- a/src/main/java/com/editora/lsp/LspManager.java
+++ b/src/main/java/com/editora/lsp/LspManager.java
@@ -571,14 +571,19 @@ public final class LspManager {
             if (error == null && result != null) {
                 if (result.isLeft()) {
                     for (Location l : result.getLeft()) {
-                        addTarget(targets, l.getUri(), l.getRange().getStart());
+                        var range = l.getRange(); // a non-conforming server can omit the (spec-required) range
+                        if (range != null) {
+                            addTarget(targets, l.getUri(), range.getStart());
+                        }
                     }
                 } else if (result.getRight() != null) {
                     for (LocationLink ll : result.getRight()) {
                         var range = ll.getTargetSelectionRange() != null
                                 ? ll.getTargetSelectionRange()
                                 : ll.getTargetRange();
-                        addTarget(targets, ll.getTargetUri(), range.getStart());
+                        if (range != null) {
+                            addTarget(targets, ll.getTargetUri(), range.getStart());
+                        }
                     }
                 }
             }
@@ -596,7 +601,10 @@ public final class LspManager {
             List<Target> targets = new ArrayList<>();
             if (error == null && locations != null) {
                 for (Location l : locations) {
-                    addTarget(targets, l.getUri(), l.getRange().getStart());
+                    var range = l.getRange(); // guard against a server omitting the spec-required range
+                    if (range != null) {
+                        addTarget(targets, l.getUri(), range.getStart());
+                    }
                 }
             }
             Platform.runLater(() -> cb.accept(targets));

--- a/src/main/java/com/editora/macro/Macro.java
+++ b/src/main/java/com/editora/macro/Macro.java
@@ -11,6 +11,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 public record Macro(String name, List<MacroStep> steps) {
 
     public Macro {
+        name = name == null ? "" : name; // a name-less entry in a hand-edited macros.json must not NPE lookups
         steps = steps == null ? List.of() : List.copyOf(steps);
     }
 

--- a/src/main/java/com/editora/snippet/SnippetManager.java
+++ b/src/main/java/com/editora/snippet/SnippetManager.java
@@ -108,6 +108,9 @@ public final class SnippetManager {
         }
         try (InputStream in = Files.newInputStream(file)) {
             Map<String, Dto> map = mapper.readValue(in, new TypeReference<Map<String, Dto>>() {});
+            if (map == null) {
+                return out; // a snippet file whose content is the literal `null` ⇒ no snippets
+            }
             map.forEach((name, dto) -> {
                 if (dto == null) {
                     return;
@@ -139,6 +142,9 @@ public final class SnippetManager {
                 return out;
             }
             Map<String, Dto> map = mapper.readValue(in, new TypeReference<Map<String, Dto>>() {});
+            if (map == null) {
+                return out; // a bundled snippet resource whose content is the literal `null`
+            }
             map.forEach((name, dto) -> {
                 if (dto == null) {
                     return;
@@ -246,6 +252,9 @@ public final class SnippetManager {
     private void readInto(Map<String, Snippet> byPrefix, InputStream in, String language) {
         try {
             Map<String, Dto> map = mapper.readValue(in, new TypeReference<Map<String, Dto>>() {});
+            if (map == null) {
+                return; // a snippet file whose content is the literal `null`
+            }
             map.forEach((name, dto) -> {
                 if (dto == null) {
                     return;

--- a/src/test/java/com/editora/config/MacroStoreTest.java
+++ b/src/test/java/com/editora/config/MacroStoreTest.java
@@ -31,6 +31,19 @@ class MacroStoreTest {
     }
 
     @Test
+    void namelessMacroFromCorruptedJsonDoesNotNpeLookups() {
+        // A corrupted/hand-edited macros.json entry with no "name" deserializes to a Macro with a null name
+        // component; Macro defaults it to "" so find/put/remove (which call m.name().equals(...)) never NPE.
+        Macro nameless = new Macro(null, List.of(MacroStep.text("x")));
+        assertEquals("", nameless.name());
+        MacroStore store = new MacroStore();
+        store.macros.add(nameless);
+        assertNull(store.find("anything")); // iterates + derefs m.name() — must not throw
+        store.put(new Macro("real", List.of()));
+        assertFalse(store.remove("missing"));
+    }
+
+    @Test
     void roundTripsThroughMacrosJson(@TempDir Path dir) throws Exception {
         SharedConfig cfg = new SharedConfig(dir, true);
         cfg.load();


### PR DESCRIPTION
Found via a full-codebase (~40k-line) null-flow audit across all packages. The `ui`/`editor`/`MainController`/git/process/search packages came back clean (nullable returns are guarded consistently — every `.orElse(null)` is null-checked, `getParent()` chains use ternaries). These were the only real gaps:

- **HIGH — `Macro`** didn't default `name`, so a hand-edited/corrupted `macros.json` entry without a `"name"` deserializes to `name()==null` and `MacroStore.find/put/remove` (`m.name().equals(...)`) NPE. Now defaults to `""` (covers all three call sites). Regression test added.
- **MED — `SnippetManager`** called `map.forEach` on the result of `mapper.readValue(...)`, which is `null` when a snippet file/resource content is the JSON literal `null`. Now skips it cleanly (3 sites).
- **MED — `LspManager`** go-to-definition / find-references dereferenced `Location.getRange()` / `LocationLink` range, which lsp4j doesn't enforce non-null — a non-conforming server can omit it. Now guarded (consistent with the adjacent `addTarget` `start != null` guard).
- **LOW — `DapClient.evaluate`** didn't guard a null adapter response, unlike `evaluateFull`. Now mirrors it.

`./mvnw verify` green (1255 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)