### PR TITLE
Fix: stop console CSS overriding the editor-matched font

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Test coverage: added unit tests + ratcheted the JaCoCo floors.** New tests for `config` models/stores (`Breakpoint`, `BreakpointStore`, `RecentFiles`, plus `FileIdentity` null/empty branches) raised `config` line coverage to ~88%, and new `InstallService` tests cover `findBinary`/`makeExecutable`/`Result`. The per-package `jacoco-check` floors were ratcheted to sit a few points below the measured coverage (migration·diff 0.85→0.90, config split out at 0.86, template·editorconfig 0.80→0.82, completion·http·pdf 0.68→0.70).
 
 ### Fixed
+- **Tool-window consoles really match the editor font now.** The `.run-output`/`.debug-console` CSS carried a `-fx-font-size` that overrode the programmatic font on every CSS pass, so the External Tools / Run / Debug consoles kept rendering at 12px regardless. Removed the font from those CSS rules so the editor-matched `setFont` sticks (guarded by a new `ConsoleFontFxTest`).
 - **Tool-window consoles now actually pick up the editor font.** The previous attempt set `-fx-font-size` via `setStyle`, which a JavaFX `TextArea` ignores; the consoles (External Tools / Run / Debug) now set the control's `font` property directly so they match the editor's family + size.
 - **Command palette: clicking a result now runs it.** A card-wide `MOUSE_CLICKED` consume filter was swallowing the result cells' click-to-run handler (only Enter worked).
 - **Command palette: removed the stray separator line above the command description.**

--- a/src/main/resources/com/editora/styles/app.css
+++ b/src/main/resources/com/editora/styles/app.css
@@ -1575,17 +1575,16 @@
 
 /* Run tool window (Java 25 compact source files). */
 .run-panel .run-status { -fx-text-fill: -color-fg-muted; }
-.run-panel .run-output {
-    -fx-font-family: "JetBrains Mono", monospace;
-    -fx-font-size: 12px;
-}
+/* No font here: the Run/External-Tools console font is set programmatically to match the editor
+   (RunPanel/ExternalToolPanel.setOutputFont). A -fx-font-size rule here overrides that on every CSS
+   pass, so the family/size are deliberately left to the control's font property. */
 /* Debug tool window: muted status + section labels; monospace console. Dense like the Structure/Git
    panels — borderless transparent lists with tight cells, flattened split panes, compact toolbar. */
 .debug-panel .debug-status { -fx-text-fill: -color-fg-muted; }
 .debug-panel .debug-section { -fx-text-fill: -color-fg-muted; -fx-font-size: 11px; -fx-font-weight: bold; }
 .debug-panel .debug-console {
-    -fx-font-family: "JetBrains Mono", monospace;
-    -fx-font-size: 12px;
+    /* Font set programmatically to match the editor (DebugPanel.setConsoleFont); a -fx-font-size here
+       would override it on every CSS pass. */
     -fx-background-insets: 0;
     -fx-border-width: 0;
 }

--- a/src/test/java/com/editora/ui/ConsoleFontFxTest.java
+++ b/src/test/java/com/editora/ui/ConsoleFontFxTest.java
@@ -1,0 +1,51 @@
+package com.editora.ui;
+
+import javafx.scene.Scene;
+import javafx.scene.control.TextArea;
+import javafx.scene.layout.StackPane;
+import javafx.scene.text.Font;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Guards that a tool-window console's programmatic font ({@code setOutputFont}/{@code setConsoleFont},
+ * used to match the editor) survives a CSS pass. Regression test: a {@code -fx-font-size} rule on
+ * {@code .run-output}/{@code .debug-console} used to override the control's font property on every
+ * {@code applyCss}, so the consoles never matched the editor.
+ */
+@Tag("fx")
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class ConsoleFontFxTest {
+
+    @BeforeAll
+    void setUp() throws Exception {
+        FxTestSupport.bootToolkit();
+    }
+
+    @Test
+    void consoleFontSurvivesCssPass() throws Exception {
+        FxTestSupport.runOnFx(() -> {
+            RunPanel run = new RunPanel(() -> {});
+            run.setOutputFont("JetBrains Mono", 17);
+            TextArea out = FxTestSupport.field(run, "output");
+
+            StackPane root = new StackPane(out);
+            Scene scene = new Scene(root, 400, 300);
+            scene.getStylesheets()
+                    .add(RunPanel.class
+                            .getResource("/com/editora/styles/app.css")
+                            .toExternalForm());
+            root.applyCss();
+            root.layout();
+
+            Font f = out.getFont();
+            assertEquals("JetBrains Mono", f.getFamily(), "family kept after CSS pass");
+            assertEquals(17.0, f.getSize(), 0.001, "size kept after CSS pass (CSS must not override setFont)");
+        });
+    }
+}


### PR DESCRIPTION
Third time's the charm — and now with a proof + regression test.

#220 (setStyle) and #221 (setFont) both set the console font correctly, but the consoles still rendered at 12px because the **`.run-output`/`.debug-console` CSS `-fx-font-size: 12px`** re-applied on every CSS pass and overrode the programmatic font. Verified headlessly:

```
setOutputFont(17)  → JetBrains Mono 17.0
applyCss(app.css)  → JetBrains Mono 12.0   ← CSS clobbers it
(after removing the CSS font) applyCss → 17.0  ← sticks
```

- Removed `-fx-font-family`/`-fx-font-size` from `.run-output` and `.debug-console` (kept the other `.debug-console` props). The font is now owned solely by the control's `font` property, set to the editor's family + effective size via `RunPanel`/`ExternalToolPanel.setOutputFont` and `DebugPanel.setConsoleFont` (applied at startup and on every settings/zoom change).
- Added `ConsoleFontFxTest`: sets the font, applies `app.css`, asserts size/family survive — guards the exact regression that recurred across #220/#221.

`./mvnw verify` green (1262 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)