### PR TITLE
Fix Markdown Insert Table size picker filling the editor area

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Markdown "Insert Table" size picker no longer fills the editor.** The grid picker was stretched to
+  cover the whole code area; it now hugs the grid (with padding) and is centered.
+
 - **Structure tool window: methods no longer show a doubled `()`.** When a language server (e.g. jdtls)
   already includes the parameter list in a method's name (`setX(Foo)`), the outline no longer appended a
   redundant empty `()` — so it reads `setX(Foo)` instead of `setX(Foo)()`.

--- a/src/main/java/com/editora/ui/MainController.java
+++ b/src/main/java/com/editora/ui/MainController.java
@@ -7274,6 +7274,9 @@ public class MainController implements com.editora.mcp.McpBridge {
         javafx.scene.layout.VBox card = new javafx.scene.layout.VBox(8);
         card.getStyleClass().add("table-size-picker");
         card.setPadding(new javafx.geometry.Insets(12));
+        // Hug the grid + padding — without a max-size cap the StackPane overlay stretches the card to fill
+        // the whole editor area (like QuickOpen's card, which caps to its preferred size).
+        card.setMaxSize(javafx.scene.layout.Region.USE_PREF_SIZE, javafx.scene.layout.Region.USE_PREF_SIZE);
         Label heading = new Label(tr("table.picker.prompt"));
         heading.getStyleClass().add("table-size-label");
         javafx.scene.layout.GridPane grid = new javafx.scene.layout.GridPane();
@@ -7314,7 +7317,7 @@ public class MainController implements com.editora.mcp.McpBridge {
         }
         card.getChildren().addAll(heading, grid);
         card.getProperties().put("editora.ownsKeys", true);
-        overlayHost.show(card, () -> {}, () -> {});
+        overlayHost.show(card, true, () -> {}, () -> {}); // centered — it's a small grid, not a top palette
     }
 
     private void markdownInline(String marker) {


### PR DESCRIPTION
## Summary

The Markdown **"Insert Table"** grid size-picker overlay was stretched to cover the whole code area (see screenshot in the issue), with the small 8×8 grid stuck in the top-left corner.

**Cause:** `showTableSizePicker` built the card `VBox` without a max-size cap. `OverlayHost` shows cards in a `StackPane`, which resizes a child up to its max size — so the card ballooned to fill the overlay. (`QuickOpen` already guards against this with `setMaxSize(..., USE_PREF_SIZE)`.)

**Fix:**
- `card.setMaxSize(USE_PREF_SIZE, USE_PREF_SIZE)` — the card hugs the grid + its existing 12px padding.
- `overlayHost.show(card, true, …)` — centered instead of top-anchored.

## Notes
- No new dependency / i18n / schema change.
- UI-geometry fix (JavaFX overlay), not exercisable in the headless FX harness; verified via `./mvnw verify` (BUILD SUCCESS) + the identical pattern QuickOpen uses.
- CHANGELOG updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)