### PR TITLE
Syntax highlighting for diff/patch, Makefile, justfile, proto, GraphQL, .properties, .gitattributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **More plain-text developer formats.** Syntax highlighting for **unified diffs** (`.diff`/`.patch` —
+  added/removed lines tint green/red, hunk headers stand out), **Makefiles** (`Makefile`/`GNUmakefile`/`.mk`),
+  **justfiles**, **Protocol Buffers** (`.proto`), **GraphQL** (`.graphql`/`.gql`), and **`.gitattributes`**
+  (including a repo's `.git/info/attributes`). Java **`.properties`** files get a dedicated grammar
+  (`:` and `=` separators, Unicode escapes, backslash line-continuations) instead of borrowing the INI one.
+  Proto and GraphQL also fold on braces and auto-indent like C-family code, and comment toggling
+  (`M-;`) works in all of them.
+
 - **Compare / Annotate in the Project tree.** The Project tool window's file **Git** submenu now also offers
   **Compare with Branch…** (diff the file against its version on any local or remote branch), **Compare with
   Revision…** (diff against a commit from the file's history), and **Annotate** (open the file and show inline

--- a/NOTICE
+++ b/NOTICE
@@ -28,7 +28,13 @@ desktop, and dotenv are under the MIT License). It also includes the SSH config
 grammar (ssh-config.tmLanguage.json), which shiki aggregates from
 textmate/ssh-config.tmbundle, distributed under that project's permissive
 license ("Permission to copy, use, modify, sell and distribute this software is
-granted ... provided 'as is' without warranty").
+granted ... provided 'as is' without warranty"), and the plain-text developer
+format grammars (all MIT): diff (diff.tmLanguage.json) and Makefile
+(makefile.tmLanguage.json), both aggregated from Microsoft Visual Studio Code
+(© Microsoft Corporation); Protocol Buffers (proto.tmLanguage.json) from
+zxh0/vscode-proto3; GraphQL (graphql.tmLanguage.json) from
+graphql/vscode-graphql (© GraphQL Contributors); and just
+(just.tmLanguage.json) from nefrob/vscode-just.
 
 The following grammars were instead obtained from the Eclipse tm4e
 "language_pack" (which curates grammars for the tm4e engine used here):
@@ -77,8 +83,10 @@ without warranty."
 The fstab, hosts, and Debian/Ubuntu grammars (fstab.tmLanguage.json,
 hosts.tmLanguage.json, deb822.tmLanguage.json, apt-sources.tmLanguage.json,
 interfaces.tmLanguage.json, debian-changelog.tmLanguage.json) — like the HTTP
-grammar (http.tmLanguage.json) — were written for Editora and are covered by
-Editora's own MIT License (above). The .properties files reuse the INI grammar.
+grammar (http.tmLanguage.json), the Java properties grammar
+(properties.tmLanguage.json), and the Git attributes grammar
+(gitattributes.tmLanguage.json) — were written for Editora and are covered by
+Editora's own MIT License (above).
 
 These remain under their original upstream licenses (predominantly MIT). All
 grammars are redistributed unmodified except markdown.tmLanguage.json (three
@@ -90,7 +98,8 @@ Languages bundled: Java, XML, shell, PowerShell, DOS batch, Python, Groovy,
 Kotlin, Ruby, C, C++, Rust, Go, C#, Markdown, JSON, CSS, HTML, YAML, INI, SQL,
 systemd, desktop entries, dotenv, SSH config, Git config, crontab, Caddyfile,
 fstab, hosts, .properties, deb822 (Debian control / APT sources), APT
-sources.list, network interfaces, Debian changelog.
+sources.list, network interfaces, Debian changelog, unified diff/patch,
+Makefile, justfile, Protocol Buffers, GraphQL, .gitattributes.
 
 ================================================================================
 Bundled fonts

--- a/README.md
+++ b/README.md
@@ -63,10 +63,13 @@ Editora is built with the help of AI coding tools.
   (On macOS, the Option dead keys `Option`+`e`/`i`/`u`/`n`/`` ` `` are intercepted by the OS for
   accent composition, so a few `M-`-chords like `M-e` aren't reachable by keyboard there — the
   command palette still works.)
-- **Syntax highlighting** — TextMate grammars (via [tm4e](https://github.com/eclipse/tm4e)) for 30+
-  languages: Java, TypeScript/JavaScript, XML, shell, PowerShell, DOS batch, Python, Groovy, Kotlin,
-  Ruby, PHP, C, C++, Rust, Go, C#, Lua, Markdown, JSON, CSS, HTML, YAML, INI, TOML, SQL, Dockerfile,
-  Terraform/HCL, Mermaid, and `.http`.
+- **Syntax highlighting** — TextMate grammars (via [tm4e](https://github.com/eclipse/tm4e)) for 40+
+  languages and formats: Java, TypeScript/JavaScript, XML, shell, PowerShell, DOS batch, Python,
+  Groovy, Kotlin, Ruby, PHP, C, C++, Rust, Go, C#, Lua, Markdown, JSON, CSS, HTML, YAML, INI, TOML,
+  SQL, Dockerfile, Terraform/HCL, Mermaid, `.http`, unified diffs (`.diff`/`.patch` — added/removed
+  lines tint green/red), Makefile, justfile, Protocol Buffers (`.proto`), GraphQL, Java
+  `.properties`, `.gitignore`/`.gitattributes`, dotenv, and common Linux/tool config files
+  (systemd units, SSH/Git config, crontab, hosts, fstab, …).
 - **Bundled fonts** — JetBrains Mono (default), Cascadia Code, Fira Code, IBM Plex Mono,
   and Source Code Pro ship with the app; no system install required.
 - **Editor view options** — 80-column ruler and current-line highlight.

--- a/TODO.md
+++ b/TODO.md
@@ -3,6 +3,15 @@
 A backlog of planned features and improvements. Unordered within each section.
 
 ## Recently shipped
+- [x] Plain-text developer formats — syntax highlighting for unified diffs (`.diff`/`.patch`, green/red
+      added/removed lines via new `.text.diff-*` semantic classes), Makefile (`Makefile`/`GNUmakefile`/`.mk`),
+      justfile, Protocol Buffers (`.proto`), GraphQL (`.graphql`/`.gql`), and `.gitattributes`
+      (+ `.git/info/attributes`); a dedicated Java `.properties` grammar (Unicode escapes, `:` separator,
+      `\`-continuations) replaces the INI borrow. Proto/GraphQL fold + auto-indent as brace languages;
+      comment toggling wired for all. Grammars vendored MIT from shiki tm-grammars (diff/make/proto/graphql/
+      just); properties/gitattributes written in-house.
+      *Deferred: "open this .patch in the diff viewer" action, LSP servers (buf / graphql-lsp), Makefile
+      forced-tab indent for brand-new files (existing files detect tabs).*
 - [x] Sample corpus for manual feature testing — a curated, feature-organized `samples/` folder (syntax per
       language, folding, indent, markdown, mermaid, todo, spell, search, editorconfig, http, log, diff,
       encodings) with a `README.md` manifest. `SamplesCorpusTest` guards manifest↔files sync + core-language

--- a/samples/README.md
+++ b/samples/README.md
@@ -27,6 +27,13 @@ as plain text (expected).
 `samples/syntax/sample.ps1`, `samples/syntax/sample.bat`, `samples/syntax/sample.groovy`,
 `samples/syntax/sample.ini`
 
+Plain-text developer formats: `samples/syntax/sample.patch` (unified diff — added/removed lines
+tint green/red), `samples/syntax/Makefile` (recipe lines are real tabs), `samples/syntax/justfile`,
+`samples/syntax/sample.proto`, `samples/syntax/sample.graphql`, `samples/syntax/sample.properties`
+(both `=`/`:` separators, escapes, backslash continuations). There is deliberately no
+`.gitattributes` sample — a real one would change Git's behavior for this folder (see
+*Conventions*); open any repo's `.gitattributes` to see that grammar.
+
 ## folding/ — nested fold regions
 
 - `samples/folding/deeply-nested.json` — collapse/expand several nested levels; the gutter chevrons

--- a/samples/syntax/Makefile
+++ b/samples/syntax/Makefile
@@ -1,0 +1,30 @@
+# Sample Makefile — targets, variables, functions, conditionals, recipes (real tabs).
+CC      := cc
+CFLAGS  ?= -O2 -Wall
+SRCS    := $(wildcard src/*.c)
+OBJS    := $(SRCS:.c=.o)
+PREFIX  ?= /usr/local
+
+.PHONY: all clean install
+
+all: app
+
+app: $(OBJS)
+	$(CC) $(CFLAGS) -o $@ $^
+
+%.o: %.c include/app.h
+	$(CC) $(CFLAGS) -c $< -o $@
+
+ifeq ($(OS),Windows_NT)
+EXE := .exe
+else
+EXE :=
+endif
+
+install: app
+	install -m 0755 app$(EXE) $(PREFIX)/bin/app
+
+clean:
+	rm -f app $(OBJS)   # continuation example follows
+	@echo "cleaned: \
+	all objects removed"

--- a/samples/syntax/justfile
+++ b/samples/syntax/justfile
@@ -1,0 +1,23 @@
+# Sample justfile — settings, variables, recipes with args and dependencies.
+set shell := ["bash", "-c"]
+
+version := "1.2.3"
+target  := env_var_or_default("TARGET", "debug")
+
+# build the app
+build:
+    cargo build --profile {{target}}
+
+# run the test suite (depends on build)
+test filter="": build
+    cargo test {{filter}}
+
+release: (tag version)
+    cargo publish
+
+tag v:
+    git tag -a "v{{v}}" -m "release v{{v}}"
+
+[private]
+clean:
+    rm -rf target

--- a/samples/syntax/sample.graphql
+++ b/samples/syntax/sample.graphql
@@ -1,0 +1,67 @@
+# Sample GraphQL schema + operations — types, interfaces, enums, directives, fragments.
+"""
+A user of the system.
+"""
+type User implements Node {
+  id: ID!
+  name: String!
+  email: String @deprecated(reason: "Use `emails` instead.")
+  emails: [String!]!
+  role: Role = MEMBER
+  posts(first: Int = 10, after: String): PostConnection!
+}
+
+interface Node {
+  id: ID!
+}
+
+enum Role {
+  ADMIN
+  MEMBER
+  GUEST
+}
+
+input NewPost {
+  title: String!
+  body: String
+  tags: [String!]
+}
+
+union SearchResult = User | Post
+
+type Post implements Node {
+  id: ID!
+  title: String!
+  author: User!
+}
+
+type PostConnection {
+  edges: [Post!]!
+  totalCount: Int!
+}
+
+type Query {
+  me: User
+  node(id: ID!): Node
+  search(term: String!): [SearchResult!]!
+}
+
+type Mutation {
+  createPost(input: NewPost!): Post!
+}
+
+# An operation with a fragment and variables.
+query CurrentUser($withPosts: Boolean! = true) {
+  me {
+    ...userFields
+    posts(first: 5) @include(if: $withPosts) {
+      totalCount
+    }
+  }
+}
+
+fragment userFields on User {
+  id
+  name
+  role
+}

--- a/samples/syntax/sample.patch
+++ b/samples/syntax/sample.patch
@@ -1,0 +1,20 @@
+diff --git a/src/greeter.py b/src/greeter.py
+index 3b18e51..9ae2f7c 100644
+--- a/src/greeter.py
++++ b/src/greeter.py
+@@ -1,7 +1,8 @@
+ """A tiny greeter."""
+
+-def greet(name):
+-    return "Hello, " + name
++def greet(name: str) -> str:
++    """Return a friendly greeting."""
++    return f"Hello, {name}!"
+
+ if __name__ == "__main__":
+     print(greet("Editora"))
+@@ -12,4 +13,3 @@
+ # trailing section
+ VERSION = "1.0"
+-DEBUG = True
+Only in b/src: helper.py

--- a/samples/syntax/sample.properties
+++ b/samples/syntax/sample.properties
@@ -1,0 +1,20 @@
+# Sample Java .properties — comments, both separators, escapes, continuations.
+! Exclamation comments work too (java.util.Properties).
+
+app.name = Editora Sample
+app.version=1.2.3
+app.description: A properties file exercising the grammar.
+
+# Unicode escapes and special characters in values.
+greeting = Hello! Café time…
+path.windows = C:\\Users\\editora\\config
+message.multiline = first part, \
+                    second part, \
+                    third part
+
+# Keys with escaped separators.
+key\ with\ spaces = spaces in the key
+key\:colon = escaped colon in the key
+
+empty.value =
+whitespace.separator only-whitespace-between-key-and-value

--- a/samples/syntax/sample.proto
+++ b/samples/syntax/sample.proto
@@ -1,0 +1,56 @@
+// Sample Protocol Buffers definition (proto3) — messages, enums, services, options.
+syntax = "proto3";
+
+package editora.sample.v1;
+
+import "google/protobuf/timestamp.proto";
+
+option java_package = "com.editora.sample.v1";
+option java_multiple_files = true;
+
+// A user account.
+message User {
+  string id = 1;
+  string display_name = 2;
+  repeated string emails = 3;
+  Status status = 4;
+  google.protobuf.Timestamp created_at = 5;
+
+  map<string, string> attributes = 6;
+
+  oneof avatar {
+    string avatar_url = 7;
+    bytes avatar_png = 8;
+  }
+
+  /* Nested message. */
+  message Address {
+    string street = 1;
+    string city = 2;
+    string country = 3;
+  }
+  Address address = 9;
+
+  reserved 20 to 29;
+  reserved "legacy_field";
+}
+
+enum Status {
+  STATUS_UNSPECIFIED = 0;
+  ACTIVE = 1;
+  SUSPENDED = 2;
+}
+
+service UserService {
+  rpc GetUser(GetUserRequest) returns (User);
+  rpc ListUsers(ListUsersRequest) returns (stream User);
+}
+
+message GetUserRequest {
+  string id = 1;
+}
+
+message ListUsersRequest {
+  int32 page_size = 1;
+  string page_token = 2;
+}

--- a/src/main/java/com/editora/editops/Commenter.java
+++ b/src/main/java/com/editora/editops/Commenter.java
@@ -41,7 +41,8 @@ public final class Commenter {
                     "javascript",
                     "typescript",
                     "javascriptreact",
-                    "typescriptreact" -> new CommentStyle("//", "/*", "*/");
+                    "typescriptreact",
+                    "proto" -> new CommentStyle("//", "/*", "*/");
             case "css" -> new CommentStyle(null, "/*", "*/");
             case "sql" -> new CommentStyle("--", "/*", "*/");
             case "lua" -> new CommentStyle("--", "--[[", "]]");
@@ -65,7 +66,12 @@ public final class Commenter {
                     "properties",
                     "deb822",
                     "apt-sources",
-                    "interfaces" -> new CommentStyle("#", null, null);
+                    "interfaces",
+                    "makefile",
+                    "just",
+                    "gitattributes",
+                    "ignore",
+                    "graphql" -> new CommentStyle("#", null, null);
             case "powershell" -> new CommentStyle("#", "<#", "#>");
             case "ini" -> new CommentStyle(";", null, null);
             case "batchfile" -> new CommentStyle("REM", null, null);

--- a/src/main/java/com/editora/editops/Indenter.java
+++ b/src/main/java/com/editora/editops/Indenter.java
@@ -169,6 +169,8 @@ public final class Indenter {
                     "sql",
                     "batchfile",
                     "terraform",
+                    "proto",
+                    "graphql",
                     "javascript",
                     "typescript",
                     "javascriptreact",

--- a/src/main/java/com/editora/editor/ConfigFileType.java
+++ b/src/main/java/com/editora/editor/ConfigFileType.java
@@ -42,6 +42,19 @@ public final class ConfigFileType {
         if (lower.equals(".env") || lower.startsWith(".env.") || lower.endsWith(".env")) {
             return "dotenv";
         }
+        // Makefile — extension-less ("Makefile"/"makefile"/"GNUmakefile") or a suffix form
+        // ("Makefile.inc"); the .mk/.mak/.make extensions are matched by the extension map.
+        if (lower.equals("makefile") || lower.equals("gnumakefile") || lower.startsWith("makefile.")) {
+            return "makefile";
+        }
+        // just command-runner file — "justfile"/".justfile" (case-insensitive by convention).
+        if (lower.equals("justfile") || lower.equals(".justfile")) {
+            return "just";
+        }
+        // Git attributes — ".gitattributes" anywhere, or the repo-local ".git/info/attributes".
+        if (lower.equals(".gitattributes") || (lower.equals("attributes") && hasAncestor(norm, ".git"))) {
+            return "gitattributes";
+        }
         // SSH client/daemon config — explicit names anywhere, "config" under a .ssh dir, or any file in
         // a drop-in dir (ssh_config.d / sshd_config.d, or .ssh/config.d). A bare "config" is matched only
         // via the .ssh ancestor (too generic otherwise).

--- a/src/main/java/com/editora/editor/FoldRegions.java
+++ b/src/main/java/com/editora/editor/FoldRegions.java
@@ -65,6 +65,8 @@ public final class FoldRegions {
                     "php",
                     "terraform",
                     "caddyfile",
+                    "proto",
+                    "graphql",
                     "javascript",
                     "typescript",
                     "javascriptreact",

--- a/src/main/java/com/editora/editor/GrammarRegistry.java
+++ b/src/main/java/com/editora/editor/GrammarRegistry.java
@@ -50,8 +50,6 @@ public final class GrammarRegistry {
         // The resource base name doubles as the language name (see LanguageRegistry), so the
         // inverse of scopeToResource resolves a language name to its scope.
         scopeToResource.forEach((scope, resource) -> languageNameToScope.put(resource, scope));
-        // ".properties" files are highlighted with the INI grammar but are their own language name.
-        languageNameToScope.put("properties", "source.ini");
         registry = new Registry(new IRegistryOptions() {
             @Override
             public IGrammarSource getGrammarSource(String scopeName) {
@@ -194,6 +192,13 @@ public final class GrammarRegistry {
         scopeToResource.put("source.debian-changelog", "debian-changelog");
         scopeToResource.put("source.log", "log");
         scopeToResource.put("source.ignore", "ignore"); // .gitignore / .dockerignore / .npmignore / …
+        scopeToResource.put("source.diff", "diff");
+        scopeToResource.put("source.makefile", "makefile");
+        scopeToResource.put("source.just", "just");
+        scopeToResource.put("source.proto", "proto");
+        scopeToResource.put("source.graphql", "graphql");
+        scopeToResource.put("source.java-properties", "properties");
+        scopeToResource.put("source.gitattributes", "gitattributes");
 
         // file extension -> scope name
         mapExtensions("source.java", "java");
@@ -215,7 +220,10 @@ public final class GrammarRegistry {
         mapExtensions("source.css", "css");
         mapExtensions("text.html.basic", "html", "htm", "xhtml");
         mapExtensions("source.yaml", "yaml", "yml");
-        mapExtensions("source.ini", "ini", "cfg", "conf", "properties");
+        mapExtensions("source.ini", "ini", "cfg", "conf");
+        // Java .properties — its own grammar (Unicode escapes, ':' separator, continuation lines);
+        // previously highlighted via the INI grammar.
+        mapExtensions("source.java-properties", "properties");
         mapExtensions("source.sql", "sql", "ddl", "dml");
         mapExtensions("source.mermaid", "mmd", "mermaid");
         // The TypeScript grammar tokenizes plain JS well, so .js/.mjs/.cjs reuse source.ts and
@@ -253,8 +261,19 @@ public final class GrammarRegistry {
         mapExtensions("source.desktop", "desktop", "directory");
         // Server/application log files.
         mapExtensions("source.log", "log");
-        // dotenv (.env / .env.*), Caddyfile, crontab (.cron), git/ssh config, fstab, hosts are all
-        // name/location-determined and handled by ConfigFileType (see scopeForFileName), not by extension.
+        // Unified diffs / patches.
+        mapExtensions("source.diff", "diff", "patch");
+        // Makefiles — bare "Makefile"/"GNUmakefile" handled by ConfigFileType; these are the extensions.
+        mapExtensions("source.makefile", "mk", "mak", "make");
+        // just command-runner files — bare "justfile" handled by ConfigFileType.
+        mapExtensions("source.just", "just");
+        // Protocol Buffers.
+        mapExtensions("source.proto", "proto");
+        // GraphQL schemas/queries.
+        mapExtensions("source.graphql", "graphql", "gql", "graphqls");
+        // dotenv (.env / .env.*), Caddyfile, crontab (.cron), git/ssh config, fstab, hosts, Makefile,
+        // justfile, and .gitattributes are all name/location-determined and handled by ConfigFileType
+        // (see scopeForFileName), not by extension.
     }
 
     private void mapExtensions(String scope, String... extensions) {

--- a/src/main/java/com/editora/editor/LanguageRegistry.java
+++ b/src/main/java/com/editora/editor/LanguageRegistry.java
@@ -129,10 +129,25 @@ public final class LanguageRegistry {
             // XDG desktop entries / KDE .directory files.
             Map.entry("desktop", "desktop"),
             Map.entry("directory", "desktop"),
-            // Java/INI-style .properties (highlighted with the INI grammar; see GrammarRegistry).
+            // Java .properties — its own grammar (Unicode escapes, ':' separator, continuations).
             Map.entry("properties", "properties"),
             // Server/application logs — the log viewer skins these (level highlighting, tail-follow).
-            Map.entry("log", "log"));
+            Map.entry("log", "log"),
+            // Unified diffs / patches.
+            Map.entry("diff", "diff"),
+            Map.entry("patch", "diff"),
+            // Makefiles — bare "Makefile"/"GNUmakefile" handled by ConfigFileType.
+            Map.entry("mk", "makefile"),
+            Map.entry("mak", "makefile"),
+            Map.entry("make", "makefile"),
+            // just command-runner files — bare "justfile" handled by ConfigFileType.
+            Map.entry("just", "just"),
+            // Protocol Buffers (brace-delimited; folds like C-family sources).
+            Map.entry("proto", "proto"),
+            // GraphQL schemas/queries (brace-delimited).
+            Map.entry("graphql", "graphql"),
+            Map.entry("gql", "graphql"),
+            Map.entry("graphqls", "graphql"));
 
     private LanguageRegistry() {}
 

--- a/src/main/java/com/editora/editor/TextMateHighlighter.java
+++ b/src/main/java/com/editora/editor/TextMateHighlighter.java
@@ -372,6 +372,23 @@ public final class TextMateHighlighter {
         if (scope.startsWith("constant.other.timestamp")) {
             return "log-timestamp";
         }
+        // Unified-diff lines (only the bundled source.diff grammar emits these scopes): added/removed
+        // lines tint green/red, hunk ranges + file headers stand out from the unchanged context lines.
+        if (scope.startsWith("markup.inserted")) {
+            return "diff-inserted";
+        }
+        if (scope.startsWith("markup.deleted")) {
+            return "diff-deleted";
+        }
+        if (scope.startsWith("markup.changed")) {
+            return "diff-changed";
+        }
+        if (scope.startsWith("meta.diff.range")) {
+            return "diff-range";
+        }
+        if (scope.startsWith("meta.diff") || scope.startsWith("meta.separator.diff")) {
+            return "diff-header";
+        }
         if (scope.startsWith("markup.bold")) {
             return "bold";
         }

--- a/src/main/java/com/editora/ui/FileIcons.java
+++ b/src/main/java/com/editora/ui/FileIcons.java
@@ -415,8 +415,9 @@ public final class FileIcons {
             case "terraform" -> "terraform";
             case "mermaid" -> "mermaid";
             case "sql" -> "storage";
-            case "ini", "properties", "toml", "systemd", "desktop" -> "settings";
-            case "rust", "lua", "groovy", "http" -> "code";
+            case "ini", "properties", "toml", "systemd", "desktop", "gitattributes" -> "settings";
+            case "rust", "lua", "groovy", "http", "proto", "graphql", "diff" -> "code";
+            case "makefile", "just" -> "terminal";
             default -> "generic";
         };
     }

--- a/src/main/resources/com/editora/grammars/diff.tmLanguage.json
+++ b/src/main/resources/com/editora/grammars/diff.tmLanguage.json
@@ -1,0 +1,154 @@
+{
+  "displayName": "Diff",
+  "name": "diff",
+  "patterns": [
+    {
+      "captures": {
+        "1": {
+          "name": "punctuation.definition.separator.diff"
+        }
+      },
+      "match": "^((\\*{15})|(={67})|(-{3}))$\\n?",
+      "name": "meta.separator.diff"
+    },
+    {
+      "match": "^\\d+(,\\d+)*([acd])\\d+(,\\d+)*$\\n?",
+      "name": "meta.diff.range.normal"
+    },
+    {
+      "captures": {
+        "1": {
+          "name": "punctuation.definition.range.diff"
+        },
+        "2": {
+          "name": "meta.toc-list.line-number.diff"
+        },
+        "3": {
+          "name": "punctuation.definition.range.diff"
+        }
+      },
+      "match": "^(@@)\\s*(.+?)\\s*(@@)($\\n?)?",
+      "name": "meta.diff.range.unified"
+    },
+    {
+      "captures": {
+        "3": {
+          "name": "punctuation.definition.range.diff"
+        },
+        "4": {
+          "name": "punctuation.definition.range.diff"
+        },
+        "6": {
+          "name": "punctuation.definition.range.diff"
+        },
+        "7": {
+          "name": "punctuation.definition.range.diff"
+        }
+      },
+      "match": "^(((-{3}) .+ (-{4}))|((\\*{3}) .+ (\\*{4})))$\\n?",
+      "name": "meta.diff.range.context"
+    },
+    {
+      "match": "^diff --git a/.*$\\n?",
+      "name": "meta.diff.header.git"
+    },
+    {
+      "match": "^diff (-|\\S+\\s+\\S+).*$\\n?",
+      "name": "meta.diff.header.command"
+    },
+    {
+      "captures": {
+        "4": {
+          "name": "punctuation.definition.from-file.diff"
+        },
+        "6": {
+          "name": "punctuation.definition.from-file.diff"
+        },
+        "7": {
+          "name": "punctuation.definition.from-file.diff"
+        }
+      },
+      "match": "^((((-{3}) .+)|((\\*{3}) .+))$\\n?|(={4}) .+(?= - ))",
+      "name": "meta.diff.header.from-file"
+    },
+    {
+      "captures": {
+        "2": {
+          "name": "punctuation.definition.to-file.diff"
+        },
+        "3": {
+          "name": "punctuation.definition.to-file.diff"
+        },
+        "4": {
+          "name": "punctuation.definition.to-file.diff"
+        }
+      },
+      "match": "(^(\\+{3}) .+$\\n?| (-) .* (={4})$\\n?)",
+      "name": "meta.diff.header.to-file"
+    },
+    {
+      "captures": {
+        "3": {
+          "name": "punctuation.definition.inserted.diff"
+        },
+        "6": {
+          "name": "punctuation.definition.inserted.diff"
+        }
+      },
+      "match": "^(((>)( .*)?)|((\\+).*))$\\n?",
+      "name": "markup.inserted.diff"
+    },
+    {
+      "captures": {
+        "1": {
+          "name": "punctuation.definition.changed.diff"
+        }
+      },
+      "match": "^(!).*$\\n?",
+      "name": "markup.changed.diff"
+    },
+    {
+      "captures": {
+        "3": {
+          "name": "punctuation.definition.deleted.diff"
+        },
+        "6": {
+          "name": "punctuation.definition.deleted.diff"
+        }
+      },
+      "match": "^(((<)( .*)?)|((-).*))$\\n?",
+      "name": "markup.deleted.diff"
+    },
+    {
+      "begin": "^(#)",
+      "captures": {
+        "1": {
+          "name": "punctuation.definition.comment.diff"
+        }
+      },
+      "end": "\\n",
+      "name": "comment.line.number-sign.diff"
+    },
+    {
+      "match": "^index [0-9a-f]{7,40}\\.\\.[0-9a-f]{7,40}.*$\\n?",
+      "name": "meta.diff.index.git"
+    },
+    {
+      "captures": {
+        "1": {
+          "name": "punctuation.separator.key-value.diff"
+        },
+        "2": {
+          "name": "meta.toc-list.file-name.diff"
+        }
+      },
+      "match": "^Index(:) (.+)$\\n?",
+      "name": "meta.diff.index"
+    },
+    {
+      "match": "^Only in .*: .*$\\n?",
+      "name": "meta.diff.only-in"
+    }
+  ],
+  "scopeName": "source.diff"
+}

--- a/src/main/resources/com/editora/grammars/gitattributes.tmLanguage.json
+++ b/src/main/resources/com/editora/grammars/gitattributes.tmLanguage.json
@@ -1,0 +1,76 @@
+{
+  "name": "gitattributes",
+  "scopeName": "source.gitattributes",
+  "patterns": [
+    {
+      "name": "comment.line.number-sign.gitattributes",
+      "match": "^\\s*#.*$"
+    },
+    {
+      "comment": "Macro definition: [attr]macroname attr1 attr2 ...",
+      "match": "^\\s*(\\[attr\\])([^\\s]+)",
+      "captures": {
+        "1": {
+          "name": "keyword.control.macro.gitattributes"
+        },
+        "2": {
+          "name": "entity.name.type.macro.gitattributes"
+        }
+      }
+    },
+    {
+      "comment": "The pattern (first token on the line) — same glob syntax as .gitignore.",
+      "begin": "^\\s*(?![#\\[])(?=\\S)",
+      "end": "(?=\\s|$)",
+      "patterns": [
+        {
+          "name": "keyword.operator.glob.gitattributes",
+          "match": "\\*\\*|[*?]"
+        },
+        {
+          "name": "constant.character.range.gitattributes",
+          "match": "\\[[^\\]]*\\]"
+        },
+        {
+          "name": "punctuation.separator.path.gitattributes",
+          "match": "/"
+        },
+        {
+          "name": "string.unquoted.pattern.gitattributes",
+          "match": "[^\\s*?\\[/]+"
+        }
+      ]
+    },
+    {
+      "comment": "attr=value — name, assignment, value.",
+      "match": "([A-Za-z0-9_.-]+)(=)([^\\s]*)",
+      "captures": {
+        "1": {
+          "name": "entity.other.attribute-name.gitattributes"
+        },
+        "2": {
+          "name": "punctuation.separator.key-value.gitattributes"
+        },
+        "3": {
+          "name": "string.unquoted.value.gitattributes"
+        }
+      }
+    },
+    {
+      "comment": "-attr unsets, !attr unspecifies.",
+      "match": "([-!])([A-Za-z0-9_.-]+)",
+      "captures": {
+        "1": {
+          "name": "keyword.operator.negation.gitattributes"
+        },
+        "2": {
+          "name": "entity.other.attribute-name.gitattributes"
+        }
+      }
+    },
+    {
+      "name": "entity.other.attribute-name.gitattributes",
+      "match": "[A-Za-z0-9_.-]+"
+    }
+  ]
+}

--- a/src/main/resources/com/editora/grammars/graphql.tmLanguage.json
+++ b/src/main/resources/com/editora/grammars/graphql.tmLanguage.json
@@ -1,0 +1,1292 @@
+{
+  "displayName": "GraphQL",
+  "fileTypes": [
+    "graphql",
+    "graphqls",
+    "gql",
+    "graphcool"
+  ],
+  "name": "graphql",
+  "patterns": [
+    {
+      "include": "#graphql"
+    }
+  ],
+  "repository": {
+    "graphql": {
+      "patterns": [
+        {
+          "include": "#graphql-comment"
+        },
+        {
+          "include": "#graphql-description-docstring"
+        },
+        {
+          "include": "#graphql-description-singleline"
+        },
+        {
+          "include": "#graphql-fragment-definition"
+        },
+        {
+          "include": "#graphql-directive-definition"
+        },
+        {
+          "include": "#graphql-type-interface"
+        },
+        {
+          "include": "#graphql-enum"
+        },
+        {
+          "include": "#graphql-scalar"
+        },
+        {
+          "include": "#graphql-union"
+        },
+        {
+          "include": "#graphql-schema"
+        },
+        {
+          "include": "#graphql-operation-def"
+        },
+        {
+          "include": "#literal-quasi-embedded"
+        }
+      ]
+    },
+    "graphql-ampersand": {
+      "captures": {
+        "1": {
+          "name": "keyword.operator.logical.graphql"
+        }
+      },
+      "match": "\\s*(&)"
+    },
+    "graphql-arguments": {
+      "begin": "\\s*(\\()",
+      "beginCaptures": {
+        "1": {
+          "name": "meta.brace.round.directive.graphql"
+        }
+      },
+      "end": "\\s*(\\))",
+      "endCaptures": {
+        "1": {
+          "name": "meta.brace.round.directive.graphql"
+        }
+      },
+      "name": "meta.arguments.graphql",
+      "patterns": [
+        {
+          "include": "#graphql-comment"
+        },
+        {
+          "include": "#graphql-description-docstring"
+        },
+        {
+          "include": "#graphql-description-singleline"
+        },
+        {
+          "begin": "\\s*([A-Z_a-z][0-9A-Z_a-z]*)\\s*(:)",
+          "beginCaptures": {
+            "1": {
+              "name": "variable.parameter.graphql"
+            },
+            "2": {
+              "name": "punctuation.colon.graphql"
+            }
+          },
+          "end": "(?=\\s*(?:([A-Z_a-z][0-9A-Z_a-z]*)\\s*(:)|\\)))|\\s*(,)",
+          "endCaptures": {
+            "3": {
+              "name": "punctuation.comma.graphql"
+            }
+          },
+          "patterns": [
+            {
+              "include": "#graphql-comment"
+            },
+            {
+              "include": "#graphql-description-docstring"
+            },
+            {
+              "include": "#graphql-description-singleline"
+            },
+            {
+              "include": "#graphql-directive"
+            },
+            {
+              "include": "#graphql-value"
+            },
+            {
+              "include": "#graphql-skip-newlines"
+            }
+          ]
+        },
+        {
+          "include": "#literal-quasi-embedded"
+        }
+      ]
+    },
+    "graphql-boolean-value": {
+      "captures": {
+        "1": {
+          "name": "constant.language.boolean.graphql"
+        }
+      },
+      "match": "\\s*\\b(true|false)\\b"
+    },
+    "graphql-colon": {
+      "captures": {
+        "1": {
+          "name": "punctuation.colon.graphql"
+        }
+      },
+      "match": "\\s*(:)"
+    },
+    "graphql-comma": {
+      "captures": {
+        "1": {
+          "name": "punctuation.comma.graphql"
+        }
+      },
+      "match": "\\s*(,)"
+    },
+    "graphql-comment": {
+      "patterns": [
+        {
+          "captures": {
+            "1": {
+              "name": "punctuation.whitespace.comment.leading.graphql"
+            }
+          },
+          "match": "(\\s*)(#).*",
+          "name": "comment.line.graphql.js"
+        },
+        {
+          "begin": "(\"\"\")",
+          "beginCaptures": {
+            "1": {
+              "name": "punctuation.whitespace.comment.leading.graphql"
+            }
+          },
+          "end": "(\"\"\")",
+          "name": "comment.line.graphql.js"
+        },
+        {
+          "begin": "(\")",
+          "beginCaptures": {
+            "1": {
+              "name": "punctuation.whitespace.comment.leading.graphql"
+            }
+          },
+          "end": "(\")",
+          "name": "comment.line.graphql.js"
+        }
+      ]
+    },
+    "graphql-description-docstring": {
+      "begin": "\"\"\"",
+      "end": "\"\"\"",
+      "name": "comment.block.graphql"
+    },
+    "graphql-description-singleline": {
+      "match": "#(?=([^\"]*\"[^\"]*\")*[^\"]*$).*$",
+      "name": "comment.line.number-sign.graphql"
+    },
+    "graphql-directive": {
+      "applyEndPatternLast": 1,
+      "begin": "\\s*((@)\\s*([A-Z_a-z][0-9A-Z_a-z]*))",
+      "beginCaptures": {
+        "1": {
+          "name": "entity.name.function.directive.graphql"
+        }
+      },
+      "end": "(?=.)",
+      "patterns": [
+        {
+          "include": "#graphql-comment"
+        },
+        {
+          "include": "#graphql-description-docstring"
+        },
+        {
+          "include": "#graphql-description-singleline"
+        },
+        {
+          "include": "#graphql-arguments"
+        },
+        {
+          "include": "#literal-quasi-embedded"
+        },
+        {
+          "include": "#graphql-skip-newlines"
+        }
+      ]
+    },
+    "graphql-directive-definition": {
+      "applyEndPatternLast": 1,
+      "begin": "\\s*\\b(directive)\\b\\s*(@[A-Z_a-z][0-9A-Z_a-z]*)",
+      "beginCaptures": {
+        "1": {
+          "name": "keyword.directive.graphql"
+        },
+        "2": {
+          "name": "entity.name.function.directive.graphql"
+        },
+        "3": {
+          "name": "keyword.on.graphql"
+        },
+        "4": {
+          "name": "support.type.graphql"
+        }
+      },
+      "end": "(?=.)",
+      "patterns": [
+        {
+          "include": "#graphql-variable-definitions"
+        },
+        {
+          "applyEndPatternLast": 1,
+          "begin": "\\s*\\b(on)\\b\\s*([A-Z_a-z]*)",
+          "beginCaptures": {
+            "1": {
+              "name": "keyword.on.graphql"
+            },
+            "2": {
+              "name": "support.type.location.graphql"
+            }
+          },
+          "end": "(?=.)",
+          "patterns": [
+            {
+              "include": "#graphql-skip-newlines"
+            },
+            {
+              "include": "#graphql-comment"
+            },
+            {
+              "include": "#literal-quasi-embedded"
+            },
+            {
+              "captures": {
+                "2": {
+                  "name": "support.type.location.graphql"
+                }
+              },
+              "match": "\\s*(\\|)\\s*([A-Z_a-z]*)"
+            }
+          ]
+        },
+        {
+          "include": "#graphql-skip-newlines"
+        },
+        {
+          "include": "#graphql-comment"
+        },
+        {
+          "include": "#literal-quasi-embedded"
+        }
+      ]
+    },
+    "graphql-enum": {
+      "begin": "\\s*+\\b(enum)\\b\\s*([A-Z_a-z][0-9A-Z_a-z]*)",
+      "beginCaptures": {
+        "1": {
+          "name": "keyword.enum.graphql"
+        },
+        "2": {
+          "name": "support.type.enum.graphql"
+        }
+      },
+      "end": "(?<=})",
+      "name": "meta.enum.graphql",
+      "patterns": [
+        {
+          "begin": "\\s*(\\{)",
+          "beginCaptures": {
+            "1": {
+              "name": "punctuation.operation.graphql"
+            }
+          },
+          "end": "\\s*(})",
+          "endCaptures": {
+            "1": {
+              "name": "punctuation.operation.graphql"
+            }
+          },
+          "name": "meta.type.object.graphql",
+          "patterns": [
+            {
+              "include": "#graphql-object-type"
+            },
+            {
+              "include": "#graphql-comment"
+            },
+            {
+              "include": "#graphql-description-docstring"
+            },
+            {
+              "include": "#graphql-description-singleline"
+            },
+            {
+              "include": "#graphql-directive"
+            },
+            {
+              "include": "#graphql-enum-value"
+            },
+            {
+              "include": "#literal-quasi-embedded"
+            }
+          ]
+        },
+        {
+          "include": "#graphql-comment"
+        },
+        {
+          "include": "#graphql-description-docstring"
+        },
+        {
+          "include": "#graphql-description-singleline"
+        },
+        {
+          "include": "#graphql-directive"
+        }
+      ]
+    },
+    "graphql-enum-value": {
+      "match": "\\s*(?!=\\b(true|false|null)\\b)([A-Z_a-z][0-9A-Z_a-z]*)",
+      "name": "constant.character.enum.graphql"
+    },
+    "graphql-field": {
+      "patterns": [
+        {
+          "captures": {
+            "1": {
+              "name": "string.unquoted.alias.graphql"
+            },
+            "2": {
+              "name": "punctuation.colon.graphql"
+            }
+          },
+          "match": "\\s*([A-Z_a-z][0-9A-Z_a-z]*)\\s*(:)"
+        },
+        {
+          "captures": {
+            "1": {
+              "name": "variable.graphql"
+            }
+          },
+          "match": "\\s*([A-Z_a-z][0-9A-Z_a-z]*)"
+        },
+        {
+          "include": "#graphql-arguments"
+        },
+        {
+          "include": "#graphql-directive"
+        },
+        {
+          "include": "#graphql-selection-set"
+        },
+        {
+          "include": "#literal-quasi-embedded"
+        },
+        {
+          "include": "#graphql-skip-newlines"
+        }
+      ]
+    },
+    "graphql-float-value": {
+      "captures": {
+        "1": {
+          "name": "constant.numeric.float.graphql"
+        }
+      },
+      "match": "\\s*(-?(0|[1-9][0-9]*)(\\.[0-9]+)?(([Ee])([-+])?[0-9]+)?)"
+    },
+    "graphql-fragment-definition": {
+      "begin": "\\s*\\b(fragment)\\b\\s*([A-Z_a-z][0-9A-Z_a-z]*)?\\s*\\b(on)\\b\\s*([A-Z_a-z][0-9A-Z_a-z]*)",
+      "captures": {
+        "1": {
+          "name": "keyword.fragment.graphql"
+        },
+        "2": {
+          "name": "entity.name.fragment.graphql"
+        },
+        "3": {
+          "name": "keyword.on.graphql"
+        },
+        "4": {
+          "name": "support.type.graphql"
+        }
+      },
+      "end": "(?<=})",
+      "name": "meta.fragment.graphql",
+      "patterns": [
+        {
+          "include": "#graphql-comment"
+        },
+        {
+          "include": "#graphql-description-docstring"
+        },
+        {
+          "include": "#graphql-description-singleline"
+        },
+        {
+          "include": "#graphql-selection-set"
+        },
+        {
+          "include": "#graphql-directive"
+        },
+        {
+          "include": "#graphql-skip-newlines"
+        },
+        {
+          "include": "#literal-quasi-embedded"
+        }
+      ]
+    },
+    "graphql-fragment-spread": {
+      "applyEndPatternLast": 1,
+      "begin": "\\s*(\\.\\.\\.)\\s*(?!\\bon\\b)([A-Z_a-z][0-9A-Z_a-z]*)",
+      "captures": {
+        "1": {
+          "name": "keyword.operator.spread.graphql"
+        },
+        "2": {
+          "name": "variable.fragment.graphql"
+        }
+      },
+      "end": "(?=.)",
+      "patterns": [
+        {
+          "include": "#graphql-comment"
+        },
+        {
+          "include": "#graphql-description-docstring"
+        },
+        {
+          "include": "#graphql-description-singleline"
+        },
+        {
+          "include": "#graphql-selection-set"
+        },
+        {
+          "include": "#graphql-directive"
+        },
+        {
+          "include": "#literal-quasi-embedded"
+        },
+        {
+          "include": "#graphql-skip-newlines"
+        }
+      ]
+    },
+    "graphql-ignore-spaces": {
+      "match": "\\s*"
+    },
+    "graphql-inline-fragment": {
+      "applyEndPatternLast": 1,
+      "begin": "\\s*(\\.\\.\\.)\\s*(?:\\b(on)\\b\\s*([A-Z_a-z][0-9A-Z_a-z]*))?",
+      "captures": {
+        "1": {
+          "name": "keyword.operator.spread.graphql"
+        },
+        "2": {
+          "name": "keyword.on.graphql"
+        },
+        "3": {
+          "name": "support.type.graphql"
+        }
+      },
+      "end": "(?=.)",
+      "patterns": [
+        {
+          "include": "#graphql-comment"
+        },
+        {
+          "include": "#graphql-description-docstring"
+        },
+        {
+          "include": "#graphql-description-singleline"
+        },
+        {
+          "include": "#graphql-selection-set"
+        },
+        {
+          "include": "#graphql-directive"
+        },
+        {
+          "include": "#graphql-skip-newlines"
+        },
+        {
+          "include": "#literal-quasi-embedded"
+        }
+      ]
+    },
+    "graphql-input-types": {
+      "patterns": [
+        {
+          "include": "#graphql-scalar-type"
+        },
+        {
+          "captures": {
+            "1": {
+              "name": "support.type.graphql"
+            },
+            "2": {
+              "name": "keyword.operator.nulltype.graphql"
+            }
+          },
+          "match": "\\s*([A-Z_a-z][0-9A-Z_a-z]*)(?:\\s*(!))?"
+        },
+        {
+          "begin": "\\s*(\\[)",
+          "captures": {
+            "1": {
+              "name": "meta.brace.square.graphql"
+            },
+            "2": {
+              "name": "keyword.operator.nulltype.graphql"
+            }
+          },
+          "end": "\\s*(])(?:\\s*(!))?",
+          "name": "meta.type.list.graphql",
+          "patterns": [
+            {
+              "include": "#graphql-comment"
+            },
+            {
+              "include": "#graphql-description-docstring"
+            },
+            {
+              "include": "#graphql-description-singleline"
+            },
+            {
+              "include": "#graphql-input-types"
+            },
+            {
+              "include": "#graphql-comma"
+            },
+            {
+              "include": "#literal-quasi-embedded"
+            }
+          ]
+        }
+      ]
+    },
+    "graphql-list-value": {
+      "patterns": [
+        {
+          "begin": "\\s*+(\\[)",
+          "beginCaptures": {
+            "1": {
+              "name": "meta.brace.square.graphql"
+            }
+          },
+          "end": "\\s*(])",
+          "endCaptures": {
+            "1": {
+              "name": "meta.brace.square.graphql"
+            }
+          },
+          "name": "meta.listvalues.graphql",
+          "patterns": [
+            {
+              "include": "#graphql-value"
+            }
+          ]
+        }
+      ]
+    },
+    "graphql-name": {
+      "captures": {
+        "1": {
+          "name": "entity.name.function.graphql"
+        }
+      },
+      "match": "\\s*([A-Z_a-z][0-9A-Z_a-z]*)"
+    },
+    "graphql-null-value": {
+      "captures": {
+        "1": {
+          "name": "constant.language.null.graphql"
+        }
+      },
+      "match": "\\s*\\b(null)\\b"
+    },
+    "graphql-object-field": {
+      "captures": {
+        "1": {
+          "name": "constant.object.key.graphql"
+        },
+        "2": {
+          "name": "string.unquoted.graphql"
+        },
+        "3": {
+          "name": "punctuation.graphql"
+        }
+      },
+      "match": "\\s*(([A-Z_a-z][0-9A-Z_a-z]*))\\s*(:)"
+    },
+    "graphql-object-value": {
+      "patterns": [
+        {
+          "begin": "\\s*+(\\{)",
+          "beginCaptures": {
+            "1": {
+              "name": "meta.brace.curly.graphql"
+            }
+          },
+          "end": "\\s*(})",
+          "endCaptures": {
+            "1": {
+              "name": "meta.brace.curly.graphql"
+            }
+          },
+          "name": "meta.objectvalues.graphql",
+          "patterns": [
+            {
+              "include": "#graphql-object-field"
+            },
+            {
+              "include": "#graphql-value"
+            }
+          ]
+        }
+      ]
+    },
+    "graphql-operation-def": {
+      "patterns": [
+        {
+          "include": "#graphql-query-mutation"
+        },
+        {
+          "include": "#graphql-name"
+        },
+        {
+          "include": "#graphql-variable-definitions"
+        },
+        {
+          "include": "#graphql-directive"
+        },
+        {
+          "include": "#graphql-selection-set"
+        }
+      ]
+    },
+    "graphql-query-mutation": {
+      "captures": {
+        "1": {
+          "name": "keyword.operation.graphql"
+        }
+      },
+      "match": "\\s*\\b(query|mutation)\\b"
+    },
+    "graphql-scalar": {
+      "captures": {
+        "1": {
+          "name": "keyword.scalar.graphql"
+        },
+        "2": {
+          "name": "entity.scalar.graphql"
+        }
+      },
+      "match": "\\s*\\b(scalar)\\b\\s*([A-Z_a-z][0-9A-Z_a-z]*)"
+    },
+    "graphql-scalar-type": {
+      "captures": {
+        "1": {
+          "name": "support.type.builtin.graphql"
+        },
+        "2": {
+          "name": "keyword.operator.nulltype.graphql"
+        }
+      },
+      "match": "\\s*\\b(Int|Float|String|Boolean|ID)\\b(?:\\s*(!))?"
+    },
+    "graphql-schema": {
+      "begin": "\\s*\\b(schema)\\b",
+      "beginCaptures": {
+        "1": {
+          "name": "keyword.schema.graphql"
+        }
+      },
+      "end": "(?<=})",
+      "patterns": [
+        {
+          "begin": "\\s*(\\{)",
+          "beginCaptures": {
+            "1": {
+              "name": "punctuation.operation.graphql"
+            }
+          },
+          "end": "\\s*(})",
+          "endCaptures": {
+            "1": {
+              "name": "punctuation.operation.graphql"
+            }
+          },
+          "patterns": [
+            {
+              "begin": "\\s*([A-Z_a-z][0-9A-Z_a-z]*)(?=\\s*\\(|:)",
+              "beginCaptures": {
+                "1": {
+                  "name": "variable.arguments.graphql"
+                }
+              },
+              "end": "(?=\\s*(([A-Z_a-z][0-9A-Z_a-z]*)\\s*([(:])|(})))|\\s*(,)",
+              "endCaptures": {
+                "5": {
+                  "name": "punctuation.comma.graphql"
+                }
+              },
+              "patterns": [
+                {
+                  "captures": {
+                    "1": {
+                      "name": "support.type.graphql"
+                    }
+                  },
+                  "match": "\\s*([A-Z_a-z][0-9A-Z_a-z]*)"
+                },
+                {
+                  "include": "#graphql-comment"
+                },
+                {
+                  "include": "#graphql-description-docstring"
+                },
+                {
+                  "include": "#graphql-description-singleline"
+                },
+                {
+                  "include": "#graphql-colon"
+                },
+                {
+                  "include": "#graphql-skip-newlines"
+                }
+              ]
+            },
+            {
+              "include": "#graphql-comment"
+            },
+            {
+              "include": "#graphql-description-docstring"
+            },
+            {
+              "include": "#graphql-description-singleline"
+            },
+            {
+              "include": "#graphql-skip-newlines"
+            }
+          ]
+        },
+        {
+          "include": "#graphql-comment"
+        },
+        {
+          "include": "#graphql-description-docstring"
+        },
+        {
+          "include": "#graphql-description-singleline"
+        },
+        {
+          "include": "#graphql-directive"
+        },
+        {
+          "include": "#graphql-skip-newlines"
+        }
+      ]
+    },
+    "graphql-selection-set": {
+      "begin": "\\s*(\\{)",
+      "beginCaptures": {
+        "1": {
+          "name": "punctuation.operation.graphql"
+        }
+      },
+      "end": "\\s*(})",
+      "endCaptures": {
+        "1": {
+          "name": "punctuation.operation.graphql"
+        }
+      },
+      "name": "meta.selectionset.graphql",
+      "patterns": [
+        {
+          "include": "#graphql-comment"
+        },
+        {
+          "include": "#graphql-description-docstring"
+        },
+        {
+          "include": "#graphql-description-singleline"
+        },
+        {
+          "include": "#graphql-field"
+        },
+        {
+          "include": "#graphql-fragment-spread"
+        },
+        {
+          "include": "#graphql-inline-fragment"
+        },
+        {
+          "include": "#graphql-comma"
+        },
+        {
+          "include": "#native-interpolation"
+        },
+        {
+          "include": "#literal-quasi-embedded"
+        }
+      ]
+    },
+    "graphql-skip-newlines": {
+      "match": "\\s*\\n"
+    },
+    "graphql-string-content": {
+      "patterns": [
+        {
+          "match": "\\\\[\"'/\\\\bfnrt]",
+          "name": "constant.character.escape.graphql"
+        },
+        {
+          "match": "\\\\u(\\h{4})",
+          "name": "constant.character.escape.graphql"
+        }
+      ]
+    },
+    "graphql-string-value": {
+      "begin": "\\s*+((\"))",
+      "beginCaptures": {
+        "1": {
+          "name": "string.quoted.double.graphql"
+        },
+        "2": {
+          "name": "punctuation.definition.string.begin.graphql"
+        }
+      },
+      "contentName": "string.quoted.double.graphql",
+      "end": "\\s*+(?:((\"))|(\\n))",
+      "endCaptures": {
+        "1": {
+          "name": "string.quoted.double.graphql"
+        },
+        "2": {
+          "name": "punctuation.definition.string.end.graphql"
+        },
+        "3": {
+          "name": "invalid.illegal.newline.graphql"
+        }
+      },
+      "patterns": [
+        {
+          "include": "#graphql-string-content"
+        },
+        {
+          "include": "#literal-quasi-embedded"
+        }
+      ]
+    },
+    "graphql-type-definition": {
+      "begin": "\\s*([A-Z_a-z][0-9A-Z_a-z]*)(?=\\s*\\(|:)",
+      "beginCaptures": {
+        "1": {
+          "name": "variable.graphql"
+        }
+      },
+      "end": "(?=\\s*(([A-Z_a-z][0-9A-Z_a-z]*)\\s*([(:])|(})))|\\s*(,)",
+      "endCaptures": {
+        "5": {
+          "name": "punctuation.comma.graphql"
+        }
+      },
+      "patterns": [
+        {
+          "include": "#graphql-comment"
+        },
+        {
+          "include": "#graphql-description-docstring"
+        },
+        {
+          "include": "#graphql-description-singleline"
+        },
+        {
+          "include": "#graphql-directive"
+        },
+        {
+          "include": "#graphql-variable-definitions"
+        },
+        {
+          "include": "#graphql-type-object"
+        },
+        {
+          "include": "#graphql-colon"
+        },
+        {
+          "include": "#graphql-input-types"
+        },
+        {
+          "include": "#literal-quasi-embedded"
+        }
+      ]
+    },
+    "graphql-type-interface": {
+      "applyEndPatternLast": 1,
+      "begin": "\\s*\\b(?:(extends?)?\\b\\s*\\b(type)|(interface)|(input))\\b\\s*([A-Z_a-z][0-9A-Z_a-z]*)?",
+      "captures": {
+        "1": {
+          "name": "keyword.type.graphql"
+        },
+        "2": {
+          "name": "keyword.type.graphql"
+        },
+        "3": {
+          "name": "keyword.interface.graphql"
+        },
+        "4": {
+          "name": "keyword.input.graphql"
+        },
+        "5": {
+          "name": "support.type.graphql"
+        }
+      },
+      "end": "(?=.)",
+      "name": "meta.type.interface.graphql",
+      "patterns": [
+        {
+          "begin": "\\s*\\b(implements)\\b\\s*",
+          "beginCaptures": {
+            "1": {
+              "name": "keyword.implements.graphql"
+            }
+          },
+          "end": "\\s*(?=\\{)",
+          "patterns": [
+            {
+              "captures": {
+                "1": {
+                  "name": "support.type.graphql"
+                }
+              },
+              "match": "\\s*([A-Z_a-z][0-9A-Z_a-z]*)"
+            },
+            {
+              "include": "#graphql-comment"
+            },
+            {
+              "include": "#graphql-description-docstring"
+            },
+            {
+              "include": "#graphql-description-singleline"
+            },
+            {
+              "include": "#graphql-directive"
+            },
+            {
+              "include": "#graphql-ampersand"
+            },
+            {
+              "include": "#graphql-comma"
+            }
+          ]
+        },
+        {
+          "include": "#graphql-comment"
+        },
+        {
+          "include": "#graphql-description-docstring"
+        },
+        {
+          "include": "#graphql-description-singleline"
+        },
+        {
+          "include": "#graphql-directive"
+        },
+        {
+          "include": "#graphql-type-object"
+        },
+        {
+          "include": "#literal-quasi-embedded"
+        },
+        {
+          "include": "#graphql-ignore-spaces"
+        }
+      ]
+    },
+    "graphql-type-object": {
+      "begin": "\\s*(\\{)",
+      "beginCaptures": {
+        "1": {
+          "name": "punctuation.operation.graphql"
+        }
+      },
+      "end": "\\s*(})",
+      "endCaptures": {
+        "1": {
+          "name": "punctuation.operation.graphql"
+        }
+      },
+      "name": "meta.type.object.graphql",
+      "patterns": [
+        {
+          "include": "#graphql-comment"
+        },
+        {
+          "include": "#graphql-description-docstring"
+        },
+        {
+          "include": "#graphql-description-singleline"
+        },
+        {
+          "include": "#graphql-object-type"
+        },
+        {
+          "include": "#graphql-type-definition"
+        },
+        {
+          "include": "#literal-quasi-embedded"
+        }
+      ]
+    },
+    "graphql-union": {
+      "applyEndPatternLast": 1,
+      "begin": "\\s*\\b(union)\\b\\s*([A-Z_a-z][0-9A-Z_a-z]*)",
+      "captures": {
+        "1": {
+          "name": "keyword.union.graphql"
+        },
+        "2": {
+          "name": "support.type.graphql"
+        }
+      },
+      "end": "(?=.)",
+      "patterns": [
+        {
+          "applyEndPatternLast": 1,
+          "begin": "\\s*(=)\\s*([A-Z_a-z][0-9A-Z_a-z]*)",
+          "captures": {
+            "1": {
+              "name": "punctuation.assignment.graphql"
+            },
+            "2": {
+              "name": "support.type.graphql"
+            }
+          },
+          "end": "(?=.)",
+          "patterns": [
+            {
+              "include": "#graphql-comment"
+            },
+            {
+              "include": "#graphql-description-docstring"
+            },
+            {
+              "include": "#graphql-description-singleline"
+            },
+            {
+              "include": "#graphql-skip-newlines"
+            },
+            {
+              "include": "#literal-quasi-embedded"
+            },
+            {
+              "captures": {
+                "1": {
+                  "name": "punctuation.or.graphql"
+                },
+                "2": {
+                  "name": "support.type.graphql"
+                }
+              },
+              "match": "\\s*(\\|)\\s*([A-Z_a-z][0-9A-Z_a-z]*)"
+            }
+          ]
+        },
+        {
+          "include": "#graphql-comment"
+        },
+        {
+          "include": "#graphql-description-docstring"
+        },
+        {
+          "include": "#graphql-description-singleline"
+        },
+        {
+          "include": "#graphql-skip-newlines"
+        },
+        {
+          "include": "#literal-quasi-embedded"
+        }
+      ]
+    },
+    "graphql-union-mark": {
+      "captures": {
+        "1": {
+          "name": "punctuation.union.graphql"
+        }
+      },
+      "match": "\\s*(\\|)"
+    },
+    "graphql-value": {
+      "patterns": [
+        {
+          "include": "#graphql-comment"
+        },
+        {
+          "include": "#graphql-description-docstring"
+        },
+        {
+          "include": "#graphql-variable-name"
+        },
+        {
+          "include": "#graphql-float-value"
+        },
+        {
+          "include": "#graphql-string-value"
+        },
+        {
+          "include": "#graphql-boolean-value"
+        },
+        {
+          "include": "#graphql-null-value"
+        },
+        {
+          "include": "#graphql-enum-value"
+        },
+        {
+          "include": "#graphql-list-value"
+        },
+        {
+          "include": "#graphql-object-value"
+        },
+        {
+          "include": "#literal-quasi-embedded"
+        }
+      ]
+    },
+    "graphql-variable-assignment": {
+      "applyEndPatternLast": 1,
+      "begin": "\\s(=)",
+      "beginCaptures": {
+        "1": {
+          "name": "punctuation.assignment.graphql"
+        }
+      },
+      "end": "(?=[\\n),])",
+      "patterns": [
+        {
+          "include": "#graphql-value"
+        }
+      ]
+    },
+    "graphql-variable-definition": {
+      "begin": "\\s*(\\$?[A-Z_a-z][0-9A-Z_a-z]*)(?=\\s*\\(|:)",
+      "beginCaptures": {
+        "1": {
+          "name": "variable.parameter.graphql"
+        }
+      },
+      "end": "(?=\\s*((\\$?[A-Z_a-z][0-9A-Z_a-z]*)\\s*([(:])|([)}])))|\\s*(,)",
+      "endCaptures": {
+        "5": {
+          "name": "punctuation.comma.graphql"
+        }
+      },
+      "name": "meta.variables.graphql",
+      "patterns": [
+        {
+          "include": "#graphql-comment"
+        },
+        {
+          "include": "#graphql-description-docstring"
+        },
+        {
+          "include": "#graphql-description-singleline"
+        },
+        {
+          "include": "#graphql-directive"
+        },
+        {
+          "include": "#graphql-colon"
+        },
+        {
+          "include": "#graphql-input-types"
+        },
+        {
+          "include": "#graphql-variable-assignment"
+        },
+        {
+          "include": "#literal-quasi-embedded"
+        },
+        {
+          "include": "#graphql-skip-newlines"
+        }
+      ]
+    },
+    "graphql-variable-definitions": {
+      "begin": "\\s*(\\()",
+      "captures": {
+        "1": {
+          "name": "meta.brace.round.graphql"
+        }
+      },
+      "end": "\\s*(\\))",
+      "patterns": [
+        {
+          "include": "#graphql-comment"
+        },
+        {
+          "include": "#graphql-description-docstring"
+        },
+        {
+          "include": "#graphql-description-singleline"
+        },
+        {
+          "include": "#graphql-variable-definition"
+        },
+        {
+          "include": "#literal-quasi-embedded"
+        }
+      ]
+    },
+    "graphql-variable-name": {
+      "captures": {
+        "1": {
+          "name": "variable.graphql"
+        }
+      },
+      "match": "\\s*(\\$[A-Z_a-z][0-9A-Z_a-z]*)"
+    },
+    "native-interpolation": {
+      "begin": "\\s*(\\$\\{)",
+      "beginCaptures": {
+        "1": {
+          "name": "keyword.other.substitution.begin"
+        }
+      },
+      "end": "(})",
+      "endCaptures": {
+        "1": {
+          "name": "keyword.other.substitution.end"
+        }
+      },
+      "name": "native.interpolation",
+      "patterns": [
+        {
+          "include": "source.js"
+        },
+        {
+          "include": "source.ts"
+        },
+        {
+          "include": "source.js.jsx"
+        },
+        {
+          "include": "source.tsx"
+        }
+      ]
+    }
+  },
+  "scopeName": "source.graphql"
+}

--- a/src/main/resources/com/editora/grammars/just.tmLanguage.json
+++ b/src/main/resources/com/editora/grammars/just.tmLanguage.json
@@ -1,0 +1,751 @@
+{
+  "displayName": "Just",
+  "fileTypes": [
+    "just",
+    "justfile",
+    "Justfile"
+  ],
+  "firstLineMatch": "#![\\t\\s]*/.*just\\b",
+  "name": "just",
+  "patterns": [
+    {
+      "include": "#comments"
+    },
+    {
+      "include": "#import"
+    },
+    {
+      "include": "#module"
+    },
+    {
+      "include": "#alias"
+    },
+    {
+      "include": "#assignment"
+    },
+    {
+      "include": "#builtins"
+    },
+    {
+      "include": "#keywords"
+    },
+    {
+      "include": "#expression-operators"
+    },
+    {
+      "include": "#backtick"
+    },
+    {
+      "include": "#strings"
+    },
+    {
+      "include": "#parenthesis"
+    },
+    {
+      "include": "#recipes"
+    },
+    {
+      "include": "#recipe-operators"
+    },
+    {
+      "include": "#embedded-languages"
+    },
+    {
+      "include": "#escaping"
+    }
+  ],
+  "repository": {
+    "alias": {
+      "captures": {
+        "1": {
+          "name": "keyword.other.reserved.just"
+        },
+        "2": {
+          "name": "variable.name.alias.just"
+        },
+        "3": {
+          "name": "keyword.operator.assignment.just"
+        },
+        "4": {
+          "name": "variable.other.just"
+        }
+      },
+      "match": "^(alias)\\s+([A-Z_a-z][-0-9A-Z_a-z]*)\\s*(:=)\\s*([A-Z_a-z][-0-9A-Z_a-z]*)"
+    },
+    "assignment": {
+      "patterns": [
+        {
+          "include": "#variable-assignment"
+        },
+        {
+          "include": "#setting-assignment"
+        }
+      ]
+    },
+    "backtick": {
+      "patterns": [
+        {
+          "begin": "(```)",
+          "beginCaptures": {
+            "1": {
+              "name": "string.interpolated.just"
+            }
+          },
+          "contentName": "source.shell",
+          "end": "(```)",
+          "endCaptures": {
+            "1": {
+              "name": "string.interpolated.just"
+            }
+          },
+          "patterns": [
+            {
+              "include": "source.shell"
+            }
+          ]
+        },
+        {
+          "captures": {
+            "1": {
+              "name": "string.interpolated.just"
+            },
+            "2": {
+              "name": "source.shell",
+              "patterns": [
+                {
+                  "include": "source.shell"
+                }
+              ]
+            },
+            "3": {
+              "name": "string.interpolated.just"
+            }
+          },
+          "match": "(`)([^`]*)(`)"
+        }
+      ]
+    },
+    "boolean": {
+      "patterns": [
+        {
+          "match": "\\b(true|false)\\b",
+          "name": "constant.language.boolean.just"
+        }
+      ]
+    },
+    "builtin-functions": {
+      "patterns": [
+        {
+          "match": "\\b(arch|num_cpus|os|os_family|shell|env_var|env_var_or_default|env|is_dependency|invocation_directory|invocation_dir|invocation_directory_native|invocation_dir_native|justfile|justfile_directory|justfile_dir|just_executable|just_pid|source_file|source_directory|source_dir|module_file|module_directory|module_dir|append|prepend|encode_uri_component|quote|replace|replace_regex|trim|trim_end|trim_end_match|trim_end_matches|trim_start|trim_start_match|trim_start_matches|capitalize|kebabcase|lowercamelcase|lowercase|shoutykebabcase|shoutysnakecase|snakecase|titlecase|uppercamelcase|uppercase|absolute_path|blake3|blake3_file|canonicalize|extension|file_name|file_stem|parent_directory|parent_dir|without_extension|clean|join|path_exists|error|assert|sha256|sha256_file|uuid|choose|datetime|datetime_utc|semver_matches|style|cache_directory|cache_dir|config_directory|config_dir|config_local_directory|config_local_dir|data_directory|data_dir|data_local_directory|data_local_dir|executable_directory|executable_dir|home_directory|home_dir|which|require|read)\\b",
+          "name": "support.function.builtin.just"
+        }
+      ]
+    },
+    "builtins": {
+      "patterns": [
+        {
+          "match": "\\b(HEX|HEXLOWER|HEXUPPER|PATH_SEP|PATH_VAR_SEP|CLEAR|NORMAL|BOLD|ITALIC|UNDERLINE|INVERT|HIDE|STRIKETHROUGH|BLACK|RED|GREEN|YELLOW|BLUE|MAGENTA|CYAN|WHITE|BG_BLACK|BG_RED|BG_GREEN|BG_YELLOW|BG_BLUE|BG_MAGENTA|BG_CYAN|BG_WHITE)\\b",
+          "name": "constant.language.const.just"
+        },
+        {
+          "include": "#builtin-functions"
+        },
+        {
+          "include": "#literal"
+        }
+      ]
+    },
+    "comments": {
+      "patterns": [
+        {
+          "match": "#(?!!).*$",
+          "name": "comment.line.number-sign.just"
+        }
+      ]
+    },
+    "control-keywords": {
+      "patterns": [
+        {
+          "match": "\\b(if|else)\\b",
+          "name": "keyword.control.conditional.just"
+        }
+      ]
+    },
+    "embedded-languages": {
+      "patterns": [
+        {
+          "begin": "^\\s+(#!/usr/bin/env\\s+(?:-S\\s+)?node.*)$",
+          "beginCaptures": {
+            "1": {
+              "name": "comment.line.number-sign.shebang.just"
+            }
+          },
+          "contentName": "source.js",
+          "patterns": [
+            {
+              "include": "source.js"
+            }
+          ],
+          "while": "^(?=\\s*$|\\s)"
+        },
+        {
+          "begin": "^\\s+(#!/usr/bin/env\\s+(?:-S\\s+)?deno.*)$",
+          "beginCaptures": {
+            "1": {
+              "name": "comment.line.number-sign.shebang.just"
+            }
+          },
+          "contentName": "source.ts",
+          "patterns": [
+            {
+              "include": "source.ts"
+            }
+          ],
+          "while": "^(?=\\s*$|\\s)"
+        },
+        {
+          "begin": "^\\s+(#!/usr/bin/env\\s+(?:-S\\s+)?perl.*)$",
+          "beginCaptures": {
+            "1": {
+              "name": "comment.line.number-sign.shebang.just"
+            }
+          },
+          "contentName": "source.perl",
+          "patterns": [
+            {
+              "include": "source.perl"
+            }
+          ],
+          "while": "^(?=\\s*$|\\s)"
+        },
+        {
+          "begin": "^\\s+(#!/usr/bin/env\\s+(?:-S\\s+)?python.*)$",
+          "beginCaptures": {
+            "1": {
+              "name": "comment.line.number-sign.shebang.just"
+            }
+          },
+          "contentName": "source.python",
+          "patterns": [
+            {
+              "include": "source.python"
+            }
+          ],
+          "while": "^(?=\\s*$|\\s)"
+        },
+        {
+          "begin": "^\\s+(#!/usr/bin/env\\s+(?:-S\\s+)?ruby.*)$",
+          "beginCaptures": {
+            "1": {
+              "name": "comment.line.number-sign.shebang.just"
+            }
+          },
+          "contentName": "source.ruby",
+          "patterns": [
+            {
+              "include": "source.ruby"
+            }
+          ],
+          "while": "^(?=\\s*$|\\s)"
+        },
+        {
+          "begin": "^\\s+(#!/usr/bin/env\\s+(?:-S\\s+)?(?:|ba|z|fi)sh.*)$",
+          "beginCaptures": {
+            "1": {
+              "name": "comment.line.number-sign.shebang.just"
+            }
+          },
+          "contentName": "source.shell",
+          "patterns": [
+            {
+              "include": "source.shell"
+            }
+          ],
+          "while": "^(?=\\s*$|\\s)"
+        }
+      ]
+    },
+    "escaping": {
+      "patterns": [
+        {
+          "captures": {
+            "1": {
+              "name": "string.interpolated.escape.just"
+            },
+            "2": {
+              "patterns": [
+                {
+                  "include": "#expression"
+                }
+              ]
+            },
+            "3": {
+              "name": "string.interpolated.escape.just"
+            }
+          },
+          "match": "(?<!\\{)(\\{\\{)\\{?(?!\\{)(.*?)(}})",
+          "name": "string.interpolated.escaping.just"
+        }
+      ]
+    },
+    "expression": {
+      "patterns": [
+        {
+          "include": "#backtick"
+        },
+        {
+          "include": "#builtins"
+        },
+        {
+          "include": "#control-keywords"
+        },
+        {
+          "include": "#expression-operators"
+        },
+        {
+          "include": "#parenthesis"
+        },
+        {
+          "include": "#strings"
+        }
+      ]
+    },
+    "expression-operators": {
+      "patterns": [
+        {
+          "match": "/",
+          "name": "keyword.operator.path-join.just"
+        },
+        {
+          "match": "\\+",
+          "name": "keyword.operator.concat.just"
+        },
+        {
+          "match": "&&",
+          "name": "keyword.operator.and.just"
+        },
+        {
+          "match": "\\|\\|",
+          "name": "keyword.operator.or.just"
+        },
+        {
+          "match": "(==|=~|!=)",
+          "name": "keyword.operator.equality.just"
+        }
+      ]
+    },
+    "import": {
+      "begin": "^(import)(\\?)?\\s+",
+      "beginCaptures": {
+        "1": {
+          "name": "keyword.other.reserved.just"
+        },
+        "2": {
+          "name": "punctuation.optional.just"
+        }
+      },
+      "end": "$",
+      "patterns": [
+        {
+          "include": "#strings"
+        }
+      ]
+    },
+    "keywords": {
+      "patterns": [
+        {
+          "include": "#reserved-keywords"
+        },
+        {
+          "include": "#control-keywords"
+        }
+      ]
+    },
+    "literal": {
+      "patterns": [
+        {
+          "include": "#boolean"
+        },
+        {
+          "include": "#number"
+        }
+      ]
+    },
+    "module": {
+      "begin": "^(mod)(\\?)?\\s+([A-Z_a-z][-0-9A-Z_a-z]*)(?=[$\\s])",
+      "beginCaptures": {
+        "1": {
+          "name": "keyword.other.reserved.just"
+        },
+        "2": {
+          "name": "punctuation.optional.just"
+        },
+        "3": {
+          "name": "variable.name.module.just"
+        }
+      },
+      "end": "$",
+      "patterns": [
+        {
+          "include": "#strings"
+        }
+      ]
+    },
+    "number": {
+      "patterns": [
+        {
+          "match": "(?<![-A-Z_a-z])(?:\\.\\d+|\\d+\\.\\d+|\\d+\\.|[1-9]\\d*)",
+          "name": "constant.numeric.just"
+        },
+        {
+          "match": "\\b[0-9]+[-A-Z_a-z]+\\b",
+          "name": "invalid.illegal.name.just"
+        }
+      ]
+    },
+    "parenthesis": {
+      "begin": "\\(",
+      "end": "\\)",
+      "patterns": [
+        {
+          "include": "#expression"
+        },
+        {
+          "include": "#parenthesis"
+        }
+      ]
+    },
+    "recipe-attributes": {
+      "patterns": [
+        {
+          "captures": {
+            "1": {
+              "name": "support.function.system.just"
+            },
+            "2": {
+              "name": "support.function.system.just"
+            }
+          },
+          "match": "^\\[([-A-z]+)\\s*(?:,(\\s*[-A-z]+\\s*))*]\\s*$"
+        },
+        {
+          "captures": {
+            "1": {
+              "name": "support.function.system.just"
+            },
+            "2": {
+              "name": "keyword.operator.attribute.end.just"
+            },
+            "3": {
+              "patterns": [
+                {
+                  "include": "#strings"
+                }
+              ]
+            },
+            "4": {
+              "patterns": [
+                {
+                  "include": "#strings"
+                }
+              ]
+            }
+          },
+          "match": "^\\[([-A-z]+)(?:(:)(.*?)|(\\((.*?)\\)))?]\\s*$"
+        }
+      ]
+    },
+    "recipe-dependencies": {
+      "captures": {
+        "1": {
+          "name": "entity.name.function.just"
+        },
+        "2": {
+          "patterns": [
+            {
+              "captures": {
+                "1": {
+                  "name": "entity.name.function.just"
+                },
+                "2": {
+                  "patterns": [
+                    {
+                      "include": "#expression"
+                    }
+                  ]
+                }
+              },
+              "match": "\\(([A-Z_a-z][-0-9A-Z_a-z]*)(.*)\\)"
+            }
+          ]
+        },
+        "3": {
+          "name": "keyword.operator.and.just"
+        }
+      },
+      "match": "([A-Z_a-z][-0-9A-Z_a-z]*)|(\\((?:[^()]|\\([^)]*\\))*\\))|(&&)"
+    },
+    "recipe-operators": {
+      "patterns": [
+        {
+          "captures": {
+            "1": {
+              "name": "keyword.operator.quiet.just"
+            }
+          },
+          "match": "^\\s+(@)"
+        },
+        {
+          "captures": {
+            "1": {
+              "name": "keyword.operator.error-suppression.just"
+            }
+          },
+          "match": "^\\s+(-)"
+        }
+      ]
+    },
+    "recipe-params": {
+      "captures": {
+        "1": {
+          "name": "keyword.other.recipe.variadic.just"
+        },
+        "2": {
+          "name": "variable.parameter.recipe.just"
+        },
+        "3": {
+          "name": "keyword.operator.default.just"
+        },
+        "4": {
+          "patterns": [
+            {
+              "include": "#strings"
+            }
+          ]
+        },
+        "5": {
+          "patterns": [
+            {
+              "include": "#backtick"
+            }
+          ]
+        },
+        "6": {
+          "patterns": [
+            {
+              "include": "#parenthesis"
+            }
+          ]
+        }
+      },
+      "match": "([$*+])?([A-Z_a-z][0-9A-Z_a-z]*)(?:(=)(?:[A-Z_a-z][0-9A-Z_a-z]*|(\".*?\"|'.*?')|(`.*?`)|(\\((?:[^()]|\\([^)]*\\))*\\))))?"
+    },
+    "recipes": {
+      "patterns": [
+        {
+          "captures": {
+            "1": {
+              "name": "keyword.other.recipe.prefix.just"
+            },
+            "2": {
+              "name": "entity.name.function.just"
+            },
+            "3": {
+              "patterns": [
+                {
+                  "include": "#recipe-params"
+                }
+              ]
+            },
+            "4": {
+              "name": "keyword.operator.recipe.end.just"
+            },
+            "5": {
+              "patterns": [
+                {
+                  "include": "#recipe-dependencies"
+                }
+              ]
+            }
+          },
+          "match": "^(@_|_@|[@_])?([A-Za-z][-0-9A-Z_a-z]*)(?:\\s+(.*?))?\\s*(:)(.*)"
+        },
+        {
+          "include": "#recipe-operators"
+        },
+        {
+          "include": "#recipe-attributes"
+        },
+        {
+          "include": "#embedded-languages"
+        }
+      ]
+    },
+    "reserved-keywords": {
+      "patterns": [
+        {
+          "captures": {
+            "1": {
+              "name": "keyword.other.reserved.just"
+            }
+          },
+          "match": "^(alias|export|unexport|import|mod|set)\\s+"
+        }
+      ]
+    },
+    "setting-assignment": {
+      "patterns": [
+        {
+          "begin": "^(set)\\s+([A-Z_a-z][-0-9A-Z_a-z]*)\\s*(:=)?",
+          "beginCaptures": {
+            "1": {
+              "name": "keyword.other.reserved.just"
+            },
+            "2": {
+              "name": "variable.other.just"
+            },
+            "3": {
+              "name": "keyword.operator.assignment.just"
+            }
+          },
+          "end": "$",
+          "patterns": [
+            {
+              "include": "#expression"
+            },
+            {
+              "include": "#comments"
+            }
+          ]
+        }
+      ]
+    },
+    "strings": {
+      "patterns": [
+        {
+          "match": "([\"']{1,3})\\{+(\\1)",
+          "name": "string.quoted.double.indented.just"
+        },
+        {
+          "begin": "([fx])?(\"\"\")",
+          "beginCaptures": {
+            "1": {
+              "name": "constant.character.expanded.just"
+            },
+            "2": {
+              "name": "string.quoted.double.indented.just"
+            }
+          },
+          "end": "\"\"\"",
+          "name": "string.quoted.double.indented.just",
+          "patterns": [
+            {
+              "match": "\\\\.(?:(?<=u)\\{.+?})?",
+              "name": "constant.character.escape.just"
+            },
+            {
+              "include": "#escaping"
+            }
+          ]
+        },
+        {
+          "begin": "([fx])?(\")",
+          "beginCaptures": {
+            "1": {
+              "name": "constant.character.expanded.just"
+            },
+            "2": {
+              "name": "string.quoted.double.just"
+            }
+          },
+          "end": "\"",
+          "name": "string.quoted.double.just",
+          "patterns": [
+            {
+              "match": "\\\\.(?:(?<=u)\\{.+?})?",
+              "name": "constant.character.escape.just"
+            },
+            {
+              "include": "#escaping"
+            }
+          ]
+        },
+        {
+          "begin": "([fx])?(''')",
+          "beginCaptures": {
+            "1": {
+              "name": "constant.character.expanded.just"
+            },
+            "2": {
+              "name": "string.quoted.single.indented.just"
+            }
+          },
+          "end": "'''",
+          "name": "string.quoted.single.indented.just",
+          "patterns": [
+            {
+              "include": "#escaping"
+            }
+          ]
+        },
+        {
+          "begin": "([fx])?(')",
+          "beginCaptures": {
+            "1": {
+              "name": "constant.character.expanded.just"
+            },
+            "2": {
+              "name": "string.quoted.single.just"
+            }
+          },
+          "end": "'",
+          "name": "string.quoted.single.just",
+          "patterns": [
+            {
+              "include": "#escaping"
+            }
+          ]
+        }
+      ]
+    },
+    "variable-assignment": {
+      "patterns": [
+        {
+          "captures": {
+            "1": {
+              "name": "keyword.other.reserved.just"
+            },
+            "2": {
+              "name": "variable.other.just"
+            }
+          },
+          "match": "^(unexport)\\s+([A-Z_a-z][-0-9A-Z_a-z]*)"
+        },
+        {
+          "begin": "^(?:(export)\\s+)?([A-Z_a-z][-0-9A-Z_a-z]*)\\s*(:=)",
+          "beginCaptures": {
+            "1": {
+              "name": "keyword.other.reserved.just"
+            },
+            "2": {
+              "name": "variable.other.just"
+            },
+            "3": {
+              "name": "keyword.operator.assignment.just"
+            }
+          },
+          "end": "$",
+          "patterns": [
+            {
+              "include": "#expression"
+            },
+            {
+              "include": "#comments"
+            }
+          ]
+        }
+      ]
+    }
+  },
+  "scopeName": "source.just"
+}

--- a/src/main/resources/com/editora/grammars/makefile.tmLanguage.json
+++ b/src/main/resources/com/editora/grammars/makefile.tmLanguage.json
@@ -1,0 +1,629 @@
+{
+  "displayName": "Makefile",
+  "name": "make",
+  "patterns": [
+    {
+      "include": "#comment"
+    },
+    {
+      "include": "#variables"
+    },
+    {
+      "include": "#variable-assignment"
+    },
+    {
+      "include": "#directives"
+    },
+    {
+      "include": "#recipe"
+    },
+    {
+      "include": "#target"
+    }
+  ],
+  "repository": {
+    "another-variable-braces": {
+      "patterns": [
+        {
+          "begin": "(?<=\\{)(?!})",
+          "end": "(?=}|((?<!\\\\)\\n))",
+          "name": "variable.other.makefile",
+          "patterns": [
+            {
+              "include": "#variables"
+            },
+            {
+              "match": "\\\\\\n",
+              "name": "constant.character.escape.continuation.makefile"
+            }
+          ]
+        }
+      ]
+    },
+    "another-variable-parentheses": {
+      "patterns": [
+        {
+          "begin": "(?<=\\()(?!\\))",
+          "end": "(?=\\)|((?<!\\\\)\\n))",
+          "name": "variable.other.makefile",
+          "patterns": [
+            {
+              "include": "#variables"
+            },
+            {
+              "match": "\\\\\\n",
+              "name": "constant.character.escape.continuation.makefile"
+            }
+          ]
+        }
+      ]
+    },
+    "braces-interpolation": {
+      "begin": "\\{",
+      "end": "}",
+      "patterns": [
+        {
+          "include": "#variables"
+        },
+        {
+          "include": "#interpolation"
+        }
+      ]
+    },
+    "builtin-variable-braces": {
+      "patterns": [
+        {
+          "match": "(?<=\\{)(MAKEFILES|VPATH|SHELL|MAKESHELL|MAKE|MAKELEVEL|MAKEFLAGS|MAKECMDGOALS|CURDIR|SUFFIXES|\\.LIBPATTERNS)(?=\\s*})",
+          "name": "variable.language.makefile"
+        }
+      ]
+    },
+    "builtin-variable-parentheses": {
+      "patterns": [
+        {
+          "match": "(?<=\\()(MAKEFILES|VPATH|SHELL|MAKESHELL|MAKE|MAKELEVEL|MAKEFLAGS|MAKECMDGOALS|CURDIR|SUFFIXES|\\.LIBPATTERNS)(?=\\s*\\))",
+          "name": "variable.language.makefile"
+        }
+      ]
+    },
+    "comma": {
+      "match": ",",
+      "name": "punctuation.separator.delimeter.comma.makefile"
+    },
+    "comment": {
+      "begin": "(^ +)?((?<!\\\\)(\\\\\\\\)*)(?=#)",
+      "beginCaptures": {
+        "1": {
+          "name": "punctuation.whitespace.comment.leading.makefile"
+        }
+      },
+      "end": "(?!\\G)",
+      "patterns": [
+        {
+          "begin": "#",
+          "beginCaptures": {
+            "0": {
+              "name": "punctuation.definition.comment.makefile"
+            }
+          },
+          "end": "(?=[^\\\\])$",
+          "name": "comment.line.number-sign.makefile",
+          "patterns": [
+            {
+              "match": "\\\\\\n",
+              "name": "constant.character.escape.continuation.makefile"
+            }
+          ]
+        }
+      ]
+    },
+    "directives": {
+      "patterns": [
+        {
+          "begin": "^ *([-s]?include)\\b",
+          "beginCaptures": {
+            "1": {
+              "name": "keyword.control.include.makefile"
+            }
+          },
+          "end": "^",
+          "patterns": [
+            {
+              "include": "#comment"
+            },
+            {
+              "include": "#variables"
+            },
+            {
+              "match": "%",
+              "name": "constant.other.placeholder.makefile"
+            }
+          ]
+        },
+        {
+          "begin": "^ *(vpath)\\b",
+          "beginCaptures": {
+            "1": {
+              "name": "keyword.control.vpath.makefile"
+            }
+          },
+          "end": "^",
+          "patterns": [
+            {
+              "include": "#comment"
+            },
+            {
+              "include": "#variables"
+            },
+            {
+              "match": "%",
+              "name": "constant.other.placeholder.makefile"
+            }
+          ]
+        },
+        {
+          "begin": "^\\s*(?:(override)\\s*)?(define)\\s*(\\S+)\\s*([+:?]??=)?(?=\\s)",
+          "captures": {
+            "1": {
+              "name": "keyword.control.override.makefile"
+            },
+            "2": {
+              "name": "keyword.control.define.makefile"
+            },
+            "3": {
+              "name": "variable.other.makefile"
+            },
+            "4": {
+              "name": "punctuation.separator.key-value.makefile"
+            }
+          },
+          "end": "^\\s*(endef)\\b",
+          "name": "meta.scope.conditional.makefile",
+          "patterns": [
+            {
+              "begin": "\\G(?!\\n)",
+              "end": "^",
+              "patterns": [
+                {
+                  "include": "#comment"
+                }
+              ]
+            },
+            {
+              "include": "#variables"
+            },
+            {
+              "include": "#directives"
+            }
+          ]
+        },
+        {
+          "begin": "^ *(export)\\b",
+          "beginCaptures": {
+            "1": {
+              "name": "keyword.control.$1.makefile"
+            }
+          },
+          "end": "^",
+          "patterns": [
+            {
+              "include": "#comment"
+            },
+            {
+              "include": "#variable-assignment"
+            },
+            {
+              "match": "\\S+",
+              "name": "variable.other.makefile"
+            }
+          ]
+        },
+        {
+          "begin": "^ *(override|private)\\b",
+          "beginCaptures": {
+            "1": {
+              "name": "keyword.control.$1.makefile"
+            }
+          },
+          "end": "^",
+          "patterns": [
+            {
+              "include": "#comment"
+            },
+            {
+              "include": "#variable-assignment"
+            }
+          ]
+        },
+        {
+          "begin": "^ *(un(?:export|define))\\b",
+          "beginCaptures": {
+            "1": {
+              "name": "keyword.control.$1.makefile"
+            }
+          },
+          "end": "^",
+          "patterns": [
+            {
+              "include": "#comment"
+            },
+            {
+              "match": "\\S+",
+              "name": "variable.other.makefile"
+            }
+          ]
+        },
+        {
+          "begin": "^\\s*(ifn??(?:eq|def))(?=\\s)",
+          "captures": {
+            "1": {
+              "name": "keyword.control.$1.makefile"
+            }
+          },
+          "end": "^\\s*(endif)\\b",
+          "name": "meta.scope.conditional.makefile",
+          "patterns": [
+            {
+              "begin": "\\G",
+              "end": "^",
+              "name": "meta.scope.condition.makefile",
+              "patterns": [
+                {
+                  "include": "#comma"
+                },
+                {
+                  "include": "#variables"
+                },
+                {
+                  "include": "#comment"
+                }
+              ]
+            },
+            {
+              "begin": "^\\s*else(?=\\s)\\s*(ifn??(?:eq|def))*(?=\\s)",
+              "beginCaptures": {
+                "0": {
+                  "name": "keyword.control.else.makefile"
+                }
+              },
+              "end": "^",
+              "patterns": [
+                {
+                  "include": "#comma"
+                },
+                {
+                  "include": "#variables"
+                },
+                {
+                  "include": "#comment"
+                }
+              ]
+            },
+            {
+              "include": "$self"
+            }
+          ]
+        }
+      ]
+    },
+    "flavor-variable-braces": {
+      "patterns": [
+        {
+          "begin": "(?<=\\{)(origin|flavor)\\s(?=[^}\\s]+\\s*})",
+          "beginCaptures": {
+            "1": {
+              "name": "support.function.$1.makefile"
+            }
+          },
+          "contentName": "variable.other.makefile",
+          "end": "(?=})",
+          "name": "meta.scope.function-call.makefile",
+          "patterns": [
+            {
+              "include": "#variables"
+            }
+          ]
+        }
+      ]
+    },
+    "flavor-variable-parentheses": {
+      "patterns": [
+        {
+          "begin": "(?<=\\()(origin|flavor)\\s(?=[^)\\s]+\\s*\\))",
+          "beginCaptures": {
+            "1": {
+              "name": "support.function.$1.makefile"
+            }
+          },
+          "contentName": "variable.other.makefile",
+          "end": "(?=\\))",
+          "name": "meta.scope.function-call.makefile",
+          "patterns": [
+            {
+              "include": "#variables"
+            }
+          ]
+        }
+      ]
+    },
+    "function-variable-braces": {
+      "patterns": [
+        {
+          "begin": "(?<=\\{)(subst|patsubst|strip|findstring|filter(-out)?|sort|word(list)?|firstword|lastword|dir|notdir|suffix|basename|addsuffix|addprefix|join|wildcard|realpath|abspath|info|error|warning|shell|foreach|if|or|and|call|eval|value|file|guile)\\s",
+          "beginCaptures": {
+            "1": {
+              "name": "support.function.$1.makefile"
+            }
+          },
+          "end": "(?=}|((?<!\\\\)\\n))",
+          "name": "meta.scope.function-call.makefile",
+          "patterns": [
+            {
+              "include": "#comma"
+            },
+            {
+              "include": "#variables"
+            },
+            {
+              "include": "#interpolation"
+            },
+            {
+              "match": "[%*]",
+              "name": "constant.other.placeholder.makefile"
+            },
+            {
+              "match": "\\\\\\n",
+              "name": "constant.character.escape.continuation.makefile"
+            }
+          ]
+        }
+      ]
+    },
+    "function-variable-parentheses": {
+      "patterns": [
+        {
+          "begin": "(?<=\\()(subst|patsubst|strip|findstring|filter(-out)?|sort|word(list)?|firstword|lastword|dir|notdir|suffix|basename|addsuffix|addprefix|join|wildcard|realpath|abspath|info|error|warning|shell|foreach|if|or|and|call|eval|value|file|guile)\\s",
+          "beginCaptures": {
+            "1": {
+              "name": "support.function.$1.makefile"
+            }
+          },
+          "end": "(?=\\)|((?<!\\\\)\\n))",
+          "name": "meta.scope.function-call.makefile",
+          "patterns": [
+            {
+              "include": "#comma"
+            },
+            {
+              "include": "#variables"
+            },
+            {
+              "include": "#interpolation"
+            },
+            {
+              "match": "[%*]",
+              "name": "constant.other.placeholder.makefile"
+            },
+            {
+              "match": "\\\\\\n",
+              "name": "constant.character.escape.continuation.makefile"
+            }
+          ]
+        }
+      ]
+    },
+    "interpolation": {
+      "patterns": [
+        {
+          "include": "#parentheses-interpolation"
+        },
+        {
+          "include": "#braces-interpolation"
+        }
+      ]
+    },
+    "parentheses-interpolation": {
+      "begin": "\\(",
+      "end": "\\)",
+      "patterns": [
+        {
+          "include": "#variables"
+        },
+        {
+          "include": "#interpolation"
+        }
+      ]
+    },
+    "recipe": {
+      "begin": "^\\t([-+@]*)",
+      "beginCaptures": {
+        "1": {
+          "name": "keyword.control.$1.makefile"
+        }
+      },
+      "end": "[^\\\\]$",
+      "name": "meta.scope.recipe.makefile",
+      "patterns": [
+        {
+          "match": "\\\\\\n",
+          "name": "constant.character.escape.continuation.makefile"
+        },
+        {
+          "include": "#variables"
+        }
+      ]
+    },
+    "simple-variable": {
+      "patterns": [
+        {
+          "match": "\\$[^(){}]",
+          "name": "variable.language.makefile"
+        }
+      ]
+    },
+    "target": {
+      "begin": "^(?!\\t)([^:]*)(:)(?!=)",
+      "beginCaptures": {
+        "1": {
+          "patterns": [
+            {
+              "captures": {
+                "1": {
+                  "name": "support.function.target.$1.makefile"
+                }
+              },
+              "match": "^\\s*(\\.(PHONY|SUFFIXES|DEFAULT|PRECIOUS|INTERMEDIATE|SECONDARY|SECONDEXPANSION|DELETE_ON_ERROR|IGNORE|LOW_RESOLUTION_TIME|SILENT|EXPORT_ALL_VARIABLES|NOTPARALLEL|ONESHELL|POSIX))\\s*$"
+            },
+            {
+              "begin": "(?=\\S)",
+              "end": "(?=\\s|$)",
+              "name": "entity.name.function.target.makefile",
+              "patterns": [
+                {
+                  "include": "#variables"
+                },
+                {
+                  "match": "%",
+                  "name": "constant.other.placeholder.makefile"
+                }
+              ]
+            }
+          ]
+        },
+        "2": {
+          "name": "punctuation.separator.key-value.makefile"
+        }
+      },
+      "end": "[^\\\\]$",
+      "name": "meta.scope.target.makefile",
+      "patterns": [
+        {
+          "begin": "\\G",
+          "end": "(?=[^\\\\])$",
+          "name": "meta.scope.prerequisites.makefile",
+          "patterns": [
+            {
+              "match": "\\\\\\n",
+              "name": "constant.character.escape.continuation.makefile"
+            },
+            {
+              "match": "[%*]",
+              "name": "constant.other.placeholder.makefile"
+            },
+            {
+              "include": "#comment"
+            },
+            {
+              "include": "#variables"
+            }
+          ]
+        }
+      ]
+    },
+    "variable-assignment": {
+      "begin": "(^ *|\\G\\s*)([^#:=\\s]+)\\s*((?:(?<![!+:?])|[!+:?])=)",
+      "beginCaptures": {
+        "2": {
+          "name": "variable.other.makefile",
+          "patterns": [
+            {
+              "include": "#variables"
+            }
+          ]
+        },
+        "3": {
+          "name": "punctuation.separator.key-value.makefile"
+        }
+      },
+      "end": "\\n",
+      "patterns": [
+        {
+          "match": "\\\\\\n",
+          "name": "constant.character.escape.continuation.makefile"
+        },
+        {
+          "include": "#comment"
+        },
+        {
+          "include": "#variables"
+        }
+      ]
+    },
+    "variable-braces": {
+      "patterns": [
+        {
+          "begin": "\\$\\{",
+          "captures": {
+            "0": {
+              "name": "punctuation.definition.variable.makefile"
+            }
+          },
+          "end": "}|((?<!\\\\)\\n)",
+          "name": "string.interpolated.makefile",
+          "patterns": [
+            {
+              "include": "#variables"
+            },
+            {
+              "include": "#builtin-variable-braces"
+            },
+            {
+              "include": "#function-variable-braces"
+            },
+            {
+              "include": "#flavor-variable-braces"
+            },
+            {
+              "include": "#another-variable-braces"
+            }
+          ]
+        }
+      ]
+    },
+    "variable-parentheses": {
+      "patterns": [
+        {
+          "begin": "\\$\\(",
+          "captures": {
+            "0": {
+              "name": "punctuation.definition.variable.makefile"
+            }
+          },
+          "end": "\\)|((?<!\\\\)\\n)",
+          "name": "string.interpolated.makefile",
+          "patterns": [
+            {
+              "include": "#variables"
+            },
+            {
+              "include": "#builtin-variable-parentheses"
+            },
+            {
+              "include": "#function-variable-parentheses"
+            },
+            {
+              "include": "#flavor-variable-parentheses"
+            },
+            {
+              "include": "#another-variable-parentheses"
+            }
+          ]
+        }
+      ]
+    },
+    "variables": {
+      "patterns": [
+        {
+          "include": "#simple-variable"
+        },
+        {
+          "include": "#variable-parentheses"
+        },
+        {
+          "include": "#variable-braces"
+        }
+      ]
+    }
+  },
+  "scopeName": "source.makefile"
+}

--- a/src/main/resources/com/editora/grammars/properties.tmLanguage.json
+++ b/src/main/resources/com/editora/grammars/properties.tmLanguage.json
@@ -1,0 +1,45 @@
+{
+  "name": "properties",
+  "scopeName": "source.java-properties",
+  "patterns": [
+    {
+      "comment": "Comment lines start with # or ! (java.util.Properties).",
+      "name": "comment.line.number-sign.properties",
+      "match": "^\\s*[#!].*$"
+    },
+    {
+      "comment": "key [=|:|whitespace] value — the value block stays open across \\-continued lines.",
+      "begin": "^\\s*((?:[^\\\\=:\\s]|\\\\.)+)\\s*([=:])?[ \\t]*",
+      "beginCaptures": {
+        "1": {
+          "name": "keyword.other.key.properties",
+          "patterns": [
+            {
+              "name": "constant.character.escape.properties",
+              "match": "\\\\."
+            }
+          ]
+        },
+        "2": {
+          "name": "punctuation.separator.key-value.properties"
+        }
+      },
+      "end": "(?<!\\\\)$",
+      "contentName": "string.unquoted.value.properties",
+      "patterns": [
+        {
+          "name": "constant.character.escape.unicode.properties",
+          "match": "\\\\u[0-9A-Fa-f]{4}"
+        },
+        {
+          "name": "constant.character.escape.continuation.properties",
+          "match": "\\\\$"
+        },
+        {
+          "name": "constant.character.escape.properties",
+          "match": "\\\\."
+        }
+      ]
+    }
+  ]
+}

--- a/src/main/resources/com/editora/grammars/proto.tmLanguage.json
+++ b/src/main/resources/com/editora/grammars/proto.tmLanguage.json
@@ -1,0 +1,507 @@
+{
+  "displayName": "Protocol Buffer 3",
+  "fileTypes": [
+    "proto"
+  ],
+  "name": "proto",
+  "patterns": [
+    {
+      "include": "#comments"
+    },
+    {
+      "include": "#syntax"
+    },
+    {
+      "include": "#package"
+    },
+    {
+      "include": "#import"
+    },
+    {
+      "include": "#optionStmt"
+    },
+    {
+      "include": "#message"
+    },
+    {
+      "include": "#enum"
+    },
+    {
+      "include": "#service"
+    }
+  ],
+  "repository": {
+    "comments": {
+      "patterns": [
+        {
+          "begin": "/\\*",
+          "end": "\\*/",
+          "name": "comment.block.proto"
+        },
+        {
+          "begin": "//",
+          "end": "$\\n?",
+          "name": "comment.line.double-slash.proto"
+        }
+      ]
+    },
+    "constants": {
+      "match": "\\b(true|false|max|[A-Z_]+)\\b",
+      "name": "constant.language.proto"
+    },
+    "enum": {
+      "begin": "(enum)(\\s+)([A-Za-z][0-9A-Z_a-z]*)(\\s*)(\\{)?",
+      "beginCaptures": {
+        "1": {
+          "name": "keyword.other.proto"
+        },
+        "3": {
+          "name": "entity.name.class.proto"
+        }
+      },
+      "end": "}",
+      "patterns": [
+        {
+          "include": "#reserved"
+        },
+        {
+          "include": "#optionStmt"
+        },
+        {
+          "include": "#comments"
+        },
+        {
+          "begin": "([A-Za-z][0-9A-Z_a-z]*)\\s*(=)\\s*(-?0[Xx]\\h+|-?[0-9]+)",
+          "beginCaptures": {
+            "1": {
+              "name": "variable.other.proto"
+            },
+            "2": {
+              "name": "keyword.operator.assignment.proto"
+            },
+            "3": {
+              "name": "constant.numeric.proto"
+            }
+          },
+          "end": "(;)",
+          "endCaptures": {
+            "1": {
+              "name": "punctuation.terminator.proto"
+            }
+          },
+          "patterns": [
+            {
+              "include": "#fieldOptions"
+            }
+          ]
+        }
+      ]
+    },
+    "field": {
+      "begin": "\\s*(optional|repeated|required)?\\s*(\\.?[.\\w]+)\\s+(\\w+)\\s*(=)\\s*(0[Xx]\\h+|[0-9]+)",
+      "beginCaptures": {
+        "1": {
+          "name": "storage.modifier.proto"
+        },
+        "2": {
+          "name": "storage.type.proto"
+        },
+        "3": {
+          "name": "variable.other.proto"
+        },
+        "4": {
+          "name": "keyword.operator.assignment.proto"
+        },
+        "5": {
+          "name": "constant.numeric.proto"
+        }
+      },
+      "end": "(;)",
+      "endCaptures": {
+        "1": {
+          "name": "punctuation.terminator.proto"
+        }
+      },
+      "patterns": [
+        {
+          "include": "#fieldOptions"
+        }
+      ]
+    },
+    "fieldOptions": {
+      "begin": "\\[",
+      "end": "]",
+      "patterns": [
+        {
+          "include": "#constants"
+        },
+        {
+          "include": "#number"
+        },
+        {
+          "include": "#string"
+        },
+        {
+          "include": "#subMsgOption"
+        },
+        {
+          "include": "#optionName"
+        }
+      ]
+    },
+    "ident": {
+      "match": "\\.?[A-Za-z][.0-9A-Z_a-z]*",
+      "name": "entity.name.class.proto"
+    },
+    "import": {
+      "captures": {
+        "1": {
+          "name": "keyword.other.proto"
+        },
+        "2": {
+          "name": "keyword.other.proto"
+        },
+        "3": {
+          "name": "string.quoted.double.proto.import"
+        },
+        "4": {
+          "name": "punctuation.terminator.proto"
+        }
+      },
+      "match": "\\s*(import)\\s+(weak|public)?\\s*(\"[^\"]+\")\\s*(;)"
+    },
+    "kv": {
+      "begin": "(\\w+)\\s*(:)",
+      "beginCaptures": {
+        "1": {
+          "name": "keyword.other.proto"
+        },
+        "2": {
+          "name": "punctuation.separator.key-value.proto"
+        }
+      },
+      "end": "(;)|,|(?=[/A-Z_a-z}])",
+      "endCaptures": {
+        "1": {
+          "name": "punctuation.terminator.proto"
+        }
+      },
+      "patterns": [
+        {
+          "include": "#constants"
+        },
+        {
+          "include": "#number"
+        },
+        {
+          "include": "#string"
+        },
+        {
+          "include": "#subMsgOption"
+        }
+      ]
+    },
+    "mapfield": {
+      "begin": "\\s*(map)\\s*(<)\\s*(\\.?[.\\w]+)\\s*,\\s*(\\.?[.\\w]+)\\s*(>)\\s+(\\w+)\\s*(=)\\s*(\\d+)",
+      "beginCaptures": {
+        "1": {
+          "name": "storage.type.proto"
+        },
+        "2": {
+          "name": "punctuation.definition.typeparameters.begin.proto"
+        },
+        "3": {
+          "name": "storage.type.proto"
+        },
+        "4": {
+          "name": "storage.type.proto"
+        },
+        "5": {
+          "name": "punctuation.definition.typeparameters.end.proto"
+        },
+        "6": {
+          "name": "variable.other.proto"
+        },
+        "7": {
+          "name": "keyword.operator.assignment.proto"
+        },
+        "8": {
+          "name": "constant.numeric.proto"
+        }
+      },
+      "end": "(;)",
+      "endCaptures": {
+        "1": {
+          "name": "punctuation.terminator.proto"
+        }
+      },
+      "patterns": [
+        {
+          "include": "#fieldOptions"
+        }
+      ]
+    },
+    "message": {
+      "begin": "(message|extend)(\\s+)([A-Z_a-z][.0-9A-Z_a-z]*)(\\s*)(\\{)?",
+      "beginCaptures": {
+        "1": {
+          "name": "keyword.other.proto"
+        },
+        "3": {
+          "name": "entity.name.class.message.proto"
+        }
+      },
+      "end": "}",
+      "patterns": [
+        {
+          "include": "#reserved"
+        },
+        {
+          "include": "$self"
+        },
+        {
+          "include": "#enum"
+        },
+        {
+          "include": "#optionStmt"
+        },
+        {
+          "include": "#comments"
+        },
+        {
+          "include": "#oneof"
+        },
+        {
+          "include": "#field"
+        },
+        {
+          "include": "#mapfield"
+        }
+      ]
+    },
+    "method": {
+      "begin": "(rpc)\\s+([A-Za-z][0-9A-Z_a-z]*)",
+      "beginCaptures": {
+        "1": {
+          "name": "keyword.other.proto"
+        },
+        "2": {
+          "name": "entity.name.function"
+        }
+      },
+      "end": "}|(;)",
+      "endCaptures": {
+        "1": {
+          "name": "punctuation.terminator.proto"
+        }
+      },
+      "patterns": [
+        {
+          "include": "#comments"
+        },
+        {
+          "include": "#optionStmt"
+        },
+        {
+          "include": "#rpcKeywords"
+        },
+        {
+          "include": "#ident"
+        }
+      ]
+    },
+    "number": {
+      "match": "\\b((0([Xx])\\h*)|(([0-9]+\\.?[0-9]*)|(\\.[0-9]+))(([Ee])([-+])?[0-9]+)?)\\b",
+      "name": "constant.numeric.proto"
+    },
+    "oneof": {
+      "begin": "(oneof)\\s+([A-Za-z][0-9A-Z_a-z]*)\\s*\\{?",
+      "beginCaptures": {
+        "1": {
+          "name": "keyword.other.proto"
+        },
+        "2": {
+          "name": "variable.other.proto"
+        }
+      },
+      "end": "}",
+      "patterns": [
+        {
+          "include": "#optionStmt"
+        },
+        {
+          "include": "#comments"
+        },
+        {
+          "include": "#field"
+        }
+      ]
+    },
+    "optionName": {
+      "captures": {
+        "1": {
+          "name": "support.other.proto"
+        },
+        "2": {
+          "name": "support.other.proto"
+        },
+        "3": {
+          "name": "support.other.proto"
+        }
+      },
+      "match": "(\\w+|\\(\\w+(\\.\\w+)*\\))(\\.\\w+)*"
+    },
+    "optionStmt": {
+      "begin": "(option)\\s+(\\w+|\\(\\w+(\\.\\w+)*\\))(\\.\\w+)*\\s*(=)",
+      "beginCaptures": {
+        "1": {
+          "name": "keyword.other.proto"
+        },
+        "2": {
+          "name": "support.other.proto"
+        },
+        "3": {
+          "name": "support.other.proto"
+        },
+        "4": {
+          "name": "support.other.proto"
+        },
+        "5": {
+          "name": "keyword.operator.assignment.proto"
+        }
+      },
+      "end": "(;)",
+      "endCaptures": {
+        "1": {
+          "name": "punctuation.terminator.proto"
+        }
+      },
+      "patterns": [
+        {
+          "include": "#constants"
+        },
+        {
+          "include": "#number"
+        },
+        {
+          "include": "#string"
+        },
+        {
+          "include": "#subMsgOption"
+        }
+      ]
+    },
+    "package": {
+      "captures": {
+        "1": {
+          "name": "keyword.other.proto"
+        },
+        "2": {
+          "name": "string.unquoted.proto.package"
+        },
+        "3": {
+          "name": "punctuation.terminator.proto"
+        }
+      },
+      "match": "\\s*(package)\\s+([.\\w]+)\\s*(;)"
+    },
+    "reserved": {
+      "begin": "(reserved)\\s+",
+      "beginCaptures": {
+        "1": {
+          "name": "keyword.other.proto"
+        }
+      },
+      "end": "(;)",
+      "endCaptures": {
+        "1": {
+          "name": "punctuation.terminator.proto"
+        }
+      },
+      "patterns": [
+        {
+          "captures": {
+            "1": {
+              "name": "constant.numeric.proto"
+            },
+            "3": {
+              "name": "keyword.other.proto"
+            },
+            "4": {
+              "name": "constant.numeric.proto"
+            }
+          },
+          "match": "(\\d+)(\\s+(to)\\s+(\\d+))?"
+        },
+        {
+          "include": "#string"
+        }
+      ]
+    },
+    "rpcKeywords": {
+      "match": "\\b(stream|returns)\\b",
+      "name": "keyword.other.proto"
+    },
+    "service": {
+      "begin": "(service)\\s+([A-Za-z][.0-9A-Z_a-z]*)\\s*\\{?",
+      "beginCaptures": {
+        "1": {
+          "name": "keyword.other.proto"
+        },
+        "2": {
+          "name": "entity.name.class.message.proto"
+        }
+      },
+      "end": "}",
+      "patterns": [
+        {
+          "include": "#comments"
+        },
+        {
+          "include": "#optionStmt"
+        },
+        {
+          "include": "#method"
+        }
+      ]
+    },
+    "storagetypes": {
+      "match": "\\b(double|float|int32|int64|uint32|uint64|sint32|sint64|fixed32|fixed64|sfixed32|sfixed64|bool|string|bytes)\\b",
+      "name": "storage.type.proto"
+    },
+    "string": {
+      "match": "([\"'])(?:\\\\.|[^\\\\])*?\\1",
+      "name": "string.quoted.double.proto"
+    },
+    "subMsgOption": {
+      "begin": "\\{",
+      "end": "}",
+      "patterns": [
+        {
+          "include": "#kv"
+        },
+        {
+          "include": "#comments"
+        }
+      ]
+    },
+    "syntax": {
+      "captures": {
+        "1": {
+          "name": "keyword.other.proto"
+        },
+        "2": {
+          "name": "keyword.operator.assignment.proto"
+        },
+        "3": {
+          "name": "string.quoted.double.proto.syntax"
+        },
+        "4": {
+          "name": "punctuation.terminator.proto"
+        }
+      },
+      "match": "\\s*(syntax)\\s*(=)\\s*(\"proto[23]\")\\s*(;)"
+    }
+  },
+  "scopeName": "source.proto"
+}

--- a/src/main/resources/com/editora/styles/syntax.css
+++ b/src/main/resources/com/editora/styles/syntax.css
@@ -54,6 +54,14 @@
 /* CSV/TSV field separators (source.csv grammar): a muted tint so column boundaries stand out. */
 .text.csv-delimiter { -fx-fill: -color-fg-subtle; }
 
+/* Unified diff / patch files (source.diff grammar). Semantic looked-up colors (the log-* convention)
+   so they track the active theme with no per-editor-theme override. */
+.text.diff-inserted { -fx-fill: -color-success-fg; }
+.text.diff-deleted  { -fx-fill: -color-danger-fg; }
+.text.diff-changed  { -fx-fill: -color-warning-fg; }
+.text.diff-range    { -fx-fill: -color-accent-fg; -fx-font-weight: bold; }
+.text.diff-header   { -fx-fill: -color-fg-muted; -fx-font-weight: bold; }
+
 /* Rainbow CSV: per-column colors (cycled every 8) when rainbow highlighting is on — computed in Java
    (CsvRainbow), not the grammar. Eight well-separated hues chosen to read on both light and dark editor
    themes; the compound `.text.<class>` form (0,2,0) wins over the base fill like the token rules above. */

--- a/src/test/java/com/editora/editor/ConfigFileTypeTest.java
+++ b/src/test/java/com/editora/editor/ConfigFileTypeTest.java
@@ -183,4 +183,26 @@ class ConfigFileTypeTest {
         assertNull(ConfigFileType.resolve(".eslintrc.json")); // extension map → json
         assertNull(ConfigFileType.resolve("source.c")); // ends with "c", not "rc"
     }
+
+    @Test
+    void makefileJustfileAndGitattributesByName() {
+        // Makefile — extension-less names (case-insensitive) + the "Makefile.<suffix>" form.
+        assertEquals("makefile", ConfigFileType.resolve("Makefile"));
+        assertEquals("makefile", ConfigFileType.resolve("makefile"));
+        assertEquals("makefile", ConfigFileType.resolve("GNUmakefile"));
+        assertEquals("makefile", ConfigFileType.resolve("Makefile.inc"));
+        assertEquals("makefile", ConfigFileType.resolve("/proj/Makefile"));
+        // justfile — bare and dotfile forms.
+        assertEquals("just", ConfigFileType.resolve("justfile"));
+        assertEquals("just", ConfigFileType.resolve("Justfile"));
+        assertEquals("just", ConfigFileType.resolve(".justfile"));
+        assertEquals("just", ConfigFileType.resolve("/proj/justfile"));
+        // Git attributes — ".gitattributes" anywhere + the repo-local ".git/info/attributes".
+        assertEquals("gitattributes", ConfigFileType.resolve(".gitattributes"));
+        assertEquals("gitattributes", ConfigFileType.resolve("/proj/.gitattributes"));
+        assertEquals("gitattributes", ConfigFileType.resolve("/repo/.git/info/attributes"));
+        // A bare "attributes" outside .git must not match.
+        assertNull(ConfigFileType.resolve("attributes"));
+        assertNull(ConfigFileType.resolve("/etc/attributes"));
+    }
 }

--- a/src/test/java/com/editora/editor/GrammarRegistryTest.java
+++ b/src/test/java/com/editora/editor/GrammarRegistryTest.java
@@ -88,9 +88,39 @@ class GrammarRegistryTest {
         assertNotNull(GrammarRegistry.shared().forLanguageName("fstab"));
         assertNotNull(GrammarRegistry.shared().forFileName("/etc/fstab"));
         assertNotNull(GrammarRegistry.shared().forLanguageName("hosts"));
-        // ".properties" reuses the INI grammar.
+        // ".properties" has its own Java-properties grammar (see plainTextFormatGrammarsLoad).
         assertNotNull(GrammarRegistry.shared().forFileName("app.properties"));
         assertNotNull(GrammarRegistry.shared().forLanguageName("properties"));
+    }
+
+    @Test
+    void plainTextFormatGrammarsLoad() {
+        // Unified diffs / patches (vendored source.diff).
+        assertNotNull(GrammarRegistry.shared().forLanguageName("diff"));
+        assertNotNull(GrammarRegistry.shared().forFileName("changes.diff"));
+        assertNotNull(GrammarRegistry.shared().forFileName("fix.patch"));
+        // Makefile — bare names via ConfigFileType, plus the .mk extension.
+        assertNotNull(GrammarRegistry.shared().forLanguageName("makefile"));
+        assertNotNull(GrammarRegistry.shared().forFileName("Makefile"));
+        assertNotNull(GrammarRegistry.shared().forFileName("GNUmakefile"));
+        assertNotNull(GrammarRegistry.shared().forFileName("rules.mk"));
+        // justfile.
+        assertNotNull(GrammarRegistry.shared().forLanguageName("just"));
+        assertNotNull(GrammarRegistry.shared().forFileName("justfile"));
+        assertNotNull(GrammarRegistry.shared().forFileName(".justfile"));
+        // Protocol Buffers + GraphQL.
+        assertNotNull(GrammarRegistry.shared().forLanguageName("proto"));
+        assertNotNull(GrammarRegistry.shared().forFileName("api.proto"));
+        assertNotNull(GrammarRegistry.shared().forLanguageName("graphql"));
+        assertNotNull(GrammarRegistry.shared().forFileName("schema.graphql"));
+        assertNotNull(GrammarRegistry.shared().forFileName("query.gql"));
+        // Java .properties — its own grammar now (no longer the INI grammar).
+        assertNotNull(GrammarRegistry.shared().forLanguageName("properties"));
+        assertNotNull(GrammarRegistry.shared().forFileName("app.properties"));
+        // .gitattributes (in-house grammar) + the repo-local .git/info/attributes.
+        assertNotNull(GrammarRegistry.shared().forLanguageName("gitattributes"));
+        assertNotNull(GrammarRegistry.shared().forFileName(".gitattributes"));
+        assertNotNull(GrammarRegistry.shared().forFileName("/repo/.git/info/attributes"));
     }
 
     @Test

--- a/src/test/java/com/editora/editor/TextMateHighlighterTest.java
+++ b/src/test/java/com/editora/editor/TextMateHighlighterTest.java
@@ -46,6 +46,21 @@ class TextMateHighlighterTest {
         assertNull(TextMateHighlighter.styleForScopes(null));
     }
 
+    @Test
+    void diffScopesMapToDiffClasses() {
+        assertEquals(
+                "diff-inserted", TextMateHighlighter.styleForScopes(List.of("source.diff", "markup.inserted.diff")));
+        assertEquals("diff-deleted", TextMateHighlighter.styleForScopes(List.of("source.diff", "markup.deleted.diff")));
+        assertEquals("diff-changed", TextMateHighlighter.styleForScopes(List.of("source.diff", "markup.changed.diff")));
+        assertEquals(
+                "diff-range", TextMateHighlighter.styleForScopes(List.of("source.diff", "meta.diff.range.unified")));
+        assertEquals(
+                "diff-header",
+                TextMateHighlighter.styleForScopes(List.of("source.diff", "meta.diff.header.from-file")));
+        // markup.inserted must not shadow the log-info mapping (shared "markup.in" prefix).
+        assertEquals("log-info", TextMateHighlighter.styleForScopes(List.of("source.log", "markup.info.log")));
+    }
+
     // --- end-to-end tokenization through a real grammar ---
 
     @Test
@@ -91,6 +106,31 @@ class TextMateHighlighterTest {
                 new Case("Dockerfile", "FROM alpine:3\nRUN echo hi\n", "keyword"),
                 new Case("main.tf", "resource \"aws_s3_bucket\" \"b\" {\n  bucket = \"x\"\n}\n", "string"),
                 new Case("config.toml", "[server]\nport = 8080\n", "number"))) {
+            IGrammar g = GrammarRegistry.shared().forFileName(c.file());
+            assertNotNull(g, c.file() + " grammar should load");
+            StyleSpans<Collection<String>> spans = TextMateHighlighter.compute(c.text(), g);
+            assertNotNull(spans, c.file() + " should tokenize");
+            assertEquals(c.text().length(), spans.length());
+            assertTrue(hasStyle(spans, c.expectStyle()), c.file() + " expected a " + c.expectStyle() + " span");
+        }
+    }
+
+    @Test
+    void plainTextFormatGrammarsTokenize() {
+        // The 2026-07 plain-text-format batch: vendored diff/makefile/just/proto/graphql grammars plus
+        // the in-house properties/gitattributes ones — each loads and produces the expected span kind.
+        record Case(String file, String text, String expectStyle) {}
+        for (Case c : List.of(
+                new Case("fix.patch", "--- a/x\n+++ b/x\n@@ -1,2 +1,2 @@\n-old line\n+new line\n", "diff-inserted"),
+                new Case("fix.patch", "--- a/x\n+++ b/x\n@@ -1,2 +1,2 @@\n-old line\n+new line\n", "diff-deleted"),
+                new Case("fix.patch", "--- a/x\n+++ b/x\n@@ -1,2 +1,2 @@\n-old\n+new\n", "diff-range"),
+                new Case("Makefile", "# build\nall: main.o\n\tcc -o app main.o\n", "comment"),
+                new Case("justfile", "# recipes\nbuild:\n    cargo build\n", "comment"),
+                new Case("api.proto", "syntax = \"proto3\";\nmessage User {\n  string name = 1;\n}\n", "string"),
+                new Case("schema.graphql", "type Query {\n  user(id: ID!): User\n}\n", "keyword"),
+                new Case("app.properties", "# config\ngreeting = hello\\u0021\n", "comment"),
+                new Case("app.properties", "greeting = hello\\u0021 \\\n  continued\n", "escape"),
+                new Case(".gitattributes", "# attrs\n*.png binary\n*.java diff=java\n", "attribute"))) {
             IGrammar g = GrammarRegistry.shared().forFileName(c.file());
             assertNotNull(g, c.file() + " grammar should load");
             StyleSpans<Collection<String>> spans = TextMateHighlighter.compute(c.text(), g);

--- a/src/test/java/com/editora/ui/FileIconsTest.java
+++ b/src/test/java/com/editora/ui/FileIconsTest.java
@@ -66,6 +66,19 @@ class FileIconsTest {
     }
 
     @Test
+    void plainTextFormats() {
+        assertEquals("code", FileIcons.iconKeyFor("changes.diff"));
+        assertEquals("code", FileIcons.iconKeyFor("fix.patch"));
+        assertEquals("code", FileIcons.iconKeyFor("api.proto"));
+        assertEquals("code", FileIcons.iconKeyFor("schema.graphql"));
+        assertEquals("code", FileIcons.iconKeyFor("query.gql"));
+        assertEquals("terminal", FileIcons.iconKeyFor("Makefile"));
+        assertEquals("terminal", FileIcons.iconKeyFor("rules.mk"));
+        assertEquals("terminal", FileIcons.iconKeyFor("justfile"));
+        assertEquals("settings", FileIcons.iconKeyFor(".gitattributes"));
+    }
+
+    @Test
     void pathsAreReducedToTheLastSegment() {
         assertEquals("java", FileIcons.iconKeyFor("/home/me/src/Main.java"));
         assertEquals("python", FileIcons.iconKeyFor("C:\\project\\script.py"));
@@ -75,7 +88,6 @@ class FileIconsTest {
     @Test
     void unknownAndNullFallBackToGeneric() {
         assertEquals("generic", FileIcons.iconKeyFor("data.unknownext"));
-        assertEquals("generic", FileIcons.iconKeyFor("Makefile")); // no extension, not a known special
         assertEquals("generic", FileIcons.iconKeyFor("noextension"));
         assertEquals("generic", FileIcons.iconKeyFor(null));
     }


### PR DESCRIPTION
## Summary

Adds first-class highlighting for the common plain-text developer formats that were still rendering as plain text:

- **Unified diffs** (`.diff`/`.patch`) — added/removed lines tint green/red, hunk ranges and file headers stand out, via new `.text.diff-*` classes in AtlantaFX semantic colors (theme-adaptive, no per-theme overrides — the `log-*` convention).
- **Makefile** (`Makefile`/`makefile`/`GNUmakefile`/`Makefile.*` + `.mk`/`.mak`/`.make`).
- **justfile** (`justfile`/`.justfile` + `.just`).
- **Protocol Buffers** (`.proto`) — also folds on braces, auto-indents as a brace language, `//` + `/* */` comment toggling.
- **GraphQL** (`.graphql`/`.gql`/`.graphqls`) — braces folding + indent, `#` comments.
- **`.gitattributes`** (+ the repo-local `.git/info/attributes`) — in-house grammar: globs, `attr`/`-attr`/`!attr`/`attr=value`, `[attr]` macros.
- **Java `.properties` upgrade** — a dedicated in-house grammar (`:`/`=`/whitespace separators, `\uXXXX` escapes, backslash continuations tracked as real multi-line values) replacing the INI-grammar borrow.

Grammar sources: diff/make/proto/graphql/just vendored MIT from the shiki tm-grammars collection (attributed in NOTICE, licenses verified against its NOTICE); properties/gitattributes written for Editora. Comment toggling also gained the previously missing `.gitignore` (`ignore`) entry.

Note: `.env` and `.gitignore` from the original batch were already covered by the earlier config-files feature — this PR fills the `.gitattributes` gap and upgrades `.properties`.

## Testing

- `mvn test`: 1423 tests, 0 failures; `spotless:check` clean.
- New coverage: grammar load + end-to-end tokenization for all seven formats (`TextMateHighlighterTest.plainTextFormatGrammarsTokenize`, incl. the properties continuation-line and gitattributes attribute cases), `ConfigFileTypeTest` filename rules, `FileIconsTest`, `classify()` diff mappings (and a guard that `markup.inserted` doesn't shadow `log-info`).
- New `samples/syntax/` files (Makefile with real tab recipes; deliberately no `.gitattributes` sample — a real one would change Git's behavior for the folder) + manifest updated for `SamplesCorpusTest`.

## Performance

No hot-path cost: grammars load lazily per scope only when a matching file opens; the five new `classify()` prefix checks run only after every existing prefix misses; CSS keeps the compound `.text.<class>` form so the per-node style cache is unaffected. No new dependency, no `module-info` change.

## Known nuances (in TODO)

- A brand-new empty Makefile defaults to space indent until a tab-indented line exists (`detectUnit` is language-blind); existing Makefiles detect tabs correctly.
- A `#` comment containing an unbalanced brace can confuse proto/GraphQL folding (same pre-existing limitation as Terraform).

🤖 Generated with [Claude Code](https://claude.com/claude-code)