### PR TITLE
Add a clear (✕) button to the Project filter box

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Clear (✕) button on the Project / Current-Folder filter.** A small clear button appears at the right of the filter box once you've typed something; clicking it empties the filter (restoring the full tree) and returns focus to the field. It's hidden whenever the filter is empty.
+
 - **"Beta" pills in the Settings sidebar.** Still-beta features (Language Servers, Debugger, Web — HTTP client + HTML preview, Templates, Git, Remote, MCP) now show a small *Beta* pill beside their name in the Settings category list, so their maturity is clear at a glance.
 - **One-click install completed for the binary-only language servers** — C/C++ (`clangd`), XML (`lemminx`), Kotlin (`kotlin-language-server`), Terraform (`terraform-ls`), and Lua (`lua-language-server`). Editora downloads the right per-OS/architecture release archive (from GitHub releases, or releases.hashicorp.com for terraform-ls), extracts it into `~/.editora/plugins/lsp/<server>/`, and points that server's command at the extracted binary — so every supported language server now has an in-app installer (Install… button / banner / **Install: Language Server…** picker). With this, all 21 language servers across the npm, toolchain, and binary tiers are covered.
 

--- a/src/main/java/com/editora/ui/ProjectPanel.java
+++ b/src/main/java/com/editora/ui/ProjectPanel.java
@@ -19,17 +19,20 @@ import javafx.application.Platform;
 import javafx.collections.ObservableList;
 import javafx.geometry.Pos;
 import javafx.scene.control.Alert;
+import javafx.scene.control.Button;
 import javafx.scene.control.ButtonType;
 import javafx.scene.control.ContextMenu;
 import javafx.scene.control.Label;
 import javafx.scene.control.Menu;
 import javafx.scene.control.MenuItem;
 import javafx.scene.control.TextField;
+import javafx.scene.control.Tooltip;
 import javafx.scene.control.TreeCell;
 import javafx.scene.control.TreeItem;
 import javafx.scene.control.TreeView;
 import javafx.scene.input.KeyEvent;
 import javafx.scene.input.MouseButton;
+import javafx.scene.layout.HBox;
 import javafx.scene.layout.Priority;
 import javafx.scene.layout.StackPane;
 import javafx.scene.layout.VBox;
@@ -90,6 +93,9 @@ public class ProjectPanel extends VBox implements ToolWindowContent {
     private OverlayInput.Prompt prompt;
 
     private final TextField filterField = new TextField();
+    /** Filter row: the text field plus a trailing clear ("✕") button shown only while there's text. */
+    private final HBox filterBar = new HBox();
+
     private final TreeView<Path> tree = new TreeView<>();
     private final StackPane placeholderPane;
     private final PauseTransition filterDebounce = new PauseTransition(Duration.millis(150));
@@ -186,6 +192,24 @@ public class ProjectPanel extends VBox implements ToolWindowContent {
             }
         });
         filterDebounce.setOnFinished(e -> rebuildBody());
+
+        // Trailing clear button — visible only while the filter has text; clicking it empties the filter
+        // (which restores the lazy tree via the debounce) and returns focus to the field.
+        Button clear = new Button("✕");
+        clear.getStyleClass().add("project-filter-clear");
+        clear.setFocusTraversable(false);
+        clear.setTooltip(new Tooltip(tr("project.filterClear")));
+        clear.setOnAction(e -> {
+            filterField.clear();
+            filterField.requestFocus();
+        });
+        clear.visibleProperty().bind(filterField.textProperty().isEmpty().not());
+        clear.managedProperty().bind(clear.visibleProperty()); // reclaim its width when hidden
+
+        HBox.setHgrow(filterField, Priority.ALWAYS);
+        filterBar.getStyleClass().add("project-filter-bar");
+        filterBar.setAlignment(Pos.CENTER);
+        filterBar.getChildren().setAll(filterField, clear);
     }
 
     /** Re-renders the visible tree cells so each file's modified marker/color reflects current state. */
@@ -318,7 +342,7 @@ public class ProjectPanel extends VBox implements ToolWindowContent {
                 });
             });
         }
-        getChildren().setAll(filterField, tree);
+        getChildren().setAll(filterBar, tree);
         syncWatches(); // register the (new) tree's directories with the filesystem watcher
     }
 

--- a/src/main/resources/com/editora/i18n/messages.properties
+++ b/src/main/resources/com/editora/i18n/messages.properties
@@ -957,6 +957,7 @@ bookmarks.deleteFileBody=Remove all bookmarks in "{0}"?
 # ---- Project panel ----
 project.placeholder=No project open
 project.filterPrompt=Search files…
+project.filterClear=Clear filter
 project.renameTitle=Rename
 project.renameContent=New name:
 project.deleteFileTitle=Delete File

--- a/src/main/resources/com/editora/i18n/messages_de.properties
+++ b/src/main/resources/com/editora/i18n/messages_de.properties
@@ -953,6 +953,7 @@ bookmarks.deleteFileBody=Alle Lesezeichen in „{0}“ entfernen?
 # ---- Project panel ----
 project.placeholder=Kein Projekt geöffnet
 project.filterPrompt=Dateien suchen…
+project.filterClear=Filter löschen
 project.renameTitle=Umbenennen
 project.renameContent=Neuer Name:
 project.deleteFileTitle=Datei löschen

--- a/src/main/resources/com/editora/i18n/messages_es.properties
+++ b/src/main/resources/com/editora/i18n/messages_es.properties
@@ -953,6 +953,7 @@ bookmarks.deleteFileBody=¿Quitar todos los marcadores de «{0}»?
 # ---- Project panel ----
 project.placeholder=Ningún proyecto abierto
 project.filterPrompt=Buscar archivos…
+project.filterClear=Borrar filtro
 project.renameTitle=Renombrar
 project.renameContent=Nuevo nombre:
 project.deleteFileTitle=Eliminar archivo

--- a/src/main/resources/com/editora/i18n/messages_fr.properties
+++ b/src/main/resources/com/editora/i18n/messages_fr.properties
@@ -953,6 +953,7 @@ bookmarks.deleteFileBody=Supprimer tous les signets dans « {0} » ?
 # ---- Project panel ----
 project.placeholder=Aucun projet ouvert
 project.filterPrompt=Rechercher des fichiers…
+project.filterClear=Effacer le filtre
 project.renameTitle=Renommer
 project.renameContent=Nouveau nom :
 project.deleteFileTitle=Supprimer le fichier

--- a/src/main/resources/com/editora/i18n/messages_it.properties
+++ b/src/main/resources/com/editora/i18n/messages_it.properties
@@ -953,6 +953,7 @@ bookmarks.deleteFileBody=Rimuovere tutti i segnalibri in «{0}»?
 # ---- Project panel ----
 project.placeholder=Nessun progetto aperto
 project.filterPrompt=Cerca file…
+project.filterClear=Cancella filtro
 project.renameTitle=Rinomina
 project.renameContent=Nuovo nome:
 project.deleteFileTitle=Elimina file

--- a/src/main/resources/com/editora/i18n/messages_pt.properties
+++ b/src/main/resources/com/editora/i18n/messages_pt.properties
@@ -953,6 +953,7 @@ bookmarks.deleteFileBody=Remover todos os marcadores em «{0}»?
 # ---- Project panel ----
 project.placeholder=Nenhum projeto aberto
 project.filterPrompt=Pesquisar arquivos…
+project.filterClear=Limpar filtro
 project.renameTitle=Renomear
 project.renameContent=Novo nome:
 project.deleteFileTitle=Excluir arquivo

--- a/src/main/resources/com/editora/styles/app.css
+++ b/src/main/resources/com/editora/styles/app.css
@@ -568,6 +568,23 @@
     -project-folder-color: -color-accent-fg;
     -project-file-color: -color-fg-muted;
 }
+
+/* Filter row: the search field + a trailing clear ("✕") button (shown only while there's text). */
+.project-filter-bar {
+    -fx-spacing: 2;
+}
+.project-filter-bar .project-filter-clear {
+    -fx-background-color: transparent;
+    -fx-background-radius: 4;
+    -fx-text-fill: -color-fg-muted;
+    -fx-padding: 0 6 0 6;
+    -fx-font-size: 11px;
+    -fx-cursor: hand;
+}
+.project-filter-bar .project-filter-clear:hover {
+    -fx-background-color: -color-neutral-muted;
+    -fx-text-fill: -color-fg-default;
+}
 .project-tree .tree-cell {
     -fx-text-fill: -color-fg-default;
     -fx-padding: 1 4 1 4;

--- a/src/test/java/com/editora/ui/ProjectPanelFilterClearFxTest.java
+++ b/src/test/java/com/editora/ui/ProjectPanelFilterClearFxTest.java
@@ -1,0 +1,56 @@
+package com.editora.ui;
+
+import javafx.scene.control.Button;
+import javafx.scene.control.TextField;
+import javafx.scene.layout.HBox;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Headless-FX coverage of the Project filter's clear ("✕") button: hidden while the filter is empty,
+ * shown once it has text, and clicking it empties the field (which hides it again).
+ */
+@Tag("fx")
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class ProjectPanelFilterClearFxTest {
+
+    @BeforeAll
+    void setUp() throws Exception {
+        FxTestSupport.bootToolkit();
+    }
+
+    private static ProjectPanel newPanel() throws Exception {
+        return FxTestSupport.callOnFx(() -> new ProjectPanel(p -> {}, (a, b) -> {}, p -> {}, p -> false));
+    }
+
+    private static Button clearButton(ProjectPanel panel) {
+        HBox bar = FxTestSupport.field(panel, "filterBar");
+        return (Button) bar.getChildren().stream()
+                .filter(n -> n instanceof Button)
+                .findFirst()
+                .orElseThrow();
+    }
+
+    @Test
+    void clearButtonVisibilityTracksFilterText() throws Exception {
+        ProjectPanel panel = newPanel();
+        TextField filter = FxTestSupport.field(panel, "filterField");
+        Button clear = clearButton(panel);
+
+        assertFalse(FxTestSupport.callOnFx(clear::isVisible), "hidden while the filter is empty");
+
+        FxTestSupport.runOnFx(() -> filter.setText("foo"));
+        assertTrue(FxTestSupport.callOnFx(clear::isVisible), "shown once there is text");
+        assertTrue(FxTestSupport.callOnFx(clear::isManaged), "managed so it occupies space only when shown");
+
+        FxTestSupport.runOnFx(clear::fire);
+        assertTrue(FxTestSupport.callOnFx(() -> filter.getText().isEmpty()), "clicking it empties the filter");
+        assertFalse(FxTestSupport.callOnFx(clear::isVisible), "hidden again after clearing");
+    }
+}


### PR DESCRIPTION
Adds a small clear button to the Project / Current-Folder filter, shown **only while the filter has text** (per request).

- The filter row is now an `HBox` of the search field + a trailing `✕` button.
- The button's `visible`/`managed` are bound to `filterField.textProperty().isEmpty().not()`, so it appears once you type and collapses (reclaiming width) when empty.
- Clicking it empties the filter — which restores the full lazy tree via the existing debounce — and returns focus to the field.
- New i18n key `project.filterClear` in all six catalogs (tooltip); `.project-filter-clear` CSS is theme-aware via AtlantaFX `-color-*` vars.

`ProjectPanelFilterClearFxTest` covers: hidden when empty → shown with text → click clears and re-hides. `./mvnw verify` green (1260 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)