### PR TITLE
AI: live green/red connection status on the Settings → AI Actions page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **AI connection status (green/red).** The Settings → AI Actions page now shows a live health-check
+  indicator under the enable checkbox: green **Connected** when the configured provider/endpoint/key
+  (and model) actually accept a request, red **Not working: …** with the error otherwise (a wrong
+  endpoint path, a refused connection, a bad key, an unknown model). It checks when the page opens and
+  re-checks — debounced — after you edit the provider, endpoint, key, or model, so a misconfigured
+  local server (LM Studio/Ollama) or a typo'd URL is obvious immediately instead of failing silently at
+  first use. Also a palette command **AI: Test Connection** that reports to the status bar. The probe is
+  a tiny one-token request and never disturbs a real generation.
+
 - **Local LLMs for the AI features (LM Studio, Ollama, vLLM).** The AI actions and inline completion
   can now talk to a **local OpenAI-compatible server** instead of the Anthropic API — pick
   *Local (OpenAI-compatible)* under Settings → AI Actions → **Provider**. The default endpoint is LM

--- a/TODO.md
+++ b/TODO.md
@@ -85,6 +85,10 @@ A backlog of planned features and improvements. Unordered within each section.
       128-token cap, generation-guarded (typing supersedes the in-flight request); its own fast model
       (default `claude-haiku-4-5`). Off by default under Settings → AI Actions. *(Next: multi-line
       ghost rendering, accept-word-by-word, per-language enable list.)*
+- [x] AI connection status — a live green/red health check on Settings → AI Actions (and palette
+      AI: Test Connection): a tiny one-token ping to the configured provider/endpoint/key/model,
+      re-checked on page-open and debounced on edits. Surfaces a wrong endpoint / bad key / unknown
+      model immediately. Mirrors the Git/Mermaid/LSP found-not-found status idiom.
 - [x] Local LLM support (LM Studio / Ollama / vLLM) — an OpenAI-compatible provider for every AI feature
       (actions + inline completion): AiProvider enum + OpenAiSse reader (data-only SSE, `[DONE]`,
       `choices[].delta.content`, `finish_reason`→Anthropic stops), provider-aware AiClient headers/body,

--- a/src/main/java/com/editora/ai/AiService.java
+++ b/src/main/java/com/editora/ai/AiService.java
@@ -83,6 +83,58 @@ public final class AiService {
                 }));
     }
 
+    /** The result of a connection check: whether the endpoint accepted a minimal request, plus a message
+     *  (a stop reason on success, or the HTTP/connection error on failure). */
+    public record Ping(boolean ok, String message) {}
+
+    /**
+     * Sends a tiny (1-token) request to verify the provider/endpoint/key/model actually work — the
+     * Settings green/red health check. Never touches the generation counter, so it can't cancel (or be
+     * cancelled by) a real generation; the result is posted to the FX thread exactly once.
+     */
+    public void ping(
+            AiProvider provider, String endpoint, String apiKey, String model, java.util.function.Consumer<Ping> cb) {
+        exec.submit(() -> {
+            boolean[] delivered = {false};
+            client.stream(
+                    provider,
+                    endpoint,
+                    apiKey,
+                    AiRequests.requestFor(
+                            mapper,
+                            provider,
+                            model,
+                            "You are a health check.",
+                            "Reply with OK.",
+                            1,
+                            java.util.List.of()),
+                    () -> false,
+                    new AiClient.Listener() {
+                        @Override
+                        public void onText(String delta) {
+                            // content is irrelevant — a streaming 200 means the endpoint works
+                        }
+
+                        @Override
+                        public void onDone(String stopReason) {
+                            deliver(true, stopReason);
+                        }
+
+                        @Override
+                        public void onError(String message) {
+                            deliver(false, message);
+                        }
+
+                        private void deliver(boolean ok, String message) {
+                            if (!delivered[0]) {
+                                delivered[0] = true;
+                                Platform.runLater(() -> cb.accept(new Ping(ok, message)));
+                            }
+                        }
+                    });
+        });
+    }
+
     /** Cancels the in-flight generation (the reader stops at the next event boundary). */
     public void cancel() {
         generation.incrementAndGet();

--- a/src/main/java/com/editora/ui/AiCoordinator.java
+++ b/src/main/java/com/editora/ui/AiCoordinator.java
@@ -344,6 +344,35 @@ final class AiCoordinator {
         return provider() == AiProvider.ANTHROPIC ? DEFAULT_MODEL : "";
     }
 
+    /**
+     * Runs a live connection check for the configured provider/endpoint/key/model and delivers
+     * {@code (ok, message)} on the FX thread — green when the endpoint accepts a minimal request, red
+     * with the error otherwise. Reports the gate state (disabled / no key) without a network call.
+     */
+    void checkConnection(java.util.function.BiConsumer<Boolean, String> onResult) {
+        if (!isEnabled()) {
+            onResult.accept(false, tr("status.ai.disabled"));
+            return;
+        }
+        if (provider().requiresApiKey() && apiKey().isEmpty()) {
+            onResult.accept(false, tr("status.ai.noApiKey"));
+            return;
+        }
+        service.ping(
+                provider(),
+                endpoint(),
+                apiKey(),
+                model(),
+                ping -> onResult.accept(ping.ok(), ping.ok() ? tr("settings.ai.connected") : ping.message()));
+    }
+
+    /** {@code ai.testConnection}: run the check and echo the result to the status bar. */
+    void testConnection() {
+        host.setStatus(tr("status.ai.testing"));
+        checkConnection((ok, message) ->
+                host.setStatus(ok ? tr("status.ai.connected") : tr("status.ai.connectFailed", message)));
+    }
+
     /** Window close: cancel any stream + stop the worker threads. */
     void shutdown() {
         service.shutdown();

--- a/src/main/java/com/editora/ui/MainController.java
+++ b/src/main/java/com/editora/ui/MainController.java
@@ -545,6 +545,8 @@ public class MainController implements com.editora.mcp.McpBridge {
         this.settingsWindow.setMcpConfirm(this::confirmEnableMcp); // security notice before enabling MCP
         this.settingsWindow.setRipgrepProbe(
                 searchCoordinator::probeRipgrep); // Settings → Search found/not-found status
+        this.settingsWindow.setAiConnectionProbe(
+                aiCoordinator::checkConnection); // Settings → AI Actions green/red connection status
         this.settingsWindow.setOnKeymapChanged(this::reloadKeymap); // picker/combo → live keymap switch
         this.settingsWindow.setShortcutActions(new SettingsWindow.ShortcutActions() {
             @Override
@@ -10056,6 +10058,7 @@ public class MainController implements com.editora.mcp.McpBridge {
                         () -> config.getSettings().getAiEndpoint(),
                         v -> config.getSettings().setAiEndpoint(v),
                         null)));
+        registry.register(Command.of("ai.testConnection", aiCoordinator::testConnection));
         registry.register(Command.of("view.toggleLineHighlight", this::toggleLineHighlight));
         registry.register(Command.of("view.toggleLineNumbers", this::toggleLineNumbers));
         registry.register(Command.of("view.toggleMinimap", this::toggleMinimap));

--- a/src/main/java/com/editora/ui/SettingsWindow.java
+++ b/src/main/java/com/editora/ui/SettingsWindow.java
@@ -277,6 +277,13 @@ public class SettingsWindow {
     private TextField aiCompletionModelField;
     private ComboBox<String> aiProviderCombo;
     private TextField aiEndpointField;
+    private Label aiStatusLabel;
+    /** Injected by MainController: runs a live connection check, delivering (ok, message) on the FX thread. */
+    private java.util.function.Consumer<java.util.function.BiConsumer<Boolean, String>> aiConnectionProbe;
+    /** Coalesces rapid field edits into a single connection check (~600 ms after the last keystroke). */
+    private final javafx.animation.PauseTransition aiStatusDebounce =
+            new javafx.animation.PauseTransition(javafx.util.Duration.millis(600));
+
     private TextField mmdcPathField;
     private CheckBox debugCheck;
     /** Per-language debug-adapter controls, keyed by language id (java/python/javascript). */
@@ -1003,6 +1010,7 @@ public class SettingsWindow {
         aiCheck.selectedProperty().addListener((obs, was, now) -> {
             config.getSettings().setAiSupport(now);
             apply();
+            scheduleAiStatus();
         });
         aiProviderCombo = new ComboBox<>();
         aiProviderCombo.getItems().addAll("anthropic", "openai");
@@ -1021,25 +1029,30 @@ public class SettingsWindow {
             if (!loading && now != null) {
                 config.getSettings().setAiProvider(now);
                 apply();
+                scheduleAiStatus();
             }
         });
+        aiStatusDebounce.setOnFinished(e -> refreshAiStatus());
         aiEndpointField = new TextField();
         aiEndpointField.setPromptText(tr("settings.ai.endpointPrompt"));
         aiEndpointField.textProperty().addListener((obs, was, now) -> {
             config.getSettings().setAiEndpoint(now);
             apply();
+            scheduleAiStatus();
         });
         aiModelField = new TextField();
         aiModelField.setPromptText("claude-opus-4-8");
         aiModelField.textProperty().addListener((obs, was, now) -> {
             config.getSettings().setAiModel(now);
             apply();
+            scheduleAiStatus();
         });
         aiApiKeyField = new javafx.scene.control.PasswordField();
         aiApiKeyField.setPromptText(tr("settings.ai.apiKeyPrompt"));
         aiApiKeyField.textProperty().addListener((obs, was, now) -> {
             config.getSettings().setAiApiKey(now);
             apply();
+            scheduleAiStatus();
         });
         aiInlineCheck = new CheckBox(tr("settings.ai.inline"));
         aiInlineCheck.selectedProperty().addListener((obs, was, now) -> {
@@ -3497,9 +3510,46 @@ public class SettingsWindow {
         return p;
     }
 
+    /** Injected by MainController: runs a live AI connection check (green/red status on the AI page). */
+    public void setAiConnectionProbe(
+            java.util.function.Consumer<java.util.function.BiConsumer<Boolean, String>> probe) {
+        this.aiConnectionProbe = probe;
+    }
+
+    /** Debounced connection re-check after a field edit (avoids a network call per keystroke). */
+    private void scheduleAiStatus() {
+        if (!loading) {
+            aiStatusDebounce.playFromStart();
+        }
+    }
+
+    /** Fires the live connection check now, showing a "checking…" state until the result lands. */
+    private void refreshAiStatus() {
+        if (aiStatusLabel == null || aiConnectionProbe == null) {
+            return;
+        }
+        aiStatusLabel.getStyleClass().setAll("settings-git-status");
+        aiStatusLabel.setText(tr("settings.ai.checking"));
+        aiConnectionProbe.accept(this::syncAiStatus);
+    }
+
+    /** Colors the AI status label green/red (the Git/Mermaid/LSP idiom): connected vs the error message. */
+    private void syncAiStatus(boolean ok, String message) {
+        if (aiStatusLabel == null) {
+            return;
+        }
+        aiStatusLabel.getStyleClass().setAll("settings-git-status", ok ? "settings-git-found" : "settings-git-missing");
+        aiStatusLabel.setText(ok ? tr("settings.ai.connected") : tr("settings.ai.connectFailed", message));
+    }
+
     private VBox aiPage() {
         VBox p = page(tr("settings.cat.ai"));
         row(p, Category.AI, null, aiCheck, "ai actions anthropic claude commit message explain rewrite enable");
+        aiStatusLabel = new Label(tr("settings.ai.statusUnknown"));
+        aiStatusLabel.getStyleClass().add("settings-git-status");
+        aiStatusLabel.setWrapText(true);
+        aiStatusLabel.setMaxWidth(440);
+        row(p, Category.AI, null, aiStatusLabel, "ai connection status test green red working reachable");
         row(
                 p,
                 Category.AI,
@@ -4909,6 +4959,7 @@ public class SettingsWindow {
             aiProviderCombo.setValue(
                     com.editora.ai.AiProvider.from(settings.getAiProvider()).id());
             aiEndpointField.setText(settings.getAiEndpoint());
+            javafx.application.Platform.runLater(this::refreshAiStatus); // check once the fields are populated
             pluginCheck.setSelected(settings.isPluginSupport());
             if (pluginRequireSigCheck != null) {
                 pluginRequireSigCheck.setSelected(settings.isPluginRequireSignature());

--- a/src/main/resources/com/editora/i18n/messages.properties
+++ b/src/main/resources/com/editora/i18n/messages.properties
@@ -2731,3 +2731,12 @@ settings.ai.provider.openai=Local (OpenAI-compatible)
 settings.ai.endpoint=Endpoint URL
 settings.ai.endpointPrompt=Blank = the provider's default
 settings.ai.providerNote=Choose "Local (OpenAI-compatible)" to use LM Studio, Ollama, or any local server that serves the OpenAI chat-completions API. The default endpoint is LM Studio's local server (http://127.0.0.1:1234/v1/chat/completions); no API key is needed. Leave the model fields blank to use whatever model the server has loaded.
+command.ai.testConnection=AI: Test Connection
+command.ai.testConnection.desc=Check whether the configured AI provider/endpoint is reachable and working.
+settings.ai.statusUnknown=Connection not checked yet
+settings.ai.checking=Checking connection…
+settings.ai.connected=Connected
+settings.ai.connectFailed=Not working: {0}
+status.ai.testing=Testing AI connection…
+status.ai.connected=AI connection OK
+status.ai.connectFailed=AI connection failed: {0}

--- a/src/main/resources/com/editora/i18n/messages_de.properties
+++ b/src/main/resources/com/editora/i18n/messages_de.properties
@@ -2723,3 +2723,12 @@ settings.ai.provider.openai=Lokal (OpenAI-kompatibel)
 settings.ai.endpoint=Endpunkt-URL
 settings.ai.endpointPrompt=Leer = Standard des Anbieters
 settings.ai.providerNote=Wähle „Lokal (OpenAI-kompatibel)", um LM Studio, Ollama oder einen beliebigen lokalen Server zu verwenden, der die OpenAI-Chat-Completions-API bereitstellt. Der Standard-Endpunkt ist der lokale LM-Studio-Server (http://127.0.0.1:1234/v1/chat/completions); kein API-Schlüssel nötig. Lass die Modellfelder leer, um das im Server geladene Modell zu verwenden.
+command.ai.testConnection=KI: Verbindung testen
+command.ai.testConnection.desc=Prüfen, ob der konfigurierte KI-Anbieter/Endpunkt erreichbar ist und funktioniert.
+settings.ai.statusUnknown=Verbindung noch nicht geprüft
+settings.ai.checking=Verbindung wird geprüft…
+settings.ai.connected=Verbunden
+settings.ai.connectFailed=Funktioniert nicht: {0}
+status.ai.testing=KI-Verbindung wird getestet…
+status.ai.connected=KI-Verbindung OK
+status.ai.connectFailed=KI-Verbindung fehlgeschlagen: {0}

--- a/src/main/resources/com/editora/i18n/messages_es.properties
+++ b/src/main/resources/com/editora/i18n/messages_es.properties
@@ -2723,3 +2723,12 @@ settings.ai.provider.openai=Local (compatible con OpenAI)
 settings.ai.endpoint=URL del endpoint
 settings.ai.endpointPrompt=Vacío = el predeterminado del proveedor
 settings.ai.providerNote=Elige "Local (compatible con OpenAI)" para usar LM Studio, Ollama o cualquier servidor local que sirva la API de chat-completions de OpenAI. El endpoint predeterminado es el servidor local de LM Studio (http://127.0.0.1:1234/v1/chat/completions); no se necesita clave de API. Deja los campos de modelo en blanco para usar el modelo que el servidor tenga cargado.
+command.ai.testConnection=IA: Probar conexión
+command.ai.testConnection.desc=Comprobar si el proveedor/endpoint de IA configurado es accesible y funciona.
+settings.ai.statusUnknown=Conexión aún no comprobada
+settings.ai.checking=Comprobando la conexión…
+settings.ai.connected=Conectado
+settings.ai.connectFailed=No funciona: {0}
+status.ai.testing=Probando la conexión de IA…
+status.ai.connected=Conexión de IA correcta
+status.ai.connectFailed=Falló la conexión de IA: {0}

--- a/src/main/resources/com/editora/i18n/messages_fr.properties
+++ b/src/main/resources/com/editora/i18n/messages_fr.properties
@@ -2723,3 +2723,12 @@ settings.ai.provider.openai=Local (compatible OpenAI)
 settings.ai.endpoint=URL du point de terminaison
 settings.ai.endpointPrompt=Vide = valeur par défaut du fournisseur
 settings.ai.providerNote=Choisissez « Local (compatible OpenAI) » pour utiliser LM Studio, Ollama ou tout serveur local exposant l'API chat-completions d'OpenAI. Le point de terminaison par défaut est le serveur local de LM Studio (http://127.0.0.1:1234/v1/chat/completions) ; aucune clé d'API n'est nécessaire. Laissez les champs de modèle vides pour utiliser le modèle chargé par le serveur.
+command.ai.testConnection=IA : Tester la connexion
+command.ai.testConnection.desc=Vérifier si le fournisseur/point de terminaison IA configuré est joignable et fonctionne.
+settings.ai.statusUnknown=Connexion pas encore vérifiée
+settings.ai.checking=Vérification de la connexion…
+settings.ai.connected=Connecté
+settings.ai.connectFailed=Ne fonctionne pas : {0}
+status.ai.testing=Test de la connexion IA…
+status.ai.connected=Connexion IA OK
+status.ai.connectFailed=Échec de la connexion IA : {0}

--- a/src/main/resources/com/editora/i18n/messages_it.properties
+++ b/src/main/resources/com/editora/i18n/messages_it.properties
@@ -2723,3 +2723,12 @@ settings.ai.provider.openai=Locale (compatibile OpenAI)
 settings.ai.endpoint=URL endpoint
 settings.ai.endpointPrompt=Vuoto = predefinito del provider
 settings.ai.providerNote=Scegli "Locale (compatibile OpenAI)" per usare LM Studio, Ollama o qualsiasi server locale che espone l'API chat-completions di OpenAI. L'endpoint predefinito è il server locale di LM Studio (http://127.0.0.1:1234/v1/chat/completions); non serve una chiave API. Lascia vuoti i campi del modello per usare il modello caricato nel server.
+command.ai.testConnection=IA: Prova connessione
+command.ai.testConnection.desc=Verificare se il provider/endpoint IA configurato è raggiungibile e funziona.
+settings.ai.statusUnknown=Connessione non ancora verificata
+settings.ai.checking=Verifica della connessione…
+settings.ai.connected=Connesso
+settings.ai.connectFailed=Non funziona: {0}
+status.ai.testing=Test della connessione IA…
+status.ai.connected=Connessione IA OK
+status.ai.connectFailed=Connessione IA non riuscita: {0}

--- a/src/main/resources/com/editora/i18n/messages_pt.properties
+++ b/src/main/resources/com/editora/i18n/messages_pt.properties
@@ -2723,3 +2723,12 @@ settings.ai.provider.openai=Local (compatível com OpenAI)
 settings.ai.endpoint=URL do endpoint
 settings.ai.endpointPrompt=Vazio = padrão do provedor
 settings.ai.providerNote=Escolha "Local (compatível com OpenAI)" para usar LM Studio, Ollama ou qualquer servidor local que sirva a API de chat-completions da OpenAI. O endpoint padrão é o servidor local do LM Studio (http://127.0.0.1:1234/v1/chat/completions); não é necessária chave de API. Deixe os campos de modelo em branco para usar o modelo carregado no servidor.
+command.ai.testConnection=IA: Testar conexão
+command.ai.testConnection.desc=Verificar se o provedor/endpoint de IA configurado está acessível e funcionando.
+settings.ai.statusUnknown=Conexão ainda não verificada
+settings.ai.checking=Verificando a conexão…
+settings.ai.connected=Conectado
+settings.ai.connectFailed=Não funciona: {0}
+status.ai.testing=Testando a conexão de IA…
+status.ai.connected=Conexão de IA OK
+status.ai.connectFailed=Falha na conexão de IA: {0}


### PR DESCRIPTION
## Summary

Adds a live health-check indicator to Settings → AI Actions, so a misconfigured provider is obvious immediately instead of failing silently at first use. Directly motivated by a real setup where a typo'd LM Studio endpoint (`/chat/completitions`, missing `/v1`) would have failed quietly.

Under the enable checkbox:
- **Connected** (green) — the configured provider/endpoint/key/model accept a request.
- **Not working: …** (red) — with the actual error: a 404 path, a refused connection, a bad key, an unknown model.

It checks when the page opens and re-checks (debounced ~600 ms) after you edit the provider, endpoint, API key, or model. Also a palette command **AI: Test Connection** that reports to the status bar.

## Design

- **`AiService.ping`** — a tiny **one-token** request to the configured provider/endpoint/key/model, returning `Ping{ok, message}` on the FX thread. It reuses the existing dual-dialect `AiClient.stream` (so a streaming 200 = "works" for either Anthropic or OpenAI-compatible), and **never touches the generation counter** — it can't cancel or be cancelled by a real generation.
- **`AiCoordinator.checkConnection`** — reports the gate state without a network call (disabled / missing key) then pings; `testConnection` echoes to the status bar.
- **`SettingsWindow`** — an `aiStatusLabel` using the same `settings-git-found`/`settings-git-missing` CSS the Git/Mermaid/LSP/ripgrep status labels use, refreshed on page-open and via a `PauseTransition` debounce on field edits; the probe is injected from `MainController` (mirrors `setRipgrepProbe`).
- i18n in all six catalogs; palette parity (`ai.testConnection`). **No new dependency.**

## Performance

The probe is a single 1-token request off-thread, fired only on page-open or after a debounced settings edit — never on the editor hot paths, and nothing runs while the Settings window is closed.

## Testing

Full non-FX suite: **1505 tests, 0 failures** (incl. i18n key parity across six catalogs). The new logic is a thin FX/network wrapper over the already-tested `AiClient`/`AiRequests` dialect layer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)