### PR TITLE
Settings: describe the TODO comment syntax on the TODO page

### DIFF
--- a/src/main/java/com/editora/ui/SettingsWindow.java
+++ b/src/main/java/com/editora/ui/SettingsWindow.java
@@ -2197,6 +2197,11 @@ public class SettingsWindow {
         VBox p = page(tr("settings.cat.todo"));
         Label todoHl = section(p, tr("settings.section.todo"));
         row(p, Category.TODO, todoHl, todoHighlightCheck, "todo fixme highlight patterns tags comments annotations");
+        Label syntaxNote = note(tr("settings.todoSyntax"));
+        syntaxNote.setWrapText(true);
+        syntaxNote.setMaxWidth(560);
+        syntaxNote.managedProperty().bind(syntaxNote.visibleProperty());
+        p.getChildren().add(syntaxNote); // not a search row, so filter() never fights the visibility binding
         row(p, Category.TODO, todoHl, todoPatternsEditor(), "todo fixme pattern regex color add remove edit");
         return p;
     }

--- a/src/main/resources/com/editora/i18n/messages.properties
+++ b/src/main/resources/com/editora/i18n/messages.properties
@@ -1917,6 +1917,7 @@ todo.addPattern.nameLabel=Name (e.g. TODO)
 todo.addPattern.regexLabel=Pattern (regular expression)
 status.todo.patternAdded=Added highlight pattern: {0}
 settings.todoHighlight=Highlight TODO/FIXME patterns
+settings.todoSyntax=Syntax: KEYWORD [tag] (priority) description — e.g. TODO [auth] (high) fix login. The [tag] and (priority: critical/high/medium/low) are optional. Group, filter, and edit matches in the TODO tool window.
 settings.logViewer=Enable log viewer (.log files)
 settings.section.logs=Logs
 settings.csvPreview=Enable CSV grid preview (.csv/.tsv files)

--- a/src/main/resources/com/editora/i18n/messages_de.properties
+++ b/src/main/resources/com/editora/i18n/messages_de.properties
@@ -1909,6 +1909,7 @@ todo.addPattern.nameLabel=Name (z. B. TODO)
 todo.addPattern.regexLabel=Muster (regulärer Ausdruck)
 status.todo.patternAdded=Hervorhebungsmuster hinzugefügt: {0}
 settings.todoHighlight=TODO/FIXME-Muster hervorheben
+settings.todoSyntax=Syntax: SCHLÜSSELWORT [Tag] (Priorität) Beschreibung — z. B. TODO [auth] (high) Login reparieren. Der [Tag] und die (Priorität: critical/high/medium/low) sind optional. Treffer im TODO-Fenster gruppieren, filtern und bearbeiten.
 settings.logViewer=Log-Viewer aktivieren (.log-Dateien)
 settings.section.logs=Logs
 settings.csvPreview=CSV-Rastervorschau aktivieren (.csv/.tsv-Dateien)

--- a/src/main/resources/com/editora/i18n/messages_es.properties
+++ b/src/main/resources/com/editora/i18n/messages_es.properties
@@ -1909,6 +1909,7 @@ todo.addPattern.nameLabel=Nombre (p. ej. TODO)
 todo.addPattern.regexLabel=Patrón (expresión regular)
 status.todo.patternAdded=Patrón de resaltado añadido: {0}
 settings.todoHighlight=Resaltar patrones TODO/FIXME
+settings.todoSyntax=Sintaxis: PALABRA_CLAVE [etiqueta] (prioridad) descripción — p. ej. TODO [auth] (high) arreglar login. La [etiqueta] y la (prioridad: critical/high/medium/low) son opcionales. Agrupa, filtra y edita las coincidencias en la ventana TODO.
 settings.logViewer=Activar visor de registros (archivos .log)
 settings.section.logs=Registros
 settings.csvPreview=Habilitar vista de cuadrícula CSV (archivos .csv/.tsv)

--- a/src/main/resources/com/editora/i18n/messages_fr.properties
+++ b/src/main/resources/com/editora/i18n/messages_fr.properties
@@ -1909,6 +1909,7 @@ todo.addPattern.nameLabel=Nom (p. ex. TODO)
 todo.addPattern.regexLabel=Motif (expression régulière)
 status.todo.patternAdded=Motif de coloration ajouté : {0}
 settings.todoHighlight=Colorer les motifs TODO/FIXME
+settings.todoSyntax=Syntaxe : MOT_CLÉ [étiquette] (priorité) description — par ex. TODO [auth] (high) corriger la connexion. L'[étiquette] et la (priorité : critical/high/medium/low) sont facultatives. Groupez, filtrez et modifiez les correspondances dans la fenêtre TODO.
 settings.logViewer=Activer la visionneuse de journaux (fichiers .log)
 settings.section.logs=Journaux
 settings.csvPreview=Activer l'aperçu en grille CSV (fichiers .csv/.tsv)

--- a/src/main/resources/com/editora/i18n/messages_it.properties
+++ b/src/main/resources/com/editora/i18n/messages_it.properties
@@ -1909,6 +1909,7 @@ todo.addPattern.nameLabel=Nome (es. TODO)
 todo.addPattern.regexLabel=Pattern (espressione regolare)
 status.todo.patternAdded=Pattern di evidenziazione aggiunto: {0}
 settings.todoHighlight=Evidenzia pattern TODO/FIXME
+settings.todoSyntax=Sintassi: PAROLA_CHIAVE [tag] (priorità) descrizione — es. TODO [auth] (high) correggi login. Il [tag] e la (priorità: critical/high/medium/low) sono facoltativi. Raggruppa, filtra e modifica le corrispondenze nella finestra TODO.
 settings.logViewer=Abilita visualizzatore di log (file .log)
 settings.section.logs=Log
 settings.csvPreview=Abilita anteprima griglia CSV (file .csv/.tsv)

--- a/src/main/resources/com/editora/i18n/messages_pt.properties
+++ b/src/main/resources/com/editora/i18n/messages_pt.properties
@@ -1909,6 +1909,7 @@ todo.addPattern.nameLabel=Nome (ex. TODO)
 todo.addPattern.regexLabel=Padrão (expressão regular)
 status.todo.patternAdded=Padrão de realce adicionado: {0}
 settings.todoHighlight=Realçar padrões TODO/FIXME
+settings.todoSyntax=Sintaxe: PALAVRA_CHAVE [etiqueta] (prioridade) descrição — ex. TODO [auth] (high) corrigir login. A [etiqueta] e a (prioridade: critical/high/medium/low) são opcionais. Agrupe, filtre e edite as correspondências na janela TODO.
 settings.logViewer=Ativar visualizador de logs (arquivos .log)
 settings.section.logs=Logs
 settings.csvPreview=Ativar visualização em grade CSV (arquivos .csv/.tsv)


### PR DESCRIPTION
Small follow-up to the TODO Comment Manager: the Settings → Editor → **TODO Highlighting** page didn't explain the structured comment format, so users had no in-app hint on how to write `[tag]` / `(priority)` comments.

Adds a brief wrapping note under the enable checkbox:

> Syntax: `KEYWORD [tag] (priority) description` — e.g. `TODO [auth] (high) fix login`. The `[tag]` and `(priority: critical/high/medium/low)` are optional. Group, filter, and edit matches in the TODO tool window.

- i18n `settings.todoSyntax` in all six catalogs.
- `./mvnw clean verify` green (1458 tests). No new dependency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)