### PR TITLE
AI Agent: active-buffer context, model/mode switching, plan checklist

### DIFF
--- a/src/main/java/com/editora/agent/AcpClient.java
+++ b/src/main/java/com/editora/agent/AcpClient.java
@@ -114,12 +114,10 @@ public final class AcpClient {
         return request("initialize", AcpJson.initializeParams(mapper));
     }
 
-    /** {@code session/new} → the new session's id. */
-    public CompletableFuture<String> newSession(Path sessionCwd) {
+    /** {@code session/new} → the new session's id plus its model/mode catalogs. */
+    public CompletableFuture<AcpJson.SessionInfo> newSession(Path sessionCwd) {
         return request("session/new", AcpJson.newSessionParams(mapper, sessionCwd.toString()))
-                .thenApply(result -> result != null && result.hasNonNull("sessionId")
-                        ? result.get("sessionId").asText()
-                        : null);
+                .thenApply(AcpJson::parseSessionInfo);
     }
 
     /** {@code session/prompt} → the turn's stop reason (e.g. {@code end_turn}/{@code cancelled}). */
@@ -133,6 +131,18 @@ public final class AcpClient {
     /** {@code session/cancel} (fire-and-forget; the in-flight prompt resolves with {@code cancelled}). */
     public void cancel(String sessionId) {
         send(AcpJson.notification(mapper, "session/cancel", AcpJson.cancelParams(mapper, sessionId)));
+    }
+
+    /** {@code session/set_model} — switches the running session's active model. Result body is ignored. */
+    public CompletableFuture<Void> setModel(String sessionId, String modelId) {
+        return request("session/set_model", AcpJson.setModelParams(mapper, sessionId, modelId))
+                .thenApply(result -> null);
+    }
+
+    /** {@code session/set_mode} — switches the running session's active mode. Result body is ignored. */
+    public CompletableFuture<Void> setMode(String sessionId, String modeId) {
+        return request("session/set_mode", AcpJson.setModeParams(mapper, sessionId, modeId))
+                .thenApply(result -> null);
     }
 
     private CompletableFuture<JsonNode> request(String method, JsonNode params) {

--- a/src/main/java/com/editora/agent/AcpJson.java
+++ b/src/main/java/com/editora/agent/AcpJson.java
@@ -111,6 +111,22 @@ public final class AcpJson {
         return p;
     }
 
+    /** {@code session/set_model}. */
+    public static ObjectNode setModelParams(ObjectMapper m, String sessionId, String modelId) {
+        ObjectNode p = m.createObjectNode();
+        p.put("sessionId", sessionId);
+        p.put("modelId", modelId);
+        return p;
+    }
+
+    /** {@code session/set_mode}. */
+    public static ObjectNode setModeParams(ObjectMapper m, String sessionId, String modeId) {
+        ObjectNode p = m.createObjectNode();
+        p.put("sessionId", sessionId);
+        p.put("modeId", modeId);
+        return p;
+    }
+
     /** {@code session/request_permission} response: the user picked {@code optionId}, or cancelled (null). */
     public static ObjectNode permissionOutcome(ObjectMapper m, String optionId) {
         ObjectNode outcome = m.createObjectNode();
@@ -137,17 +153,38 @@ public final class AcpJson {
         TOOL_CALL,
         /** A tool call changed state ({@code tool_call_update}) — {@code text} is the new status. */
         TOOL_CALL_UPDATE,
-        /** The agent published/updated its plan — {@code text} is the flattened entries. */
+        /** The agent published/updated its plan — {@code text} is the flattened entries, {@code planEntries}
+         *  the structured form (status per entry). */
         PLAN,
+        /** The session's mode changed ({@code current_mode_update}) — {@code text} is the new mode id. */
+        MODE_CHANGED,
         /** Anything unrecognized (forward-compatible: ignored by the UI). */
         OTHER
     }
 
-    /** One parsed {@code session/update} notification. */
-    public record Update(String sessionId, UpdateKind kind, String text) {}
+    /** One parsed {@code session/update} notification. {@code planEntries} is non-empty only for
+     *  {@link UpdateKind#PLAN}. */
+    public record Update(String sessionId, UpdateKind kind, String text, List<PlanEntry> planEntries) {}
 
     /** A permission option offered by {@code session/request_permission}. */
     public record PermissionOption(String optionId, String name, String kind) {}
+
+    /** One selectable model, as offered by {@code session/new}'s {@code models.availableModels}. */
+    public record ModelInfo(String modelId, String name, String description) {}
+
+    /** One selectable mode, as offered by {@code session/new}'s {@code modes.availableModes}. */
+    public record ModeInfo(String id, String name, String description) {}
+
+    /** One plan task: {@code status} is {@code pending}/{@code in_progress}/{@code completed}. */
+    public record PlanEntry(String content, String status) {}
+
+    /** The parsed {@code session/new} result: the new session id plus its model/mode catalogs. */
+    public record SessionInfo(
+            String sessionId,
+            List<ModelInfo> models,
+            String currentModelId,
+            List<ModeInfo> modes,
+            String currentModeId) {}
 
     /** Parses a {@code session/update} notification's params; never throws (unknown → OTHER). */
     public static Update parseUpdate(JsonNode params) {
@@ -155,16 +192,20 @@ public final class AcpJson {
         JsonNode update = params == null ? null : params.get("update");
         String type = textOf(update, "sessionUpdate");
         if (update == null || type == null) {
-            return new Update(sessionId, UpdateKind.OTHER, "");
+            return new Update(sessionId, UpdateKind.OTHER, "", List.of());
         }
         return switch (type) {
-            case "agent_message_chunk" -> new Update(sessionId, UpdateKind.AGENT_MESSAGE, contentText(update));
-            case "agent_thought_chunk" -> new Update(sessionId, UpdateKind.AGENT_THOUGHT, contentText(update));
-            case "tool_call" -> new Update(sessionId, UpdateKind.TOOL_CALL, toolCallLabel(update));
+            case "agent_message_chunk" ->
+                new Update(sessionId, UpdateKind.AGENT_MESSAGE, contentText(update), List.of());
+            case "agent_thought_chunk" ->
+                new Update(sessionId, UpdateKind.AGENT_THOUGHT, contentText(update), List.of());
+            case "tool_call" -> new Update(sessionId, UpdateKind.TOOL_CALL, toolCallLabel(update), List.of());
             case "tool_call_update" ->
-                new Update(sessionId, UpdateKind.TOOL_CALL_UPDATE, textOrEmpty(update, "status"));
-            case "plan" -> new Update(sessionId, UpdateKind.PLAN, planText(update));
-            default -> new Update(sessionId, UpdateKind.OTHER, "");
+                new Update(sessionId, UpdateKind.TOOL_CALL_UPDATE, textOrEmpty(update, "status"), List.of());
+            case "plan" -> new Update(sessionId, UpdateKind.PLAN, planText(update), parsePlanEntries(update));
+            case "current_mode_update" ->
+                new Update(sessionId, UpdateKind.MODE_CHANGED, textOrEmpty(update, "currentModeId"), List.of());
+            default -> new Update(sessionId, UpdateKind.OTHER, "", List.of());
         };
     }
 
@@ -200,6 +241,39 @@ public final class AcpJson {
         return title != null ? title : "";
     }
 
+    /** Parses {@code session/new}'s result: the session id plus its model/mode catalogs. Null-safe
+     *  throughout — a missing/absent {@code models}/{@code modes} object yields an empty catalog. */
+    public static SessionInfo parseSessionInfo(JsonNode result) {
+        String sessionId = textOf(result, "sessionId");
+        List<ModelInfo> models = new ArrayList<>();
+        String currentModelId = null;
+        JsonNode modelsNode = result == null ? null : result.get("models");
+        if (modelsNode != null) {
+            currentModelId = textOf(modelsNode, "currentModelId");
+            JsonNode avail = modelsNode.get("availableModels");
+            if (avail != null && avail.isArray()) {
+                for (JsonNode mo : avail) {
+                    models.add(new ModelInfo(
+                            textOrEmpty(mo, "modelId"), textOrEmpty(mo, "name"), textOrEmpty(mo, "description")));
+                }
+            }
+        }
+        List<ModeInfo> modes = new ArrayList<>();
+        String currentModeId = null;
+        JsonNode modesNode = result == null ? null : result.get("modes");
+        if (modesNode != null) {
+            currentModeId = textOf(modesNode, "currentModeId");
+            JsonNode avail = modesNode.get("availableModes");
+            if (avail != null && avail.isArray()) {
+                for (JsonNode md : avail) {
+                    modes.add(new ModeInfo(
+                            textOrEmpty(md, "id"), textOrEmpty(md, "name"), textOrEmpty(md, "description")));
+                }
+            }
+        }
+        return new SessionInfo(sessionId, models, currentModelId, modes, currentModeId);
+    }
+
     private static String toolCallLabel(JsonNode update) {
         String title = textOf(update, "title");
         if (title != null && !title.isEmpty()) {
@@ -224,6 +298,18 @@ public final class AcpJson {
             }
         }
         return sb.toString();
+    }
+
+    /** The structured plan entries (content + status) — a {@code plan} update always replaces the whole list. */
+    private static List<PlanEntry> parsePlanEntries(JsonNode update) {
+        List<PlanEntry> out = new ArrayList<>();
+        JsonNode entries = update.get("entries");
+        if (entries != null && entries.isArray()) {
+            for (JsonNode e : entries) {
+                out.add(new PlanEntry(textOrEmpty(e, "content"), textOrEmpty(e, "status")));
+            }
+        }
+        return out;
     }
 
     private static String textOf(JsonNode node, String field) {

--- a/src/main/java/com/editora/config/Settings.java
+++ b/src/main/java/com/editora/config/Settings.java
@@ -10,7 +10,7 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 public class Settings {
 
     /** Current on-disk schema version of {@code settings.toml}; bump when the format changes (+ a migration). */
-    public static final int SCHEMA_VERSION = 58;
+    public static final int SCHEMA_VERSION = 59;
 
     private int schemaVersion = SCHEMA_VERSION;
 
@@ -202,6 +202,10 @@ public class Settings {
     private boolean agentSupport = false;
     /** The ACP agent command (tokenized, quote-aware); blank = {@code claude-code-acp} on PATH. */
     private String agentCommand = "";
+    /** Prefix each agent prompt with a one-line "Context: &lt;path&gt;, cursor at line N[, selected:
+     *  &quot;…&quot;]" header (not shown as if the user typed it) so the agent knows the active buffer
+     *  without asking: on by default. */
+    private boolean agentIncludeContext = true;
     /** Direct-API AI actions (commit-message generation, explain/rewrite selection): off by default. */
     private boolean aiSupport = false;
     /** The Anthropic model id for the AI actions; blank = the built-in default (claude-opus-4-8). */
@@ -503,6 +507,14 @@ public class Settings {
 
     public void setAgentCommand(String agentCommand) {
         this.agentCommand = agentCommand;
+    }
+
+    public boolean isAgentIncludeContext() {
+        return agentIncludeContext;
+    }
+
+    public void setAgentIncludeContext(boolean agentIncludeContext) {
+        this.agentIncludeContext = agentIncludeContext;
     }
 
     public boolean isAiSupport() {

--- a/src/main/java/com/editora/config/migration/ConfigSchema.java
+++ b/src/main/java/com/editora/config/migration/ConfigSchema.java
@@ -99,7 +99,8 @@ public enum ConfigSchema {
                             ConfigMigrations::identity), // v54→55: + aiInlineCompletion/aiCompletionModel (additive)
                     Map.entry(55, (Migration) ConfigMigrations::identity), // v55→56: + todoGroupBy (additive)
                     Map.entry(56, (Migration) ConfigMigrations::identity), // v56→57: + aiProvider/aiEndpoint (additive)
-                    Map.entry(57, (Migration) ConfigMigrations::identity))), // v57→58: + TODO part colors (additive)
+                    Map.entry(57, (Migration) ConfigMigrations::identity), // v57→58: + TODO part colors (additive)
+                    Map.entry(58, (Migration) ConfigMigrations::identity))), // v58→59: + agentIncludeContext (additive)
     WORKSPACE(WorkspaceState.SCHEMA_VERSION, 1, Map.of()),
     BOOKMARKS(BookmarkStore.SCHEMA_VERSION, 1, Map.of()),
     BREAKPOINTS(BreakpointStore.SCHEMA_VERSION, 1, Map.of()),

--- a/src/main/java/com/editora/ui/AgentCoordinator.java
+++ b/src/main/java/com/editora/ui/AgentCoordinator.java
@@ -18,6 +18,7 @@ import com.editora.agent.AcpClient;
 import com.editora.agent.AcpJson;
 import com.editora.editor.EditorBuffer;
 import com.editora.run.ProgramArgs;
+import org.fxmisc.richtext.CodeArea;
 
 import static com.editora.i18n.Messages.tr;
 
@@ -66,6 +67,10 @@ final class AgentCoordinator implements AcpClient.Host {
     private AgentPanel panel;
     private volatile AcpClient client;
     private volatile String sessionId;
+    private volatile List<AcpJson.ModelInfo> models = List.of();
+    private volatile List<AcpJson.ModeInfo> modes = List.of();
+    private volatile String currentModelId;
+    private volatile String currentModeId;
 
     AgentCoordinator(CoordinatorHost host, Ops ops) {
         this.host = host;
@@ -80,7 +85,7 @@ final class AgentCoordinator implements AcpClient.Host {
     /** The chat tool window's content (built lazily; {@code MainController} wraps it in a {@code ToolWindow}). */
     AgentPanel panel() {
         if (panel == null) {
-            panel = new AgentPanel(this::stopTurn, this::newSession);
+            panel = new AgentPanel(this::stopTurn, this::newSession, this::pickModel, this::pickMode);
             panel.setOnSend(this::sendPrompt);
             applyPanelFont();
         }
@@ -118,7 +123,14 @@ final class AgentCoordinator implements AcpClient.Host {
                 c.cancel(sid);
             }
             sessionId = null;
+            models = List.of();
+            modes = List.of();
+            currentModelId = null;
+            currentModeId = null;
             panel().clearTranscript();
+            panel().clearPlan();
+            panel().setModelLabel(null);
+            panel().setModeLabel(null);
             panel().setBusy(false);
             host.setStatus(tr("status.agent.newSession"));
         });
@@ -135,16 +147,109 @@ final class AgentCoordinator implements AcpClient.Host {
         });
     }
 
-    /** Sends one prompt turn (the panel blocks re-entry while a turn is running). */
+    /** {@code agent.selectModel}: opens a picker over the session's available models (shared by the
+     *  header label click and the palette command). */
+    void pickModel() {
+        ifAgent(() -> {
+            if (models.isEmpty()) {
+                host.setStatus(tr("status.agent.noModels"));
+                return;
+            }
+            QuickOpen<AcpJson.ModelInfo> picker = new QuickOpen<>(
+                    tr("command.agent.selectModel"),
+                    tr("palette.agent.selectModelPrompt"),
+                    () -> models,
+                    AcpJson.ModelInfo::name,
+                    AcpJson.ModelInfo::description,
+                    this::setModel);
+            picker.setOverlayHost(host.overlayHost());
+            picker.show(host.window());
+        });
+    }
+
+    /** {@code agent.selectMode}: opens a picker over the session's available modes (shared by the header
+     *  label click and the palette command). */
+    void pickMode() {
+        ifAgent(() -> {
+            if (modes.isEmpty()) {
+                host.setStatus(tr("status.agent.noModes"));
+                return;
+            }
+            QuickOpen<AcpJson.ModeInfo> picker = new QuickOpen<>(
+                    tr("command.agent.selectMode"),
+                    tr("palette.agent.selectModePrompt"),
+                    () -> modes,
+                    AcpJson.ModeInfo::name,
+                    AcpJson.ModeInfo::description,
+                    this::setMode);
+            picker.setOverlayHost(host.overlayHost());
+            picker.show(host.window());
+        });
+    }
+
+    /** Switches the running session's active model. */
+    private void setModel(AcpJson.ModelInfo model) {
+        AcpClient c = client;
+        String sid = sessionId;
+        if (c == null || sid == null) {
+            return;
+        }
+        c.setModel(sid, model.modelId())
+                .whenComplete((v, err) -> Platform.runLater(() -> {
+                    if (err == null) {
+                        currentModelId = model.modelId();
+                        panel().setModelLabel(model.name());
+                    } else {
+                        host.setStatus(tr(
+                                "status.agent.failed",
+                                String.valueOf(rootCause(err).getMessage())));
+                    }
+                }));
+    }
+
+    /** Switches the running session's active mode. */
+    private void setMode(AcpJson.ModeInfo mode) {
+        AcpClient c = client;
+        String sid = sessionId;
+        if (c == null || sid == null) {
+            return;
+        }
+        c.setMode(sid, mode.id())
+                .whenComplete((v, err) -> Platform.runLater(() -> {
+                    if (err == null) {
+                        currentModeId = mode.id();
+                        panel().setModeLabel(mode.name());
+                    } else {
+                        host.setStatus(tr(
+                                "status.agent.failed",
+                                String.valueOf(rootCause(err).getMessage())));
+                    }
+                }));
+    }
+
+    /** Max chars of quoted selection text included in the context header (bounds token cost). */
+    private static final int SELECTION_PREVIEW_LIMIT = 200;
+
+    /**
+     * Sends one prompt turn (the panel blocks re-entry while a turn is running). When
+     * {@code Settings.agentIncludeContext} is on, the active buffer's path/cursor/selection is prefixed
+     * to what's actually sent to the agent (never merged into the echoed transcript line) so the common
+     * "explain this line" case works without the agent having to ask which file.
+     */
     void sendPrompt(String text) {
         if (!isEnabled()) {
             host.setStatus(tr("status.agent.disabled"));
             return;
         }
         panel().appendLine("❯ " + text);
+        String context = host.settings().isAgentIncludeContext() ? activeBufferContext() : null;
+        if (context != null) {
+            panel().appendLine(context);
+        }
+        String composed = context == null ? text : context + "\n\n" + text;
         panel().setBusy(true);
         ensureSession()
-                .thenCompose(sid -> client.prompt(sid, text))
+                .thenCompose(sid -> client.prompt(sid, composed))
                 .whenComplete((stopReason, error) -> Platform.runLater(() -> {
                     panel().setBusy(false);
                     if (error != null) {
@@ -155,6 +260,49 @@ final class AgentCoordinator implements AcpClient.Host {
                         panel().appendLine(tr("agent.turnCancelled"));
                     }
                 }));
+    }
+
+    /** The active buffer's context header, or null if there is no active editor buffer (e.g. the Welcome
+     *  tab). Recomputed on every call — the active buffer/caret can change between turns in one session. */
+    private String activeBufferContext() {
+        EditorBuffer b = host.activeBuffer();
+        if (b == null) {
+            return null;
+        }
+        CodeArea area = b.getFocusedArea() != null ? b.getFocusedArea() : b.getArea();
+        return formatContext(bufferLabel(b), area.getCurrentParagraph() + 1, area.getSelectedText());
+    }
+
+    /** The path shown to the agent: relativized against {@link #sessionCwd()} (the same frame of
+     *  reference the agent's own tools use) when possible, else the absolute path, else the buffer's
+     *  title (an untitled or remote buffer, where a cwd-relative path would be meaningless). */
+    private String bufferLabel(EditorBuffer b) {
+        Path path = b.getPath();
+        if (path == null || !host.isLocalBuffer(b)) {
+            return b.getTitle();
+        }
+        try {
+            Path rel = sessionCwd().toAbsolutePath().relativize(path.toAbsolutePath());
+            if (!rel.startsWith("..")) {
+                return rel.toString();
+            }
+        } catch (IllegalArgumentException ignored) {
+            // different filesystem roots (e.g. Windows drive letters) — fall through to the absolute path
+        }
+        return path.toString();
+    }
+
+    /** Pure: builds the one-line context header. Package-private + static so it's directly unit-tested
+     *  (the {@link #slice} idiom), even though it resolves through {@code tr(...)}. */
+    static String formatContext(String label, int line, String selectedText) {
+        StringBuilder sb = new StringBuilder(tr("agent.context.header", label, line));
+        if (selectedText != null && !selectedText.isEmpty()) {
+            String preview = selectedText.length() > SELECTION_PREVIEW_LIMIT
+                    ? selectedText.substring(0, SELECTION_PREVIEW_LIMIT) + "…"
+                    : selectedText;
+            sb.append(tr("agent.context.selected", preview.replace("\n", "\\n")));
+        }
+        return sb.toString();
     }
 
     /** The running client's session, starting the agent + a session on first use (off the FX thread). */
@@ -178,15 +326,26 @@ final class AgentCoordinator implements AcpClient.Host {
                         lifecycleExec)
                 .thenCompose(fresh -> fresh.initialize()
                         .thenCompose(init -> fresh.newSession(cwd))
-                        .thenApply(newSid -> {
-                            if (newSid == null) {
+                        .thenApply(info -> {
+                            if (info.sessionId() == null) {
                                 fresh.dispose();
                                 throw new CompletionException(new IOException(tr("status.agent.noSession")));
                             }
                             client = fresh;
-                            sessionId = newSid;
-                            return newSid;
+                            sessionId = info.sessionId();
+                            models = info.models();
+                            modes = info.modes();
+                            currentModelId = info.currentModelId();
+                            currentModeId = info.currentModeId();
+                            Platform.runLater(this::refreshPanelHeader);
+                            return info.sessionId();
                         }));
+    }
+
+    /** Pushes the current model/mode display state to the panel header (after a fresh session starts). */
+    private void refreshPanelHeader() {
+        panel().setModelLabel(modelDisplayName(models, currentModelId));
+        panel().setModeLabel(modeDisplayName(modes, currentModeId));
     }
 
     /** The configured agent command (quote-aware tokens; blank ⇒ {@link #DEFAULT_COMMAND}). */
@@ -226,10 +385,10 @@ final class AgentCoordinator implements AcpClient.Host {
                         panel().appendLine("⚙ ✗ " + tr("agent.toolFailed"));
                     }
                 }
-                case PLAN -> {
-                    if (!update.text().isEmpty()) {
-                        panel().appendLine("· " + update.text().replace("\n", "\n· "));
-                    }
+                case PLAN -> panel().setPlan(update.planEntries());
+                case MODE_CHANGED -> {
+                    currentModeId = update.text();
+                    panel().setModeLabel(modeDisplayName(modes, update.text()));
                 }
                 case AGENT_THOUGHT, OTHER -> {
                     // thoughts are noisy in a plain transcript; unknown updates are ignored (forward-compatible)
@@ -325,6 +484,32 @@ final class AgentCoordinator implements AcpClient.Host {
         return String.join("\n", java.util.Arrays.copyOfRange(lines, from, to));
     }
 
+    /** The display name for {@code modelId} (falls back to the bare id if not found, empty if null). Pure. */
+    static String modelDisplayName(List<AcpJson.ModelInfo> models, String modelId) {
+        if (modelId == null) {
+            return "";
+        }
+        for (AcpJson.ModelInfo m : models) {
+            if (m.modelId().equals(modelId)) {
+                return m.name();
+            }
+        }
+        return modelId;
+    }
+
+    /** The display name for {@code modeId} (falls back to the bare id if not found, empty if null). Pure. */
+    static String modeDisplayName(List<AcpJson.ModeInfo> modes, String modeId) {
+        if (modeId == null) {
+            return "";
+        }
+        for (AcpJson.ModeInfo mo : modes) {
+            if (mo.id().equals(modeId)) {
+                return mo.name();
+            }
+        }
+        return modeId;
+    }
+
     /** Runs {@code task} on the FX thread and blocks (with a timeout) for its result — for the fs bridge,
      *  which the agent calls on its own request threads. */
     private static <T> T fxCall(java.util.function.Supplier<T> task) throws Exception {
@@ -361,11 +546,18 @@ final class AgentCoordinator implements AcpClient.Host {
         AcpClient c = client;
         client = null;
         sessionId = null;
+        models = List.of();
+        modes = List.of();
+        currentModelId = null;
+        currentModeId = null;
         if (c != null) {
             c.dispose();
         }
         if (panel != null) {
             panel.setBusy(false);
+            panel.setModelLabel(null);
+            panel.setModeLabel(null);
+            panel.clearPlan();
         }
     }
 

--- a/src/main/java/com/editora/ui/AgentPanel.java
+++ b/src/main/java/com/editora/ui/AgentPanel.java
@@ -1,5 +1,6 @@
 package com.editora.ui;
 
+import java.util.List;
 import java.util.function.Consumer;
 
 import javafx.geometry.Insets;
@@ -12,6 +13,8 @@ import javafx.scene.layout.HBox;
 import javafx.scene.layout.Priority;
 import javafx.scene.layout.Region;
 import javafx.scene.layout.VBox;
+
+import com.editora.agent.AcpJson;
 
 import static com.editora.i18n.Messages.tr;
 
@@ -29,6 +32,9 @@ public final class AgentPanel extends VBox implements ToolWindowContent {
     private static final int MAX_CHARS = 400_000;
 
     private final Label status = new Label();
+    private final Label modelLabel = new Label();
+    private final Label modeLabel = new Label();
+    private final VBox planBox = new VBox(2);
     private final TextArea transcript = new TextArea();
     private final TextArea input = new TextArea();
     private final Button sendButton = new Button();
@@ -37,20 +43,27 @@ public final class AgentPanel extends VBox implements ToolWindowContent {
     /** Receives the prompt text when the user sends (coordinator → agent). */
     private Consumer<String> onSend;
 
-    public AgentPanel(Runnable onStop, Runnable onNewSession) {
+    public AgentPanel(Runnable onStop, Runnable onNewSession, Runnable onPickModel, Runnable onPickMode) {
         getStyleClass().add("agent-panel");
         getProperties().put("editora.ownsKeys", Boolean.TRUE);
         setSpacing(6);
         setPadding(new Insets(6));
 
         status.getStyleClass().add("agent-status");
+        modelLabel.getStyleClass().add("agent-header-label");
+        modelLabel.setOnMouseClicked(e -> onPickModel.run());
+        modeLabel.getStyleClass().add("agent-header-label");
+        modeLabel.setOnMouseClicked(e -> onPickMode.run());
         stopButton.setText(tr("agent.stop"));
         stopButton.setDisable(true);
         stopButton.setOnAction(e -> onStop.run());
         newSessionButton.setText(tr("agent.newSession"));
         newSessionButton.setOnAction(e -> onNewSession.run());
-        HBox header = new HBox(8, status, spacer(), newSessionButton, stopButton);
+        HBox header = new HBox(8, status, modelLabel, modeLabel, spacer(), newSessionButton, stopButton);
         header.setAlignment(Pos.CENTER_LEFT);
+
+        planBox.setManaged(false);
+        planBox.setVisible(false);
 
         transcript.setEditable(false);
         transcript.setWrapText(true);
@@ -75,7 +88,7 @@ public final class AgentPanel extends VBox implements ToolWindowContent {
         HBox.setHgrow(input, Priority.ALWAYS);
 
         VBox.setVgrow(transcript, Priority.ALWAYS);
-        getChildren().addAll(header, transcript, inputRow);
+        getChildren().addAll(header, planBox, transcript, inputRow);
         setBusy(false);
         status.setText(tr("agent.idle"));
     }
@@ -132,6 +145,48 @@ public final class AgentPanel extends VBox implements ToolWindowContent {
         stopButton.setDisable(!busy);
         sendButton.setDisable(busy);
         status.setText(tr(busy ? "agent.running" : "agent.idle"));
+    }
+
+    /** Sets the model-picker label's text (e.g. "Model: Claude Opus"); {@code null}/blank shows a placeholder. */
+    public void setModelLabel(String name) {
+        modelLabel.setText(tr("agent.modelLabel", name == null || name.isEmpty() ? "—" : name));
+    }
+
+    /** Sets the mode-picker label's text (e.g. "Mode: Plan"); {@code null}/blank shows a placeholder. */
+    public void setModeLabel(String name) {
+        modeLabel.setText(tr("agent.modeLabel", name == null || name.isEmpty() ? "—" : name));
+    }
+
+    /** Renders the agent's current plan as a checklist (one line per entry, status glyph prefixed).
+     *  Each {@code plan} update is a full replacement, never incremental, so this replaces the whole
+     *  checklist wholesale rather than appending. */
+    public void setPlan(List<AcpJson.PlanEntry> entries) {
+        planBox.getChildren().clear();
+        for (AcpJson.PlanEntry e : entries) {
+            Label line = new Label(glyphFor(e.status()) + " " + e.content());
+            line.getStyleClass()
+                    .add("plan-entry-" + (e.status() == null || e.status().isEmpty() ? "pending" : e.status()));
+            line.setWrapText(true);
+            planBox.getChildren().add(line);
+        }
+        boolean show = !entries.isEmpty();
+        planBox.setManaged(show);
+        planBox.setVisible(show);
+    }
+
+    /** Clears the plan checklist (a new session starts with no plan shown). */
+    public void clearPlan() {
+        setPlan(List.of());
+    }
+
+    /** The checkbox-style glyph for a plan entry's status. Package-private + static: pure, no FX toolkit
+     *  needed, so it's directly unit-tested. */
+    static String glyphFor(String status) {
+        return switch (status == null ? "" : status) {
+            case "completed" -> "☑";
+            case "in_progress" -> "◐";
+            default -> "☐"; // "pending" and any unrecognized status
+        };
     }
 
     @Override

--- a/src/main/java/com/editora/ui/MainController.java
+++ b/src/main/java/com/editora/ui/MainController.java
@@ -10162,6 +10162,8 @@ public class MainController implements com.editora.mcp.McpBridge {
         registry.register(Command.of("tool.agent", agentCoordinator::toggleToolWindow));
         registry.register(Command.of("agent.newSession", agentCoordinator::newSession));
         registry.register(Command.of("agent.stop", agentCoordinator::stopTurn));
+        registry.register(Command.of("agent.selectModel", agentCoordinator::pickModel));
+        registry.register(Command.of("agent.selectMode", agentCoordinator::pickMode));
         registry.register(Command.of(
                 "view.toggleAgent",
                 () -> toggleSetting(
@@ -10176,6 +10178,13 @@ public class MainController implements com.editora.mcp.McpBridge {
                         () -> config.getSettings().getAgentCommand(),
                         v -> config.getSettings().setAgentCommand(v),
                         this::applyAgentSupport)));
+        registry.register(Command.of(
+                "view.toggleAgentContext",
+                () -> toggleSetting(
+                        "view.toggleAgentContext",
+                        () -> config.getSettings().isAgentIncludeContext(),
+                        v -> config.getSettings().setAgentIncludeContext(v),
+                        null))); // read fresh on the next sendPrompt call — nothing cached to re-push
         registry.register(Command.of("ai.generateCommitMessage", aiCoordinator::generateCommitMessage));
         registry.register(Command.of("ai.explainSelection", aiCoordinator::explainSelection));
         registry.register(Command.of("ai.rewriteSelection", aiCoordinator::rewriteSelection));

--- a/src/main/java/com/editora/ui/SettingsWindow.java
+++ b/src/main/java/com/editora/ui/SettingsWindow.java
@@ -275,6 +275,7 @@ public class SettingsWindow {
     private CheckBox mcpCheck;
     private CheckBox agentCheck;
     private TextField agentCommandField;
+    private CheckBox agentIncludeContextCheck;
     private CheckBox aiCheck;
     private TextField aiModelField;
     private TextField aiApiKeyField;
@@ -1008,6 +1009,11 @@ public class SettingsWindow {
         agentCommandField.setPromptText("claude-code-acp");
         agentCommandField.textProperty().addListener((obs, was, now) -> {
             config.getSettings().setAgentCommand(now);
+            apply();
+        });
+        agentIncludeContextCheck = new CheckBox(tr("settings.agent.includeContext"));
+        agentIncludeContextCheck.selectedProperty().addListener((obs, was, now) -> {
+            config.getSettings().setAgentIncludeContext(now);
             apply();
         });
 
@@ -3592,6 +3598,12 @@ public class SettingsWindow {
                 null,
                 exePathRow(tr("settings.agent.command"), agentCommandField),
                 "ai agent acp command executable claude-code-acp path");
+        row(
+                p,
+                Category.AGENT,
+                null,
+                agentIncludeContextCheck,
+                "ai agent acp context cursor line selection file attach prompt");
         Label hint = note(tr("settings.agent.hint"));
         hint.setWrapText(true);
         hint.setMaxWidth(440);
@@ -5054,6 +5066,7 @@ public class SettingsWindow {
             mcpCheck.setSelected(settings.isMcpSupport());
             agentCheck.setSelected(settings.isAgentSupport());
             agentCommandField.setText(settings.getAgentCommand());
+            agentIncludeContextCheck.setSelected(settings.isAgentIncludeContext());
             aiCheck.setSelected(settings.isAiSupport());
             aiModelField.setText(settings.getAiModel());
             aiApiKeyField.setText(settings.getAiApiKey());

--- a/src/main/resources/com/editora/i18n/messages.properties
+++ b/src/main/resources/com/editora/i18n/messages.properties
@@ -2681,6 +2681,12 @@ command.view.toggleAgent=Toggle AI Agent
 command.view.toggleAgent.desc=Enable or disable the embedded AI agent (Agent Client Protocol).
 command.agent.setCommand=Agent: Set Command
 command.agent.setCommand.desc=Set the ACP agent command (blank = claude-code-acp on PATH).
+command.view.toggleAgentContext=Toggle Agent Context
+command.view.toggleAgentContext.desc=Include or omit the active file/cursor/selection as a one-line context header on each agent prompt.
+command.agent.selectModel=Agent: Select Model
+command.agent.selectModel.desc=Choose the ACP agent's active model for this session.
+command.agent.selectMode=Agent: Select Mode
+command.agent.selectMode.desc=Choose the ACP agent's active mode for this session (e.g. Plan Mode).
 toolwindow.agent=AI Agent
 agent.idle=Idle
 agent.running=Working…
@@ -2694,15 +2700,24 @@ agent.exited=(agent exited: {0})
 agent.permissionTitle=AI Agent — Permission Request
 agent.permissionHeader=The agent asks permission to proceed
 agent.permissionBody=Allow the requested action?
+agent.context.header=Context: {0}, cursor at line {1}
+agent.context.selected=, selected: "{0}"
+agent.modelLabel=Model: {0}
+agent.modeLabel=Mode: {0}
+palette.agent.selectModelPrompt=Pick a model…
+palette.agent.selectModePrompt=Pick a mode…
 status.agent.disabled=AI Agent is disabled (enable it in Settings → AI Agent)
 status.agent.failed=Agent failed: {0}
 status.agent.newSession=Started a new agent session
 status.agent.startFailed=Could not start the agent: {0}
 status.agent.noSession=The agent did not create a session
 status.agent.editedBuffer=AI agent edited {0} (undoable, unsaved)
+status.agent.noModels=This agent session has no selectable models
+status.agent.noModes=This agent session has no selectable modes
 settings.cat.agent=AI Agent
 settings.agent.enable=Enable AI Agent
 settings.agent.command=Agent command
+settings.agent.includeContext=Include editor context in prompts
 settings.agent.hint=Chat with an embedded coding agent over the Agent Client Protocol (ACP). The agent is an external tool you install — the default command is claude-code-acp (npm i -g @zed-industries/claude-code-acp), which drives Claude Code. File reads serve open buffers' unsaved text; edits to open files apply as undoable buffer edits you review and save.
 
 # --- AI actions (direct Anthropic API) ---

--- a/src/main/resources/com/editora/i18n/messages_de.properties
+++ b/src/main/resources/com/editora/i18n/messages_de.properties
@@ -2673,6 +2673,12 @@ command.view.toggleAgent=KI-Agent umschalten
 command.view.toggleAgent.desc=Den eingebetteten KI-Agenten (Agent Client Protocol) aktivieren oder deaktivieren.
 command.agent.setCommand=Agent: Befehl festlegen
 command.agent.setCommand.desc=Den ACP-Agent-Befehl festlegen (leer = claude-code-acp im PATH).
+command.view.toggleAgentContext=Agentenkontext umschalten
+command.view.toggleAgentContext.desc=Die aktive Datei/Cursorposition/Auswahl als einzeiligen Kontext-Header bei jedem Agenten-Prompt ein- oder ausblenden.
+command.agent.selectModel=Agent: Modell auswählen
+command.agent.selectModel.desc=Das aktive Modell des ACP-Agenten für diese Sitzung auswählen.
+command.agent.selectMode=Agent: Modus auswählen
+command.agent.selectMode.desc=Den aktiven Modus des ACP-Agenten für diese Sitzung auswählen (z. B. Planungsmodus).
 toolwindow.agent=KI-Agent
 agent.idle=Bereit
 agent.running=Arbeitet…
@@ -2686,15 +2692,24 @@ agent.exited=(Agent beendet: {0})
 agent.permissionTitle=KI-Agent — Berechtigungsanfrage
 agent.permissionHeader=Der Agent bittet um Erlaubnis fortzufahren
 agent.permissionBody=Die angeforderte Aktion erlauben?
+agent.context.header=Kontext: {0}, Cursor in Zeile {1}
+agent.context.selected=, ausgewählt: "{0}"
+agent.modelLabel=Modell: {0}
+agent.modeLabel=Modus: {0}
+palette.agent.selectModelPrompt=Modell auswählen…
+palette.agent.selectModePrompt=Modus auswählen…
 status.agent.disabled=KI-Agent ist deaktiviert (aktivieren unter Einstellungen → KI-Agent)
 status.agent.failed=Agent fehlgeschlagen: {0}
 status.agent.newSession=Neue Agent-Sitzung gestartet
 status.agent.startFailed=Agent konnte nicht gestartet werden: {0}
 status.agent.noSession=Der Agent hat keine Sitzung erstellt
 status.agent.editedBuffer=KI-Agent hat {0} bearbeitet (rückgängig machbar, ungespeichert)
+status.agent.noModels=Diese Agent-Sitzung hat keine auswählbaren Modelle
+status.agent.noModes=Diese Agent-Sitzung hat keine auswählbaren Modi
 settings.cat.agent=KI-Agent
 settings.agent.enable=KI-Agent aktivieren
 settings.agent.command=Agent-Befehl
+settings.agent.includeContext=Editor-Kontext in Prompts einschließen
 settings.agent.hint=Chatte mit einem eingebetteten Coding-Agenten über das Agent Client Protocol (ACP). Der Agent ist ein extern installiertes Tool — der Standardbefehl ist claude-code-acp (npm i -g @zed-industries/claude-code-acp), das Claude Code steuert. Dateilesezugriffe liefern den ungespeicherten Text offener Puffer; Änderungen an offenen Dateien werden als rückgängig machbare Puffer-Bearbeitungen angewendet, die du prüfst und speicherst.
 
 # --- KI-Aktionen (direkte Anthropic-API) ---

--- a/src/main/resources/com/editora/i18n/messages_es.properties
+++ b/src/main/resources/com/editora/i18n/messages_es.properties
@@ -2673,6 +2673,12 @@ command.view.toggleAgent=Alternar agente de IA
 command.view.toggleAgent.desc=Activar o desactivar el agente de IA integrado (Agent Client Protocol).
 command.agent.setCommand=Agente: Establecer comando
 command.agent.setCommand.desc=Establecer el comando del agente ACP (vacío = claude-code-acp en el PATH).
+command.view.toggleAgentContext=Alternar contexto del agente
+command.view.toggleAgentContext.desc=Incluir u omitir el archivo activo/cursor/selección como encabezado de contexto de una línea en cada prompt del agente.
+command.agent.selectModel=Agente: Seleccionar modelo
+command.agent.selectModel.desc=Elegir el modelo activo del agente ACP para esta sesión.
+command.agent.selectMode=Agente: Seleccionar modo
+command.agent.selectMode.desc=Elegir el modo activo del agente ACP para esta sesión (p. ej. Modo de planificación).
 toolwindow.agent=Agente de IA
 agent.idle=Inactivo
 agent.running=Trabajando…
@@ -2686,15 +2692,24 @@ agent.exited=(el agente terminó: {0})
 agent.permissionTitle=Agente de IA — Solicitud de permiso
 agent.permissionHeader=El agente pide permiso para continuar
 agent.permissionBody=¿Permitir la acción solicitada?
+agent.context.header=Contexto: {0}, cursor en la línea {1}
+agent.context.selected=, seleccionado: "{0}"
+agent.modelLabel=Modelo: {0}
+agent.modeLabel=Modo: {0}
+palette.agent.selectModelPrompt=Elige un modelo…
+palette.agent.selectModePrompt=Elige un modo…
 status.agent.disabled=El agente de IA está desactivado (actívalo en Ajustes → Agente de IA)
 status.agent.failed=El agente falló: {0}
 status.agent.newSession=Nueva sesión del agente iniciada
 status.agent.startFailed=No se pudo iniciar el agente: {0}
 status.agent.noSession=El agente no creó una sesión
 status.agent.editedBuffer=El agente de IA editó {0} (deshacible, sin guardar)
+status.agent.noModels=Esta sesión del agente no tiene modelos seleccionables
+status.agent.noModes=Esta sesión del agente no tiene modos seleccionables
 settings.cat.agent=Agente de IA
 settings.agent.enable=Activar el agente de IA
 settings.agent.command=Comando del agente
+settings.agent.includeContext=Incluir contexto del editor en los prompts
 settings.agent.hint=Chatea con un agente de programación integrado mediante el Agent Client Protocol (ACP). El agente es una herramienta externa que instalas — el comando por defecto es claude-code-acp (npm i -g @zed-industries/claude-code-acp), que controla Claude Code. Las lecturas de archivos sirven el texto sin guardar de los búferes abiertos; las ediciones de archivos abiertos se aplican como cambios deshacibles que revisas y guardas.
 
 # --- Acciones de IA (API directa de Anthropic) ---

--- a/src/main/resources/com/editora/i18n/messages_fr.properties
+++ b/src/main/resources/com/editora/i18n/messages_fr.properties
@@ -2673,6 +2673,12 @@ command.view.toggleAgent=Basculer l'agent IA
 command.view.toggleAgent.desc=Activer ou désactiver l'agent IA intégré (Agent Client Protocol).
 command.agent.setCommand=Agent : Définir la commande
 command.agent.setCommand.desc=Définir la commande de l'agent ACP (vide = claude-code-acp dans le PATH).
+command.view.toggleAgentContext=Basculer le contexte de l'agent
+command.view.toggleAgentContext.desc=Inclure ou omettre le fichier actif/curseur/sélection comme en-tête de contexte d'une ligne dans chaque invite envoyée à l'agent.
+command.agent.selectModel=Agent : Sélectionner le modèle
+command.agent.selectModel.desc=Choisir le modèle actif de l'agent ACP pour cette session.
+command.agent.selectMode=Agent : Sélectionner le mode
+command.agent.selectMode.desc=Choisir le mode actif de l'agent ACP pour cette session (p. ex. mode Plan).
 toolwindow.agent=Agent IA
 agent.idle=Inactif
 agent.running=En cours…
@@ -2686,15 +2692,24 @@ agent.exited=(agent terminé : {0})
 agent.permissionTitle=Agent IA — Demande d'autorisation
 agent.permissionHeader=L'agent demande l'autorisation de continuer
 agent.permissionBody=Autoriser l'action demandée ?
+agent.context.header=Contexte : {0}, curseur à la ligne {1}
+agent.context.selected=, sélection : « {0} »
+agent.modelLabel=Modèle : {0}
+agent.modeLabel=Mode : {0}
+palette.agent.selectModelPrompt=Choisir un modèle…
+palette.agent.selectModePrompt=Choisir un mode…
 status.agent.disabled=L'agent IA est désactivé (activez-le dans Réglages → Agent IA)
 status.agent.failed=Échec de l'agent : {0}
 status.agent.newSession=Nouvelle session de l'agent démarrée
 status.agent.startFailed=Impossible de démarrer l'agent : {0}
 status.agent.noSession=L'agent n'a pas créé de session
 status.agent.editedBuffer=L'agent IA a modifié {0} (annulable, non enregistré)
+status.agent.noModels=Cette session de l'agent n'a aucun modèle sélectionnable
+status.agent.noModes=Cette session de l'agent n'a aucun mode sélectionnable
 settings.cat.agent=Agent IA
 settings.agent.enable=Activer l'agent IA
 settings.agent.command=Commande de l'agent
+settings.agent.includeContext=Inclure le contexte de l'éditeur dans les invites
 settings.agent.hint=Discutez avec un agent de codage intégré via l'Agent Client Protocol (ACP). L'agent est un outil externe que vous installez — la commande par défaut est claude-code-acp (npm i -g @zed-industries/claude-code-acp), qui pilote Claude Code. Les lectures de fichiers servent le texte non enregistré des tampons ouverts ; les modifications de fichiers ouverts s'appliquent comme des éditions annulables que vous relisez et enregistrez.
 
 # --- Actions IA (API Anthropic directe) ---

--- a/src/main/resources/com/editora/i18n/messages_it.properties
+++ b/src/main/resources/com/editora/i18n/messages_it.properties
@@ -2673,6 +2673,12 @@ command.view.toggleAgent=Attiva/disattiva agente IA
 command.view.toggleAgent.desc=Abilita o disabilita l'agente IA integrato (Agent Client Protocol).
 command.agent.setCommand=Agente: Imposta comando
 command.agent.setCommand.desc=Imposta il comando dell'agente ACP (vuoto = claude-code-acp nel PATH).
+command.view.toggleAgentContext=Attiva/disattiva contesto agente
+command.view.toggleAgentContext.desc=Includi o ometti il file attivo/cursore/selezione come intestazione di contesto di una riga in ogni prompt inviato all'agente.
+command.agent.selectModel=Agente: Seleziona modello
+command.agent.selectModel.desc=Scegli il modello attivo dell'agente ACP per questa sessione.
+command.agent.selectMode=Agente: Seleziona modalità
+command.agent.selectMode.desc=Scegli la modalità attiva dell'agente ACP per questa sessione (es. modalità Piano).
 toolwindow.agent=Agente IA
 agent.idle=Inattivo
 agent.running=Al lavoro…
@@ -2686,15 +2692,24 @@ agent.exited=(agente terminato: {0})
 agent.permissionTitle=Agente IA — Richiesta di autorizzazione
 agent.permissionHeader=L'agente chiede il permesso di procedere
 agent.permissionBody=Consentire l'azione richiesta?
+agent.context.header=Contesto: {0}, cursore alla riga {1}
+agent.context.selected=, selezionato: "{0}"
+agent.modelLabel=Modello: {0}
+agent.modeLabel=Modalità: {0}
+palette.agent.selectModelPrompt=Scegli un modello…
+palette.agent.selectModePrompt=Scegli una modalità…
 status.agent.disabled=L'agente IA è disabilitato (abilitalo in Impostazioni → Agente IA)
 status.agent.failed=Agente non riuscito: {0}
 status.agent.newSession=Nuova sessione dell'agente avviata
 status.agent.startFailed=Impossibile avviare l'agente: {0}
 status.agent.noSession=L'agente non ha creato una sessione
 status.agent.editedBuffer=L'agente IA ha modificato {0} (annullabile, non salvato)
+status.agent.noModels=Questa sessione dell'agente non ha modelli selezionabili
+status.agent.noModes=Questa sessione dell'agente non ha modalità selezionabili
 settings.cat.agent=Agente IA
 settings.agent.enable=Abilita agente IA
 settings.agent.command=Comando dell'agente
+settings.agent.includeContext=Includi il contesto dell'editor nei prompt
 settings.agent.hint=Chatta con un agente di programmazione integrato tramite l'Agent Client Protocol (ACP). L'agente è uno strumento esterno che installi — il comando predefinito è claude-code-acp (npm i -g @zed-industries/claude-code-acp), che guida Claude Code. Le letture dei file servono il testo non salvato dei buffer aperti; le modifiche ai file aperti vengono applicate come modifiche annullabili che rivedi e salvi.
 
 # --- Azioni IA (API Anthropic diretta) ---

--- a/src/main/resources/com/editora/i18n/messages_pt.properties
+++ b/src/main/resources/com/editora/i18n/messages_pt.properties
@@ -2673,6 +2673,12 @@ command.view.toggleAgent=Alternar agente de IA
 command.view.toggleAgent.desc=Ativar ou desativar o agente de IA incorporado (Agent Client Protocol).
 command.agent.setCommand=Agente: Definir comando
 command.agent.setCommand.desc=Definir o comando do agente ACP (vazio = claude-code-acp no PATH).
+command.view.toggleAgentContext=Alternar contexto do agente
+command.view.toggleAgentContext.desc=Incluir ou omitir o arquivo ativo/cursor/seleção como um cabeçalho de contexto de uma linha em cada prompt enviado ao agente.
+command.agent.selectModel=Agente: Selecionar modelo
+command.agent.selectModel.desc=Escolher o modelo ativo do agente ACP para esta sessão.
+command.agent.selectMode=Agente: Selecionar modo
+command.agent.selectMode.desc=Escolher o modo ativo do agente ACP para esta sessão (ex.: modo Plano).
 toolwindow.agent=Agente de IA
 agent.idle=Ocioso
 agent.running=Trabalhando…
@@ -2686,15 +2692,24 @@ agent.exited=(agente encerrou: {0})
 agent.permissionTitle=Agente de IA — Pedido de permissão
 agent.permissionHeader=O agente pede permissão para continuar
 agent.permissionBody=Permitir a ação solicitada?
+agent.context.header=Contexto: {0}, cursor na linha {1}
+agent.context.selected=, selecionado: "{0}"
+agent.modelLabel=Modelo: {0}
+agent.modeLabel=Modo: {0}
+palette.agent.selectModelPrompt=Escolha um modelo…
+palette.agent.selectModePrompt=Escolha um modo…
 status.agent.disabled=O agente de IA está desativado (ative em Configurações → Agente de IA)
 status.agent.failed=Falha do agente: {0}
 status.agent.newSession=Nova sessão do agente iniciada
 status.agent.startFailed=Não foi possível iniciar o agente: {0}
 status.agent.noSession=O agente não criou uma sessão
 status.agent.editedBuffer=O agente de IA editou {0} (reversível, não salvo)
+status.agent.noModels=Esta sessão do agente não tem modelos selecionáveis
+status.agent.noModes=Esta sessão do agente não tem modos selecionáveis
 settings.cat.agent=Agente de IA
 settings.agent.enable=Ativar agente de IA
 settings.agent.command=Comando do agente
+settings.agent.includeContext=Incluir contexto do editor nos prompts
 settings.agent.hint=Converse com um agente de programação incorporado pelo Agent Client Protocol (ACP). O agente é uma ferramenta externa que você instala — o comando padrão é claude-code-acp (npm i -g @zed-industries/claude-code-acp), que controla o Claude Code. Leituras de arquivos servem o texto não salvo dos buffers abertos; edições em arquivos abertos são aplicadas como edições reversíveis que você revisa e salva.
 
 # --- Ações de IA (API direta da Anthropic) ---

--- a/src/main/resources/com/editora/styles/app.css
+++ b/src/main/resources/com/editora/styles/app.css
@@ -1755,6 +1755,21 @@
     -fx-padding: 3 6 3 6;
 }
 
+/* AI Agent header's clickable Model/Mode labels (same hover spirit as .status-segment-clickable). */
+.agent-panel .agent-header-label {
+    -fx-text-fill: -color-fg-muted;
+    -fx-padding: 3 6 3 6;
+}
+.agent-panel .agent-header-label:hover {
+    -fx-background-color: -color-bg-inset;
+    -fx-cursor: hand;
+}
+
+/* AI Agent plan checklist rows — muted by default; completed dims further, in-progress reads as active. */
+.plan-entry-pending { -fx-text-fill: -color-fg-default; }
+.plan-entry-in_progress { -fx-text-fill: -color-accent-fg; -fx-font-weight: bold; }
+.plan-entry-completed { -fx-text-fill: -color-fg-muted; }
+
 /* Green play glyph for the gutter Run marker (compact source main line) + the right-click Run item. */
 .run-marker { -fx-fill: #3fb950; }
 .fold-gutter .run-slot:hover .run-marker { -fx-fill: #56d364; }

--- a/src/test/java/com/editora/agent/AcpJsonTest.java
+++ b/src/test/java/com/editora/agent/AcpJsonTest.java
@@ -90,9 +90,78 @@ class AcpJsonTest {
     void parsesPlanEntries() throws Exception {
         AcpJson.Update u = AcpJson.parseUpdate(
                 m.readTree("{\"sessionId\":\"s\",\"update\":{\"sessionUpdate\":\"plan\",\"entries\":"
-                        + "[{\"content\":\"step one\"},{\"content\":\"step two\"}]}}"));
+                        + "[{\"content\":\"step one\",\"status\":\"completed\"},"
+                        + "{\"content\":\"step two\",\"status\":\"in_progress\"},"
+                        + "{\"content\":\"step three\"}]}}"));
         assertEquals(AcpJson.UpdateKind.PLAN, u.kind());
-        assertEquals("step one\nstep two", u.text());
+        assertEquals("step one\nstep two\nstep three", u.text());
+        assertEquals(3, u.planEntries().size());
+        assertEquals(
+                new AcpJson.PlanEntry("step one", "completed"), u.planEntries().get(0));
+        assertEquals(
+                new AcpJson.PlanEntry("step two", "in_progress"),
+                u.planEntries().get(1));
+        // a missing "status" field defaults to empty string (textOrEmpty semantics), never null
+        assertEquals(new AcpJson.PlanEntry("step three", ""), u.planEntries().get(2));
+    }
+
+    @Test
+    void nonPlanUpdatesHaveEmptyPlanEntries() throws Exception {
+        AcpJson.Update u = AcpJson.parseUpdate(m.readTree("{\"sessionId\":\"s1\",\"update\":{\"sessionUpdate\":"
+                + "\"agent_message_chunk\",\"content\":{\"type\":\"text\",\"text\":\"hi\"}}}"));
+        assertEquals(List.of(), u.planEntries());
+    }
+
+    @Test
+    void parsesModeChangedUpdate() throws Exception {
+        AcpJson.Update u = AcpJson.parseUpdate(
+                m.readTree(
+                        "{\"sessionId\":\"s\",\"update\":{\"sessionUpdate\":\"current_mode_update\",\"currentModeId\":\"plan\"}}"));
+        assertEquals(AcpJson.UpdateKind.MODE_CHANGED, u.kind());
+        assertEquals("plan", u.text());
+    }
+
+    @Test
+    void parsesSessionInfoModelsAndModes() throws Exception {
+        JsonNode result = m.readTree("{\"sessionId\":\"s1\","
+                + "\"models\":{\"currentModelId\":\"opus\",\"availableModels\":["
+                + "{\"modelId\":\"opus\",\"name\":\"Claude Opus\",\"description\":\"Most capable\"},"
+                + "{\"modelId\":\"sonnet\",\"name\":\"Claude Sonnet\",\"description\":\"Balanced\"}]},"
+                + "\"modes\":{\"currentModeId\":\"default\",\"availableModes\":["
+                + "{\"id\":\"default\",\"name\":\"Default\",\"description\":\"Standard behavior\"},"
+                + "{\"id\":\"plan\",\"name\":\"Plan Mode\",\"description\":\"Planning, no execution\"}]}}");
+        AcpJson.SessionInfo info = AcpJson.parseSessionInfo(result);
+        assertEquals("s1", info.sessionId());
+        assertEquals("opus", info.currentModelId());
+        assertEquals(2, info.models().size());
+        assertEquals(
+                new AcpJson.ModelInfo("opus", "Claude Opus", "Most capable"),
+                info.models().get(0));
+        assertEquals("default", info.currentModeId());
+        assertEquals(2, info.modes().size());
+        assertEquals(
+                new AcpJson.ModeInfo("plan", "Plan Mode", "Planning, no execution"),
+                info.modes().get(1));
+    }
+
+    @Test
+    void parseSessionInfoIsNullSafe() {
+        AcpJson.SessionInfo info = AcpJson.parseSessionInfo(null);
+        assertNull(info.sessionId());
+        assertEquals(List.of(), info.models());
+        assertNull(info.currentModelId());
+        assertEquals(List.of(), info.modes());
+        assertNull(info.currentModeId());
+    }
+
+    @Test
+    void setModelAndSetModeParamsShape() {
+        ObjectNode modelParams = AcpJson.setModelParams(m, "s1", "opus");
+        assertEquals("s1", modelParams.get("sessionId").asText());
+        assertEquals("opus", modelParams.get("modelId").asText());
+        ObjectNode modeParams = AcpJson.setModeParams(m, "s1", "plan");
+        assertEquals("s1", modeParams.get("sessionId").asText());
+        assertEquals("plan", modeParams.get("modeId").asText());
     }
 
     @Test

--- a/src/test/java/com/editora/ui/AgentContextTest.java
+++ b/src/test/java/com/editora/ui/AgentContextTest.java
@@ -1,0 +1,46 @@
+package com.editora.ui;
+
+import com.editora.i18n.Messages;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/** Pure tests for {@link AgentCoordinator#formatContext} — the one-line context header prefixed to an
+ *  agent prompt (path/cursor/selection). */
+class AgentContextTest {
+
+    @BeforeAll
+    static void initMessages() {
+        Messages.init("en");
+    }
+
+    @Test
+    void noSelectionIsJustPathAndLine() {
+        assertEquals(
+                "Context: src/Foo.java, cursor at line 23", AgentCoordinator.formatContext("src/Foo.java", 23, ""));
+        assertEquals(
+                "Context: src/Foo.java, cursor at line 23", AgentCoordinator.formatContext("src/Foo.java", 23, null));
+    }
+
+    @Test
+    void shortSelectionIsAppended() {
+        assertEquals(
+                "Context: src/Foo.java, cursor at line 23, selected: \"int x = 1;\"",
+                AgentCoordinator.formatContext("src/Foo.java", 23, "int x = 1;"));
+    }
+
+    @Test
+    void longSelectionIsTruncatedWithEllipsis() {
+        String selection = "x".repeat(250);
+        String result = AgentCoordinator.formatContext("src/Foo.java", 1, selection);
+        assertEquals("Context: src/Foo.java, cursor at line 1, selected: \"" + "x".repeat(200) + "…\"", result);
+    }
+
+    @Test
+    void multilineSelectionStaysOneLine() {
+        assertEquals(
+                "Context: src/Foo.java, cursor at line 5, selected: \"a\\nb\"",
+                AgentCoordinator.formatContext("src/Foo.java", 5, "a\nb"));
+    }
+}

--- a/src/test/java/com/editora/ui/AgentDisplayNameTest.java
+++ b/src/test/java/com/editora/ui/AgentDisplayNameTest.java
@@ -1,0 +1,51 @@
+package com.editora.ui;
+
+import java.util.List;
+
+import com.editora.agent.AcpJson;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/** Pure tests for {@link AgentCoordinator#modelDisplayName}/{@link AgentCoordinator#modeDisplayName} —
+ *  the model/mode id → display-name lookup backing the AI Agent header labels. */
+class AgentDisplayNameTest {
+
+    private static final List<AcpJson.ModelInfo> MODELS = List.of(
+            new AcpJson.ModelInfo("opus", "Claude Opus", "Most capable"),
+            new AcpJson.ModelInfo("sonnet", "Claude Sonnet", "Balanced"));
+
+    private static final List<AcpJson.ModeInfo> MODES = List.of(
+            new AcpJson.ModeInfo("default", "Default", "Standard behavior"),
+            new AcpJson.ModeInfo("plan", "Plan Mode", "Planning, no execution"));
+
+    @Test
+    void modelFoundReturnsDisplayName() {
+        assertEquals("Claude Opus", AgentCoordinator.modelDisplayName(MODELS, "opus"));
+    }
+
+    @Test
+    void modelNotFoundFallsBackToId() {
+        assertEquals("mystery-model", AgentCoordinator.modelDisplayName(MODELS, "mystery-model"));
+    }
+
+    @Test
+    void modelNullIdReturnsEmpty() {
+        assertEquals("", AgentCoordinator.modelDisplayName(MODELS, null));
+    }
+
+    @Test
+    void modeFoundReturnsDisplayName() {
+        assertEquals("Plan Mode", AgentCoordinator.modeDisplayName(MODES, "plan"));
+    }
+
+    @Test
+    void modeNotFoundFallsBackToId() {
+        assertEquals("acceptEdits", AgentCoordinator.modeDisplayName(MODES, "acceptEdits"));
+    }
+
+    @Test
+    void modeNullIdReturnsEmpty() {
+        assertEquals("", AgentCoordinator.modeDisplayName(MODES, null));
+    }
+}

--- a/src/test/java/com/editora/ui/AgentPanelGlyphTest.java
+++ b/src/test/java/com/editora/ui/AgentPanelGlyphTest.java
@@ -1,0 +1,28 @@
+package com.editora.ui;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/** Pure test for {@link AgentPanel#glyphFor} — the plan-checklist status glyph. No FX toolkit needed:
+ *  {@code AgentPanel} has no static state, so calling its static method directly is safe. */
+class AgentPanelGlyphTest {
+
+    @Test
+    void completedIsChecked() {
+        assertEquals("☑", AgentPanel.glyphFor("completed"));
+    }
+
+    @Test
+    void inProgressIsHalf() {
+        assertEquals("◐", AgentPanel.glyphFor("in_progress"));
+    }
+
+    @Test
+    void pendingAndUnrecognizedAreEmptyBox() {
+        assertEquals("☐", AgentPanel.glyphFor("pending"));
+        assertEquals("☐", AgentPanel.glyphFor("something_new"));
+        assertEquals("☐", AgentPanel.glyphFor(""));
+        assertEquals("☐", AgentPanel.glyphFor(null));
+    }
+}


### PR DESCRIPTION
## Summary
- **Active-buffer context**: every prompt now carries a one-line `Context: <path>, cursor at line N[, selected: "..."]` header built from the active editor buffer (gated by `Settings.agentIncludeContext`, on by default). Shown in the transcript as its own note, never merged into the echoed prompt — fixes the agent having to ask "which file?" for the common "explain this line" case.
- **Model/mode switching**: the chat header now shows the ACP session's current model and mode (`session/new`'s response already returned this — it was just discarded). Clicking either label opens a `QuickOpen` picker to switch via `session/set_model`/`session/set_mode`; also reachable as palette commands "Agent: Select Model" / "Agent: Select Mode", sharing the exact same picker as the header click. The mode label also updates live on the agent's own `current_mode_update` notification.
- **Plan checklist**: the agent's plan now renders as a real checklist (☐ pending / ◐ in progress / ☑ completed per entry) instead of flattened, statusless text lines, and correctly replaces the whole list on every update (matching the protocol's full-replacement semantics) rather than appending to history.
- Confirmed via direct inspection of the installed ACP SDK/adapter that token/cost usage (`usage_update`) is defined in the protocol schema but never emitted by the installed `claude-code-acp` adapter — correctly left out of scope.

## Test plan
- [x] `mvn compile` — clean build
- [x] `mvn spotless:apply` — no formatting diffs
- [x] `mvn test -DexcludedGroups=fx` — 1543 tests pass, incl. extended `AcpJsonTest`, new `AgentContextTest`/`AgentDisplayNameTest`/`AgentPanelGlyphTest`, and `MessagesTest`'s six-locale key-parity check
- [ ] Manual: open the AI Agent chat with a real `claude-code-acp` session, confirm the context header appears, the Model/Mode labels populate and are switchable, and a multi-step prompt renders a checklist that updates in place

🤖 Generated with [Claude Code](https://claude.com/claude-code)