### PR TITLE
TODO Comment Manager (P1): structured-comment parse + more default keywords

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **More default TODO keywords + structured comments (Comment Manager, in progress).** The built-in TODO
+  highlight keywords now include **HACK, NOTE, XXX** and **DONE** alongside TODO/FIXME (existing custom
+  patterns are kept; the defaults grow on upgrade). Groundwork also lands for the IntelliJ-style
+  `KEYWORD [tag] (priority) description` comment format — e.g. `// TODO [auth] (high) fix token refresh` —
+  which upcoming changes will color per-part and group in the TODO tool window.
+
 - **Image viewer.** Opening a raster image (`.png`, `.jpg`/`.jpeg`, `.gif`, `.bmp`) now renders the picture in
   a read-only tab instead of dumping its binary bytes into a text buffer. A small top bar zooms out / in /
   fit-to-window / actual size (and **Ctrl**+mouse-wheel zooms); large images scroll, small ones center. SVG is

--- a/src/main/java/com/editora/config/Settings.java
+++ b/src/main/java/com/editora/config/Settings.java
@@ -10,7 +10,7 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 public class Settings {
 
     /** Current on-disk schema version of {@code settings.toml}; bump when the format changes (+ a migration). */
-    public static final int SCHEMA_VERSION = 49;
+    public static final int SCHEMA_VERSION = 50;
 
     private int schemaVersion = SCHEMA_VERSION;
 

--- a/src/main/java/com/editora/config/migration/ConfigMigrations.java
+++ b/src/main/java/com/editora/config/migration/ConfigMigrations.java
@@ -149,4 +149,42 @@ public final class ConfigMigrations {
         o.set("openProjectIds", ids);
         return o;
     }
+
+    /**
+     * v49 → v50 for {@code settings.toml}: grow an existing user's {@code todoPatterns} to include the new
+     * built-in keyword defaults (HACK / NOTE / XXX / DONE) that joined TODO / FIXME, appending any whose
+     * {@code name} isn't already present (custom entries are untouched, order preserved). Absent
+     * {@code todoPatterns} needs nothing — the read path merges onto {@link com.editora.todo.TodoPatterns#defaults()},
+     * which already lists every keyword.
+     */
+    static JsonNode growTodoDefaultKeywords(JsonNode input) {
+        if (!(input instanceof ObjectNode o)) {
+            return input;
+        }
+        JsonNode node = o.get("todoPatterns");
+        if (node == null || !node.isArray()) {
+            return input;
+        }
+        ArrayNode arr = (ArrayNode) node;
+        java.util.Set<String> present = new java.util.HashSet<>();
+        for (JsonNode e : arr) {
+            JsonNode nm = e.get("name");
+            if (nm != null && nm.isTextual()) {
+                present.add(nm.asText());
+            }
+        }
+        for (com.editora.todo.TodoPattern p : com.editora.todo.TodoPatterns.defaults()) {
+            if (present.contains(p.getName())) {
+                continue;
+            }
+            ObjectNode t = JsonNodeFactory.instance.objectNode();
+            t.put("name", p.getName());
+            t.put("pattern", p.getPattern());
+            t.put("color", p.getColor());
+            t.put("caseSensitive", p.isCaseSensitive());
+            t.put("enabled", p.isEnabled());
+            arr.add(t);
+        }
+        return o;
+    }
 }

--- a/src/main/java/com/editora/config/migration/ConfigSchema.java
+++ b/src/main/java/com/editora/config/migration/ConfigSchema.java
@@ -87,7 +87,9 @@ public enum ConfigSchema {
                     Map.entry(45, (Migration) ConfigMigrations::identity), // v45→46: + wordWrap (additive)
                     Map.entry(46, (Migration) ConfigMigrations::identity), // v46→47: + adminSave (additive)
                     Map.entry(47, (Migration) ConfigMigrations::identity), // v47→48: + csvPreview (additive)
-                    Map.entry(48, (Migration) ConfigMigrations::identity))), // v48→49: + csvRainbow (additive)
+                    Map.entry(48, (Migration) ConfigMigrations::identity), // v48→49: + csvRainbow (additive)
+                    Map.entry(
+                            49, (Migration) ConfigMigrations::growTodoDefaultKeywords))), // v49→50: grow TODO keywords
     WORKSPACE(WorkspaceState.SCHEMA_VERSION, 1, Map.of()),
     BOOKMARKS(BookmarkStore.SCHEMA_VERSION, 1, Map.of()),
     BREAKPOINTS(BreakpointStore.SCHEMA_VERSION, 1, Map.of()),

--- a/src/main/java/com/editora/todo/TodoComment.java
+++ b/src/main/java/com/editora/todo/TodoComment.java
@@ -1,0 +1,136 @@
+package com.editora.todo;
+
+import java.util.List;
+import java.util.Locale;
+
+/**
+ * The structured parse of a TODO-style comment, the IntelliJ "Comment Manager" format:
+ *
+ * <pre>{@code   KEYWORD [tag] (priority) description}</pre>
+ *
+ * e.g. {@code // TODO [auth] (high) token refresh races on logout}. Only the {@code keyword} is required;
+ * the {@code [tag]} and {@code (priority)} are optional and, when present, come in that order right after
+ * the keyword (an optional {@code :} directly after the keyword is tolerated, so {@code TODO: fix it}
+ * parses). {@code priority} is one of {@code critical/high/medium/low} (case-insensitive) — a {@code (…)}
+ * that isn't one of those is left as part of the description. Everything after the recognized parts is the
+ * {@code description}.
+ *
+ * <p>Offsets ({@code *Start}/{@code *End}) are 0-based indices <b>within the line</b> and {@code -1} when the
+ * part is absent; the {@code [tag]} / {@code (priority)} spans <b>include</b> their brackets/parens so the
+ * highlighter can color the delimiters. Pure + unit-tested (no JavaFX / no IO).
+ */
+public record TodoComment(
+        String keyword,
+        String tag,
+        String priority,
+        String description,
+        int tagStart,
+        int tagEnd,
+        int priorityStart,
+        int priorityEnd,
+        int descriptionStart,
+        int descriptionEnd) {
+
+    /** The recognized priorities, most-urgent first (the index is the sort rank). */
+    public static final List<String> PRIORITY_ORDER = List.of("critical", "high", "medium", "low");
+
+    /**
+     * Parses the {@code [tag] (priority) description} that follows the keyword in {@code lineText}, where
+     * the keyword occupies {@code [keywordStart, keywordEnd)} (0-based, within the line — the span
+     * {@link TodoScanner} matched).
+     */
+    public static TodoComment parse(String lineText, int keywordStart, int keywordEnd) {
+        String keyword = lineText.substring(keywordStart, keywordEnd);
+        int n = lineText.length();
+        int i = keywordEnd;
+        if (i < n && lineText.charAt(i) == ':') {
+            i++; // tolerate the common "TODO:" colon right after the keyword
+        }
+
+        String tag = null;
+        int tagStart = -1;
+        int tagEnd = -1;
+        String priority = null;
+        int priorityStart = -1;
+        int priorityEnd = -1;
+
+        // Consume an optional [tag] then an optional (priority), in that order, skipping whitespace between.
+        for (int guard = 0; guard < 2; guard++) {
+            int j = i;
+            while (j < n && Character.isWhitespace(lineText.charAt(j))) {
+                j++;
+            }
+            if (j >= n) {
+                break;
+            }
+            char c = lineText.charAt(j);
+            if (c == '[' && tag == null) {
+                int close = lineText.indexOf(']', j + 1);
+                if (close < 0) {
+                    break;
+                }
+                String content = lineText.substring(j + 1, close).trim();
+                if (content.isEmpty()) {
+                    break; // an empty [] isn't a tag — leave it in the description
+                }
+                tag = content;
+                tagStart = j;
+                tagEnd = close + 1;
+                i = close + 1;
+            } else if (c == '(' && priority == null) {
+                int close = lineText.indexOf(')', j + 1);
+                if (close < 0) {
+                    break;
+                }
+                String content = lineText.substring(j + 1, close).trim().toLowerCase(Locale.ROOT);
+                if (!PRIORITY_ORDER.contains(content)) {
+                    break; // a non-priority (…) belongs to the description
+                }
+                priority = content;
+                priorityStart = j;
+                priorityEnd = close + 1;
+                i = close + 1;
+            } else {
+                break;
+            }
+        }
+
+        int ds = i;
+        while (ds < n && Character.isWhitespace(lineText.charAt(ds))) {
+            ds++;
+        }
+        int de = n;
+        while (de > ds && Character.isWhitespace(lineText.charAt(de - 1))) {
+            de--;
+        }
+        String description = ds < de ? lineText.substring(ds, de) : "";
+        int descriptionStart = description.isEmpty() ? -1 : ds;
+        int descriptionEnd = description.isEmpty() ? -1 : de;
+
+        return new TodoComment(
+                keyword,
+                tag,
+                priority,
+                description,
+                tagStart,
+                tagEnd,
+                priorityStart,
+                priorityEnd,
+                descriptionStart,
+                descriptionEnd);
+    }
+
+    public boolean hasTag() {
+        return tag != null;
+    }
+
+    public boolean hasPriority() {
+        return priority != null;
+    }
+
+    /** Sort rank for the priority (0 = critical … 3 = low), or {@code 4} when there's no priority. */
+    public int priorityRank() {
+        int idx = priority == null ? -1 : PRIORITY_ORDER.indexOf(priority);
+        return idx < 0 ? PRIORITY_ORDER.size() : idx;
+    }
+}

--- a/src/main/java/com/editora/todo/TodoMatch.java
+++ b/src/main/java/com/editora/todo/TodoMatch.java
@@ -3,6 +3,14 @@ package com.editora.todo;
 /**
  * One pattern hit found by {@link TodoScanner}: absolute {@code [start,end)} offsets in the text (for the
  * in-editor highlight), the 1-based {@code line} and {@code col} plus the full {@code lineText} (for the
- * tool-window list), and the matched {@code patternName} + {@code color} (web hex) it belongs to.
+ * tool-window list), the matched {@code patternName} + {@code color} (web hex) it belongs to, and the
+ * {@link TodoComment} structured parse of the rest of the comment ({@code [tag] (priority) description}).
  */
-public record TodoMatch(int start, int end, int line, int col, String lineText, String patternName, String color) {}
+public record TodoMatch(
+        int start, int end, int line, int col, String lineText, String patternName, String color, TodoComment parsed) {
+
+    /** Back-compat constructor for callers/tests that don't supply a parsed structure ({@code parsed} = null). */
+    public TodoMatch(int start, int end, int line, int col, String lineText, String patternName, String color) {
+        this(start, end, line, col, lineText, patternName, color, null);
+    }
+}

--- a/src/main/java/com/editora/todo/TodoPatterns.java
+++ b/src/main/java/com/editora/todo/TodoPatterns.java
@@ -45,11 +45,23 @@ public final class TodoPatterns {
         return out;
     }
 
-    /** The built-in defaults: TODO (amber) and FIXME (red), both whole-word and case-sensitive. */
+    /**
+     * The built-in default keywords — TODO, FIXME, HACK, NOTE, XXX (plus DONE, the "marked done" state) —
+     * each whole-word and case-sensitive, mirroring the IntelliJ "Comment Manager" defaults. The order and
+     * names are also the source of truth for {@link #DEFAULT_KEYWORDS} (the migration that grows an existing
+     * user's list) and {@link #DONE_KEYWORD}.
+     */
     public static List<TodoPattern> defaults() {
         List<TodoPattern> list = new ArrayList<>();
-        list.add(new TodoPattern("TODO", "\\bTODO\\b", "#E5C07B", true, true));
-        list.add(new TodoPattern("FIXME", "\\bFIXME\\b", "#E06C75", true, true));
+        list.add(new TodoPattern("TODO", "\\bTODO\\b", "#E5C07B", true, true)); // amber
+        list.add(new TodoPattern("FIXME", "\\bFIXME\\b", "#E06C75", true, true)); // red
+        list.add(new TodoPattern("HACK", "\\bHACK\\b", "#D19A66", true, true)); // orange
+        list.add(new TodoPattern("NOTE", "\\bNOTE\\b", "#61AFEF", true, true)); // blue
+        list.add(new TodoPattern("XXX", "\\bXXX\\b", "#C678DD", true, true)); // magenta
+        list.add(new TodoPattern(DONE_KEYWORD, "\\bDONE\\b", "#98C379", true, true)); // green (done state)
         return list;
     }
+
+    /** The keyword an item's keyword is rewritten to when it is "marked done" from the tool window. */
+    public static final String DONE_KEYWORD = "DONE";
 }

--- a/src/main/java/com/editora/todo/TodoScanner.java
+++ b/src/main/java/com/editora/todo/TodoScanner.java
@@ -50,7 +50,9 @@ public final class TodoScanner {
                     from = s + 1; // zero-length match — step past it so we can't loop forever
                     continue;
                 }
-                out.add(new TodoMatch(lineStart + s, lineStart + e, line, s + 1, lineText, c.name(), c.color()));
+                TodoComment parsed = TodoComment.parse(lineText, s, e);
+                out.add(new TodoMatch(
+                        lineStart + s, lineStart + e, line, s + 1, lineText, c.name(), c.color(), parsed));
                 from = e;
             }
         }

--- a/src/test/java/com/editora/config/migration/ConfigMigrationsTest.java
+++ b/src/test/java/com/editora/config/migration/ConfigMigrationsTest.java
@@ -95,4 +95,29 @@ class ConfigMigrationsTest {
         ConfigMigrations.backup(f, 2);
         assertEquals("original-backup", Files.readString(bak), "first backup is preserved");
     }
+
+    @Test
+    void growTodoDefaultKeywordsAppendsMissingKeywordsPreservingCustomEntries() {
+        ObjectNode settings = mapper.createObjectNode();
+        ArrayNode patterns = settings.putArray("todoPatterns");
+        patterns.add(mapper.createObjectNode().put("name", "TODO").put("pattern", "\\bTODO\\b"));
+        patterns.add(mapper.createObjectNode().put("name", "MINE").put("pattern", "\\bMINE\\b")); // custom, kept
+
+        ObjectNode out = (ObjectNode) ConfigMigrations.growTodoDefaultKeywords(settings);
+        ArrayNode result = (ArrayNode) out.get("todoPatterns");
+        java.util.List<String> names = new java.util.ArrayList<>();
+        result.forEach(n -> names.add(n.get("name").asText()));
+
+        assertTrue(names.contains("MINE"), "a custom keyword is untouched");
+        assertEquals(1, names.stream().filter("TODO"::equals).count(), "an existing default isn't duplicated");
+        for (String kw : new String[] {"FIXME", "HACK", "NOTE", "XXX", "DONE"}) {
+            assertTrue(names.contains(kw), "missing default keyword " + kw + " is appended");
+        }
+    }
+
+    @Test
+    void growTodoDefaultKeywordsNoOpsWhenPatternsAbsent() {
+        ObjectNode settings = mapper.createObjectNode().put("x", 1); // no todoPatterns ⇒ defaults() supplies them
+        assertFalse(ConfigMigrations.growTodoDefaultKeywords(settings).has("todoPatterns"));
+    }
 }

--- a/src/test/java/com/editora/todo/TodoCommentTest.java
+++ b/src/test/java/com/editora/todo/TodoCommentTest.java
@@ -1,0 +1,102 @@
+package com.editora.todo;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class TodoCommentTest {
+
+    /** Parses {@code text}, locating the keyword by substring (its first occurrence). */
+    private static TodoComment parse(String text, String keyword) {
+        int s = text.indexOf(keyword);
+        return TodoComment.parse(text, s, s + keyword.length());
+    }
+
+    @Test
+    void keywordOnly() {
+        TodoComment c = parse("// TODO clean this up", "TODO");
+        assertEquals("TODO", c.keyword());
+        assertNull(c.tag());
+        assertNull(c.priority());
+        assertEquals("clean this up", c.description());
+        assertFalse(c.hasTag());
+        assertFalse(c.hasPriority());
+    }
+
+    @Test
+    void fullFormat() {
+        String text = "// TODO [auth] (high) token refresh races on logout";
+        TodoComment c = parse(text, "TODO");
+        assertEquals("auth", c.tag());
+        assertEquals("high", c.priority());
+        assertEquals("token refresh races on logout", c.description());
+        // spans include the brackets/parens
+        assertEquals("[auth]", text.substring(c.tagStart(), c.tagEnd()));
+        assertEquals("(high)", text.substring(c.priorityStart(), c.priorityEnd()));
+        assertEquals("token refresh races on logout", text.substring(c.descriptionStart(), c.descriptionEnd()));
+    }
+
+    @Test
+    void tagOnly() {
+        TodoComment c = parse("// FIXME [billing] refund webhook double-fires", "FIXME");
+        assertEquals("billing", c.tag());
+        assertNull(c.priority());
+        assertEquals("refund webhook double-fires", c.description());
+    }
+
+    @Test
+    void priorityOnly() {
+        TodoComment c = parse("# HACK (medium) re-hash on every call", "HACK");
+        assertNull(c.tag());
+        assertEquals("medium", c.priority());
+        assertEquals("re-hash on every call", c.description());
+    }
+
+    @Test
+    void colonAfterKeywordIsTolerated() {
+        TodoComment c = parse("// TODO: [api] (low) add retry", "TODO");
+        assertEquals("api", c.tag());
+        assertEquals("low", c.priority());
+        assertEquals("add retry", c.description());
+    }
+
+    @Test
+    void priorityIsCaseInsensitiveAndNormalizedToLowercase() {
+        assertEquals("critical", parse("TODO (CRITICAL) boom", "TODO").priority());
+        assertEquals("high", parse("TODO (High) x", "TODO").priority());
+    }
+
+    @Test
+    void unknownParenIsDescriptionNotPriority() {
+        TodoComment c = parse("// TODO (later) revisit this (maybe)", "TODO");
+        assertNull(c.priority());
+        assertEquals("(later) revisit this (maybe)", c.description());
+    }
+
+    @Test
+    void emptyBracketsAreNotATag() {
+        TodoComment c = parse("// TODO [] nothing here", "TODO");
+        assertNull(c.tag());
+        assertEquals("[] nothing here", c.description());
+    }
+
+    @Test
+    void noDescription() {
+        TodoComment c = parse("// TODO [ui] (high)", "TODO");
+        assertEquals("ui", c.tag());
+        assertEquals("high", c.priority());
+        assertEquals("", c.description());
+        assertEquals(-1, c.descriptionStart());
+    }
+
+    @Test
+    void priorityRankOrdersUrgentFirst() {
+        assertTrue(parse("TODO (critical) x", "TODO").priorityRank()
+                < parse("TODO (low) x", "TODO").priorityRank());
+        assertEquals(
+                TodoComment.PRIORITY_ORDER.size(), parse("TODO plain", "TODO").priorityRank()); // no priority = last
+    }
+}

--- a/src/test/java/com/editora/todo/TodoPatternsTest.java
+++ b/src/test/java/com/editora/todo/TodoPatternsTest.java
@@ -10,14 +10,13 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 class TodoPatternsTest {
 
     @Test
-    void defaultsAreTodoAndFixme() {
+    void defaultsAreTheStandardKeywords() {
         List<TodoPattern> d = TodoPatterns.defaults();
-        assertEquals(2, d.size());
-        assertEquals("TODO", d.get(0).getName());
-        assertEquals("FIXME", d.get(1).getName());
-        assertTrue(d.get(0).isCaseSensitive(), "defaults are case-sensitive");
-        assertTrue(d.get(1).isCaseSensitive(), "defaults are case-sensitive");
-        assertEquals(2, TodoPatterns.compile(d).size());
+        List<String> names = d.stream().map(TodoPattern::getName).toList();
+        assertEquals(List.of("TODO", "FIXME", "HACK", "NOTE", "XXX", "DONE"), names);
+        assertTrue(d.stream().allMatch(TodoPattern::isCaseSensitive), "defaults are case-sensitive");
+        assertEquals(d.size(), TodoPatterns.compile(d).size(), "all defaults compile");
+        assertEquals("DONE", TodoPatterns.DONE_KEYWORD);
     }
 
     @Test


### PR DESCRIPTION
First phase of upgrading the TODO-highlight feature toward the IntelliJ **"TODO Highlighter & Comment Manager"** model. This PR is the parsing groundwork + a visible bump to the default keyword set; per-part coloring, grouped tool window, and editable write-back follow in later phases.

## Changes

- **`todo/TodoComment`** (pure, unit-tested) parses `KEYWORD [tag] (priority) description` — optional `[tag]` then optional `(priority)` in that order, a tolerated `TODO:` colon, priority ∈ critical/high/medium/low (case-insensitive), the rest is the description. Records each part's line offsets (brackets/parens included) for the upcoming highlighter.
- **`TodoMatch`** carries the parsed `TodoComment` (back-compat constructor keeps existing callers/tests); **`TodoScanner`** populates it.
- **Default keywords grow** from TODO/FIXME to **TODO, FIXME, HACK, NOTE, XXX** + **DONE** (the mark-done state), each whole-word + case-sensitive with a distinct color.
- **Additive settings migration (schema 49→50)** appends the new default keywords to an existing user's `todoPatterns`, preserving custom entries and never duplicating ones already present.

## Behavior

No change beyond the extra highlighted keywords. The structured parse is wired but not yet surfaced (coloring/grouping/editing come next).

## Tests

`TodoCommentTest` (parse cases), `TodoPatternsTest` (updated for the new defaults), `ConfigMigrationsTest` (the keyword-growth migration). `./mvnw clean verify` green (1444 tests). No new dependency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)