### PR TITLE
AI: non-streaming connection check (fully bounded timeout, no more stuck "Checking…")

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- **AI connection check no longer hangs on a slow endpoint.** The Settings → AI Actions health check
-  now bounds the wait for a response (30 s) — a slow-to-start local server (e.g. LM Studio loading a
-  large model) or an unreachable endpoint resolves to a red "Not working: …" instead of sticking on
-  "Checking connection…" forever. Real AI requests gained a 120 s time-to-first-response cap too
-  (unchanged for a healthy streaming generation, which streams to completion after the first token).
+- **AI connection check no longer hangs on a slow endpoint.** The Settings → AI Actions health check is
+  now a **non-streaming** request whose 30 s timeout bounds the *entire* exchange — so a local server
+  that sends response headers immediately but is slow to produce the first token (LM Studio warming up a
+  model) can no longer leave the status stuck on "Checking connection…". It resolves to green
+  **Connected** or a red **Not working: …** (with the HTTP error / "timed out"). Real streaming AI
+  requests also gained a 120 s time-to-first-response cap (unchanged for a healthy generation).
 
 ### Added
 

--- a/src/main/java/com/editora/ai/AiClient.java
+++ b/src/main/java/com/editora/ai/AiClient.java
@@ -166,6 +166,46 @@ public final class AiClient {
         }
     }
 
+    /**
+     * A blocking, <em>non-streaming</em> health check: POSTs {@code request} and returns null on HTTP 200,
+     * else a human-readable error. Unlike {@link #stream}, the {@code timeout} bounds the <em>entire</em>
+     * exchange (a non-streaming body handler receives the whole response before {@code send} returns), so
+     * a slow local server warming up a model can't leave the caller hanging — it fails with a clear
+     * "timed out" instead. Used by the Settings connection check.
+     */
+    public String check(
+            AiProvider provider, String endpoint, String apiKey, JsonNode request, java.time.Duration timeout) {
+        try {
+            HttpRequest.Builder b = HttpRequest.newBuilder(URI.create(endpoint))
+                    .timeout(timeout)
+                    .header("content-type", "application/json")
+                    .POST(HttpRequest.BodyPublishers.ofString(mapper.writeValueAsString(request)));
+            if (provider == AiProvider.OPENAI) {
+                if (apiKey != null && !apiKey.isBlank()) {
+                    b.header("Authorization", "Bearer " + apiKey);
+                }
+            } else {
+                b.header("x-api-key", apiKey).header("anthropic-version", "2023-06-01");
+            }
+            HttpResponse<String> resp = http.send(b.build(), HttpResponse.BodyHandlers.ofString());
+            return resp.statusCode() == 200 ? null : errorBodyString(resp.statusCode(), resp.body());
+        } catch (java.net.http.HttpTimeoutException e) {
+            return "timed out";
+        } catch (Exception e) {
+            return String.valueOf(e.getMessage());
+        }
+    }
+
+    /** Parses an {@code error.message} out of a String error body (Anthropic + OpenAI share the shape). */
+    private String errorBodyString(int status, String body) {
+        try {
+            String msg = mapper.readTree(body).path("error").path("message").asText("");
+            return "HTTP " + status + (msg.isEmpty() ? "" : ": " + msg);
+        } catch (Exception e) {
+            return "HTTP " + status;
+        }
+    }
+
     private String errorBody(HttpResponse<java.io.InputStream> resp) {
         try (var in = resp.body()) {
             JsonNode body = mapper.readTree(in);

--- a/src/main/java/com/editora/ai/AiRequests.java
+++ b/src/main/java/com/editora/ai/AiRequests.java
@@ -136,6 +136,14 @@ public final class AiRequests {
         return r;
     }
 
+    /** A minimal, <em>non-streaming</em> request for the Settings connection check (dialect-aware). */
+    public static ObjectNode pingRequest(ObjectMapper m, AiProvider provider, String model) {
+        ObjectNode r =
+                requestFor(m, provider, model, "You are a health check.", "Reply with OK.", 1, java.util.List.of());
+        r.put("stream", false);
+        return r;
+    }
+
     /** Output cap for inline completion — one short line, never an essay. */
     public static final int COMPLETION_MAX_TOKENS = 128;
 

--- a/src/main/java/com/editora/ai/AiService.java
+++ b/src/main/java/com/editora/ai/AiService.java
@@ -95,44 +95,9 @@ public final class AiService {
     public void ping(
             AiProvider provider, String endpoint, String apiKey, String model, java.util.function.Consumer<Ping> cb) {
         exec.submit(() -> {
-            boolean[] delivered = {false};
-            client.stream(
-                    provider,
-                    endpoint,
-                    apiKey,
-                    AiRequests.requestFor(
-                            mapper,
-                            provider,
-                            model,
-                            "You are a health check.",
-                            "Reply with OK.",
-                            1,
-                            java.util.List.of()),
-                    AiClient.PING_TIMEOUT,
-                    () -> false,
-                    new AiClient.Listener() {
-                        @Override
-                        public void onText(String delta) {
-                            // content is irrelevant — a streaming 200 means the endpoint works
-                        }
-
-                        @Override
-                        public void onDone(String stopReason) {
-                            deliver(true, stopReason);
-                        }
-
-                        @Override
-                        public void onError(String message) {
-                            deliver(false, message);
-                        }
-
-                        private void deliver(boolean ok, String message) {
-                            if (!delivered[0]) {
-                                delivered[0] = true;
-                                Platform.runLater(() -> cb.accept(new Ping(ok, message)));
-                            }
-                        }
-                    });
+            String error = client.check(
+                    provider, endpoint, apiKey, AiRequests.pingRequest(mapper, provider, model), AiClient.PING_TIMEOUT);
+            Platform.runLater(() -> cb.accept(new Ping(error == null, error == null ? "" : error)));
         });
     }
 

--- a/src/test/java/com/editora/ai/OpenAiSseTest.java
+++ b/src/test/java/com/editora/ai/OpenAiSseTest.java
@@ -74,6 +74,18 @@ class OpenAiSseTest {
     }
 
     @Test
+    void pingRequestIsNonStreamingInBothDialects() {
+        var openai = AiRequests.pingRequest(m, AiProvider.OPENAI, "");
+        assertFalse(openai.get("stream").asBoolean());
+        assertFalse(openai.has("model")); // blank model omitted → server uses the loaded model
+        assertEquals("system", openai.get("messages").get(0).get("role").asText());
+        var anthropic = AiRequests.pingRequest(m, AiProvider.ANTHROPIC, "claude-opus-4-8");
+        assertFalse(anthropic.get("stream").asBoolean());
+        assertEquals("claude-opus-4-8", anthropic.get("model").asText());
+        assertEquals(1, anthropic.get("max_tokens").asInt());
+    }
+
+    @Test
     void requestForSelectsDialect() {
         assertTrue(AiRequests.requestFor(m, AiProvider.OPENAI, "x", "s", "u", 64, java.util.List.of())
                 .has("messages"));


### PR DESCRIPTION
## Problem

The status stayed on **"Checking connection…"** even after #317 added a response timeout. Root cause: a streaming server (LM Studio) sends `200` response headers *immediately*, then streams the body — and my previous timeout only bounded the wait for headers, not the body. So while LM Studio warmed up the model (or resolved the wrong `claude-opus-4-8` model name), the body read blocked with no bound.

## Fix

The health check is now a dedicated **non-streaming** request:
- `AiRequests.pingRequest` builds a minimal `stream:false` request in the right dialect.
- `AiClient.check` POSTs it with `HttpRequest.timeout(30 s)` and a `String` body handler. For a non-streaming body, the timeout bounds the **entire** exchange (headers *and* body) — so the check always resolves: green **Connected** on `200`, or red **Not working: …** with the HTTP error / `timed out`.

The streaming path (real generations) is unchanged and keeps its 120 s time-to-first-token cap.

## Testing

- `OpenAiSseTest` extended: `pingRequest` is non-streaming in both dialects (blank model omitted for OpenAI so the server uses its loaded model; kept for Anthropic).
- Full non-FX suite: **1506 tests, 0 failures**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)