### PR TITLE
AI: local LLM support via an OpenAI-compatible provider (LM Studio, Ollama, vLLM)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Local LLMs for the AI features (LM Studio, Ollama, vLLM).** The AI actions and inline completion
+  can now talk to a **local OpenAI-compatible server** instead of the Anthropic API — pick
+  *Local (OpenAI-compatible)* under Settings → AI Actions → **Provider**. The default endpoint is LM
+  Studio's local server (`http://127.0.0.1:1234/v1/chat/completions`) and **no API key is required**;
+  the endpoint is configurable for Ollama/vLLM/llama.cpp. Leave the model fields blank to use whatever
+  model the server has loaded, or name one explicitly. The OpenAI chat-completions streaming dialect
+  (SSE `data:` chunks → `[DONE]`, `choices[].delta.content`, `finish_reason`) is handled alongside the
+  Anthropic Messages format; commit-message generation, explain/rewrite selection, and ghost-text
+  completion all work against either. Palette: *AI: Set Provider* / *AI: Set Endpoint*. Schema 56→57,
+  additive.
+
 - **AI inline completion (ghost text).** After a short typing pause with the caret at the end of a
   line, a muted single-line AI suggestion appears at the caret — **Tab accepts it**, Esc or typing
   dismisses it (the same ghost-text presentation prose autocomplete already uses). Requests are

--- a/README.md
+++ b/README.md
@@ -339,6 +339,8 @@ Editora is built with the help of AI coding tools.
   **AI inline completion**: after a typing pause, a muted one-line ghost suggestion at the caret — Tab
   accepts (its own fast model, default `claude-haiku-4-5`). Off by default (Settings → AI Actions); model
   configurable (default `claude-opus-4-8`); API key from `ANTHROPIC_API_KEY` or a Settings override.
+  **Local models**: switch the Provider to *Local (OpenAI-compatible)* to run every AI feature against
+  LM Studio, Ollama, or any local OpenAI-compatible server — no API key, configurable endpoint.
 - **AI Agent** _(Beta)_ — chat with an embedded coding agent over the
   [Agent Client Protocol](https://agentclientprotocol.com) (ACP). The default command is
   `claude-code-acp` (Claude Code's ACP adapter; any ACP agent works via Settings → AI Agent). The

--- a/TODO.md
+++ b/TODO.md
@@ -85,6 +85,11 @@ A backlog of planned features and improvements. Unordered within each section.
       128-token cap, generation-guarded (typing supersedes the in-flight request); its own fast model
       (default `claude-haiku-4-5`). Off by default under Settings → AI Actions. *(Next: multi-line
       ghost rendering, accept-word-by-word, per-language enable list.)*
+- [x] Local LLM support (LM Studio / Ollama / vLLM) — an OpenAI-compatible provider for every AI feature
+      (actions + inline completion): AiProvider enum + OpenAiSse reader (data-only SSE, `[DONE]`,
+      `choices[].delta.content`, `finish_reason`→Anthropic stops), provider-aware AiClient headers/body,
+      Settings.aiProvider/aiEndpoint (default LM Studio localhost, no key). Palette AI: Set Provider /
+      Set Endpoint. *(Next: base/FIM completion models, per-request timeout tuning, model-list picker.)*
 - [x] AI actions (direct Anthropic API) — streamed one-shot features over `java.net.http` (no SDK, no new
       dependency): commit-message generation from the staged diff (into the Commit window), explain
       selection (into a Markdown buffer), rewrite selection per instruction (one undoable edit, aborts if

--- a/src/main/java/com/editora/ai/AiClient.java
+++ b/src/main/java/com/editora/ai/AiClient.java
@@ -22,9 +22,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
  */
 public final class AiClient {
 
-    /** The Messages API endpoint. */
-    static final String ENDPOINT = "https://api.anthropic.com/v1/messages";
-
     private static final Duration CONNECT_TIMEOUT = Duration.ofSeconds(15);
 
     /** Receives the streamed response (on the calling thread — the service marshals to FX). */
@@ -42,18 +39,31 @@ public final class AiClient {
             HttpClient.newBuilder().connectTimeout(CONNECT_TIMEOUT).build();
 
     /**
-     * Sends {@code request} (a {@link AiRequests#streamingRequest} body) and streams the reply into
-     * {@code listener}, polling {@code cancelled} between events so a stale generation stops reading.
+     * Sends {@code request} (an {@link AiRequests#requestFor} body matching {@code provider}'s dialect)
+     * to {@code endpoint} and streams the reply into {@code listener}, polling {@code cancelled}
+     * between events so a stale generation stops reading. For {@link AiProvider#OPENAI} the key is
+     * optional (local servers) and sent as a bearer token when present.
      */
-    public void stream(String apiKey, JsonNode request, BooleanSupplier cancelled, Listener listener) {
+    public void stream(
+            AiProvider provider,
+            String endpoint,
+            String apiKey,
+            JsonNode request,
+            BooleanSupplier cancelled,
+            Listener listener) {
         HttpRequest req;
         try {
-            req = HttpRequest.newBuilder(URI.create(ENDPOINT))
-                    .header("x-api-key", apiKey)
-                    .header("anthropic-version", "2023-06-01")
+            HttpRequest.Builder b = HttpRequest.newBuilder(URI.create(endpoint))
                     .header("content-type", "application/json")
-                    .POST(HttpRequest.BodyPublishers.ofString(mapper.writeValueAsString(request)))
-                    .build();
+                    .POST(HttpRequest.BodyPublishers.ofString(mapper.writeValueAsString(request)));
+            if (provider == AiProvider.OPENAI) {
+                if (apiKey != null && !apiKey.isBlank()) {
+                    b.header("Authorization", "Bearer " + apiKey);
+                }
+            } else {
+                b.header("x-api-key", apiKey).header("anthropic-version", "2023-06-01");
+            }
+            req = b.build();
         } catch (Exception e) {
             listener.onError(String.valueOf(e.getMessage()));
             return;
@@ -75,6 +85,27 @@ public final class AiClient {
                     }
                     SseParser.Event event = parser.feed(line);
                     if (event == null) {
+                        continue;
+                    }
+                    if (provider == AiProvider.OPENAI) {
+                        if (OpenAiSse.isDone(event.data())) {
+                            listener.onDone(stopReason);
+                            return;
+                        }
+                        JsonNode chunk = mapper.readTree(event.data());
+                        String error = OpenAiSse.errorMessage(chunk);
+                        if (error != null) {
+                            listener.onError(error);
+                            return;
+                        }
+                        String delta = OpenAiSse.textDelta(chunk);
+                        if (delta != null && !delta.isEmpty()) {
+                            listener.onText(delta);
+                        }
+                        String finish = OpenAiSse.finishReason(chunk);
+                        if (finish != null) {
+                            stopReason = finish;
+                        }
                         continue;
                     }
                     JsonNode data = mapper.readTree(event.data());

--- a/src/main/java/com/editora/ai/AiProvider.java
+++ b/src/main/java/com/editora/ai/AiProvider.java
@@ -1,0 +1,41 @@
+package com.editora.ai;
+
+import java.util.Locale;
+
+/**
+ * Which wire dialect the AI features speak: Anthropic's Messages API, or the OpenAI-compatible
+ * chat-completions API that local inference servers expose (LM Studio, Ollama, vLLM, llama.cpp).
+ * Pure (java.base only) and unit-tested; persisted in {@code Settings.aiProvider} by {@link #id()}.
+ */
+public enum AiProvider {
+    /** api.anthropic.com — needs an API key. */
+    ANTHROPIC("https://api.anthropic.com/v1/messages"),
+    /** An OpenAI-compatible server; the default endpoint is LM Studio's local server. */
+    OPENAI("http://127.0.0.1:1234/v1/chat/completions");
+
+    private final String defaultEndpoint;
+
+    AiProvider(String defaultEndpoint) {
+        this.defaultEndpoint = defaultEndpoint;
+    }
+
+    /** The endpoint used when {@code Settings.aiEndpoint} is blank. */
+    public String defaultEndpoint() {
+        return defaultEndpoint;
+    }
+
+    /** Local OpenAI-compatible servers need no key; Anthropic always does. */
+    public boolean requiresApiKey() {
+        return this == ANTHROPIC;
+    }
+
+    /** The persisted id ({@code "anthropic"}/{@code "openai"}). */
+    public String id() {
+        return name().toLowerCase(Locale.ROOT);
+    }
+
+    /** Parses a persisted id; blank/unknown → {@link #ANTHROPIC} (the pre-provider default). */
+    public static AiProvider from(String id) {
+        return id != null && id.strip().equalsIgnoreCase("openai") ? OPENAI : ANTHROPIC;
+    }
+}

--- a/src/main/java/com/editora/ai/AiRequests.java
+++ b/src/main/java/com/editora/ai/AiRequests.java
@@ -86,6 +86,56 @@ public final class AiRequests {
                 + (language == null || language.isEmpty() ? "code" : language) + ":\n\n" + truncate(code);
     }
 
+    /** The request body for {@code provider}'s dialect (one system prompt + one user turn, streamed). */
+    public static ObjectNode requestFor(
+            ObjectMapper m,
+            AiProvider provider,
+            String model,
+            String system,
+            String user,
+            int maxTokens,
+            java.util.List<String> stopSequences) {
+        return provider == AiProvider.OPENAI
+                ? openAiStreamingRequest(m, model, system, user, maxTokens, stopSequences)
+                : streamingRequest(m, model, system, user, maxTokens, stopSequences);
+    }
+
+    /**
+     * An OpenAI-compatible chat-completions request (LM Studio, Ollama, vLLM): the system prompt is a
+     * leading {@code system} message and stops go under {@code stop}. A blank {@code model} is omitted
+     * entirely — LM Studio then serves the currently loaded model (Ollama requires an explicit name).
+     */
+    public static ObjectNode openAiStreamingRequest(
+            ObjectMapper m,
+            String model,
+            String system,
+            String user,
+            int maxTokens,
+            java.util.List<String> stopSequences) {
+        ObjectNode sys = m.createObjectNode();
+        sys.put("role", "system");
+        sys.put("content", system);
+        ObjectNode msg = m.createObjectNode();
+        msg.put("role", "user");
+        msg.put("content", user);
+        ArrayNode messages = m.createArrayNode();
+        messages.add(sys);
+        messages.add(msg);
+        ObjectNode r = m.createObjectNode();
+        if (model != null && !model.isBlank()) {
+            r.put("model", model.strip());
+        }
+        r.put("max_tokens", maxTokens);
+        r.put("stream", true);
+        r.set("messages", messages);
+        if (!stopSequences.isEmpty()) {
+            ArrayNode stops = m.createArrayNode();
+            stopSequences.forEach(stops::add);
+            r.set("stop", stops);
+        }
+        return r;
+    }
+
     /** Output cap for inline completion — one short line, never an essay. */
     public static final int COMPLETION_MAX_TOKENS = 128;
 

--- a/src/main/java/com/editora/ai/AiService.java
+++ b/src/main/java/com/editora/ai/AiService.java
@@ -36,12 +36,21 @@ public final class AiService {
     private final AtomicLong generation = new AtomicLong();
 
     /** Streams one generation; a later {@link #cancel}/generate supersedes it (stale callbacks dropped). */
-    public void generate(String apiKey, String model, String system, String user, Callbacks cb) {
-        generate(apiKey, model, system, user, AiRequests.MAX_TOKENS, java.util.List.of(), cb);
+    public void generate(
+            AiProvider provider,
+            String endpoint,
+            String apiKey,
+            String model,
+            String system,
+            String user,
+            Callbacks cb) {
+        generate(provider, endpoint, apiKey, model, system, user, AiRequests.MAX_TOKENS, java.util.List.of(), cb);
     }
 
     /** The full form: an explicit output cap + stop sequences (inline completion stops at end-of-line). */
     public void generate(
+            AiProvider provider,
+            String endpoint,
             String apiKey,
             String model,
             String system,
@@ -51,8 +60,10 @@ public final class AiService {
             Callbacks cb) {
         long gen = generation.incrementAndGet();
         exec.submit(() -> client.stream(
+                provider,
+                endpoint,
                 apiKey,
-                AiRequests.streamingRequest(mapper, model, system, user, maxTokens, stopSequences),
+                AiRequests.requestFor(mapper, provider, model, system, user, maxTokens, stopSequences),
                 () -> gen != generation.get(),
                 new AiClient.Listener() {
                     @Override

--- a/src/main/java/com/editora/ai/OpenAiSse.java
+++ b/src/main/java/com/editora/ai/OpenAiSse.java
@@ -1,0 +1,58 @@
+package com.editora.ai;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+/**
+ * Pure readers for the OpenAI-compatible streaming dialect (LM Studio, Ollama, vLLM): data-only SSE
+ * events terminated by a literal {@code [DONE]}, with text at {@code choices[0].delta.content}.
+ * {@link AiClient} drives these from its response loop; everything here is side-effect-free and
+ * unit-tested.
+ */
+public final class OpenAiSse {
+
+    /** The stream-end sentinel sent as a bare data payload. */
+    public static final String DONE = "[DONE]";
+
+    private OpenAiSse() {}
+
+    /** True when {@code data} is the {@code [DONE]} terminator (never valid JSON — check first). */
+    public static boolean isDone(String data) {
+        return data != null && DONE.equals(data.strip());
+    }
+
+    /** The chunk's text delta ({@code choices[0].delta.content}), or null when none. */
+    public static String textDelta(JsonNode data) {
+        JsonNode content = choice(data).path("delta").path("content");
+        return content.isTextual() ? content.asText() : null;
+    }
+
+    /** The finish reason mapped to the Anthropic-style stop reasons the callers already handle
+     *  ({@code stop} → {@code end_turn}, {@code length} → {@code max_tokens}); null when absent. */
+    public static String finishReason(JsonNode data) {
+        JsonNode reason = choice(data).path("finish_reason");
+        if (!reason.isTextual()) {
+            return null;
+        }
+        return switch (reason.asText()) {
+            case "stop" -> "end_turn";
+            case "length" -> "max_tokens";
+            case "content_filter" -> "refusal";
+            default -> reason.asText();
+        };
+    }
+
+    /** The error message of an {@code {"error":{…}}} payload, or null when this isn't an error. */
+    public static String errorMessage(JsonNode data) {
+        if (data == null || !data.has("error")) {
+            return null;
+        }
+        JsonNode msg = data.path("error").path("message");
+        return msg.isTextual() ? msg.asText() : "stream error";
+    }
+
+    private static JsonNode choice(JsonNode data) {
+        return data == null
+                ? com.fasterxml.jackson.databind.node.MissingNode.getInstance()
+                : data.path("choices").path(0);
+    }
+}

--- a/src/main/java/com/editora/config/Settings.java
+++ b/src/main/java/com/editora/config/Settings.java
@@ -10,7 +10,7 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 public class Settings {
 
     /** Current on-disk schema version of {@code settings.toml}; bump when the format changes (+ a migration). */
-    public static final int SCHEMA_VERSION = 56;
+    public static final int SCHEMA_VERSION = 57;
 
     private int schemaVersion = SCHEMA_VERSION;
 
@@ -207,6 +207,12 @@ public class Settings {
     private boolean aiInlineCompletion = false;
     /** The model for inline completion; blank = the built-in default (claude-haiku-4-5 — latency). */
     private String aiCompletionModel = "";
+    /** The AI wire dialect: {@code "anthropic"} (default) or {@code "openai"} — an OpenAI-compatible
+     *  local server such as LM Studio, Ollama, or vLLM (no API key required). */
+    private String aiProvider = "";
+    /** The AI endpoint URL; blank = the provider's default (Anthropic's API, or LM Studio's local
+     *  {@code http://127.0.0.1:1234/v1/chat/completions}). */
+    private String aiEndpoint = "";
     /** Java debugging (DAP) support: off by default. Layered on the Java LSP server (jdtls) + the
      *  Microsoft java-debug plugin; effective only when LSP is on, the java server is enabled/detected,
      *  and the plugin jar is found. */
@@ -530,6 +536,22 @@ public class Settings {
 
     public void setAiCompletionModel(String aiCompletionModel) {
         this.aiCompletionModel = aiCompletionModel;
+    }
+
+    public String getAiProvider() {
+        return aiProvider == null ? "" : aiProvider;
+    }
+
+    public void setAiProvider(String aiProvider) {
+        this.aiProvider = aiProvider;
+    }
+
+    public String getAiEndpoint() {
+        return aiEndpoint == null ? "" : aiEndpoint;
+    }
+
+    public void setAiEndpoint(String aiEndpoint) {
+        this.aiEndpoint = aiEndpoint;
     }
 
     public String getIjhttpCommand() {

--- a/src/main/java/com/editora/config/migration/ConfigSchema.java
+++ b/src/main/java/com/editora/config/migration/ConfigSchema.java
@@ -97,7 +97,9 @@ public enum ConfigSchema {
                             ConfigMigrations::identity), // v53→54: + aiSupport/aiModel/aiApiKey (additive)
                     Map.entry(54, (Migration)
                             ConfigMigrations::identity), // v54→55: + aiInlineCompletion/aiCompletionModel (additive)
-                    Map.entry(55, (Migration) ConfigMigrations::identity))), // v55→56: + todoGroupBy (additive)
+                    Map.entry(55, (Migration) ConfigMigrations::identity), // v55→56: + todoGroupBy (additive)
+                    Map.entry(
+                            56, (Migration) ConfigMigrations::identity))), // v56→57: + aiProvider/aiEndpoint (additive)
     WORKSPACE(WorkspaceState.SCHEMA_VERSION, 1, Map.of()),
     BOOKMARKS(BookmarkStore.SCHEMA_VERSION, 1, Map.of()),
     BREAKPOINTS(BreakpointStore.SCHEMA_VERSION, 1, Map.of()),

--- a/src/main/java/com/editora/ui/AiCoordinator.java
+++ b/src/main/java/com/editora/ui/AiCoordinator.java
@@ -3,6 +3,7 @@ package com.editora.ui;
 import java.nio.file.Path;
 import java.util.function.Consumer;
 
+import com.editora.ai.AiProvider;
 import com.editora.ai.AiRequests;
 import com.editora.ai.AiService;
 import com.editora.editor.EditorBuffer;
@@ -63,9 +64,11 @@ final class AiCoordinator {
         return host.settings().isAiSupport() && !host.simpleModeActive();
     }
 
-    /** The effective inline-completion gate: master + sub-toggle + a usable API key. */
+    /** The effective inline-completion gate: master + sub-toggle + a key when the provider needs one. */
     boolean isInlineCompletionEnabled() {
-        return isEnabled() && host.settings().isAiInlineCompletion() && !apiKey().isEmpty();
+        return isEnabled()
+                && host.settings().isAiInlineCompletion()
+                && (!provider().requiresApiKey() || !apiKey().isEmpty());
     }
 
     /** {@code EditorBuffer.AiCompletionProvider}: one short, stop-at-newline completion per idle pause.
@@ -77,6 +80,8 @@ final class AiCoordinator {
         }
         StringBuilder out = new StringBuilder();
         completionService.generate(
+                provider(),
+                endpoint(),
                 apiKey(),
                 completionModel(),
                 AiRequests.completionSystem(),
@@ -103,7 +108,22 @@ final class AiCoordinator {
 
     private String completionModel() {
         String configured = host.settings().getAiCompletionModel();
-        return configured == null || configured.isBlank() ? DEFAULT_COMPLETION_MODEL : configured.trim();
+        if (configured != null && !configured.isBlank()) {
+            return configured.trim();
+        }
+        // OpenAI-compatible: a blank model is omitted from the request (LM Studio serves the loaded model).
+        return provider() == AiProvider.ANTHROPIC ? DEFAULT_COMPLETION_MODEL : "";
+    }
+
+    /** The configured wire dialect (Anthropic vs an OpenAI-compatible local server). */
+    private AiProvider provider() {
+        return AiProvider.from(host.settings().getAiProvider());
+    }
+
+    /** The configured endpoint, or the provider's default (Anthropic's API / LM Studio's local port). */
+    private String endpoint() {
+        String configured = host.settings().getAiEndpoint();
+        return configured == null || configured.isBlank() ? provider().defaultEndpoint() : configured.trim();
     }
 
     /** {@code ai.cancel}: drop the in-flight generation. */
@@ -130,6 +150,8 @@ final class AiCoordinator {
                 StringBuilder out = new StringBuilder();
                 start(tr("status.ai.generatingCommit"));
                 service.generate(
+                        provider(),
+                        endpoint(),
                         apiKey(),
                         model(),
                         AiRequests.commitMessageSystem(),
@@ -175,6 +197,8 @@ final class AiCoordinator {
             ops.openTab(target);
             start(tr("status.ai.explaining"));
             service.generate(
+                    provider(),
+                    endpoint(),
                     apiKey(),
                     model(),
                     AiRequests.explainSystem(),
@@ -226,6 +250,8 @@ final class AiCoordinator {
                 StringBuilder out = new StringBuilder();
                 start(tr("status.ai.rewriting"));
                 service.generate(
+                        provider(),
+                        endpoint(),
                         apiKey(),
                         model(),
                         AiRequests.rewriteSystem(),
@@ -270,7 +296,7 @@ final class AiCoordinator {
             host.setStatus(tr("status.ai.disabled"));
             return;
         }
-        if (apiKey().isEmpty()) {
+        if (provider().requiresApiKey() && apiKey().isEmpty()) {
             host.setStatus(tr("status.ai.noApiKey"));
             return;
         }
@@ -312,7 +338,10 @@ final class AiCoordinator {
 
     private String model() {
         String configured = host.settings().getAiModel();
-        return configured == null || configured.isBlank() ? DEFAULT_MODEL : configured.trim();
+        if (configured != null && !configured.isBlank()) {
+            return configured.trim();
+        }
+        return provider() == AiProvider.ANTHROPIC ? DEFAULT_MODEL : "";
     }
 
     /** Window close: cancel any stream + stop the worker threads. */

--- a/src/main/java/com/editora/ui/MainController.java
+++ b/src/main/java/com/editora/ui/MainController.java
@@ -10031,6 +10031,31 @@ public class MainController implements com.editora.mcp.McpBridge {
                         () -> config.getSettings().getAiCompletionModel(),
                         v -> config.getSettings().setAiCompletionModel(v),
                         null)));
+        registry.register(Command.of(
+                "ai.setProvider",
+                () -> chooseSetting(
+                        "ai.setProvider",
+                        () -> List.of("anthropic", "openai"),
+                        id -> tr("settings.ai.provider." + id),
+                        id -> {
+                            config.getSettings().setAiProvider(id);
+                            requestSave();
+                            applyAutocomplete(); // re-gate inline completion (key requirement changed)
+                            if (settingsWindow != null) {
+                                settingsWindow.syncAll();
+                            }
+                            setStatus(tr(
+                                    "status.settingChanged",
+                                    commandTitle("ai.setProvider"),
+                                    tr("settings.ai.provider." + id)));
+                        })));
+        registry.register(Command.of(
+                "ai.setEndpoint",
+                () -> promptStringSetting(
+                        "ai.setEndpoint",
+                        () -> config.getSettings().getAiEndpoint(),
+                        v -> config.getSettings().setAiEndpoint(v),
+                        null)));
         registry.register(Command.of("view.toggleLineHighlight", this::toggleLineHighlight));
         registry.register(Command.of("view.toggleLineNumbers", this::toggleLineNumbers));
         registry.register(Command.of("view.toggleMinimap", this::toggleMinimap));

--- a/src/main/java/com/editora/ui/SettingsWindow.java
+++ b/src/main/java/com/editora/ui/SettingsWindow.java
@@ -275,6 +275,8 @@ public class SettingsWindow {
     private TextField aiApiKeyField;
     private CheckBox aiInlineCheck;
     private TextField aiCompletionModelField;
+    private ComboBox<String> aiProviderCombo;
+    private TextField aiEndpointField;
     private TextField mmdcPathField;
     private CheckBox debugCheck;
     /** Per-language debug-adapter controls, keyed by language id (java/python/javascript). */
@@ -1000,6 +1002,31 @@ public class SettingsWindow {
         aiCheck = new CheckBox(tr("settings.ai.enable"));
         aiCheck.selectedProperty().addListener((obs, was, now) -> {
             config.getSettings().setAiSupport(now);
+            apply();
+        });
+        aiProviderCombo = new ComboBox<>();
+        aiProviderCombo.getItems().addAll("anthropic", "openai");
+        aiProviderCombo.setConverter(new StringConverter<>() {
+            @Override
+            public String toString(String id) {
+                return id == null ? "" : tr("settings.ai.provider." + id);
+            }
+
+            @Override
+            public String fromString(String s) {
+                return s;
+            }
+        });
+        aiProviderCombo.valueProperty().addListener((obs, was, now) -> {
+            if (!loading && now != null) {
+                config.getSettings().setAiProvider(now);
+                apply();
+            }
+        });
+        aiEndpointField = new TextField();
+        aiEndpointField.setPromptText(tr("settings.ai.endpointPrompt"));
+        aiEndpointField.textProperty().addListener((obs, was, now) -> {
+            config.getSettings().setAiEndpoint(now);
             apply();
         });
         aiModelField = new TextField();
@@ -3477,6 +3504,22 @@ public class SettingsWindow {
                 p,
                 Category.AI,
                 null,
+                labeledRow(tr("settings.ai.provider"), aiProviderCombo),
+                "ai provider anthropic openai local lm studio ollama vllm");
+        row(
+                p,
+                Category.AI,
+                null,
+                labeledRow(tr("settings.ai.endpoint"), aiEndpointField),
+                "ai endpoint url local server lm studio ollama port");
+        Label providerNote = note(tr("settings.ai.providerNote"));
+        providerNote.setWrapText(true);
+        providerNote.setMaxWidth(440);
+        row(p, Category.AI, null, providerNote, "ai provider local lm studio no api key endpoint");
+        row(
+                p,
+                Category.AI,
+                null,
                 exePathRow(tr("settings.ai.model"), aiModelField),
                 "ai model anthropic claude opus id");
         row(
@@ -4092,6 +4135,14 @@ public class SettingsWindow {
     }
 
     /** A "[label] [path field] [Browse…]" row for picking a CLI executable. */
+    /** A simple "label: control" row (no Browse button), used for the AI provider combo + endpoint URL. */
+    private HBox labeledRow(String label, javafx.scene.control.Control control) {
+        HBox.setHgrow(control, Priority.ALWAYS);
+        HBox box = new HBox(6, new Label(label), control);
+        box.setAlignment(Pos.CENTER_LEFT);
+        return box;
+    }
+
     private HBox exePathRow(String label, TextField field) {
         Button browse = new Button(tr("settings.mermaid.browse"));
         browse.setOnAction(e -> {
@@ -4855,6 +4906,9 @@ public class SettingsWindow {
             aiApiKeyField.setText(settings.getAiApiKey());
             aiInlineCheck.setSelected(settings.isAiInlineCompletion());
             aiCompletionModelField.setText(settings.getAiCompletionModel());
+            aiProviderCombo.setValue(
+                    com.editora.ai.AiProvider.from(settings.getAiProvider()).id());
+            aiEndpointField.setText(settings.getAiEndpoint());
             pluginCheck.setSelected(settings.isPluginSupport());
             if (pluginRequireSigCheck != null) {
                 pluginRequireSigCheck.setSelected(settings.isPluginRequireSignature());
@@ -5269,6 +5323,10 @@ public class SettingsWindow {
             aiApiKeyField.setText(config.getSettings().getAiApiKey());
             aiInlineCheck.setSelected(config.getSettings().isAiInlineCompletion());
             aiCompletionModelField.setText(config.getSettings().getAiCompletionModel());
+            aiProviderCombo.setValue(
+                    com.editora.ai.AiProvider.from(config.getSettings().getAiProvider())
+                            .id());
+            aiEndpointField.setText(config.getSettings().getAiEndpoint());
         } finally {
             loading = prev;
         }

--- a/src/main/resources/com/editora/i18n/messages.properties
+++ b/src/main/resources/com/editora/i18n/messages.properties
@@ -2721,3 +2721,13 @@ command.ai.setCompletionModel.desc=Set the model for inline completion (blank = 
 settings.ai.inline=Enable AI inline completion (ghost text)
 settings.ai.completionModel=Completion model
 settings.ai.inlineHint=After a short typing pause at the end of a line, a muted single-line suggestion appears at the caret — Tab accepts it, Esc or typing dismisses it. One small request per pause (capped at one line); uses the fast model above.
+command.ai.setProvider=AI: Set Provider
+command.ai.setProvider.desc=Choose the AI provider — Anthropic API or a local OpenAI-compatible server.
+command.ai.setEndpoint=AI: Set Endpoint
+command.ai.setEndpoint.desc=Set the AI endpoint URL (blank = the provider's default).
+settings.ai.provider=Provider
+settings.ai.provider.anthropic=Anthropic API
+settings.ai.provider.openai=Local (OpenAI-compatible)
+settings.ai.endpoint=Endpoint URL
+settings.ai.endpointPrompt=Blank = the provider's default
+settings.ai.providerNote=Choose "Local (OpenAI-compatible)" to use LM Studio, Ollama, or any local server that serves the OpenAI chat-completions API. The default endpoint is LM Studio's local server (http://127.0.0.1:1234/v1/chat/completions); no API key is needed. Leave the model fields blank to use whatever model the server has loaded.

--- a/src/main/resources/com/editora/i18n/messages_de.properties
+++ b/src/main/resources/com/editora/i18n/messages_de.properties
@@ -2713,3 +2713,13 @@ command.ai.setCompletionModel.desc=Das Modell für die Inline-Vervollständigung
 settings.ai.inline=KI-Inline-Vervollständigung aktivieren (Geistertext)
 settings.ai.completionModel=Vervollständigungsmodell
 settings.ai.inlineHint=Nach einer kurzen Tippppause am Zeilenende erscheint ein gedämpfter einzeiliger Vorschlag am Cursor — Tab übernimmt ihn, Esc oder Weitertippen verwirft ihn. Eine kleine Anfrage pro Pause (auf eine Zeile begrenzt); verwendet das schnelle Modell oben.
+command.ai.setProvider=KI: Anbieter festlegen
+command.ai.setProvider.desc=Den KI-Anbieter wählen — Anthropic-API oder einen lokalen OpenAI-kompatiblen Server.
+command.ai.setEndpoint=KI: Endpunkt festlegen
+command.ai.setEndpoint.desc=Die KI-Endpunkt-URL festlegen (leer = Standard des Anbieters).
+settings.ai.provider=Anbieter
+settings.ai.provider.anthropic=Anthropic-API
+settings.ai.provider.openai=Lokal (OpenAI-kompatibel)
+settings.ai.endpoint=Endpunkt-URL
+settings.ai.endpointPrompt=Leer = Standard des Anbieters
+settings.ai.providerNote=Wähle „Lokal (OpenAI-kompatibel)", um LM Studio, Ollama oder einen beliebigen lokalen Server zu verwenden, der die OpenAI-Chat-Completions-API bereitstellt. Der Standard-Endpunkt ist der lokale LM-Studio-Server (http://127.0.0.1:1234/v1/chat/completions); kein API-Schlüssel nötig. Lass die Modellfelder leer, um das im Server geladene Modell zu verwenden.

--- a/src/main/resources/com/editora/i18n/messages_es.properties
+++ b/src/main/resources/com/editora/i18n/messages_es.properties
@@ -2713,3 +2713,13 @@ command.ai.setCompletionModel.desc=Establecer el modelo del autocompletado en l�
 settings.ai.inline=Activar autocompletado de IA en línea (texto fantasma)
 settings.ai.completionModel=Modelo de autocompletado
 settings.ai.inlineHint=Tras una breve pausa al final de una línea, aparece una sugerencia tenue de una línea en el cursor — Tab la acepta, Esc o seguir escribiendo la descarta. Una petición pequeña por pausa (limitada a una línea); usa el modelo rápido de arriba.
+command.ai.setProvider=IA: Establecer proveedor
+command.ai.setProvider.desc=Elegir el proveedor de IA — la API de Anthropic o un servidor local compatible con OpenAI.
+command.ai.setEndpoint=IA: Establecer endpoint
+command.ai.setEndpoint.desc=Establecer la URL del endpoint de IA (vacío = el predeterminado del proveedor).
+settings.ai.provider=Proveedor
+settings.ai.provider.anthropic=API de Anthropic
+settings.ai.provider.openai=Local (compatible con OpenAI)
+settings.ai.endpoint=URL del endpoint
+settings.ai.endpointPrompt=Vacío = el predeterminado del proveedor
+settings.ai.providerNote=Elige "Local (compatible con OpenAI)" para usar LM Studio, Ollama o cualquier servidor local que sirva la API de chat-completions de OpenAI. El endpoint predeterminado es el servidor local de LM Studio (http://127.0.0.1:1234/v1/chat/completions); no se necesita clave de API. Deja los campos de modelo en blanco para usar el modelo que el servidor tenga cargado.

--- a/src/main/resources/com/editora/i18n/messages_fr.properties
+++ b/src/main/resources/com/editora/i18n/messages_fr.properties
@@ -2713,3 +2713,13 @@ command.ai.setCompletionModel.desc=Définir le modèle de la complétion en lign
 settings.ai.inline=Activer la complétion IA en ligne (texte fantôme)
 settings.ai.completionModel=Modèle de complétion
 settings.ai.inlineHint=Après une courte pause de frappe en fin de ligne, une suggestion discrète d'une ligne apparaît au curseur — Tab l'accepte, Échap ou la frappe la rejette. Une petite requête par pause (limitée à une ligne) ; utilise le modèle rapide ci-dessus.
+command.ai.setProvider=IA : Définir le fournisseur
+command.ai.setProvider.desc=Choisir le fournisseur d'IA — l'API Anthropic ou un serveur local compatible OpenAI.
+command.ai.setEndpoint=IA : Définir le point de terminaison
+command.ai.setEndpoint.desc=Définir l'URL du point de terminaison IA (vide = valeur par défaut du fournisseur).
+settings.ai.provider=Fournisseur
+settings.ai.provider.anthropic=API Anthropic
+settings.ai.provider.openai=Local (compatible OpenAI)
+settings.ai.endpoint=URL du point de terminaison
+settings.ai.endpointPrompt=Vide = valeur par défaut du fournisseur
+settings.ai.providerNote=Choisissez « Local (compatible OpenAI) » pour utiliser LM Studio, Ollama ou tout serveur local exposant l'API chat-completions d'OpenAI. Le point de terminaison par défaut est le serveur local de LM Studio (http://127.0.0.1:1234/v1/chat/completions) ; aucune clé d'API n'est nécessaire. Laissez les champs de modèle vides pour utiliser le modèle chargé par le serveur.

--- a/src/main/resources/com/editora/i18n/messages_it.properties
+++ b/src/main/resources/com/editora/i18n/messages_it.properties
@@ -2713,3 +2713,13 @@ command.ai.setCompletionModel.desc=Impostare il modello del completamento inline
 settings.ai.inline=Abilita completamento IA inline (testo fantasma)
 settings.ai.completionModel=Modello di completamento
 settings.ai.inlineHint=Dopo una breve pausa di digitazione a fine riga, un suggerimento attenuato di una riga appare al cursore — Tab lo accetta, Esc o continuare a digitare lo scarta. Una piccola richiesta per pausa (limitata a una riga); usa il modello veloce qui sopra.
+command.ai.setProvider=IA: Imposta provider
+command.ai.setProvider.desc=Scegliere il provider IA — l'API di Anthropic o un server locale compatibile con OpenAI.
+command.ai.setEndpoint=IA: Imposta endpoint
+command.ai.setEndpoint.desc=Impostare l'URL dell'endpoint IA (vuoto = predefinito del provider).
+settings.ai.provider=Provider
+settings.ai.provider.anthropic=API Anthropic
+settings.ai.provider.openai=Locale (compatibile OpenAI)
+settings.ai.endpoint=URL endpoint
+settings.ai.endpointPrompt=Vuoto = predefinito del provider
+settings.ai.providerNote=Scegli "Locale (compatibile OpenAI)" per usare LM Studio, Ollama o qualsiasi server locale che espone l'API chat-completions di OpenAI. L'endpoint predefinito è il server locale di LM Studio (http://127.0.0.1:1234/v1/chat/completions); non serve una chiave API. Lascia vuoti i campi del modello per usare il modello caricato nel server.

--- a/src/main/resources/com/editora/i18n/messages_pt.properties
+++ b/src/main/resources/com/editora/i18n/messages_pt.properties
@@ -2713,3 +2713,13 @@ command.ai.setCompletionModel.desc=Definir o modelo do preenchimento em linha (v
 settings.ai.inline=Ativar preenchimento de IA em linha (texto fantasma)
 settings.ai.completionModel=Modelo de preenchimento
 settings.ai.inlineHint=Após uma breve pausa na digitação no fim de uma linha, uma sugestão discreta de uma linha aparece no cursor — Tab aceita, Esc ou continuar digitando descarta. Uma pequena solicitação por pausa (limitada a uma linha); usa o modelo rápido acima.
+command.ai.setProvider=IA: Definir provedor
+command.ai.setProvider.desc=Escolher o provedor de IA — a API da Anthropic ou um servidor local compatível com OpenAI.
+command.ai.setEndpoint=IA: Definir endpoint
+command.ai.setEndpoint.desc=Definir a URL do endpoint de IA (vazio = padrão do provedor).
+settings.ai.provider=Provedor
+settings.ai.provider.anthropic=API da Anthropic
+settings.ai.provider.openai=Local (compatível com OpenAI)
+settings.ai.endpoint=URL do endpoint
+settings.ai.endpointPrompt=Vazio = padrão do provedor
+settings.ai.providerNote=Escolha "Local (compatível com OpenAI)" para usar LM Studio, Ollama ou qualquer servidor local que sirva a API de chat-completions da OpenAI. O endpoint padrão é o servidor local do LM Studio (http://127.0.0.1:1234/v1/chat/completions); não é necessária chave de API. Deixe os campos de modelo em branco para usar o modelo carregado no servidor.

--- a/src/test/java/com/editora/ai/OpenAiSseTest.java
+++ b/src/test/java/com/editora/ai/OpenAiSseTest.java
@@ -1,0 +1,84 @@
+package com.editora.ai;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/** {@link OpenAiSse} + {@link AiProvider}: OpenAI-compatible streaming readers and provider defaults. */
+class OpenAiSseTest {
+
+    private final ObjectMapper m = new ObjectMapper();
+
+    private JsonNode json(String s) throws Exception {
+        return m.readTree(s);
+    }
+
+    @Test
+    void detectsDoneSentinel() {
+        assertTrue(OpenAiSse.isDone("[DONE]"));
+        assertTrue(OpenAiSse.isDone("  [DONE] "));
+        assertFalse(OpenAiSse.isDone("{\"x\":1}"));
+        assertFalse(OpenAiSse.isDone(null));
+    }
+
+    @Test
+    void readsTextDelta() throws Exception {
+        JsonNode chunk = json("{\"choices\":[{\"delta\":{\"content\":\"Hello\"}}]}");
+        assertEquals("Hello", OpenAiSse.textDelta(chunk));
+        assertNull(OpenAiSse.textDelta(json("{\"choices\":[{\"delta\":{}}]}")));
+        assertNull(OpenAiSse.textDelta(json("{}")));
+    }
+
+    @Test
+    void mapsFinishReasonToAnthropicStops() throws Exception {
+        assertEquals("end_turn", OpenAiSse.finishReason(json("{\"choices\":[{\"finish_reason\":\"stop\"}]}")));
+        assertEquals("max_tokens", OpenAiSse.finishReason(json("{\"choices\":[{\"finish_reason\":\"length\"}]}")));
+        assertNull(OpenAiSse.finishReason(json("{\"choices\":[{\"finish_reason\":null}]}")));
+    }
+
+    @Test
+    void readsErrorPayload() throws Exception {
+        assertEquals("bad model", OpenAiSse.errorMessage(json("{\"error\":{\"message\":\"bad model\"}}")));
+        assertNull(OpenAiSse.errorMessage(json("{\"choices\":[]}")));
+    }
+
+    @Test
+    void providerDefaultsAndKeyRequirement() {
+        assertEquals(AiProvider.ANTHROPIC, AiProvider.from(""));
+        assertEquals(AiProvider.ANTHROPIC, AiProvider.from("unknown"));
+        assertEquals(AiProvider.OPENAI, AiProvider.from("openai"));
+        assertEquals(AiProvider.OPENAI, AiProvider.from("OpenAI"));
+        assertTrue(AiProvider.ANTHROPIC.requiresApiKey());
+        assertFalse(AiProvider.OPENAI.requiresApiKey());
+        assertTrue(AiProvider.ANTHROPIC.defaultEndpoint().contains("api.anthropic.com"));
+        assertTrue(AiProvider.OPENAI.defaultEndpoint().contains("/v1/chat/completions"));
+        assertEquals("openai", AiProvider.OPENAI.id());
+    }
+
+    @Test
+    void openAiRequestShapeOmitsBlankModelAndCarriesStop() {
+        var r = AiRequests.openAiStreamingRequest(m, "", "sys", "user", 128, java.util.List.of("\n"));
+        assertFalse(r.has("model")); // blank model omitted → server uses the loaded model
+        assertTrue(r.get("stream").asBoolean());
+        assertEquals("system", r.get("messages").get(0).get("role").asText());
+        assertEquals("user", r.get("messages").get(1).get("role").asText());
+        assertEquals("\n", r.get("stop").get(0).asText());
+        var named = AiRequests.openAiStreamingRequest(m, "qwen2.5-coder", "s", "u", 64, java.util.List.of());
+        assertEquals("qwen2.5-coder", named.get("model").asText());
+        assertFalse(named.has("stop"));
+    }
+
+    @Test
+    void requestForSelectsDialect() {
+        assertTrue(AiRequests.requestFor(m, AiProvider.OPENAI, "x", "s", "u", 64, java.util.List.of())
+                .has("messages"));
+        // Anthropic keeps the system prompt as a top-level field, not a message
+        var anthropic = AiRequests.requestFor(m, AiProvider.ANTHROPIC, "x", "s", "u", 64, java.util.List.of());
+        assertEquals("s", anthropic.get("system").asText());
+    }
+}


### PR DESCRIPTION
## Summary

Lets every AI feature (the AI actions + inline completion) talk to a **local OpenAI-compatible server** instead of the Anthropic API. Pick **Provider → Local (OpenAI-compatible)** under Settings → AI Actions; the default endpoint is **LM Studio's** local server (`http://127.0.0.1:1234/v1/chat/completions`) and **no API key is required**. Configurable for Ollama / vLLM / llama.cpp.

## Design

- **`ai/AiProvider`** (`ANTHROPIC` | `OPENAI`) — pure enum with each provider's default endpoint and key requirement.
- **`ai/OpenAiSse`** — pure readers for the OpenAI chat-completions streaming dialect: data-only SSE, the `[DONE]` sentinel, `choices[0].delta.content`, and `finish_reason` mapped onto the Anthropic-style stop reasons (`stop`→`end_turn`, `length`→`max_tokens`) the callers already handle. So the rest of the pipeline is unchanged.
- **`AiRequests.requestFor`** branches per provider; the OpenAI builder emits a `system`+`user` message array, puts stops under `stop`, and **omits a blank model** (LM Studio then serves whatever model is loaded; naming one explicitly also works, which Ollama needs).
- **`AiClient.stream`** is provider-aware — OpenAI sends an *optional* bearer token (local servers need none) and reads via `OpenAiSse`; Anthropic keeps `x-api-key` + the Messages events. `AiService.generate` threads `provider`+`endpoint` through.
- **`AiCoordinator`** resolves `provider()`/`endpoint()`; a blank model falls back to the built-in default only for Anthropic; the API-key gate is skipped for a local provider (so inline completion works keyless against LM Studio).
- **Config**: `Settings.aiProvider`/`aiEndpoint` (schema 56→57, additive-identity); Settings → AI Actions gains a Provider combo + Endpoint field + explanatory note; palette `ai.setProvider` / `ai.setEndpoint`; i18n in all six catalogs. **No new dependency.**

## Performance

No change to the hot paths — the provider branch is a single enum check inside code that already runs off-thread per request. When AI is off (default), nothing runs.

## Testing

- `OpenAiSseTest`: `[DONE]` detection, text-delta/finish-reason/error readers, provider defaults + key requirement, and both request dialects (blank-model omission, stop placement).
- Full non-FX suite: **1505 tests, 0 failures** (incl. i18n key parity across six catalogs).

## How to test with LM Studio

1. In LM Studio, load a model (e.g. Qwen2.5-Coder-7B-Instruct) and start the local server (Developer tab → Start Server, port 1234).
2. In Editora `--dev`: enable Settings → AI Actions, set **Provider → Local (OpenAI-compatible)** (endpoint auto-fills), leave the model fields blank.
3. Stage a change and run **AI: Generate Commit Message**, or enable inline completion and type in a code buffer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)