### PR TITLE
Keymaps editor: reveal Record/Reset only for the selected shortcut row

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Test coverage: added unit tests + ratcheted the JaCoCo floors.** New tests for `config` models/stores (`Breakpoint`, `BreakpointStore`, `RecentFiles`, plus `FileIdentity` null/empty branches) raised `config` line coverage to ~88%, and new `InstallService` tests cover `findBinary`/`makeExecutable`/`Result`. The per-package `jacoco-check` floors were ratcheted to sit a few points below the measured coverage (migration·diff 0.85→0.90, config split out at 0.86, template·editorconfig 0.80→0.82, completion·http·pdf 0.68→0.70).
 
 ### Changed
+- **Settings → Keymaps → Customize shortcuts now reveals the Record/Reset buttons only for the selected row.** Every command row used to show both buttons, cluttering the long list; a row's actions now appear only when you click to select it (the selected row is highlighted), so the list reads as a clean command + chord table.
 - **Save As from the command palette (or a keybinding) now prompts for the path in-scene** instead of opening the native file chooser, keeping the keyboard flow mouse-free. The field is pre-filled with the current file's path (or the project folder + suggested name for an untitled buffer); a bare name resolves against that folder and `~` expands to home. The **toolbar Save-As button still opens the native file chooser** (it's a mouse action), and overwriting a different existing file asks for confirmation.
 
 ### Fixed

--- a/src/main/java/com/editora/ui/SettingsWindow.java
+++ b/src/main/java/com/editora/ui/SettingsWindow.java
@@ -158,6 +158,7 @@ public class SettingsWindow {
     private TextField shortcutFilter; // filters the shortcut list
     private VBox shortcutListBox; // rebuilt from shortcutActions.rows() on each change/filter
     private String recordingCommandId; // command id whose row is currently capturing a chord, or null
+    private String selectedShortcutId; // command id of the selected row (shows its Record/Reset), or null
     private ComboBox<String> fontFamily;
     private Spinner<Integer> fontSize;
     private ComboBox<String> themeCombo;
@@ -1295,17 +1296,30 @@ public class SettingsWindow {
             Label chord = new Label(s.chord() == null ? tr("settings.shortcuts.unbound") : s.chord());
             chord.getStyleClass().add(s.chord() == null ? "shortcut-unbound" : "shortcut-chord");
             chord.setMinWidth(150);
-            Button record = new Button(tr("settings.shortcuts.record"));
-            record.setOnAction(e -> {
-                recordingCommandId = s.id();
-                refreshShortcuts();
+            row.getChildren().addAll(title, chord);
+            // Record/Reset are shown only for the selected row (click a row to reveal them), keeping the
+            // list uncluttered. Clicking the row selects it; the buttons then act on that command.
+            row.getStyleClass().add("shortcut-row-clickable");
+            row.setOnMouseClicked(e -> {
+                if (!s.id().equals(selectedShortcutId)) {
+                    selectedShortcutId = s.id();
+                    refreshShortcuts();
+                }
             });
-            Button reset = new Button(tr("settings.shortcuts.reset"));
-            reset.setOnAction(e -> {
-                shortcutActions.reset(s.id());
-                refreshShortcuts();
-            });
-            row.getChildren().addAll(title, chord, record, reset);
+            if (s.id().equals(selectedShortcutId)) {
+                row.getStyleClass().add("shortcut-row-selected");
+                Button record = new Button(tr("settings.shortcuts.record"));
+                record.setOnAction(e -> {
+                    recordingCommandId = s.id();
+                    refreshShortcuts();
+                });
+                Button reset = new Button(tr("settings.shortcuts.reset"));
+                reset.setOnAction(e -> {
+                    shortcutActions.reset(s.id());
+                    refreshShortcuts();
+                });
+                row.getChildren().addAll(record, reset);
+            }
         }
         return row;
     }

--- a/src/main/resources/com/editora/styles/app.css
+++ b/src/main/resources/com/editora/styles/app.css
@@ -1814,6 +1814,21 @@
     -fx-padding: 6 12 6 24;
 }
 
+/* Keymaps → Customize shortcuts: a row reveals its Record/Reset buttons only when selected
+   (click to select), so the list stays uncluttered. */
+.shortcut-row-clickable {
+    -fx-cursor: hand;
+    -fx-padding: 2 4 2 4;
+    -fx-background-radius: 4;
+}
+.shortcut-row-clickable:hover {
+    -fx-background-color: -color-bg-subtle;
+}
+.shortcut-row-selected {
+    -fx-background-color: -color-accent-subtle;
+    -fx-background-radius: 4;
+}
+
 /* Small "Beta" pill shown beside a still-beta feature's name in the Settings sidebar. */
 .settings-beta-pill {
     -fx-background-color: -color-accent-muted;


### PR DESCRIPTION
Settings → Keymaps → **Customize shortcuts** showed a **Record** and **Reset** button on *every* command row, cluttering the long list.

Now a row reveals its two buttons **only when selected** — click a row to select it (the selected row is highlighted); the buttons then act on that command. Recording and reset behavior is unchanged. This makes the list read as a clean command + chord table.

## Changes
- `SettingsWindow`: new `selectedShortcutId` field; `shortcutRow` renders the Record/Reset buttons (and the `.shortcut-row-selected` highlight) only for the selected command, and makes each row click-to-select.
- `app.css`: `.shortcut-row-clickable` (hand cursor + hover) and `.shortcut-row-selected`.
- CHANGELOG.

## Verification
`./mvnw verify` green (Spotless + tests + JaCoCo). UI-only change; the recording flow (capture field / Save / Cancel) and Reset-all are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)