### PR TITLE
Package release builds from a clean tree (fixes installer dead-keyboard)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,7 +45,12 @@ jobs:
 
       - name: Build native installer (-Pdist)
         shell: bash
-        run: ./mvnw -B --no-transfer-progress -Pdist -DskipTests package
+        # `clean` is REQUIRED, not just tidiness: an incremental compile does not regenerate a synthetic
+        # `$SwitchMap` inner class (e.g. KeyDispatcher$1 for an enum `switch`) that a prior/parallel build
+        # or an IDE compiler left deleted in target/classes — javac sees the .java as up-to-date and skips
+        # it. jlink then ships a jimage missing that class and the packaged app throws ClassNotFoundException
+        # on the first keypress. A clean target/ guarantees every class is regenerated.
+        run: ./mvnw -B --no-transfer-progress clean -Pdist -DskipTests package
 
       # Portable single-file Linux build from the AOT-trained app-image (no sandbox — host tools work;
       # see scripts/build-appimage.sh). Best-effort: continue-on-error so a flaky appimagetool / FUSE /

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Release builds package from a clean tree, fixing a rare "dead keyboard" in the installer.** The
+  native-installer build fed jlink from an incrementally-compiled `target/`, where a synthetic
+  `$SwitchMap` class (emitted for a `switch` over an enum, e.g. the key dispatcher's) could go missing if
+  a background compiler or an interrupted build left `target/classes` inconsistent — javac won't
+  regenerate it while the source looks up-to-date. The packaged app then threw a `ClassNotFoundException`
+  on the first keypress. The release workflow now runs `clean` before `-Pdist`, guaranteeing every class
+  is regenerated. (Only the native installers could be affected, and only when built from a dirty tree;
+  `mvn javafx:run` and the fat jar were never affected.)
+
 - **Markdown "Insert Table" size picker no longer fills the editor.** The grid picker was stretched to
   cover the whole code area; it now hugs the grid (with padding) and is centered.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,9 +7,18 @@ Maven, modular (JPMS, module `com.editora`).
 
 - Run the app: `mvn javafx:run`
 - Run tests: `mvn test`
-- Build app image / native installer: `mvn -Pdist package`
+- Build app image / native installer: **`mvn clean -Pdist package`** (`clean` is REQUIRED, not optional).
   - Produces `target/dist/Editora.app` (macOS); OS profiles auto-select DMG/MSI/DEB.
-  - Quick unpackaged bundle: `mvn -Pdist -DskipTests -Djpackage.type=APP_IMAGE package` ⇒ `target/dist/Editora.app`.
+  - Quick unpackaged bundle: `mvn clean -Pdist -DskipTests -Djpackage.type=APP_IMAGE package` ⇒ `target/dist/Editora.app`.
+  - **Always package from a clean `target/`.** The dist JAR (jlink's input for the `com.editora` module)
+    is built from `target/classes`; an **incremental** compile does **not** regenerate a synthetic
+    `$SwitchMap` inner class (e.g. `KeyDispatcher$1`, `QuickOpen$1`, `MarkdownViewToggle$1`, emitted for a
+    `switch` over an *external* enum) once it's missing — javac sees the `.java` as up-to-date and skips
+    it. Anything that leaves `target/classes` inconsistent — a background **jdtls/Eclipse** compiler
+    writing there, an interrupted build, a partial clean — then makes `-Pdist package` ship a jimage
+    **missing that class**, and the packaged app throws `ClassNotFoundException` on the **first keypress**
+    (dead keyboard). A `clean` regenerates every class and avoids it. `release.yml`'s `-Pdist` step runs
+    `clean` for this reason. (`mvn javafx:run` and the fat jar are immune — they don't jlink a stale JAR.)
   - **Both** also run the AOT-cache training step (a GUI window flashes for ~2.5 s, then the build
     injects `editora.aot`) — see the AOT-cache note under *Conventions → performance*. It's
     failure-tolerant, so on a display-less machine it just skips the cache.


### PR DESCRIPTION
## Summary

Fixes a rare "keyboard is dead in the packaged app" crash — `NoClassDefFoundError: com/editora/command/KeyDispatcher$1` (and `QuickOpen$1`, `MarkdownViewToggle$1`) on the **first keypress** in a native installer — by packaging from a clean tree.

### Root cause (not AOT)

The dist build feeds jlink from the JAR built off `target/classes`. A synthetic `$SwitchMap` inner class (emitted for a `switch` over an *external* enum, e.g. `KeyDispatcher`'s over javafx `KeyCode`) can go **missing** from `target/classes` if a background compiler (jdtls/Eclipse) or an interrupted build leaves it inconsistent — and an **incremental** `mvn compile` will **not** regenerate it, because javac sees the `.java` as up-to-date and skips it. `-Pdist package` (no `clean`) then ships a jimage missing that class, and the app throws `ClassNotFoundException` on the first key event.

Proven: deleting `target/classes/.../KeyDispatcher$1.class` and re-running `mvn compile` does **not** bring it back; a `clean` does. This is independent of the AOT cache (which is left enabled) — `mvn javafx:run` and the fat jar were never affected, and it only bites when the installer is built from a dirty tree. Explains "worked for weeks with the same JDK": those were clean builds / fresh CI runners.

### Changes

- **`.github/workflows/release.yml`** — the `-Pdist` step now runs `clean` (with an explanatory comment). The `-Pfatjar` step is intentionally **not** cleaned: it runs before *Stage artifacts* and reuses the fresh tree, so a `clean` there would delete `target/dist` before the installers are staged.
- **CLAUDE.md** — build command is now `mvn clean -Pdist package`, with a note that packaging must run from a clean `target/` and why.
- **CHANGELOG.md** — Fixed entry.

Docs/workflow only; no code or `pom.xml` change, AOT cache untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)