### PR TITLE
MCP: list_tabs and todo_scan tools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **MCP: `list_tabs` and `todo_scan` tools.** The MCP bridge gains two read tools — `list_tabs` (every
+  open tab including non-editor tabs — Welcome/image/hex/diff — with each tab's type + which is active)
+  and `todo_scan` (scans the project + open buffers for the configured TODO/FIXME highlight patterns,
+  returning file/line/col/keyword/tag/priority/text) — bringing the tool count to fourteen.
+
 - **External Tools: editor right-click submenu.** The editor context menu now shows an **External Tools**
   submenu listing every enabled tool, so you can run one on the active file without the palette or a
   keybinding (hidden when no tool is enabled or in Simple UI mode).

--- a/README.md
+++ b/README.md
@@ -349,9 +349,9 @@ Editora is built with the help of AI coding tools.
   user-installed external tool, never bundled.
 - **MCP server** _(Beta)_ — embed a [Model Context Protocol](https://modelcontextprotocol.io) server in the
   running editor so an LLM agent (Claude Code, etc.) can observe live editor state, edit files, and drive the
-  command registry. A small **loopback-only** HTTP/JSON-RPC server with **bearer-token auth** exposes twelve
-  tools — reads (`list_open_files`, `read_buffer`, `get_selection`, `get_diagnostics`, `document_symbols`,
-  `git_status`, `find_in_files`, `list_commands`), writes (`edit_buffer` — undoable str-replace edits —
+  command registry. A small **loopback-only** HTTP/JSON-RPC server with **bearer-token auth** exposes fourteen
+  tools — reads (`list_open_files`, `list_tabs`, `read_buffer`, `get_selection`, `get_diagnostics`,
+  `document_symbols`, `git_status`, `todo_scan`, `find_in_files`, `list_commands`), writes (`edit_buffer` — undoable str-replace edits —
   `save_buffer`), and actions (`open_file`, `execute_command`) — and writes its endpoint to
   `<configDir>/mcp-endpoint.json` for discovery. A status-bar
   **MCP** indicator shows when it's running (click to copy the connection command). Off by default and

--- a/src/main/java/com/editora/mcp/McpBridge.java
+++ b/src/main/java/com/editora/mcp/McpBridge.java
@@ -17,6 +17,15 @@ public interface McpBridge {
     /** One open tab/buffer. {@code path} is null for an unsaved (untitled) buffer. */
     record OpenFile(String path, String title, String language, boolean dirty, boolean active) {}
 
+    /** One tab in the strip — including non-editor tabs. {@code type} is {@code editor}/{@code image}/
+     *  {@code hex}/{@code diff}/{@code merge}/{@code welcome}/{@code other}; {@code path} is null when the
+     *  tab has no file (Welcome, an untitled buffer). */
+    record TabInfo(String type, String title, String path, boolean active) {}
+
+    /** One scanned TODO/highlight match (1-based line/col). {@code keyword}/{@code tag}/{@code priority}
+     *  are the parsed comment structure ({@code null} when absent). */
+    record TodoItem(String file, int line, int col, String keyword, String tag, String priority, String text) {}
+
     /** A buffer's live (possibly unsaved) text plus identity. */
     record BufferContent(String path, String title, String language, boolean dirty, String text) {}
 
@@ -102,4 +111,12 @@ public interface McpBridge {
 
     /** The Git status for this window's context (branch, ahead/behind, changed files). */
     GitState gitStatus();
+
+    /** Every open tab in the strip, including non-editor tabs (Welcome, image, hex, diff), with which one
+     *  is active. */
+    List<TabInfo> listTabs();
+
+    /** Scans the window's project tree (plus open buffers' unsaved text) for the configured TODO/highlight
+     *  patterns; empty when TODO highlighting is off. */
+    List<TodoItem> todoScan();
 }

--- a/src/main/java/com/editora/mcp/McpTools.java
+++ b/src/main/java/com/editora/mcp/McpTools.java
@@ -110,6 +110,16 @@ final class McpTools {
                 "git_status",
                 "Get the Git status for the editor's context: branch, upstream, ahead/behind, changed files.",
                 obj()));
+        tools.add(tool(
+                "list_tabs",
+                "List every open tab, including non-editor tabs (Welcome, image, hex, diff), with each tab's"
+                        + " type and which one is active.",
+                obj()));
+        tools.add(tool(
+                "todo_scan",
+                "Scan the active project (and open buffers' unsaved text) for TODO/FIXME-style highlight"
+                        + " patterns; returns each match's file, line/col, keyword, tag, priority, and line text.",
+                obj()));
         ObjectNode r = m.createObjectNode();
         r.set("tools", tools);
         return r;
@@ -137,6 +147,8 @@ final class McpTools {
             case "get_selection" -> selectionResult();
             case "document_symbols" -> symbolsResult(text(args, "path"));
             case "git_status" -> gitStatusResult();
+            case "list_tabs" -> tabsResult();
+            case "todo_scan" -> todoScanResult();
             default -> errorResult("Unknown tool: " + name);
         };
     }
@@ -150,6 +162,35 @@ final class McpTools {
             o.put("language", f.language());
             o.put("dirty", f.dirty());
             o.put("active", f.active());
+            arr.add(o);
+        }
+        return textResult(arr);
+    }
+
+    private ObjectNode tabsResult() {
+        ArrayNode arr = m.createArrayNode();
+        for (McpBridge.TabInfo t : bridge.listTabs()) {
+            ObjectNode o = m.createObjectNode();
+            o.put("type", t.type());
+            o.put("title", t.title());
+            o.put("path", t.path());
+            o.put("active", t.active());
+            arr.add(o);
+        }
+        return textResult(arr);
+    }
+
+    private ObjectNode todoScanResult() {
+        ArrayNode arr = m.createArrayNode();
+        for (McpBridge.TodoItem t : bridge.todoScan()) {
+            ObjectNode o = m.createObjectNode();
+            o.put("file", t.file());
+            o.put("line", t.line());
+            o.put("col", t.col());
+            o.put("keyword", t.keyword());
+            o.put("tag", t.tag());
+            o.put("priority", t.priority());
+            o.put("text", t.text());
             arr.add(o);
         }
         return textResult(arr);

--- a/src/main/java/com/editora/ui/MainController.java
+++ b/src/main/java/com/editora/ui/MainController.java
@@ -3365,6 +3365,73 @@ public class MainController implements com.editora.mcp.McpBridge {
         return new GitState(true, state.root().toString(), st.branch(), st.upstream(), st.ahead(), st.behind(), files);
     }
 
+    @Override
+    public java.util.List<TabInfo> listTabs() {
+        return mcpOnFx(() -> {
+            Tab active = tabPane.getSelectionModel().getSelectedItem();
+            java.util.List<TabInfo> out = new java.util.ArrayList<>();
+            for (Tab tab : tabPane.getTabs()) {
+                Path p = tabPath(tab);
+                out.add(new TabInfo(tabType(tab), bufferTitle(tab), p == null ? null : p.toString(), tab == active));
+            }
+            return out;
+        });
+    }
+
+    @Override
+    public java.util.List<TodoItem> todoScan() {
+        java.util.concurrent.CompletableFuture<com.editora.todo.TodoService.Outcome> fut =
+                new java.util.concurrent.CompletableFuture<>();
+        javafx.application.Platform.runLater(() -> todoCoordinator.scanForMcp(fut::complete));
+        com.editora.todo.TodoService.Outcome outcome;
+        try {
+            outcome = fut.get(30, java.util.concurrent.TimeUnit.SECONDS);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+        java.util.List<TodoItem> out = new java.util.ArrayList<>();
+        for (com.editora.todo.TodoService.FileTodos ft : outcome.files()) {
+            String file = ft.file().toString();
+            for (com.editora.todo.TodoMatch m : ft.matches()) {
+                com.editora.todo.TodoComment c = m.parsed();
+                out.add(new TodoItem(
+                        file,
+                        m.line() + 1,
+                        m.col() + 1,
+                        c == null ? m.patternName() : c.keyword(),
+                        c == null ? null : c.tag(),
+                        c == null ? null : c.priority(),
+                        m.lineText()));
+            }
+        }
+        return out;
+    }
+
+    /** The MCP {@code type} label for a tab: {@code editor}/{@code image}/{@code hex}/{@code diff}/
+     *  {@code merge}/{@code welcome}/{@code other}. */
+    private static String tabType(Tab tab) {
+        if (bufferOf(tab) != null) {
+            return "editor";
+        }
+        if (imagePaneOf(tab) != null) {
+            return "image";
+        }
+        if (hexPaneOf(tab) != null) {
+            return "hex";
+        }
+        Object data = tab == null ? null : tab.getUserData();
+        if (data instanceof DiffViewerPane) {
+            return "diff";
+        }
+        if (data instanceof MergeViewerPane) {
+            return "merge";
+        }
+        if (data instanceof WelcomePane) {
+            return "welcome";
+        }
+        return "other";
+    }
+
     /** Finds the open buffer whose file matches {@code path} (by canonical path), or null. */
     private EditorBuffer openBufferForPath(String path) {
         Path key = canonicalPath(Path.of(path));

--- a/src/main/java/com/editora/ui/TodoCoordinator.java
+++ b/src/main/java/com/editora/ui/TodoCoordinator.java
@@ -276,6 +276,26 @@ final class TodoCoordinator {
         });
     }
 
+    /** One-off TODO scan for the MCP bridge — same scope/patterns as {@link #runScan} but delivering the
+     *  raw {@link TodoService.Outcome} to {@code cb} (no panel/status side-effects). Empty when the feature
+     *  is off. FX-thread call; {@code cb} fires on the FX thread. */
+    void scanForMcp(java.util.function.Consumer<TodoService.Outcome> cb) {
+        Settings s = host.settings();
+        if (!s.isTodoHighlight()) {
+            cb.accept(new TodoService.Outcome(List.of(), 0, 0, false));
+            return;
+        }
+        List<TodoPatterns.Compiled> compiled = TodoPatterns.compile(s.getTodoPatterns());
+        Map<Path, String> open = new HashMap<>();
+        host.forEachBuffer(b -> {
+            if (b.getPath() != null) {
+                open.put(b.getPath().toAbsolutePath().normalize(), b.getContent());
+            }
+        });
+        service.setRespectGitignore(s.isSearchRespectGitignore());
+        service.scan(compiled, ops.projectRoot(), open, cb);
+    }
+
     /** Pushes the current TODO scan scope to the panel's label: this window's project tree (when one is
      *  open), else the open-files-only scope — matching what {@link #runScan} actually scans. */
     private void refreshScope() {

--- a/src/test/java/com/editora/mcp/McpServerTest.java
+++ b/src/test/java/com/editora/mcp/McpServerTest.java
@@ -88,6 +88,16 @@ class McpServerTest {
         public GitState gitStatus() {
             return new GitState(true, "/tmp", "main", "origin/main", 1, 0, List.of());
         }
+
+        @Override
+        public List<TabInfo> listTabs() {
+            return List.of();
+        }
+
+        @Override
+        public List<TodoItem> todoScan() {
+            return List.of();
+        }
     }
 
     @Test

--- a/src/test/java/com/editora/mcp/McpToolsTest.java
+++ b/src/test/java/com/editora/mcp/McpToolsTest.java
@@ -26,6 +26,8 @@ class McpToolsTest {
         Selection selection;
         List<Symbol> symbols = List.of();
         GitState gitState = new GitState(false, null, null, null, 0, 0, List.of());
+        List<TabInfo> tabs = List.of();
+        List<TodoItem> todos = List.of();
 
         String openedPath;
         int openedLine;
@@ -103,6 +105,16 @@ class McpToolsTest {
         public GitState gitStatus() {
             return gitState;
         }
+
+        @Override
+        public List<TabInfo> listTabs() {
+            return tabs;
+        }
+
+        @Override
+        public List<TodoItem> todoScan() {
+            return todos;
+        }
     }
 
     private final ObjectMapper mapper = new ObjectMapper();
@@ -147,9 +159,35 @@ class McpToolsTest {
                 "save_buffer",
                 "get_selection",
                 "document_symbols",
-                "git_status")) {
+                "git_status",
+                "list_tabs",
+                "todo_scan")) {
             assertTrue(names.contains(expected), "missing tool: " + expected);
         }
+    }
+
+    @Test
+    void listTabsIncludesNonEditorTabs() throws Exception {
+        bridge.tabs = List.of(
+                new McpBridge.TabInfo("editor", "Main.java", "/p/Main.java", true),
+                new McpBridge.TabInfo("welcome", "Welcome", null, false));
+        JsonNode arr = payload(call("list_tabs", null));
+        assertEquals(2, arr.size());
+        assertEquals("editor", arr.get(0).get("type").asText());
+        assertTrue(arr.get(0).get("active").asBoolean());
+        assertEquals("welcome", arr.get(1).get("type").asText());
+        assertTrue(arr.get(1).get("path").isNull());
+    }
+
+    @Test
+    void todoScanReportsMatches() throws Exception {
+        bridge.todos = List.of(new McpBridge.TodoItem("/p/a.java", 12, 5, "TODO", "auth", "!", "// TODO(auth)!: fix"));
+        JsonNode arr = payload(call("todo_scan", null));
+        assertEquals(1, arr.size());
+        assertEquals("/p/a.java", arr.get(0).get("file").asText());
+        assertEquals(12, arr.get(0).get("line").asInt());
+        assertEquals("TODO", arr.get(0).get("keyword").asText());
+        assertEquals("auth", arr.get(0).get("tag").asText());
     }
 
     @Test


### PR DESCRIPTION
Quick win #10. Two new read tools on the MCP bridge (fourteen total):

- **`list_tabs`** — every open tab including non-editor tabs (Welcome / image / hex / diff / merge), each with a `type` label + which is active. `list_open_files` only covers editor buffers.
- **`todo_scan`** — scans the window's project (plus open buffers' unsaved text) for the configured TODO/FIXME highlight patterns, returning `file`/`line`/`col`/`keyword`/`tag`/`priority`/`text`. Reuses a new `TodoCoordinator.scanForMcp`.

`McpBridge` gains `TabInfo`/`TodoItem` records + the two methods; `MainController` implements them (`list_tabs` on the FX thread via `mcpOnFx`, `todo_scan` async via a `CompletableFuture` like `find_in_files`); `McpTools` registers/dispatches/serializes them. Two `McpToolsTest` cases added.

`./mvnw clean verify` green (1618 tests). No new dependency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)