### PR TITLE
Project filter: breadth-first search so top-level files aren't starved

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Project / Current-Folder filter now finds top-level files in a large root.** The filter-box search walked the tree depth-first, so under a big root (e.g. a home directory with huge `.cache`/`.m2`/`node_modules` subtrees) it exhausted its visit budget deep inside one subtree before ever reaching a shallow file like `.profile` — which then never appeared in the results. The search is now breadth-first, visiting every shallower entry before descending, so top-level matches are never starved by a deep sibling subtree.
+
 - **Hardened several spots against NullPointerExceptions from corrupted config or non-conforming servers** (found via a full-codebase null-flow audit). `Macro` now defaults a missing `name` to `""`, so a hand-edited/corrupted `macros.json` entry without a name can't NPE macro lookups (find/save/delete). `SnippetManager` skips a snippet file whose content is the literal `null` instead of throwing. `LspManager` go-to-definition / find-references guard a `Location`/`LocationLink` range that a non-conforming language server leaves null. `DapClient.evaluate` tolerates a null adapter response like `evaluateFull` already did. (The wider audit found the `ui`/`editor`/`MainController` packages already guard nullable returns consistently.)
 
 - **Hardened the Bookmarks drag-reorder against a theoretical NPE.** `handleDrop` dereferenced a dragged mark row's `getParent()` directly; it's always non-null today (a mark is always under a file group), but a defensive guard now returns early if a detached row is ever dropped, so a future tree-shape change can't turn it into a crash.

--- a/src/main/java/com/editora/ui/ProjectPanel.java
+++ b/src/main/java/com/editora/ui/ProjectPanel.java
@@ -1,11 +1,8 @@
 package com.editora.ui;
 
 import java.io.IOException;
-import java.nio.file.FileVisitResult;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.SimpleFileVisitor;
-import java.nio.file.attribute.BasicFileAttributes;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
@@ -436,50 +433,43 @@ public class ProjectPanel extends VBox implements ToolWindowContent {
         searchExecutor.shutdownNow();
     }
 
-    /** Bounded project-wide filename search: dot-dirs skipped, capped on entries visited and matches. */
-    private static List<Path> search(Path root, String query, boolean includeHidden) {
+    /**
+     * Bounded, <em>breadth-first</em> project-wide filename search: dot-dirs skipped (unless showing
+     * hidden), capped on entries visited and matches. BFS is deliberate — a depth-first walk descends fully
+     * into the first subtree it meets, so under a large root (e.g. a home dir with huge {@code .cache}/
+     * {@code .m2}/{@code node_modules} trees) the {@link #MAX_VISIT} budget is exhausted deep inside one of
+     * them before a shallow, top-level file (like {@code .profile}) is ever reached. BFS visits every
+     * shallower entry before descending, so a top-level match is never starved by a deep sibling subtree.
+     * Package-visible for tests.
+     */
+    static List<Path> search(Path root, String query, boolean includeHidden) {
         String q = query.toLowerCase(Locale.ROOT);
         List<Path> matches = new ArrayList<>();
-        int[] visited = {0};
-        try {
-            Files.walkFileTree(
-                    root,
-                    java.util.EnumSet.noneOf(java.nio.file.FileVisitOption.class),
-                    MAX_DEPTH,
-                    new SimpleFileVisitor<>() {
-                        @Override
-                        public FileVisitResult preVisitDirectory(Path dir, BasicFileAttributes a) {
-                            if (!includeHidden
-                                    && !dir.equals(root)
-                                    && dir.getFileName().toString().startsWith(".")) {
-                                return FileVisitResult.SKIP_SUBTREE; // skip .git, etc.
-                            }
-                            return cap();
+        record Dir(Path path, int depth) {}
+        java.util.Deque<Dir> queue = new java.util.ArrayDeque<>();
+        queue.add(new Dir(root, 0));
+        int visited = 0;
+        while (!queue.isEmpty() && visited <= MAX_VISIT && matches.size() < MAX_MATCHES) {
+            Dir current = queue.poll();
+            try (java.nio.file.DirectoryStream<Path> entries = Files.newDirectoryStream(current.path())) {
+                for (Path p : entries) {
+                    if (++visited > MAX_VISIT || matches.size() >= MAX_MATCHES) {
+                        break;
+                    }
+                    String name = p.getFileName().toString();
+                    boolean hidden = name.startsWith(".");
+                    if (Files.isDirectory(p, java.nio.file.LinkOption.NOFOLLOW_LINKS)) {
+                        if (current.depth() + 1 < MAX_DEPTH && (includeHidden || !hidden)) {
+                            queue.add(new Dir(p, current.depth() + 1)); // descend later — shallower first
                         }
-
-                        @Override
-                        public FileVisitResult visitFile(Path file, BasicFileAttributes a) {
-                            String name = file.getFileName().toString();
-                            if ((includeHidden || !name.startsWith("."))
-                                    && name.toLowerCase(Locale.ROOT).contains(q)) {
-                                matches.add(file);
-                            }
-                            return cap();
-                        }
-
-                        @Override
-                        public FileVisitResult visitFileFailed(Path file, IOException exc) {
-                            return cap();
-                        }
-
-                        private FileVisitResult cap() {
-                            return ++visited[0] > MAX_VISIT || matches.size() >= MAX_MATCHES
-                                    ? FileVisitResult.TERMINATE
-                                    : FileVisitResult.CONTINUE;
-                        }
-                    });
-        } catch (IOException | RuntimeException ex) {
-            // Best effort — return whatever matched before the error.
+                    } else if ((includeHidden || !hidden)
+                            && name.toLowerCase(Locale.ROOT).contains(q)) {
+                        matches.add(p);
+                    }
+                }
+            } catch (IOException | RuntimeException ex) {
+                // Unreadable directory — skip it, keep searching the rest (best effort).
+            }
         }
         matches.sort(Comparator.comparing(p -> p.getFileName().toString(), String.CASE_INSENSITIVE_ORDER));
         return matches;

--- a/src/test/java/com/editora/ui/ProjectPanelSearchTest.java
+++ b/src/test/java/com/editora/ui/ProjectPanelSearchTest.java
@@ -1,0 +1,76 @@
+package com.editora.ui;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.io.TempDir;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Tests for {@link ProjectPanel#search} (the filter-box file search). The key case is the bug fix: a
+ * top-level dotfile like {@code .profile} must be found even when the root also contains subdirectories —
+ * the breadth-first walk visits shallow entries before descending, so a top-level match is never starved
+ * by a deep sibling subtree (the old depth-first walk could exhaust its visit budget inside a huge
+ * {@code .cache}/{@code node_modules} subtree before ever reaching it). Tagged fx only to keep class
+ * loading off the toolkit's path; {@code search} itself is pure file IO.
+ */
+@Tag("fx")
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class ProjectPanelSearchTest {
+
+    @BeforeAll
+    void setUp() throws Exception {
+        FxTestSupport.bootToolkit();
+    }
+
+    private static boolean containsName(List<Path> results, String name) {
+        return results.stream().anyMatch(p -> p.getFileName().toString().equals(name));
+    }
+
+    @Test
+    void findsTopLevelDotfileWhenShowingHidden(@TempDir Path root) throws Exception {
+        Files.writeString(root.resolve(".profile"), "export X=1\n");
+        Files.writeString(root.resolve("notes.txt"), "hi\n");
+        Files.createDirectories(root.resolve("sub")); // a sibling subtree that the old DFS could dive into
+        Files.writeString(root.resolve("sub/deep.txt"), "x\n");
+
+        List<Path> hits = ProjectPanel.search(root, ".profile", true);
+        assertTrue(containsName(hits, ".profile"), "top-level .profile is found (breadth-first)");
+    }
+
+    @Test
+    void hiddenFilesExcludedUnlessShowingHidden(@TempDir Path root) throws Exception {
+        Files.writeString(root.resolve(".profile"), "x\n");
+        assertTrue(ProjectPanel.search(root, "profile", false).isEmpty(), "dotfile excluded when not showing hidden");
+        assertTrue(
+                containsName(ProjectPanel.search(root, "profile", true), ".profile"), "included when showing hidden");
+    }
+
+    @Test
+    void findsNestedFilesAndSkipsHiddenDirsWhenNotShowingHidden(@TempDir Path root) throws Exception {
+        Files.createDirectories(root.resolve("sub"));
+        Files.writeString(root.resolve("sub/deep.txt"), "x\n");
+        Files.createDirectories(root.resolve(".hidden"));
+        Files.writeString(root.resolve(".hidden/secret.txt"), "x\n");
+
+        assertTrue(containsName(ProjectPanel.search(root, "deep", false), "deep.txt"), "nested non-hidden file found");
+        assertTrue(ProjectPanel.search(root, "secret", false).isEmpty(), "files under a dot-dir skipped (hidden off)");
+        assertTrue(
+                containsName(ProjectPanel.search(root, "secret", true), "secret.txt"),
+                "files under a dot-dir found when showing hidden");
+    }
+
+    @Test
+    void caseInsensitiveMatch(@TempDir Path root) throws Exception {
+        Files.writeString(root.resolve("README.md"), "x\n");
+        assertTrue(containsName(ProjectPanel.search(root, "readme", false), "README.md"));
+        assertFalse(ProjectPanel.search(root, "nomatch", false).stream().anyMatch(p -> true));
+    }
+}


### PR DESCRIPTION
**Bug:** in the Project / Current-Folder tool window, typing a filename like `.profile` returned nothing even though the file sits at the root of the folder (reported with a home-directory root).

**Cause:** `ProjectPanel.search` used a depth-first `Files.walkFileTree` with a 20,000-entry visit cap. Under a large root — a home dir with huge `.cache`/`.m2`/`.npm`/`node_modules` subtrees, especially with *show hidden* on (so dot-dirs are descended into) — the walk dives fully into the first big subtree and burns the entire budget there before it ever returns to visit a shallow, top-level file. So `.profile` was never reached → 0 matches → the panel showed just the root node with no children.

**Fix:** rewrote `search()` as a **bounded breadth-first** walk (a queue of directories, shallower entries processed before descending). Every top-level entry is matched in the first iteration, so a shallow file can never be starved by a deep sibling subtree. Same `MAX_VISIT`/`MAX_MATCHES`/`MAX_DEPTH` caps, same hidden-file/dir gating, same case-insensitive `contains` match — and BFS also tends to surface closer (more relevant) results first.

Added `ProjectPanelSearchTest` (top-level dotfile found, hidden gating, nested files, dot-dir skip, case-insensitivity). `./mvnw verify` green (1259 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)