### PR TITLE
Find-in-Files popup: include/exclude glob fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Find-in-Files popup: include/exclude globs.** The keyboard-first *Find in Files* popup now has the same
+  comma-separated **include / exclude glob** fields as the tool window (e.g. `*.java, src/**` / `**/test/**`),
+  narrowing the search live as you type.
+
 - **Remote-file (SFTP) status indicator.** When the active file lives on a remote host, the status bar now
   shows a **⇅ SFTP** badge (with the `host:/path` in its tooltip; click it to manage connections), so it's
   clear at a glance that you're editing over SFTP. (The tab already showed a cloud icon + path tooltip.)

--- a/src/main/java/com/editora/ui/SearchCoordinator.java
+++ b/src/main/java/com/editora/ui/SearchCoordinator.java
@@ -137,8 +137,19 @@ final class SearchCoordinator {
                 }
 
                 @Override
-                public void search(SearchQuery query, Path root, Consumer<SearchService.Outcome> onResult) {
-                    service.search(query, root, collectOpenBuffers(), onResult);
+                public void search(
+                        SearchQuery query,
+                        Path root,
+                        String includeGlobs,
+                        String excludeGlobs,
+                        Consumer<SearchService.Outcome> onResult) {
+                    service.search(
+                            query,
+                            root,
+                            collectOpenBuffers(),
+                            Globs.split(includeGlobs),
+                            Globs.split(excludeGlobs),
+                            onResult);
                 }
 
                 @Override

--- a/src/main/java/com/editora/ui/SearchInFilesPopup.java
+++ b/src/main/java/com/editora/ui/SearchInFilesPopup.java
@@ -59,8 +59,14 @@ final class SearchInFilesPopup {
         /** The folder to seed the search root with on open (project root, else the active file's folder). */
         Path defaultRoot();
 
-        /** Runs the multi-file search off-thread; {@code onResult} is delivered on the FX thread. */
-        void search(SearchQuery query, Path root, Consumer<SearchService.Outcome> onResult);
+        /** Runs the multi-file search off-thread with comma-separated include/exclude globs; {@code onResult}
+         *  is delivered on the FX thread. */
+        void search(
+                SearchQuery query,
+                Path root,
+                String includeGlobs,
+                String excludeGlobs,
+                Consumer<SearchService.Outcome> onResult);
 
         /** Opens {@code file} and jumps to {@code line}/{@code col} (1-based), focusing the editor. */
         void openMatch(Path file, int line, int col);
@@ -81,6 +87,10 @@ final class SearchInFilesPopup {
     private final CheckBox regex = new CheckBox(".*");
     private final CheckBox wholeWord = new CheckBox("W");
     private final TextField rootField = new TextField();
+    /** Comma-separated include / exclude globs (e.g. {@code *.java, src/**}), mirroring the Find-in-Files panel. */
+    private final TextField include = new TextField();
+
+    private final TextField exclude = new TextField();
     /** Shown only when ripgrep is the effective backend (pushed from the coordinator), mirroring the panel. */
     private final Label backendBadge = new Label("ripgrep");
 
@@ -136,6 +146,15 @@ final class SearchInFilesPopup {
         HBox rootRow = new HBox(6, rootLabel, rootField);
         rootRow.setAlignment(Pos.CENTER_LEFT);
 
+        include.setPromptText(tr("search.includePrompt"));
+        exclude.setPromptText(tr("search.excludePrompt"));
+        include.textProperty().addListener((o, a, b) -> debounce.playFromStart());
+        exclude.textProperty().addListener((o, a, b) -> debounce.playFromStart());
+        HBox.setHgrow(include, Priority.ALWAYS);
+        HBox.setHgrow(exclude, Priority.ALWAYS);
+        HBox globRow = new HBox(6, include, exclude);
+        globRow.setAlignment(Pos.CENTER_LEFT);
+
         list.setItems(rows);
         list.setFixedCellSize(CELL_HEIGHT);
         list.setCellFactory(v -> new ResultCell());
@@ -147,7 +166,7 @@ final class SearchInFilesPopup {
         Label hint = new Label(tr("search.popupHint"));
         hint.getStyleClass().add("palette-hint");
 
-        VBox card = new VBox(6, title, query, toggles, rootRow, list, status, hint);
+        VBox card = new VBox(6, title, query, toggles, rootRow, globRow, list, status, hint);
         card.getStyleClass().addAll("command-palette", "fif-popup");
         card.setPrefWidth(CARD_WIDTH);
         card.setMaxSize(CARD_WIDTH, Region.USE_PREF_SIZE);
@@ -276,7 +295,7 @@ final class SearchInFilesPopup {
         status.setText(tr("search.searching"));
         SearchQuery sq = new SearchQuery(q, caseSensitive.isSelected(), regex.isSelected(), wholeWord.isSelected());
         Path scope = root;
-        ops.search(sq, scope, outcome -> populate(outcome, scope));
+        ops.search(sq, scope, include.getText(), exclude.getText(), outcome -> populate(outcome, scope));
     }
 
     private void populate(SearchService.Outcome outcome, Path root) {


### PR DESCRIPTION
Quick win #9. The keyboard-first *Find in Files* popup now has the same comma-separated **include / exclude glob** fields as the tool window (e.g. `*.java, src/**` / `**/test/**`), narrowing the search live as you type.

- Two debounced `TextField`s feed a widened `SearchInFilesPopup.Ops.search`; `SearchCoordinator` splits them via `Globs.split` and calls the 6-arg `SearchService.search` (applied to both backends + the open-buffer overlay).
- Reuses the existing `search.includePrompt`/`search.excludePrompt` i18n.

`./mvnw clean verify` green (1616 tests). No new dependency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)