### PR TITLE
Persist the TODO tool window's Group by choice

### DIFF
--- a/src/main/java/com/editora/config/Settings.java
+++ b/src/main/java/com/editora/config/Settings.java
@@ -10,7 +10,7 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 public class Settings {
 
     /** Current on-disk schema version of {@code settings.toml}; bump when the format changes (+ a migration). */
-    public static final int SCHEMA_VERSION = 55;
+    public static final int SCHEMA_VERSION = 56;
 
     private int schemaVersion = SCHEMA_VERSION;
 
@@ -100,6 +100,8 @@ public class Settings {
     private boolean todoHighlight = true;
     /** The highlight patterns (regex + color); defaults to TODO (amber) + FIXME (red). */
     private java.util.List<com.editora.todo.TodoPattern> todoPatterns = com.editora.todo.TodoPatterns.defaults();
+    /** The TODO tool window's "Group by" dimension (FILE/PRIORITY/TAG/KEYWORD); persisted across sessions. */
+    private String todoGroupBy = "FILE";
 
     private java.util.List<com.editora.externaltool.ExternalTool> externalTools = new java.util.ArrayList<>();
     /** Lint Markdown buffers (squiggles + the Markdown Lint tool window). */
@@ -729,6 +731,14 @@ public class Settings {
 
     public void setTodoPatterns(java.util.List<com.editora.todo.TodoPattern> todoPatterns) {
         this.todoPatterns = todoPatterns;
+    }
+
+    public String getTodoGroupBy() {
+        return todoGroupBy == null ? "FILE" : todoGroupBy;
+    }
+
+    public void setTodoGroupBy(String todoGroupBy) {
+        this.todoGroupBy = todoGroupBy;
     }
 
     public java.util.List<com.editora.externaltool.ExternalTool> getExternalTools() {

--- a/src/main/java/com/editora/config/migration/ConfigSchema.java
+++ b/src/main/java/com/editora/config/migration/ConfigSchema.java
@@ -96,7 +96,8 @@ public enum ConfigSchema {
                     Map.entry(53, (Migration)
                             ConfigMigrations::identity), // v53→54: + aiSupport/aiModel/aiApiKey (additive)
                     Map.entry(54, (Migration)
-                            ConfigMigrations::identity))), // v54→55: + aiInlineCompletion/aiCompletionModel (additive)
+                            ConfigMigrations::identity), // v54→55: + aiInlineCompletion/aiCompletionModel (additive)
+                    Map.entry(55, (Migration) ConfigMigrations::identity))), // v55→56: + todoGroupBy (additive)
     WORKSPACE(WorkspaceState.SCHEMA_VERSION, 1, Map.of()),
     BOOKMARKS(BookmarkStore.SCHEMA_VERSION, 1, Map.of()),
     BREAKPOINTS(BreakpointStore.SCHEMA_VERSION, 1, Map.of()),

--- a/src/main/java/com/editora/ui/TodoCoordinator.java
+++ b/src/main/java/com/editora/ui/TodoCoordinator.java
@@ -13,6 +13,7 @@ import com.editora.config.Settings;
 import com.editora.editor.EditorBuffer;
 import com.editora.editor.TodoMark;
 import com.editora.editor.TodoMatcher;
+import com.editora.todo.TodoGrouping;
 import com.editora.todo.TodoMatch;
 import com.editora.todo.TodoPattern;
 import com.editora.todo.TodoPatterns;
@@ -104,6 +105,41 @@ final class TodoCoordinator {
                                         m.lineText(), m.col() - 1, m.parsed(), text)));
             }
         });
+        // Persist any group-by change the user makes. The lambda reads settings lazily (config isn't set at
+        // construction time — the coordinator is a MainController field), and the restore below is guarded so
+        // it doesn't re-save the value it just restored.
+        panel.setGroupByChangeHandler(g -> {
+            if (restoringGroupBy) {
+                return;
+            }
+            host.settings().setTodoGroupBy(g.name());
+            host.requestSave();
+        });
+    }
+
+    /** True while {@link #restoreGroupByOnce} is programmatically setting the group-by (suppresses re-saving). */
+    private boolean restoringGroupBy;
+
+    private boolean groupByRestored;
+
+    /** Restores the persisted "Group by" dimension once, on the first {@link #applyHighlight} (config is ready). */
+    private void restoreGroupByOnce() {
+        if (groupByRestored) {
+            return;
+        }
+        groupByRestored = true;
+        restoringGroupBy = true;
+        panel.setGroupBy(parseGroupBy(host.settings().getTodoGroupBy()));
+        restoringGroupBy = false;
+    }
+
+    /** Parses a persisted "Group by" name back to the enum, defaulting to {@code FILE} for anything unknown. */
+    private static TodoGrouping.GroupBy parseGroupBy(String name) {
+        try {
+            return TodoGrouping.GroupBy.valueOf(name);
+        } catch (IllegalArgumentException | NullPointerException e) {
+            return TodoGrouping.GroupBy.FILE;
+        }
     }
 
     /** Rewrites the match's source line (undoable) via the controller, then re-scans if the panel is open. */
@@ -149,6 +185,7 @@ final class TodoCoordinator {
     /** Compiles the configured patterns and pushes the highlight matcher + on/off to every buffer. On by
      *  default; the project / open-files scan in the TODO tool window is lazy (refreshed on demand). */
     void applyHighlight() {
+        restoreGroupByOnce(); // first apply (init) runs after config is set — safe to read the saved group-by
         Settings s = host.settings();
         highlightOn = s.isTodoHighlight();
         List<TodoPatterns.Compiled> compiled = highlightOn ? TodoPatterns.compile(s.getTodoPatterns()) : List.of();

--- a/src/main/java/com/editora/ui/TodoPanel.java
+++ b/src/main/java/com/editora/ui/TodoPanel.java
@@ -65,6 +65,8 @@ public final class TodoPanel extends VBox implements ToolWindowContent {
 
     private TodoService.Outcome lastOutcome;
     private Path activeFile;
+    /** Notified when the user changes the "Group by" dimension, so the coordinator can persist it. */
+    private java.util.function.Consumer<TodoGrouping.GroupBy> onGroupByChanged;
 
     public TodoPanel(Actions actions) {
         this.actions = actions;
@@ -99,7 +101,12 @@ public final class TodoPanel extends VBox implements ToolWindowContent {
                 return null;
             }
         });
-        groupBy.valueProperty().addListener((o, a, b) -> rebuild());
+        groupBy.valueProperty().addListener((o, a, b) -> {
+            rebuild();
+            if (onGroupByChanged != null && b != null) {
+                onGroupByChanged.accept(b);
+            }
+        });
 
         Button refreshBtn = new Button();
         refreshBtn.setGraphic(Icons.refresh());
@@ -123,6 +130,19 @@ public final class TodoPanel extends VBox implements ToolWindowContent {
         addEventFilter(KeyEvent.KEY_PRESSED, this::onKey);
 
         getChildren().addAll(scopeRow, toolbar, tree);
+    }
+
+    /** Selects the "Group by" dimension. Call before {@link #setGroupByChangeHandler} to restore a saved value
+     *  without re-persisting it (the handler is still null when this fires the listener). */
+    public void setGroupBy(TodoGrouping.GroupBy g) {
+        if (g != null && g != groupBy.getValue()) {
+            groupBy.getSelectionModel().select(g);
+        }
+    }
+
+    /** Registers the callback fired when the user changes the "Group by" dimension (coordinator persists it). */
+    public void setGroupByChangeHandler(java.util.function.Consumer<TodoGrouping.GroupBy> handler) {
+        this.onGroupByChanged = handler;
     }
 
     /** Sets the displayed scan-scope folder. */


### PR DESCRIPTION
Quick win #1 of the batch. The TODO tool window's **Group by** (File/Priority/Tag/Keyword) reset to *File* on every launch.

- New `Settings.todoGroupBy` (default `FILE`; additive schema **55→56**).
- `TodoPanel.setGroupBy` + a change handler; `TodoCoordinator` restores the saved value **once** on the first `applyHighlight` (which runs after `config` is set — reading settings in the coordinator constructor NPEs because it's a `MainController` field) and persists any user change, guarded so the restore doesn't re-save.

`./mvnw clean verify` green (1602 tests). No new dependency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)