### PR TITLE
Fix macOS release build failure on a pre-1.0 version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,15 @@ First tagged release.
 
 ### Fixed
 
+- **macOS release build failure on a pre-1.0 version.** jpackage rejects an `--app-version` whose first
+  number is zero or negative, so a `0.x.y` `pom.xml` version (like this release's `0.9.0`) failed the
+  macOS legs of the release build with "The first number in an app-version cannot be zero or negative."
+  The macOS build now uses a bundle-metadata-only `jpackage.appVersion` (a leading `0.` bumped to `1.`, e.g.
+  `1.9.0`) for jpackage's internal `CFBundleVersion`/`CFBundleShortVersionString`; the public release
+  version — the git tag, this CHANGELOG, and the app's own `--version`/About dialog — is unaffected. Linux
+  and Windows are untouched (jpackage accepts a leading-zero version there).
+
+
 - **AI connection check no longer hangs on a slow endpoint.** The Settings → AI Actions health check is
   now a **non-streaming** request whose 30 s timeout bounds the *entire* exchange — so a local server
   that sends response headers immediately but is slow to produce the first token (LM Studio warming up a

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -74,7 +74,16 @@ fat jar via `-Pfatjar` (`Editora-<version>-<target>.jar`). Installers are rename
 `Editora-<version>-<target>.<ext>` per target — one consistent `Editora-<version>-<target>` prefix
 across all artifacts (jpackage's DMG/MSI names omit the version + arch; the
 version comes from a `Resolve version` step — the tag minus `v`, else the pom version) and uploaded as
-artifacts alongside the fat jar; a final job
+artifacts alongside the fat jar. **macOS pre-1.0 app-version:** jpackage's `--app-version` (which becomes
+`CFBundleVersion`/`CFBundleShortVersionString`) rejects a version whose first number is zero/negative, so a
+`0.x.y` `pom.xml` version fails jpackage on macOS only (Linux/Windows accept it fine) — the `os-mac` profile
+computes a bundle-metadata-only `jpackage.appVersion` via a `maven-antrun-plugin` execution (Ant
+`loadresource`/`propertyresource`/`tokenfilter replaceregex`, `initialize` phase, `exportAntProperties`)
+that bumps a leading `0.` to `1.` (`0.9.0`→`1.9.0`); `os-windows`/`os-linux` just alias it to
+`${project.version}`. Both jpackage invocations — the `jpackage-app-image` execution and
+`aot_build.java`'s later DMG-wrap call — read `${jpackage.appVersion}`, not `${project.version}`, so the
+in-app `--version`/About dialog and the CI-renamed installer filename (via the `Resolve version` step
+above) stay the real semver regardless. A final job
 hands them to **JReleaser** (`jreleaser.yml`, via `jreleaser/release-action`) which creates the
 GitHub release with all installers + fat jars + `checksums.txt` + a changelog. JReleaser only *orchestrates the release* — it does not
 build (the `dist` profile is reused as-is) and there is **no `pom.xml`/Maven change**, so the normal

--- a/pom.xml
+++ b/pom.xml
@@ -1078,6 +1078,47 @@
                  UTI (a .txt is public.plain-text), so it would not appear in Open With. aot_build injects a
                  single CFBundleDocumentTypes entry declaring the *system* UTIs public.text / public.source-code
                  instead, which every text/source file conforms to. -->
+            <build>
+                <plugins>
+                    <!-- jpackage's app-version flag sets CFBundleVersion/CFBundleShortVersionString on
+                         macOS, and jpackage REJECTS a version whose first component is zero/negative ("The
+                         first number in an app-version cannot be zero or negative"), so a pre-1.0
+                         project.version like 0.9.0 fails both the jpackage-maven-plugin app-image build
+                         below AND aot_build.java's later DMG-wrap invocation. Bump a leading "0." to "1."
+                         (0.9.0 to 1.9.0) into jpackage.appVersion, used by both instead of
+                         ${project.version} directly; cosmetic macOS bundle metadata only, the public
+                         release version (tag, CHANGELOG, About dialog, DMG filename via the CI "Resolve
+                         version" step) is unaffected. A version already >=1.x (no leading "0.") passes
+                         through unchanged. -->
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-antrun-plugin</artifactId>
+                        <version>3.1.0</version>
+                        <executions>
+                            <execution>
+                                <id>mac-jpackage-app-version</id>
+                                <phase>initialize</phase>
+                                <goals>
+                                    <goal>run</goal>
+                                </goals>
+                                <configuration>
+                                    <exportAntProperties>true</exportAntProperties>
+                                    <target>
+                                        <loadresource property="jpackage.appVersion">
+                                            <propertyresource name="project.version"/>
+                                            <filterchain>
+                                                <tokenfilter>
+                                                    <replaceregex pattern="^0\." replace="1." flags="g"/>
+                                                </tokenfilter>
+                                            </filterchain>
+                                        </loadresource>
+                                    </target>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
         </profile>
         <profile>
             <id>os-windows</id>
@@ -1087,6 +1128,8 @@
                 <jpackage.icon>${project.basedir}/branding/editora.ico</jpackage.icon>
                 <!-- Keep Direct3D first on Windows (Metal is macOS-only); es2/sw fallback. -->
                 <prism.pipeline>d3d,es2,sw</prism.pipeline>
+                <!-- Windows/Linux jpackage accepts a leading-zero version fine — unlike macOS (see os-mac). -->
+                <jpackage.appVersion>${project.version}</jpackage.appVersion>
             </properties>
         </profile>
         <profile>
@@ -1101,6 +1144,7 @@
                 <jpackage.icon>${project.basedir}/branding/editora.png</jpackage.icon>
                 <!-- es2 first on Linux (no Metal/Direct3D there); sw fallback. -->
                 <prism.pipeline>es2,sw</prism.pipeline>
+                <jpackage.appVersion>${project.version}</jpackage.appVersion>
             </properties>
         </profile>
 
@@ -1210,7 +1254,7 @@
                                 <configuration>
                                     <type>APP_IMAGE</type>
                                     <name>Editora</name>
-                                    <appVersion>${project.version}</appVersion>
+                                    <appVersion>${jpackage.appVersion}</appVersion>
                                     <vendor>Editora</vendor>
                                     <icon>${jpackage.icon}</icon>
                                     <module>com.editora/com.editora.App</module>
@@ -1312,7 +1356,7 @@
                                         <argument>${project.basedir}/scripts/aot_build.java</argument>
                                         <argument>${project.build.directory}/aot-image</argument>
                                         <argument>Editora</argument>
-                                        <argument>${project.version}</argument>
+                                        <argument>${jpackage.appVersion}</argument>
                                         <argument>${jpackage.type}</argument>
                                         <argument>${jpackage.icon}</argument>
                                         <argument>${project.build.directory}/dist</argument>


### PR DESCRIPTION
The v0.9.0 release run's macOS legs (arm64 + x64) failed:

```
[ERROR] Exit code: 1 - Bundler Mac Application Image skipped because of a configuration problem: The first number in an app-version cannot be zero or negative.
```

jpackage rejects an `--app-version` whose first component is zero/negative — a hard macOS-only restriction (Linux/Windows both accepted `0.9.0` fine, confirmed by the same run's `linux-arm64`/`linux-x64`/`windows-x64` legs succeeding).

**Fix:** a new `jpackage.appVersion` property, used by both macOS jpackage invocations instead of `${project.version}` directly:
- `os-mac` computes it dynamically via a `maven-antrun-plugin` execution (Ant `loadresource`/`propertyresource`/`tokenfilter replaceregex`, `initialize` phase) that bumps a leading `0.` to `1.` (`0.9.0` → `1.9.0`); anything already `>=1.x` passes through unchanged.
- `os-windows`/`os-linux` just alias it to `${project.version}` (no restriction there, so nothing changes for those platforms).

This only touches jpackage's internal bundle metadata (`CFBundleVersion`/`CFBundleShortVersionString`) — the public-facing version (git tag, CHANGELOG, the app's own `--version`/About dialog via `AppInfo.VERSION`, and the CI-renamed installer filename) is completely unaffected.

**Verified locally end-to-end** (I'm on macOS): `mvn clean -Pdist -DskipTests -Djpackage.type=APP_IMAGE package` — jpackage received `--app-version 1.9.0`, `Editora.app`'s `Info.plist` shows `1.9.0`, and `Editora.app/Contents/MacOS/Editora --version` still correctly prints `Editora 0.9.0`.

`./mvnw clean verify` green (1660 tests). No new Maven dependency (`maven-antrun-plugin` is already used elsewhere in the `dist` profile).

🤖 Generated with [Claude Code](https://claude.com/claude-code)