### PR TITLE
Release v0.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.0] - 2026-07-06
+
+First tagged release.
+
 ### Fixed
 
 - **AI connection check no longer hangs on a slow endpoint.** The Settings → AI Actions health check is

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.editora</groupId>
     <artifactId>editora</artifactId>
-    <version>1.0.0</version>
+    <version>0.9.0</version>
     <packaging>jar</packaging>
 
     <name>Editora</name>

--- a/src/main/java/com/editora/AppInfo.java
+++ b/src/main/java/com/editora/AppInfo.java
@@ -11,7 +11,7 @@ import java.util.Properties;
 public final class AppInfo {
 
     public static final String NAME = "Editora";
-    public static final String VERSION = "1.0.0";
+    public static final String VERSION = "0.9.0";
     /** Project home page (the website's custom domain). */
     public static final String HOMEPAGE = "https://editora-project.dev";
     /** Copyright notice (matches the bundled {@code LICENSE} file). */


### PR DESCRIPTION
Bumps the version to **0.9.0** (`pom.xml` + `AppInfo.VERSION`) for the project's first tagged release, and cuts the CHANGELOG's `Unreleased` section into `[0.9.0] - 2026-07-06` with a fresh empty `Unreleased` section above it.

`./mvnw clean verify` green (1660 tests).

After this merges, I'll push the `v0.9.0` tag to trigger the release build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)