### PR TITLE
AI inline completion: ghost-text continuations at the caret (Tab accepts)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **AI inline completion (ghost text).** After a short typing pause with the caret at the end of a
+  line, a muted single-line AI suggestion appears at the caret — **Tab accepts it**, Esc or typing
+  dismisses it (the same ghost-text presentation prose autocomplete already uses). Requests are
+  strictly bounded: one per ~600 ms idle pause, a windowed prefix/suffix prompt, a one-line stop
+  sequence, and a small output cap — and each keystroke supersedes the in-flight request, so stale
+  suggestions never appear. Runs on its own fast model (default `claude-haiku-4-5`, configurable)
+  independent of the AI-actions model, and never competes with the local snippet/dictionary popup.
+  Off by default (Settings → AI Actions → "Enable AI inline completion"; palette "Toggle AI Inline
+  Completion"); needs the AI Actions feature + an API key; inert in large files and read-only buffers.
+
 - **AI actions — one-shot Anthropic-API features, no agent required.** Three streamed, palette-driven
   actions that call the Anthropic Messages API directly (a hand-rolled `java.net.http` client — no SDK,
   no new dependency): **AI: Generate Commit Message** turns the staged diff into a commit message and

--- a/README.md
+++ b/README.md
@@ -335,9 +335,10 @@ Editora is built with the help of AI coding tools.
   a signed `index.json`) at [adriandeleon/editora-plugins](https://github.com/adriandeleon/editora-plugins).
 - **AI actions** _(Beta)_ — one-shot AI features that call the Anthropic API directly (streamed, no SDK):
   generate a **commit message** from the staged diff into the Commit window, **explain the selection** in
-  a new Markdown buffer, or **rewrite the selection** per an instruction as a single undoable edit. Off by
-  default (Settings → AI Actions); model configurable (default `claude-opus-4-8`); API key from
-  `ANTHROPIC_API_KEY` or a Settings override.
+  a new Markdown buffer, or **rewrite the selection** per an instruction as a single undoable edit. Plus
+  **AI inline completion**: after a typing pause, a muted one-line ghost suggestion at the caret — Tab
+  accepts (its own fast model, default `claude-haiku-4-5`). Off by default (Settings → AI Actions); model
+  configurable (default `claude-opus-4-8`); API key from `ANTHROPIC_API_KEY` or a Settings override.
 - **AI Agent** _(Beta)_ — chat with an embedded coding agent over the
   [Agent Client Protocol](https://agentclientprotocol.com) (ACP). The default command is
   `claude-code-acp` (Claude Code's ACP adapter; any ACP agent works via Settings → AI Agent). The

--- a/TODO.md
+++ b/TODO.md
@@ -80,6 +80,11 @@ A backlog of planned features and improvements. Unordered within each section.
       utf-16le/be, round-tripped on read & save), `max_line_length` (column ruler), and on-save
       `trim_trailing_whitespace` / `insert_final_newline`. Glob sections (`*` `**` `?` `[seq]` `{a,b}`
       `{n1..n2}`). On by default; Settings → Editor + **View: Toggle EditorConfig**. Local files only
+- [x] AI inline completion — ghost-text continuations at the caret after a ~600 ms pause (Tab accepts),
+      riding the existing prose-ghost presentation; windowed prefix/suffix prompt, stop-at-newline,
+      128-token cap, generation-guarded (typing supersedes the in-flight request); its own fast model
+      (default `claude-haiku-4-5`). Off by default under Settings → AI Actions. *(Next: multi-line
+      ghost rendering, accept-word-by-word, per-language enable list.)*
 - [x] AI actions (direct Anthropic API) — streamed one-shot features over `java.net.http` (no SDK, no new
       dependency): commit-message generation from the staged diff (into the Commit window), explain
       selection (into a Markdown buffer), rewrite selection per instruction (one undoable edit, aborts if

--- a/src/main/java/com/editora/ai/AiRequests.java
+++ b/src/main/java/com/editora/ai/AiRequests.java
@@ -21,6 +21,17 @@ public final class AiRequests {
 
     /** A streaming Messages API request: one system prompt + one user turn. */
     public static ObjectNode streamingRequest(ObjectMapper m, String model, String system, String user) {
+        return streamingRequest(m, model, system, user, MAX_TOKENS, java.util.List.of());
+    }
+
+    /** The full form: an explicit output cap + optional stop sequences (inline completion stops at EOL). */
+    public static ObjectNode streamingRequest(
+            ObjectMapper m,
+            String model,
+            String system,
+            String user,
+            int maxTokens,
+            java.util.List<String> stopSequences) {
         ObjectNode msg = m.createObjectNode();
         msg.put("role", "user");
         msg.put("content", user);
@@ -28,10 +39,15 @@ public final class AiRequests {
         messages.add(msg);
         ObjectNode r = m.createObjectNode();
         r.put("model", model);
-        r.put("max_tokens", MAX_TOKENS);
+        r.put("max_tokens", maxTokens);
         r.put("stream", true);
         r.put("system", system);
         r.set("messages", messages);
+        if (!stopSequences.isEmpty()) {
+            ArrayNode stops = m.createArrayNode();
+            stopSequences.forEach(stops::add);
+            r.set("stop_sequences", stops);
+        }
         return r;
     }
 
@@ -68,6 +84,21 @@ public final class AiRequests {
     public static String rewriteUser(String language, String instruction, String code) {
         return "Instruction: " + instruction + "\n\nRewrite this "
                 + (language == null || language.isEmpty() ? "code" : language) + ":\n\n" + truncate(code);
+    }
+
+    /** Output cap for inline completion — one short line, never an essay. */
+    public static final int COMPLETION_MAX_TOKENS = 128;
+
+    public static String completionSystem() {
+        return "You are an inline code-completion engine. The user gives text before and after a <CURSOR>"
+                + " marker. Reply with ONLY the text to insert at the cursor — no explanation, no markdown"
+                + " fences, no repetition of the surrounding text. Prefer completing the current line or"
+                + " statement. Reply with nothing when no useful continuation exists.";
+    }
+
+    public static String completionUser(String language, String prefix, String suffix) {
+        return "Language: " + (language == null || language.isEmpty() ? "plain text" : language) + "\n\n" + prefix
+                + "<CURSOR>" + suffix;
     }
 
     // --- helpers --------------------------------------------------------------------------------------

--- a/src/main/java/com/editora/ai/AiService.java
+++ b/src/main/java/com/editora/ai/AiService.java
@@ -37,10 +37,22 @@ public final class AiService {
 
     /** Streams one generation; a later {@link #cancel}/generate supersedes it (stale callbacks dropped). */
     public void generate(String apiKey, String model, String system, String user, Callbacks cb) {
+        generate(apiKey, model, system, user, AiRequests.MAX_TOKENS, java.util.List.of(), cb);
+    }
+
+    /** The full form: an explicit output cap + stop sequences (inline completion stops at end-of-line). */
+    public void generate(
+            String apiKey,
+            String model,
+            String system,
+            String user,
+            int maxTokens,
+            java.util.List<String> stopSequences,
+            Callbacks cb) {
         long gen = generation.incrementAndGet();
         exec.submit(() -> client.stream(
                 apiKey,
-                AiRequests.streamingRequest(mapper, model, system, user),
+                AiRequests.streamingRequest(mapper, model, system, user, maxTokens, stopSequences),
                 () -> gen != generation.get(),
                 new AiClient.Listener() {
                     @Override

--- a/src/main/java/com/editora/config/Settings.java
+++ b/src/main/java/com/editora/config/Settings.java
@@ -10,7 +10,7 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 public class Settings {
 
     /** Current on-disk schema version of {@code settings.toml}; bump when the format changes (+ a migration). */
-    public static final int SCHEMA_VERSION = 54;
+    public static final int SCHEMA_VERSION = 55;
 
     private int schemaVersion = SCHEMA_VERSION;
 
@@ -200,6 +200,11 @@ public class Settings {
     /** Anthropic API key override; blank = the ANTHROPIC_API_KEY environment variable. Stored in
      *  settings.toml as plain text — prefer the environment variable on shared machines. */
     private String aiApiKey = "";
+    /** AI inline ghost-text completion (a short continuation after a typing pause): off by default;
+     *  effective only when {@link #aiSupport} is on and an API key is available. */
+    private boolean aiInlineCompletion = false;
+    /** The model for inline completion; blank = the built-in default (claude-haiku-4-5 — latency). */
+    private String aiCompletionModel = "";
     /** Java debugging (DAP) support: off by default. Layered on the Java LSP server (jdtls) + the
      *  Microsoft java-debug plugin; effective only when LSP is on, the java server is enabled/detected,
      *  and the plugin jar is found. */
@@ -507,6 +512,22 @@ public class Settings {
 
     public void setAiApiKey(String aiApiKey) {
         this.aiApiKey = aiApiKey;
+    }
+
+    public boolean isAiInlineCompletion() {
+        return aiInlineCompletion;
+    }
+
+    public void setAiInlineCompletion(boolean aiInlineCompletion) {
+        this.aiInlineCompletion = aiInlineCompletion;
+    }
+
+    public String getAiCompletionModel() {
+        return aiCompletionModel == null ? "" : aiCompletionModel;
+    }
+
+    public void setAiCompletionModel(String aiCompletionModel) {
+        this.aiCompletionModel = aiCompletionModel;
     }
 
     public String getIjhttpCommand() {

--- a/src/main/java/com/editora/config/migration/ConfigSchema.java
+++ b/src/main/java/com/editora/config/migration/ConfigSchema.java
@@ -94,7 +94,9 @@ public enum ConfigSchema {
                             ConfigMigrations::identity), // v51→52: + agentSupport/agentCommand (additive)
                     Map.entry(52, (Migration) ConfigMigrations::identity), // v52→53: + autoCloseTags (additive)
                     Map.entry(53, (Migration)
-                            ConfigMigrations::identity))), // v53→54: + aiSupport/aiModel/aiApiKey (additive)
+                            ConfigMigrations::identity), // v53→54: + aiSupport/aiModel/aiApiKey (additive)
+                    Map.entry(54, (Migration)
+                            ConfigMigrations::identity))), // v54→55: + aiInlineCompletion/aiCompletionModel (additive)
     WORKSPACE(WorkspaceState.SCHEMA_VERSION, 1, Map.of()),
     BOOKMARKS(BookmarkStore.SCHEMA_VERSION, 1, Map.of()),
     BREAKPOINTS(BreakpointStore.SCHEMA_VERSION, 1, Map.of()),

--- a/src/main/java/com/editora/editor/EditorBuffer.java
+++ b/src/main/java/com/editora/editor/EditorBuffer.java
@@ -290,6 +290,12 @@ public class EditorBuffer implements TabContent {
     /** Inline "ghost text" suggestion (prose buffers): a single muted suffix drawn after the caret. */
     private Label ghostLabel;
 
+    /** AI inline completion (any buffer): provider + gate + stale-result guard (see ui.AiCoordinator). */
+    private AiCompletionProvider aiCompletionProvider;
+
+    private boolean aiCompletionEnabled;
+    private long aiCompletionGen;
+
     private String ghostSuffix;
     private CodeArea ghostArea;
     /** The two document offsets currently carrying the {@code brace-match} style, or null. */
@@ -5567,6 +5573,29 @@ public class EditorBuffer implements TabContent {
         }
     }
 
+    // ---- AI inline completion (ghost text from an AI provider; see ui.AiCoordinator) ----
+
+    /** Requests a short AI continuation of the text around the caret; the result must be delivered on
+     *  the FX thread (null/empty = nothing to show). Kept editor-neutral so {@code editor} stays free
+     *  of {@code ai}/{@code ui}. */
+    public interface AiCompletionProvider {
+        void complete(String language, String prefix, String suffix, java.util.function.Consumer<String> onResult);
+    }
+
+    /** Injects the AI completion lookup (set by the controller), mirroring {@link #setCompletionProvider}. */
+    public void setAiCompletionProvider(AiCompletionProvider provider) {
+        this.aiCompletionProvider = provider;
+    }
+
+    /** Applies the effective AI-inline-completion gate (feature on + key present, pushed by the controller). */
+    public void setAiCompletionEnabled(boolean enabled) {
+        this.aiCompletionEnabled = enabled;
+        if (!enabled) {
+            aiCompletionGen++; // drop any in-flight request's result
+            hideGhost();
+        }
+    }
+
     private CompletionPopup completionPopup() {
         if (completionPopup == null) {
             completionPopup = new CompletionPopup();
@@ -5795,6 +5824,13 @@ public class EditorBuffer implements TabContent {
                 updateCompletion(a, false);
             }
         });
+        // AI inline completion rides a longer pause (~600 ms) so it never races the local popup/ghost;
+        // each edit bumps the generation, superseding the in-flight request. Zero work while disabled.
+        a.multiPlainChanges().successionEnds(Duration.ofMillis(600)).subscribe(ignored -> {
+            if (a.isFocused()) {
+                maybeRequestAiCompletion(a);
+            }
+        });
         // Any caret move or scroll invalidates the inline ghost's position; clear it (the debounce
         // re-shows it after the next pause in typing). The popup manages its own key/caret handling.
         a.caretPositionProperty().addListener((o, ov, nv) -> {
@@ -5938,6 +5974,58 @@ public class EditorBuffer implements TabContent {
         docPopupActive = completionDocEnabled; // arm the doc popup for this session (Ctrl+Q toggles it)
         completionPopup().setQuery(prefix);
         completionPopup().show(a.getScene().getWindow(), caretScreen, items, 0);
+    }
+
+    /** Prompt-window sizes for AI inline completion (chars before/after the caret). */
+    private static final int AI_COMPLETION_PREFIX_CHARS = 4000;
+
+    private static final int AI_COMPLETION_SUFFIX_CHARS = 1000;
+
+    /**
+     * Fires one AI inline-completion request after a typing pause: only in an editable, non-large buffer
+     * with the caret at end-of-line content (the prose-ghost convention — the suggestion never overlaps
+     * following text) and no completion popup open. The async result shows as ghost text (Tab accepts)
+     * only if the caret hasn't moved and no newer request superseded it.
+     */
+    private void maybeRequestAiCompletion(CodeArea a) {
+        if (!aiCompletionEnabled
+                || aiCompletionProvider == null
+                || largeFile
+                || !isEditable()
+                || hasActiveSnippet()
+                || a.getSelection().getLength() > 0
+                || completionPopupShowing()) {
+            return;
+        }
+        int caret = a.getCaretPosition();
+        if (caret == 0) {
+            return; // nothing to continue yet
+        }
+        String text = a.getText();
+        int lineEnd = caret;
+        while (lineEnd < text.length() && text.charAt(lineEnd) != '\n') {
+            lineEnd++;
+        }
+        if (!text.substring(caret, lineEnd).isBlank()) {
+            return;
+        }
+        String prefix = text.substring(Math.max(0, caret - AI_COMPLETION_PREFIX_CHARS), caret);
+        String suffix = text.substring(caret, Math.min(text.length(), caret + AI_COMPLETION_SUFFIX_CHARS));
+        long gen = ++aiCompletionGen;
+        aiCompletionProvider.complete(language, prefix, suffix, result -> {
+            if (gen != aiCompletionGen
+                    || result == null
+                    || result.isBlank()
+                    || !a.isFocused()
+                    || a.getCaretPosition() != caret
+                    || completionPopupShowing()) {
+                return;
+            }
+            String oneLine = result.lines().findFirst().orElse("").stripTrailing();
+            if (!oneLine.isEmpty()) {
+                showGhost(a, oneLine);
+            }
+        });
     }
 
     /** The suffix of the best word completion that continues {@code prefix}, or null if none qualifies. */

--- a/src/main/java/com/editora/ui/AiCoordinator.java
+++ b/src/main/java/com/editora/ui/AiCoordinator.java
@@ -23,6 +23,9 @@ final class AiCoordinator {
     /** The default model for all AI actions (user-overridable via Settings / {@code ai.setModel}). */
     static final String DEFAULT_MODEL = "claude-opus-4-8";
 
+    /** The default model for inline completion — the fastest tier, since latency is the whole game. */
+    static final String DEFAULT_COMPLETION_MODEL = "claude-haiku-4-5";
+
     /** The AI-specific window services beyond {@link CoordinatorHost}. */
     interface Ops {
         /** The active Git repo root, or null (Git off / not a repo). */
@@ -44,6 +47,10 @@ final class AiCoordinator {
     private final CoordinatorHost host;
     private final Ops ops;
     private final AiService service = new AiService();
+    /** Inline completion streams on its own service so it can never cancel (or be cancelled by) an
+     *  explicit action like commit-message generation; each keystroke's request supersedes the last. */
+    private final AiService completionService = new AiService();
+
     private boolean busy;
 
     AiCoordinator(CoordinatorHost host, Ops ops) {
@@ -54,6 +61,49 @@ final class AiCoordinator {
     /** Whether the AI actions are enabled (the setting, suppressed in Simple UI mode). */
     boolean isEnabled() {
         return host.settings().isAiSupport() && !host.simpleModeActive();
+    }
+
+    /** The effective inline-completion gate: master + sub-toggle + a usable API key. */
+    boolean isInlineCompletionEnabled() {
+        return isEnabled() && host.settings().isAiInlineCompletion() && !apiKey().isEmpty();
+    }
+
+    /** {@code EditorBuffer.AiCompletionProvider}: one short, stop-at-newline completion per idle pause.
+     *  Errors are silent by design — an inline suggester must never nag; the buffer's generation guard
+     *  drops a stale result. */
+    void inlineComplete(String language, String prefix, String suffix, Consumer<String> onResult) {
+        if (!isInlineCompletionEnabled()) {
+            return;
+        }
+        StringBuilder out = new StringBuilder();
+        completionService.generate(
+                apiKey(),
+                completionModel(),
+                AiRequests.completionSystem(),
+                AiRequests.completionUser(language, prefix, suffix),
+                AiRequests.COMPLETION_MAX_TOKENS,
+                java.util.List.of("\n"),
+                new AiService.Callbacks() {
+                    @Override
+                    public void onText(String delta) {
+                        out.append(delta);
+                    }
+
+                    @Override
+                    public void onDone(String stopReason) {
+                        onResult.accept(out.toString());
+                    }
+
+                    @Override
+                    public void onError(String message) {
+                        // silent — see the method note
+                    }
+                });
+    }
+
+    private String completionModel() {
+        String configured = host.settings().getAiCompletionModel();
+        return configured == null || configured.isBlank() ? DEFAULT_COMPLETION_MODEL : configured.trim();
     }
 
     /** {@code ai.cancel}: drop the in-flight generation. */
@@ -265,8 +315,9 @@ final class AiCoordinator {
         return configured == null || configured.isBlank() ? DEFAULT_MODEL : configured.trim();
     }
 
-    /** Window close: cancel any stream + stop the worker thread. */
+    /** Window close: cancel any stream + stop the worker threads. */
     void shutdown() {
         service.shutdown();
+        completionService.shutdown();
     }
 }

--- a/src/main/java/com/editora/ui/MainController.java
+++ b/src/main/java/com/editora/ui/MainController.java
@@ -4548,6 +4548,8 @@ public class MainController implements com.editora.mcp.McpBridge {
         buffer.setOnEnableEditing(() -> enableEditing(buffer)); // "Enable Editing" banner button
         buffer.setSnippetProvider((lang, prefix) -> snippets.byPrefix(lang, prefix));
         buffer.setCompletionProvider(completion::complete);
+        buffer.setAiCompletionProvider(aiCoordinator::inlineComplete);
+        buffer.setAiCompletionEnabled(aiCoordinator.isInlineCompletionEnabled());
         buffer.setMenuContributor(
                 () -> pluginCoordinator.editorMenuItems(buffer)); // plugin-contributed right-click items
         Settings acs = config.getSettings();
@@ -9025,12 +9027,14 @@ public class MainController implements com.editora.mcp.McpBridge {
     private void applyAutocomplete() {
         Settings s = config.getSettings();
         boolean mermaidAc = mermaid.effectiveAutocomplete();
+        boolean aiInline = aiCoordinator.isInlineCompletionEnabled();
         for (Tab tab : tabPane.getTabs()) {
             EditorBuffer buffer = bufferOf(tab);
             if (buffer != null) {
                 buffer.setAutocomplete(
                         s.isAutocomplete(), s.isAutocompleteProse(), s.isAutocompleteSnippets(), mermaidAc);
                 buffer.setCompletionDocEnabled(s.isCompletionDoc());
+                buffer.setAiCompletionEnabled(aiInline);
             }
         }
     }
@@ -10012,6 +10016,20 @@ public class MainController implements com.editora.mcp.McpBridge {
                         "ai.setModel",
                         () -> config.getSettings().getAiModel(),
                         v -> config.getSettings().setAiModel(v),
+                        null)));
+        registry.register(Command.of(
+                "view.toggleAiCompletion",
+                () -> toggleSetting(
+                        "view.toggleAiCompletion",
+                        () -> config.getSettings().isAiInlineCompletion(),
+                        v -> config.getSettings().setAiInlineCompletion(v),
+                        this::applyAutocomplete)));
+        registry.register(Command.of(
+                "ai.setCompletionModel",
+                () -> promptStringSetting(
+                        "ai.setCompletionModel",
+                        () -> config.getSettings().getAiCompletionModel(),
+                        v -> config.getSettings().setAiCompletionModel(v),
                         null)));
         registry.register(Command.of("view.toggleLineHighlight", this::toggleLineHighlight));
         registry.register(Command.of("view.toggleLineNumbers", this::toggleLineNumbers));

--- a/src/main/java/com/editora/ui/SettingsWindow.java
+++ b/src/main/java/com/editora/ui/SettingsWindow.java
@@ -273,6 +273,8 @@ public class SettingsWindow {
     private CheckBox aiCheck;
     private TextField aiModelField;
     private TextField aiApiKeyField;
+    private CheckBox aiInlineCheck;
+    private TextField aiCompletionModelField;
     private TextField mmdcPathField;
     private CheckBox debugCheck;
     /** Per-language debug-adapter controls, keyed by language id (java/python/javascript). */
@@ -1010,6 +1012,17 @@ public class SettingsWindow {
         aiApiKeyField.setPromptText(tr("settings.ai.apiKeyPrompt"));
         aiApiKeyField.textProperty().addListener((obs, was, now) -> {
             config.getSettings().setAiApiKey(now);
+            apply();
+        });
+        aiInlineCheck = new CheckBox(tr("settings.ai.inline"));
+        aiInlineCheck.selectedProperty().addListener((obs, was, now) -> {
+            config.getSettings().setAiInlineCompletion(now);
+            apply();
+        });
+        aiCompletionModelField = new TextField();
+        aiCompletionModelField.setPromptText("claude-haiku-4-5");
+        aiCompletionModelField.textProperty().addListener((obs, was, now) -> {
+            config.getSettings().setAiCompletionModel(now);
             apply();
         });
 
@@ -3476,6 +3489,17 @@ public class SettingsWindow {
         keyNote.setWrapText(true);
         keyNote.setMaxWidth(440);
         row(p, Category.AI, null, keyNote, "ai api key environment variable plain text security");
+        row(p, Category.AI, null, aiInlineCheck, "ai inline ghost completion suggestion copilot autocomplete");
+        row(
+                p,
+                Category.AI,
+                null,
+                exePathRow(tr("settings.ai.completionModel"), aiCompletionModelField),
+                "ai inline completion model haiku fast latency");
+        Label inlineNote = note(tr("settings.ai.inlineHint"));
+        inlineNote.setWrapText(true);
+        inlineNote.setMaxWidth(440);
+        row(p, Category.AI, null, inlineNote, "ai inline ghost completion tab accept cost");
         Label hint = note(tr("settings.ai.hint"));
         hint.setWrapText(true);
         hint.setMaxWidth(440);
@@ -4829,6 +4853,8 @@ public class SettingsWindow {
             aiCheck.setSelected(settings.isAiSupport());
             aiModelField.setText(settings.getAiModel());
             aiApiKeyField.setText(settings.getAiApiKey());
+            aiInlineCheck.setSelected(settings.isAiInlineCompletion());
+            aiCompletionModelField.setText(settings.getAiCompletionModel());
             pluginCheck.setSelected(settings.isPluginSupport());
             if (pluginRequireSigCheck != null) {
                 pluginRequireSigCheck.setSelected(settings.isPluginRequireSignature());
@@ -5241,6 +5267,8 @@ public class SettingsWindow {
             aiCheck.setSelected(config.getSettings().isAiSupport());
             aiModelField.setText(config.getSettings().getAiModel());
             aiApiKeyField.setText(config.getSettings().getAiApiKey());
+            aiInlineCheck.setSelected(config.getSettings().isAiInlineCompletion());
+            aiCompletionModelField.setText(config.getSettings().getAiCompletionModel());
         } finally {
             loading = prev;
         }

--- a/src/main/resources/com/editora/i18n/messages.properties
+++ b/src/main/resources/com/editora/i18n/messages.properties
@@ -2714,3 +2714,10 @@ settings.ai.apiKey=API key
 settings.ai.apiKeyPrompt=Uses ANTHROPIC_API_KEY when empty
 settings.ai.apiKeyNote=The key is stored in settings.toml as plain text — prefer the ANTHROPIC_API_KEY environment variable on shared machines.
 settings.ai.hint=One-shot AI actions that call the Anthropic API directly (streamed): generate a commit message from the staged diff, explain the selection in a Markdown buffer, or rewrite the selection per an instruction as a single undoable edit. Separate from the AI Agent chat window.
+command.view.toggleAiCompletion=Toggle AI Inline Completion
+command.view.toggleAiCompletion.desc=Enable or disable AI ghost-text completion after a typing pause (Tab accepts).
+command.ai.setCompletionModel=AI: Set Completion Model
+command.ai.setCompletionModel.desc=Set the model for inline completion (blank = claude-haiku-4-5).
+settings.ai.inline=Enable AI inline completion (ghost text)
+settings.ai.completionModel=Completion model
+settings.ai.inlineHint=After a short typing pause at the end of a line, a muted single-line suggestion appears at the caret — Tab accepts it, Esc or typing dismisses it. One small request per pause (capped at one line); uses the fast model above.

--- a/src/main/resources/com/editora/i18n/messages_de.properties
+++ b/src/main/resources/com/editora/i18n/messages_de.properties
@@ -2706,3 +2706,10 @@ settings.ai.apiKey=API-Schlüssel
 settings.ai.apiKeyPrompt=Verwendet ANTHROPIC_API_KEY, wenn leer
 settings.ai.apiKeyNote=Der Schlüssel wird als Klartext in settings.toml gespeichert — auf gemeinsam genutzten Rechnern besser die Umgebungsvariable ANTHROPIC_API_KEY verwenden.
 settings.ai.hint=Einmalige KI-Aktionen, die die Anthropic-API direkt aufrufen (gestreamt): eine Commit-Nachricht aus dem gestagten Diff generieren, die Auswahl in einem Markdown-Puffer erklären oder die Auswahl nach einer Anweisung als eine einzige rückgängig machbare Bearbeitung umschreiben. Getrennt vom KI-Agent-Chatfenster.
+command.view.toggleAiCompletion=KI-Inline-Vervollständigung umschalten
+command.view.toggleAiCompletion.desc=KI-Geistertext-Vervollständigung nach einer Tippppause aktivieren oder deaktivieren (Tab übernimmt).
+command.ai.setCompletionModel=KI: Vervollständigungsmodell festlegen
+command.ai.setCompletionModel.desc=Das Modell für die Inline-Vervollständigung festlegen (leer = claude-haiku-4-5).
+settings.ai.inline=KI-Inline-Vervollständigung aktivieren (Geistertext)
+settings.ai.completionModel=Vervollständigungsmodell
+settings.ai.inlineHint=Nach einer kurzen Tippppause am Zeilenende erscheint ein gedämpfter einzeiliger Vorschlag am Cursor — Tab übernimmt ihn, Esc oder Weitertippen verwirft ihn. Eine kleine Anfrage pro Pause (auf eine Zeile begrenzt); verwendet das schnelle Modell oben.

--- a/src/main/resources/com/editora/i18n/messages_es.properties
+++ b/src/main/resources/com/editora/i18n/messages_es.properties
@@ -2706,3 +2706,10 @@ settings.ai.apiKey=Clave de API
 settings.ai.apiKeyPrompt=Usa ANTHROPIC_API_KEY cuando está vacío
 settings.ai.apiKeyNote=La clave se guarda en settings.toml como texto plano — en equipos compartidos, prefiere la variable de entorno ANTHROPIC_API_KEY.
 settings.ai.hint=Acciones de IA puntuales que llaman directamente a la API de Anthropic (en streaming): generar un mensaje de commit a partir del diff preparado, explicar la selección en un búfer Markdown o reescribir la selección según una instrucción como una única edición deshacible. Independiente de la ventana de chat del Agente de IA.
+command.view.toggleAiCompletion=Alternar autocompletado de IA en línea
+command.view.toggleAiCompletion.desc=Activar o desactivar el texto fantasma de IA tras una pausa al escribir (Tab acepta).
+command.ai.setCompletionModel=IA: Establecer modelo de autocompletado
+command.ai.setCompletionModel.desc=Establecer el modelo del autocompletado en línea (vacío = claude-haiku-4-5).
+settings.ai.inline=Activar autocompletado de IA en línea (texto fantasma)
+settings.ai.completionModel=Modelo de autocompletado
+settings.ai.inlineHint=Tras una breve pausa al final de una línea, aparece una sugerencia tenue de una línea en el cursor — Tab la acepta, Esc o seguir escribiendo la descarta. Una petición pequeña por pausa (limitada a una línea); usa el modelo rápido de arriba.

--- a/src/main/resources/com/editora/i18n/messages_fr.properties
+++ b/src/main/resources/com/editora/i18n/messages_fr.properties
@@ -2706,3 +2706,10 @@ settings.ai.apiKey=Clé d'API
 settings.ai.apiKeyPrompt=Utilise ANTHROPIC_API_KEY si vide
 settings.ai.apiKeyNote=La clé est stockée en clair dans settings.toml — sur les machines partagées, préférez la variable d'environnement ANTHROPIC_API_KEY.
 settings.ai.hint=Actions IA ponctuelles qui appellent directement l'API Anthropic (en streaming) : générer un message de commit à partir du diff indexé, expliquer la sélection dans un tampon Markdown, ou réécrire la sélection selon une instruction en une seule modification annulable. Distinct de la fenêtre de discussion Agent IA.
+command.view.toggleAiCompletion=Basculer la complétion IA en ligne
+command.view.toggleAiCompletion.desc=Activer ou désactiver le texte fantôme IA après une pause de frappe (Tab accepte).
+command.ai.setCompletionModel=IA : Définir le modèle de complétion
+command.ai.setCompletionModel.desc=Définir le modèle de la complétion en ligne (vide = claude-haiku-4-5).
+settings.ai.inline=Activer la complétion IA en ligne (texte fantôme)
+settings.ai.completionModel=Modèle de complétion
+settings.ai.inlineHint=Après une courte pause de frappe en fin de ligne, une suggestion discrète d'une ligne apparaît au curseur — Tab l'accepte, Échap ou la frappe la rejette. Une petite requête par pause (limitée à une ligne) ; utilise le modèle rapide ci-dessus.

--- a/src/main/resources/com/editora/i18n/messages_it.properties
+++ b/src/main/resources/com/editora/i18n/messages_it.properties
@@ -2706,3 +2706,10 @@ settings.ai.apiKey=Chiave API
 settings.ai.apiKeyPrompt=Usa ANTHROPIC_API_KEY se vuoto
 settings.ai.apiKeyNote=La chiave è salvata in settings.toml come testo in chiaro — sui computer condivisi preferisci la variabile d'ambiente ANTHROPIC_API_KEY.
 settings.ai.hint=Azioni IA una tantum che chiamano direttamente l'API Anthropic (in streaming): generare un messaggio di commit dal diff in stage, spiegare la selezione in un buffer Markdown o riscrivere la selezione secondo un'istruzione come una singola modifica annullabile. Separato dalla finestra di chat dell'Agente IA.
+command.view.toggleAiCompletion=Attiva/disattiva completamento IA inline
+command.view.toggleAiCompletion.desc=Abilitare o disabilitare il testo fantasma IA dopo una pausa di digitazione (Tab accetta).
+command.ai.setCompletionModel=IA: Imposta modello di completamento
+command.ai.setCompletionModel.desc=Impostare il modello del completamento inline (vuoto = claude-haiku-4-5).
+settings.ai.inline=Abilita completamento IA inline (testo fantasma)
+settings.ai.completionModel=Modello di completamento
+settings.ai.inlineHint=Dopo una breve pausa di digitazione a fine riga, un suggerimento attenuato di una riga appare al cursore — Tab lo accetta, Esc o continuare a digitare lo scarta. Una piccola richiesta per pausa (limitata a una riga); usa il modello veloce qui sopra.

--- a/src/main/resources/com/editora/i18n/messages_pt.properties
+++ b/src/main/resources/com/editora/i18n/messages_pt.properties
@@ -2706,3 +2706,10 @@ settings.ai.apiKey=Chave de API
 settings.ai.apiKeyPrompt=Usa ANTHROPIC_API_KEY quando vazio
 settings.ai.apiKeyNote=A chave é armazenada em settings.toml como texto simples — em máquinas compartilhadas, prefira a variável de ambiente ANTHROPIC_API_KEY.
 settings.ai.hint=Ações de IA pontuais que chamam a API da Anthropic diretamente (em streaming): gerar uma mensagem de commit a partir do diff preparado, explicar a seleção em um buffer Markdown ou reescrever a seleção conforme uma instrução como uma única edição reversível. Separado da janela de chat do Agente de IA.
+command.view.toggleAiCompletion=Alternar preenchimento de IA em linha
+command.view.toggleAiCompletion.desc=Ativar ou desativar o texto fantasma de IA após uma pausa na digitação (Tab aceita).
+command.ai.setCompletionModel=IA: Definir modelo de preenchimento
+command.ai.setCompletionModel.desc=Definir o modelo do preenchimento em linha (vazio = claude-haiku-4-5).
+settings.ai.inline=Ativar preenchimento de IA em linha (texto fantasma)
+settings.ai.completionModel=Modelo de preenchimento
+settings.ai.inlineHint=Após uma breve pausa na digitação no fim de uma linha, uma sugestão discreta de uma linha aparece no cursor — Tab aceita, Esc ou continuar digitando descarta. Uma pequena solicitação por pausa (limitada a uma linha); usa o modelo rápido acima.

--- a/src/test/java/com/editora/ai/AiRequestsTest.java
+++ b/src/test/java/com/editora/ai/AiRequestsTest.java
@@ -53,6 +53,25 @@ class AiRequestsTest {
     }
 
     @Test
+    void completionRequestCarriesStopSequencesAndCap() {
+        ObjectNode r = AiRequests.streamingRequest(
+                m, "claude-haiku-4-5", "sys", "u", AiRequests.COMPLETION_MAX_TOKENS, java.util.List.of("\n"));
+        assertEquals(AiRequests.COMPLETION_MAX_TOKENS, r.get("max_tokens").asInt());
+        assertEquals("\n", r.get("stop_sequences").get(0).asText());
+        // the 4-arg form omits stop_sequences entirely
+        assertTrue(AiRequests.streamingRequest(m, "x", "s", "u").get("stop_sequences") == null);
+    }
+
+    @Test
+    void completionPromptMarksCursorBetweenPrefixAndSuffix() {
+        String user = AiRequests.completionUser("java", "int x = ", ";");
+        assertTrue(user.contains("int x = <CURSOR>;"));
+        assertTrue(user.startsWith("Language: java"));
+        assertTrue(AiRequests.completionUser("", "a", "b").startsWith("Language: plain text"));
+        assertTrue(AiRequests.completionSystem().contains("ONLY the text to insert"));
+    }
+
+    @Test
     void truncateCapsHugeInput() {
         String huge = "x".repeat(AiRequests.MAX_INPUT_CHARS + 100);
         String out = AiRequests.truncate(huge);


### PR DESCRIPTION
## Summary

Tier 4 of the AI integration: **inline ghost-text completion**. After a ~600 ms typing pause with the caret at end-of-line content, a muted single-line AI suggestion appears at the caret — **Tab accepts**, Esc / typing / caret-move dismisses. It rides the exact ghost-text presentation prose autocomplete already uses (`showGhost`/`acceptGhost` + the existing Tab filter), so there is no new UI surface to maintain.

## Design

- **`EditorBuffer`** — an injected, editor-neutral `AiCompletionProvider` + a `setAiCompletionEnabled` gate. A second `multiPlainChanges` debounce (600 ms, vs the local popup's 280 ms) fires `maybeRequestAiCompletion`, which bails in large files, read-only buffers, snippet sessions, with a selection, or while the completion popup is open. Results are **generation-guarded and caret-checked** — a keystroke supersedes the in-flight request, so a stale suggestion can never appear.
- **`ai/`** — `AiRequests` gains a `<CURSOR>` prefix/suffix completion prompt (4000/1000-char windows cut in the buffer) and a `streamingRequest` overload with an output cap + `stop_sequences`; inline requests stop at the first newline and cap at **128 tokens**, so each one is tiny.
- **`AiCoordinator`** — a **dedicated `AiService` instance** for completion, so inline requests never cancel (or get cancelled by) an explicit action like commit-message generation. Errors are silent by design — an inline suggester must never nag. Default model **`claude-haiku-4-5`** (latency is the whole game), configurable separately from the AI-actions model.
- **Config/conventions**: `Settings.aiInlineCompletion` (default **off**, effective only with AI Actions on + an API key) + `aiCompletionModel` (schema 54→55, additive-identity); Settings → AI Actions rows; palette `view.toggleAiCompletion` / `ai.setCompletionModel`; i18n in all six catalogs. **No new dependency.**

## Performance / cost

Off (default): one boolean check per idle pulse — nothing else. On: one bounded request per idle pause (windowed prompt, one-line stop, 128-token cap), auto-superseded by the next keystroke; the ghost render is the existing single-Label overlay. No per-keystroke or per-scroll work is added in either state.

## Testing

- `AiRequestsTest` extended: stop-sequences/output-cap request shape (and the 4-arg form omitting `stop_sequences`), `<CURSOR>` prompt assembly, plain-text language fallback.
- Full non-FX suite: **1498 tests, 0 failures** (incl. i18n key parity across six catalogs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)