### PR TITLE
Fix command palette: click-to-run + stray description line

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Test coverage: added unit tests + ratcheted the JaCoCo floors.** New tests for `config` models/stores (`Breakpoint`, `BreakpointStore`, `RecentFiles`, plus `FileIdentity` null/empty branches) raised `config` line coverage to ~88%, and new `InstallService` tests cover `findBinary`/`makeExecutable`/`Result`. The per-package `jacoco-check` floors were ratcheted to sit a few points below the measured coverage (migration·diff 0.85→0.90, config split out at 0.86, template·editorconfig 0.80→0.82, completion·http·pdf 0.68→0.70).
 
 ### Fixed
+- **Command palette: clicking a result now runs it.** A card-wide `MOUSE_CLICKED` consume filter was swallowing the result cells' click-to-run handler (only Enter worked).
+- **Command palette: removed the stray separator line above the command description.**
 
 - **Project / Current-Folder filter now finds top-level files in a large root.** The filter-box search walked the tree depth-first, so under a big root (e.g. a home directory with huge `.cache`/`.m2`/`node_modules` subtrees) it exhausted its visit budget deep inside one subtree before ever reaching a shallow file like `.profile` — which then never appeared in the results. The search is now breadth-first, visiting every shallower entry before descending, so top-level matches are never starved by a deep sibling subtree.
 

--- a/src/main/java/com/editora/ui/CommandPalette.java
+++ b/src/main/java/com/editora/ui/CommandPalette.java
@@ -17,7 +17,6 @@ import javafx.scene.control.ListView;
 import javafx.scene.control.TextField;
 import javafx.scene.input.KeyEvent;
 import javafx.scene.input.MouseButton;
-import javafx.scene.input.MouseEvent;
 import javafx.scene.layout.HBox;
 import javafx.scene.layout.Priority;
 import javafx.scene.layout.Region;
@@ -139,8 +138,9 @@ public class CommandPalette {
         content.setMaxSize(620, Region.USE_PREF_SIZE); // hug its content; don't stretch to fill the overlay
         // Editor-context chords (C-n/C-p/arrows) are left to the palette's own handler while it's open.
         content.getProperties().put("editora.ownsKeys", Boolean.TRUE);
-        // Clicks on the card must not reach the backdrop (which hides the palette).
-        content.addEventFilter(MouseEvent.MOUSE_CLICKED, MouseEvent::consume);
+        // (No MOUSE_CLICKED consume on the card: the backdrop dismisses on MOUSE_PRESSED targeted at
+        // itself, so a click inside the card never reaches it — and consuming MOUSE_CLICKED here would
+        // swallow the result cells' own click-to-run handler.)
     }
 
     /** Injects the shared overlay host used to show the palette card. */

--- a/src/main/resources/com/editora/styles/app.css
+++ b/src/main/resources/com/editora/styles/app.css
@@ -1323,8 +1323,6 @@
     -fx-text-fill: -color-fg-muted;
     -fx-font-size: 12px;
     -fx-padding: 6 4 2 4;
-    -fx-border-color: -color-border-default transparent transparent transparent;
-    -fx-border-width: 1 0 0 0;
 }
 
 .find-bar {


### PR DESCRIPTION
Two command-palette fixes:

- **Clicking a result now runs it.** The palette card had a `content.addEventFilter(MOUSE_CLICKED, MouseEvent::consume)` that swallowed the result cells' own click-to-run handler in the capturing phase — selection happens on `MOUSE_PRESSED` (so highlighting worked), but the run on `MOUSE_CLICKED` never fired, so only Enter worked. Removed it; the backdrop dismisses on `MOUSE_PRESSED` targeted at *itself*, so a click inside the card never reaches it and the filter was unnecessary.
- **Removed the stray separator line above the command description** (`.palette-desc` had a top border).

QuickOpen pickers don't use that filter, so they were unaffected and are untouched.

`./mvnw verify` green (1261 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)