### PR TITLE
TODO Comment Manager (P2): per-part comment highlighting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,9 +11,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **More default TODO keywords + structured comments (Comment Manager, in progress).** The built-in TODO
   highlight keywords now include **HACK, NOTE, XXX** and **DONE** alongside TODO/FIXME (existing custom
-  patterns are kept; the defaults grow on upgrade). Groundwork also lands for the IntelliJ-style
+  patterns are kept; the defaults grow on upgrade). Editora now recognizes the IntelliJ-style
   `KEYWORD [tag] (priority) description` comment format — e.g. `// TODO [auth] (high) fix token refresh` —
-  which upcoming changes will color per-part and group in the TODO tool window.
+  and **colors each part** in the editor: the keyword in its pattern color, the `[tag]` in blue (underlined),
+  and the `(priority)` by level (critical→red, high→orange, medium→amber, low→cyan). Grouping these in the
+  TODO tool window comes next.
 
 - **Image viewer.** Opening a raster image (`.png`, `.jpg`/`.jpeg`, `.gif`, `.bmp`) now renders the picture in
   a read-only tab instead of dumping its binary bytes into a text buffer. A small top bar zooms out / in /

--- a/src/main/java/com/editora/editor/TodoHighlightOverlay.java
+++ b/src/main/java/com/editora/editor/TodoHighlightOverlay.java
@@ -14,23 +14,23 @@ import org.fxmisc.richtext.CodeArea;
 import org.fxmisc.richtext.model.TwoDimensional.Bias;
 
 /**
- * Highlights configured TODO/FIXME-style pattern matches behind the editor text, each in its pattern's
- * color, without touching the document's style spans (so it never fights the syntax highlighter). A
- * mouse-transparent {@link Canvas} modeled on {@link SearchHighlightOverlay}: sized to the viewport,
- * redrawn coalesced (one per pulse) on scroll / edit / resize / fold, only for the visible paragraphs,
- * and dropped to 1x1 (no GPU texture) when there are no matches. Driven by {@link #setMarks}.
+ * Highlights configured TODO/FIXME-style pattern matches behind the editor text, without touching the
+ * document's style spans (so it never fights the syntax highlighter). Each match is colored per structural
+ * part of the {@code KEYWORD [tag] (priority) description} comment: the keyword in its pattern color, the
+ * {@code [tag]} in the tag color (with an underline), and the {@code (priority)} in its level color; the
+ * description keeps the normal text color. A mouse-transparent {@link Canvas} modeled on
+ * {@link SearchHighlightOverlay}: sized to the viewport, redrawn coalesced (one per pulse) on scroll / edit /
+ * resize / fold, only for the visible paragraphs, and dropped to 1x1 (no GPU texture) when there are no
+ * matches. Driven by {@link #setMarks}.
  */
 final class TodoHighlightOverlay extends Region {
 
-    /** Opacity of the highlight wash drawn over each match (the pattern color provides the hue). */
+    /** Opacity of the highlight wash drawn over each part (the part color provides the hue). */
     private static final double WASH_ALPHA = 0.30;
 
     private final CodeArea area;
     private final Canvas canvas = new Canvas(1, 1);
-    /** Parsed spans (offsets + already-washed color), parallel to the supplied marks. */
-    private List<int[]> ranges = List.of();
-
-    private List<Color> colors = List.of();
+    private List<TodoMark> marks = List.of();
     private boolean active;
     private boolean redrawPending;
 
@@ -47,21 +47,17 @@ final class TodoHighlightOverlay extends Region {
     }
 
     /** Sets the highlight marks (null/empty clears and releases the canvas). */
-    void setMarks(List<TodoMark> marks) {
-        List<int[]> r = new ArrayList<>();
-        List<Color> c = new ArrayList<>();
-        if (marks != null) {
-            for (TodoMark m : marks) {
-                if (m == null || m.end() <= m.start()) {
-                    continue;
+    void setMarks(List<TodoMark> newMarks) {
+        List<TodoMark> valid = new ArrayList<>();
+        if (newMarks != null) {
+            for (TodoMark m : newMarks) {
+                if (m != null && m.end() > m.start()) {
+                    valid.add(m);
                 }
-                r.add(new int[] {m.start(), m.end()});
-                c.add(washColor(m.colorWeb()));
             }
         }
-        this.ranges = r;
-        this.colors = c;
-        boolean show = !r.isEmpty();
+        this.marks = valid;
+        boolean show = !valid.isEmpty();
         if (active != show) {
             active = show;
             setVisible(show);
@@ -81,6 +77,14 @@ final class TodoHighlightOverlay extends Region {
             return Color.web(web, WASH_ALPHA);
         } catch (RuntimeException ignored) {
             return Color.web("#E5C07B", WASH_ALPHA); // fall back to the default amber on a bad hex
+        }
+    }
+
+    private static Color solidColor(String web) {
+        try {
+            return Color.web(web);
+        } catch (RuntimeException ignored) {
+            return Color.web("#E5C07B");
         }
     }
 
@@ -132,27 +136,55 @@ final class TodoHighlightOverlay extends Region {
             int firstOffset = area.getAbsolutePosition(first, 0);
             int lastOffset = area.getAbsolutePosition(
                     last, area.getParagraph(last).getText().length());
-            for (int i = 0; i < ranges.size(); i++) {
-                int[] m = ranges.get(i);
-                if (m[1] < firstOffset || m[0] > lastOffset) {
+            for (TodoMark m : marks) {
+                int spanEnd = Math.max(m.end(), Math.max(m.tagEnd(), m.priEnd()));
+                if (spanEnd < firstOffset || m.start() > lastOffset) {
                     continue; // off-screen — cheap reject before the costly offset→position conversion
                 }
-                paintMark(g, m, colors.get(i), first, last, w, h);
+                paintSpan(g, m.start(), m.end(), washColor(m.colorWeb()), null, first, last, w, h);
+                if (m.hasTag()) {
+                    paintSpan(
+                            g,
+                            m.tagStart(),
+                            m.tagEnd(),
+                            washColor(m.tagColorWeb()),
+                            solidColor(m.tagColorWeb()),
+                            first,
+                            last,
+                            w,
+                            h);
+                }
+                if (m.hasPriority() && m.priColorWeb() != null) {
+                    paintSpan(g, m.priStart(), m.priEnd(), washColor(m.priColorWeb()), null, first, last, w, h);
+                }
             }
         } catch (RuntimeException ignored) {
             // Viewport mid-layout — skip this frame; a later event will redraw.
         }
     }
 
-    private void paintMark(GraphicsContext g, int[] match, Color color, int first, int last, double w, double h) {
-        var startPos = area.offsetToPosition(match[0], Bias.Forward);
-        var endPos = area.offsetToPosition(Math.max(match[1], match[0]), Bias.Backward);
+    /** Paints a wash over {@code [start,end)}; when {@code underline} is non-null, also strokes a 1px line
+     *  along the bottom of each covered line in that (opaque) color (used to underline the tag). */
+    private void paintSpan(
+            GraphicsContext g,
+            int start,
+            int end,
+            Color color,
+            Color underline,
+            int first,
+            int last,
+            double w,
+            double h) {
+        if (end <= start) {
+            return;
+        }
+        var startPos = area.offsetToPosition(start, Bias.Forward);
+        var endPos = area.offsetToPosition(Math.max(end, start), Bias.Backward);
         int startLine = startPos.getMajor();
         int endLine = endPos.getMajor();
         if (endLine < first || startLine > last) {
             return;
         }
-        g.setFill(color);
         for (int line = Math.max(startLine, first); line <= Math.min(endLine, last); line++) {
             if (area.isFolded(line)) {
                 continue;
@@ -169,7 +201,14 @@ final class TodoHighlightOverlay extends Region {
             if (b == null || b.getMaxX() < 0 || b.getMinX() > w || b.getMaxY() < 0 || b.getMinY() > h) {
                 continue;
             }
+            g.setFill(color);
             g.fillRect(b.getMinX(), b.getMinY(), b.getWidth(), b.getHeight());
+            if (underline != null) {
+                g.setStroke(underline);
+                g.setLineWidth(1);
+                double y = Math.floor(b.getMaxY()) - 0.5;
+                g.strokeLine(b.getMinX(), y, b.getMaxX(), y);
+            }
         }
     }
 

--- a/src/main/java/com/editora/editor/TodoMark.java
+++ b/src/main/java/com/editora/editor/TodoMark.java
@@ -3,8 +3,38 @@ package com.editora.editor;
 /**
  * A neutral in-editor TODO/highlight match for {@link TodoHighlightOverlay} (which uses the absolute
  * {@code [start,end)} offsets) and the {@link TodoStripe}/{@link Minimap} overview stripes (which use the
- * 0-based {@code line} + {@code lineText} for the hover tooltip). {@code colorWeb} is the pattern's web hex
- * (e.g. {@code #E5C07B}). Kept in {@code editor} so the package stays free of the
- * {@code com.editora.todo}/{@code config} packages — {@code MainController} maps scanner results into these.
+ * 0-based {@code line} + {@code lineText} for the hover tooltip). {@code colorWeb} is the keyword's web hex
+ * (e.g. {@code #E5C07B}).
+ *
+ * <p>The optional structured parts — the {@code [tag]} span ({@code tagStart}/{@code tagEnd}/{@code tagColorWeb})
+ * and the {@code (priority)} span ({@code priStart}/{@code priEnd}/{@code priColorWeb}), all <b>absolute</b>
+ * offsets — let the overlay color each part of a {@code KEYWORD [tag] (priority) description} comment
+ * separately; a span is absent when its {@code *Start} is {@code -1}. Kept in {@code editor} so the package
+ * stays free of {@code com.editora.todo}/{@code config} — {@code TodoCoordinator} maps scanner results here.
  */
-public record TodoMark(int start, int end, int line, String lineText, String colorWeb) {}
+public record TodoMark(
+        int start,
+        int end,
+        int line,
+        String lineText,
+        String colorWeb,
+        int tagStart,
+        int tagEnd,
+        String tagColorWeb,
+        int priStart,
+        int priEnd,
+        String priColorWeb) {
+
+    /** Back-compat constructor for a keyword-only mark (no structured tag/priority parts). */
+    public TodoMark(int start, int end, int line, String lineText, String colorWeb) {
+        this(start, end, line, lineText, colorWeb, -1, -1, null, -1, -1, null);
+    }
+
+    public boolean hasTag() {
+        return tagStart >= 0 && tagEnd > tagStart;
+    }
+
+    public boolean hasPriority() {
+        return priStart >= 0 && priEnd > priStart;
+    }
+}

--- a/src/main/java/com/editora/todo/TodoColors.java
+++ b/src/main/java/com/editora/todo/TodoColors.java
@@ -1,0 +1,31 @@
+package com.editora.todo;
+
+/**
+ * The default per-part colors for a structured TODO comment ({@code KEYWORD [tag] (priority) description}):
+ * a color per priority level and one for tags. The keyword's own color comes from its {@link TodoPattern};
+ * the description stays the editor's normal text color. Pure + unit-tested (web-hex strings, no JavaFX).
+ */
+public final class TodoColors {
+
+    /** Tag ({@code [tag]}) color — a blue that reads on both light and dark editor themes. */
+    public static final String TAG_COLOR = "#61AFEF";
+
+    private TodoColors() {}
+
+    /**
+     * The color (web hex) for a {@code (priority)} level — red→amber by urgency, a muted cyan for {@code low}
+     * — or {@code null} when {@code priority} is null / not one of {@link TodoComment#PRIORITY_ORDER}.
+     */
+    public static String priorityColor(String priority) {
+        if (priority == null) {
+            return null;
+        }
+        return switch (priority) {
+            case "critical" -> "#E06C75"; // red
+            case "high" -> "#D19A66"; // orange
+            case "medium" -> "#E5C07B"; // amber
+            case "low" -> "#56B6C2"; // cyan
+            default -> null;
+        };
+    }
+}

--- a/src/main/java/com/editora/ui/TodoCoordinator.java
+++ b/src/main/java/com/editora/ui/TodoCoordinator.java
@@ -124,11 +124,38 @@ final class TodoCoordinator {
         b.setTodoHighlightEnabled(highlightOn);
     }
 
-    /** Maps pure scanner matches to the editor's neutral highlight marks (offsets + 0-based line + color). */
+    /**
+     * Maps pure scanner matches to the editor's neutral highlight marks: the keyword offsets + 0-based line +
+     * color, plus the absolute {@code [tag]} / {@code (priority)} spans (with their part colors) when the
+     * comment parsed structurally, so the overlay can color each part. Part offsets are line-relative in the
+     * parse, so they're rebased to absolute via the line start ({@code keywordStart − (col − 1)}).
+     */
     private static List<TodoMark> toTodoMarks(List<TodoMatch> matches) {
         List<TodoMark> out = new ArrayList<>(matches.size());
         for (TodoMatch m : matches) {
-            out.add(new TodoMark(m.start(), m.end(), Math.max(0, m.line() - 1), m.lineText(), m.color()));
+            int line0 = Math.max(0, m.line() - 1);
+            com.editora.todo.TodoComment p = m.parsed();
+            if (p == null) {
+                out.add(new TodoMark(m.start(), m.end(), line0, m.lineText(), m.color()));
+                continue;
+            }
+            int lineStart = m.start() - (m.col() - 1); // absolute offset of the line's first char
+            int tagStart = p.hasTag() ? lineStart + p.tagStart() : -1;
+            int tagEnd = p.hasTag() ? lineStart + p.tagEnd() : -1;
+            int priStart = p.hasPriority() ? lineStart + p.priorityStart() : -1;
+            int priEnd = p.hasPriority() ? lineStart + p.priorityEnd() : -1;
+            out.add(new TodoMark(
+                    m.start(),
+                    m.end(),
+                    line0,
+                    m.lineText(),
+                    m.color(),
+                    tagStart,
+                    tagEnd,
+                    p.hasTag() ? com.editora.todo.TodoColors.TAG_COLOR : null,
+                    priStart,
+                    priEnd,
+                    com.editora.todo.TodoColors.priorityColor(p.priority())));
         }
         return out;
     }

--- a/src/test/java/com/editora/todo/TodoColorsTest.java
+++ b/src/test/java/com/editora/todo/TodoColorsTest.java
@@ -1,0 +1,30 @@
+package com.editora.todo;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class TodoColorsTest {
+
+    @Test
+    void everyKnownPriorityHasAColor() {
+        for (String p : TodoComment.PRIORITY_ORDER) {
+            String c = TodoColors.priorityColor(p);
+            assertNotNull(c, "priority " + p + " has a color");
+            assertTrue(c.startsWith("#"), "web hex");
+        }
+    }
+
+    @Test
+    void nullOrUnknownPriorityHasNoColor() {
+        assertNull(TodoColors.priorityColor(null));
+        assertNull(TodoColors.priorityColor("someday"));
+    }
+
+    @Test
+    void tagColorIsAWebHex() {
+        assertTrue(TodoColors.TAG_COLOR.startsWith("#"));
+    }
+}


### PR DESCRIPTION
Second phase of the [TODO Comment Manager](https://plugins.jetbrains.com/plugin/32376-todo-highlighter--comment-manager/user-guide) upgrade (follows P1 #298). The editor now colors each **part** of a structured `KEYWORD [tag] (priority) description` comment, not just the keyword.

## Changes

- **`todo/TodoColors`** (pure, unit-tested) — the per-priority colors (critical→red, high→orange, medium→amber, low→cyan) + the tag color (blue).
- **`editor/TodoMark`** now carries the absolute `[tag]` / `(priority)` spans and their colors (back-compat keyword-only constructor kept).
- **`TodoCoordinator.toTodoMarks`** rebases the parse's line-relative part offsets to absolute and attaches part colors.
- **`TodoHighlightOverlay`** paints each part in its color, with an **underline** under the tag — reusing the same visible-only, coalesced, size-independent canvas wash.

So `// TODO [auth] (high) fix token refresh` shows the keyword amber, `[auth]` blue+underlined, `(high)` orange, and the text normal.

## Perf

No new hot-path work: the overlay still redraws coalesced (one per pulse), visible paragraphs only, and drops to 1×1 (no GPU texture) when there are no matches. Per match it now paints up to 3 small spans instead of 1 — negligible, all inside the existing visible-only pass.

## Tests

`TodoColorsTest`; existing overlay path unchanged in shape. `./mvnw clean verify` green (1447 tests). No new dependency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)