### PR TITLE
Hex viewer: add scrollbars (wrap CodeArea in VirtualizedScrollPane)

### DIFF
--- a/src/main/java/com/editora/ui/HexViewerPane.java
+++ b/src/main/java/com/editora/ui/HexViewerPane.java
@@ -15,6 +15,7 @@ import javafx.scene.layout.Priority;
 import javafx.scene.layout.StackPane;
 
 import com.editora.editor.TabContent;
+import org.fxmisc.flowless.VirtualizedScrollPane;
 import org.fxmisc.richtext.CodeArea;
 
 import static com.editora.i18n.Messages.tr;
@@ -47,7 +48,9 @@ public final class HexViewerPane implements TabContent {
         area.setEditable(false);
         area.setWrapText(false);
         area.getStyleClass().add("hex-viewer-area");
-        root.setCenter(area);
+        // A bare CodeArea virtualizes but shows no scrollbars; wrap it like the editor does so the dump
+        // scrolls vertically (65k+ rows) and horizontally (a narrow window clips the ASCII column).
+        root.setCenter(new VirtualizedScrollPane<>(area));
         load();
     }
 


### PR DESCRIPTION
Follow-up to the hex viewer (#304). The dump sat in a bare RichTextFX `CodeArea`, which virtualizes but shows **no scrollbars** — so it could only be scrolled with the mouse wheel, and a narrow window clipped the ASCII column with no way to reach it.

Wrap the area in a `VirtualizedScrollPane` (exactly as `EditorBuffer` does), so the dump scrolls both vertically (65k+ rows) and horizontally.

`./mvnw clean verify` green (1473 tests). No new dependency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)