### PR TITLE
Repaint the editor on tab switch so the content isn't blank

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -136,6 +136,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Blank editor after switching tabs.** Clicking a tab could occasionally show a blank editor until you
+  clicked it a second time to give it focus. The editor area now repaints on the layout pulse right after the
+  tab is shown, so its content appears on the first click (without moving the scroll position or stealing
+  focus from a Find-in-Files preview).
+
 - **Markdown print preview: tables no longer get pushed to their own page.** When printing (or print-
   previewing) a Markdown file, a table could be bumped onto the next page even when it easily fit under the
   preceding heading, leaving the first page mostly blank. The page-layout measurement was collapsing the

--- a/src/main/java/com/editora/editor/EditorBuffer.java
+++ b/src/main/java/com/editora/editor/EditorBuffer.java
@@ -3627,6 +3627,24 @@ public class EditorBuffer implements TabContent {
         }
     }
 
+    /**
+     * Nudges the just-revealed editor area to repaint after a {@code TabPane} tab switch. Flowless's
+     * {@code VirtualFlow} lays out synchronously while the tab content is being swapped in — before its
+     * viewport bounds are established — so it can present <em>blank</em> until the next layout pulse (which,
+     * before this, only a second click into the area supplied). A deferred {@code requestLayout} runs on the
+     * following pulse, once bounds are set, forcing a re-measure + repaint of the visible paragraphs. It does
+     * <em>not</em> move the scroll position or steal focus, so a Find-in-Files preview that keeps focus in its
+     * results tree is unaffected. Called by the controller on tab selection.
+     */
+    public void onTabShown() {
+        javafx.application.Platform.runLater(() -> {
+            area.requestLayout();
+            if (area2 != null) {
+                area2.requestLayout();
+            }
+        });
+    }
+
     /** Sets the minimap's block and viewport-overlay colors (the minimap is canvas-drawn, not CSS). */
     public void setMinimapColors(Color text, Color viewport) {
         this.minimapText = text;

--- a/src/main/java/com/editora/ui/MainController.java
+++ b/src/main/java/com/editora/ui/MainController.java
@@ -1554,6 +1554,7 @@ public class MainController implements com.editora.mcp.McpBridge {
             EditorBuffer buffer = bufferOf(now);
             if (buffer != null) {
                 buffer.setRenderingActive(true);
+                buffer.onTabShown(); // force a repaint: a switched-to area can come up blank until the next pulse
             }
             fileInfoPanel.attach(buffer);
             structurePanel.attach(buffer);


### PR DESCRIPTION
## Problem

Clicking a tab could occasionally show a **blank editor** — you had to click the tab a second time (which focuses the area) to make the content appear. Reported switching to a large file (`MainController.java`).

## Cause

After a `TabPane` tab swap, flowless's `VirtualFlow` lays out synchronously while the new tab content is being installed — *before* its viewport bounds are established — so the just-shown editor area can present blank until its next layout pulse. The second click supplied that pulse.

## Fix

`EditorBuffer.onTabShown()` issues a deferred (`Platform.runLater`) `requestLayout()` on the shown area(s). It runs on the following pulse, once bounds are set, forcing a re-measure + repaint of the visible paragraphs. The tab-selection listener calls it right after `setRenderingActive(true)`.

Deliberately focus-free and scroll-preserving:
- It does **not** `requestFocus`, so a Find-in-Files preview (which selects a match's tab but keeps focus in its results tree so you can keep arrowing) is unaffected.
- It does **not** move the scroll position, so switching back to a file lands where you left it.

## Perf

Negligible — one deferred `requestLayout` per tab switch (an event the user triggers, not a hot path); layout would run on the next pulse regardless.

## Tests

`./mvnw clean verify` green (1432 tests). This is a rendering-timing fix that can't be asserted headlessly; it targets the known flowless "blank-until-next-pulse" cause and should be confirmed in daily use.

🤖 Generated with [Claude Code](https://claude.com/claude-code)