### PR TITLE
Fix: console fonts via the font property, not setStyle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Test coverage: added unit tests + ratcheted the JaCoCo floors.** New tests for `config` models/stores (`Breakpoint`, `BreakpointStore`, `RecentFiles`, plus `FileIdentity` null/empty branches) raised `config` line coverage to ~88%, and new `InstallService` tests cover `findBinary`/`makeExecutable`/`Result`. The per-package `jacoco-check` floors were ratcheted to sit a few points below the measured coverage (migration·diff 0.85→0.90, config split out at 0.86, template·editorconfig 0.80→0.82, completion·http·pdf 0.68→0.70).
 
 ### Fixed
+- **Tool-window consoles now actually pick up the editor font.** The previous attempt set `-fx-font-size` via `setStyle`, which a JavaFX `TextArea` ignores; the consoles (External Tools / Run / Debug) now set the control's `font` property directly so they match the editor's family + size.
 - **Command palette: clicking a result now runs it.** A card-wide `MOUSE_CLICKED` consume filter was swallowing the result cells' click-to-run handler (only Enter worked).
 - **Command palette: removed the stray separator line above the command description.**
 

--- a/src/main/java/com/editora/ui/DebugPanel.java
+++ b/src/main/java/com/editora/ui/DebugPanel.java
@@ -584,9 +584,11 @@ public final class DebugPanel extends VBox implements ToolWindowContent {
         }
     }
 
-    /** Matches the console font to the editor's code-area font (family + effective size). */
+    /** Matches the console font to the editor's code-area font (family + effective size). Sets the
+     *  control's {@code font} property directly (user-set, so the {@code .debug-console} stylesheet rule
+     *  can't override it) rather than {@code -fx-font-size} via setStyle, which a TextArea ignores. */
     public void setConsoleFont(String family, int size) {
-        console.setStyle("-fx-font-family: \"" + family + "\"; -fx-font-size: " + size + "px;");
+        console.setFont(javafx.scene.text.Font.font(family, size));
     }
 
     /** Appends program/console output (trimmed to a cap), auto-scrolling to the bottom. */

--- a/src/main/java/com/editora/ui/ExternalToolPanel.java
+++ b/src/main/java/com/editora/ui/ExternalToolPanel.java
@@ -58,9 +58,11 @@ public final class ExternalToolPanel extends VBox implements ToolWindowContent {
         this.onLink = onLink;
     }
 
-    /** Matches the console font to the editor's code-area font (family + effective size). */
+    /** Matches the console font to the editor's code-area font (family + effective size). Sets the
+     *  control's {@code font} property directly (user-set, so the {@code .run-output} stylesheet rule
+     *  can't override it) rather than {@code -fx-font-size} via setStyle, which a TextArea ignores. */
     public void setOutputFont(String family, int size) {
-        output.setStyle("-fx-font-family: \"" + family + "\"; -fx-font-size: " + size + "px;");
+        output.setFont(javafx.scene.text.Font.font(family, size));
     }
 
     /** Clears the output console (the Clear button + the {@code externalTool.clearOutput} palette command). */

--- a/src/main/java/com/editora/ui/RunPanel.java
+++ b/src/main/java/com/editora/ui/RunPanel.java
@@ -95,9 +95,11 @@ public final class RunPanel extends VBox implements ToolWindowContent {
         this.onLink = onLink;
     }
 
-    /** Matches the console font to the editor's code-area font (family + effective size). */
+    /** Matches the console font to the editor's code-area font (family + effective size). Sets the
+     *  control's {@code font} property directly (user-set, so the {@code .run-output} stylesheet rule
+     *  can't override it) rather than {@code -fx-font-size} via setStyle, which a TextArea ignores. */
     public void setOutputFont(String family, int size) {
-        output.setStyle("-fx-font-family: \"" + family + "\"; -fx-font-size: " + size + "px;");
+        output.setFont(javafx.scene.text.Font.font(family, size));
     }
 
     /** Double-clicking a console line that holds a stack-trace location jumps to it. Shared with the


### PR DESCRIPTION
Follow-up to #220. The consoles still didn't match the editor font after rebuild because the previous attempt set `-fx-font-size` via `setStyle`, which a JavaFX `TextArea` **ignores** for its rendered text (it works for the editor's RichTextFX `CodeArea`, but not a plain `TextArea`).

Now the External Tools / Run / Debug consoles set the control's **`font` property** directly (`setFont(Font.font(family, size))`) — rendered by the skin, and (being user-set) immune to the `.run-output`/`.debug-console` stylesheet rule. They now match the editor's family + effective (zoomed) size, applied at startup and on every settings/zoom change.

`./mvnw verify` green (1261 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)