### PR TITLE
AI: bound the connection check with a response timeout (no more stuck "Checking…")

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **AI connection check no longer hangs on a slow endpoint.** The Settings → AI Actions health check
+  now bounds the wait for a response (30 s) — a slow-to-start local server (e.g. LM Studio loading a
+  large model) or an unreachable endpoint resolves to a red "Not working: …" instead of sticking on
+  "Checking connection…" forever. Real AI requests gained a 120 s time-to-first-response cap too
+  (unchanged for a healthy streaming generation, which streams to completion after the first token).
+
 ### Added
 
 - **AI connection status (green/red).** The Settings → AI Actions page now shows a live health-check

--- a/src/main/java/com/editora/ai/AiClient.java
+++ b/src/main/java/com/editora/ai/AiClient.java
@@ -23,6 +23,10 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 public final class AiClient {
 
     private static final Duration CONNECT_TIMEOUT = Duration.ofSeconds(15);
+    /** Generous default response-headers timeout (a reasoning model can be slow to first token). */
+    static final Duration DEFAULT_RESPONSE_TIMEOUT = Duration.ofSeconds(120);
+    /** Short timeout for the Settings connection check — it must resolve quickly, not hang. */
+    public static final Duration PING_TIMEOUT = Duration.ofSeconds(30);
 
     /** Receives the streamed response (on the calling thread — the service marshals to FX). */
     public interface Listener {
@@ -51,9 +55,27 @@ public final class AiClient {
             JsonNode request,
             BooleanSupplier cancelled,
             Listener listener) {
+        stream(provider, endpoint, apiKey, request, DEFAULT_RESPONSE_TIMEOUT, cancelled, listener);
+    }
+
+    /**
+     * As {@link #stream(AiProvider, String, String, JsonNode, BooleanSupplier, Listener)}, with an explicit
+     * response timeout. The timeout bounds the wait for the response <em>headers</em> (not the streamed
+     * body), so a dead / slow-to-start endpoint fails fast instead of hanging forever — while a long,
+     * healthy generation still streams to completion. {@code onError} fires on timeout.
+     */
+    public void stream(
+            AiProvider provider,
+            String endpoint,
+            String apiKey,
+            JsonNode request,
+            Duration responseTimeout,
+            BooleanSupplier cancelled,
+            Listener listener) {
         HttpRequest req;
         try {
             HttpRequest.Builder b = HttpRequest.newBuilder(URI.create(endpoint))
+                    .timeout(responseTimeout)
                     .header("content-type", "application/json")
                     .POST(HttpRequest.BodyPublishers.ofString(mapper.writeValueAsString(request)));
             if (provider == AiProvider.OPENAI) {

--- a/src/main/java/com/editora/ai/AiService.java
+++ b/src/main/java/com/editora/ai/AiService.java
@@ -108,6 +108,7 @@ public final class AiService {
                             "Reply with OK.",
                             1,
                             java.util.List.of()),
+                    AiClient.PING_TIMEOUT,
                     () -> false,
                     new AiClient.Listener() {
                         @Override


### PR DESCRIPTION
## Problem

The Settings → AI Actions connection check had **no request timeout**, so a slow-to-respond endpoint left the status stuck on "Checking connection…" forever. This reproduces with a real LM Studio setup where the server is loading a large model (or the model field names a model that isn't loaded) — the check never resolves.

## Fix

`AiClient.stream` gains an explicit **response-headers timeout**. This bounds the wait for the response line — *not* the streamed body — so:
- a dead / slow-to-start endpoint fails fast with a red **Not working: …**;
- a healthy long generation still streams to completion after the first token.

The Settings ping uses a short **30 s** cap; real generations use a generous **120 s** time-to-first-token default. On timeout, `onError` fires, so the status label flips red with the reason instead of hanging.

## Testing

Full non-FX suite: **1505 tests, 0 failures**. (The timeout is a `java.net.http` request setting; the parsing/dialect layer it wraps is already unit-tested.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)