### PR TITLE
Parse generic "rc" config files as INI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **The "install language support?" banner no longer shows when the language server is actually installed and running.** It was reading the server-availability flag before startup detection finished (and never re-checking), so it could falsely claim e.g. Java support was missing while jdtls was serving the file. The banner now only appears once a server is *confirmed* absent (not merely "not probed yet"), never when a live session is already serving the file, and re-evaluates as soon as detection settles. Also fixed the banner text dropping its apostrophe ("isnt") — the message runs through `MessageFormat`, where `'` must be doubled.
 
 ### Added
+- **Generic `rc` config files now highlight as INI.** An unrecognized runtime-config file whose name ends in `rc` (extension-less or a single-dot dotfile — e.g. `.vimrc`, `.inputrc`, `.screenrc`, `.curlrc`, `/etc/inputrc`) is parsed as INI. Specific rc formats still win (`.bashrc`=shell, `.npmrc`=ini, `.babelrc`=json, `.condarc`=yaml).
 - **Jump to next/previous TODO** — `todo.next` / `todo.previous` (`M-g ]` / `M-g [`) move the caret between TODO/FIXME (highlight-pattern) matches in the active file, wrapping around.
 - **Clickable inline note marker** — click a personal note's amber start triangle to edit it (restores the click-to-edit the old gutter marker had).
 - **`notes.toggleResolved`** — resolve/reopen the personal note at the caret from the keyboard (was panel-only).

--- a/src/main/java/com/editora/editor/ConfigFileType.java
+++ b/src/main/java/com/editora/editor/ConfigFileType.java
@@ -218,6 +218,17 @@ public final class ConfigFileType {
         if (lower.equals(".classpath") || lower.equals(".project")) {
             return "xml";
         }
+        // Generic "rc" config files not caught by a more specific rule above (e.g. .vimrc, .inputrc,
+        // .screenrc, .nanorc, .curlrc, .wgetrc, .netrc, .mailrc, /etc/inputrc): most "rc" runtime-config
+        // files are INI-style key/value, so default them to INI. Restricted to an extension-less name
+        // (or a single-dot dotfile) ending in "rc" so it can't hijack ordinary files that merely contain
+        // "rc" (e.g. march.txt → text via the extension map). Specific rc formats handled above win
+        // (.bashrc=shell, .npmrc=ini, .babelrc=json, .condarc=yaml, ...).
+        boolean dotfileNoExt = base.startsWith(".") && base.indexOf('.', 1) < 0;
+        boolean noExtension = base.indexOf('.') < 0;
+        if (lower.length() > 2 && lower.endsWith("rc") && (noExtension || dotfileNoExt)) {
+            return "ini";
+        }
         return null;
     }
 

--- a/src/test/java/com/editora/editor/ConfigFileTypeTest.java
+++ b/src/test/java/com/editora/editor/ConfigFileTypeTest.java
@@ -161,4 +161,26 @@ class ConfigFileTypeTest {
         assertNull(ConfigFileType.resolve("Main.java"));
         assertNull(ConfigFileType.resolve("/src/app.py"));
     }
+
+    @Test
+    void genericRcFilesDefaultToIni() {
+        // Unmatched "rc" runtime-config files → INI (dotfiles and /etc forms).
+        assertEquals("ini", ConfigFileType.resolve(".vimrc"));
+        assertEquals("ini", ConfigFileType.resolve(".inputrc"));
+        assertEquals("ini", ConfigFileType.resolve(".screenrc"));
+        assertEquals("ini", ConfigFileType.resolve(".nanorc"));
+        assertEquals("ini", ConfigFileType.resolve(".curlrc"));
+        assertEquals("ini", ConfigFileType.resolve(".netrc"));
+        assertEquals("ini", ConfigFileType.resolve("/home/me/.mailrc"));
+        assertEquals("ini", ConfigFileType.resolve("/etc/inputrc"));
+        // More specific rc rules above still win over the generic fallback.
+        assertEquals("shell", ConfigFileType.resolve(".bashrc"));
+        assertEquals("json", ConfigFileType.resolve(".babelrc"));
+        assertEquals("yaml", ConfigFileType.resolve(".condarc"));
+        // Ordinary files that merely contain/​end-ish with "rc" but have a real extension are untouched
+        // (so the caller's extension map decides — e.g. text for .txt).
+        assertNull(ConfigFileType.resolve("march.txt"));
+        assertNull(ConfigFileType.resolve(".eslintrc.json")); // extension map → json
+        assertNull(ConfigFileType.resolve("source.c")); // ends with "c", not "rc"
+    }
 }


### PR DESCRIPTION
Many runtime-config files use the `rc` naming convention and are INI-style key/value configs. A new fallback at the end of `ConfigFileType.resolve` defaults unrecognized `rc` files to INI, so `.vimrc`, `.inputrc`, `.screenrc`, `.nanorc`, `.curlrc`, `.netrc`, `/etc/inputrc`, … now highlight as INI (both the editor language and the TextMate grammar, since `resolve()` is shared).

**Scoping** (avoids false positives):
- Only fires for a name **ending in `rc`** that is **extension-less or a single-dot dotfile** — so `march.txt`, `.eslintrc.json`, and the Windows-resource-script `.rc` *extension* are left to the extension map.
- Specific rc formats above still take precedence: `.bashrc`→shell, `.npmrc`→ini, `.babelrc`→json, `.condarc`→yaml.

10 `ConfigFileTypeTest` cases (positives + precedence + negatives). `./mvnw verify` green (1263 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)