### PR TITLE
Fix macOS delivered app showing the jpackage app-version placeholder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,10 @@ First tagged release.
   app's own `--version`/About dialog all correctly show `0.9.0`. Linux and Windows are untouched (jpackage
   accepts a leading-zero version there).
 
+- **Release job failed to check out branch `main`.** JReleaser defaults to a branch named `main` when none
+  is configured; this repo's default branch is `master`, so the final "Release" job failed with
+  "Could not checkout branch main" even after every platform's installer build succeeded.
+  `jreleaser.yml`'s `release.github` now sets `branch: master` explicitly.
 
 - **AI connection check no longer hangs on a slow endpoint.** The Settings → AI Actions health check is
   now a **non-streaming** request whose 30 s timeout bounds the *entire* exchange — so a local server

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,11 +15,14 @@ First tagged release.
 
 - **macOS release build failure on a pre-1.0 version.** jpackage rejects an `--app-version` whose first
   number is zero or negative, so a `0.x.y` `pom.xml` version (like this release's `0.9.0`) failed the
-  macOS legs of the release build with "The first number in an app-version cannot be zero or negative."
-  The macOS build now uses a bundle-metadata-only `jpackage.appVersion` (a leading `0.` bumped to `1.`, e.g.
-  `1.9.0`) for jpackage's internal `CFBundleVersion`/`CFBundleShortVersionString`; the public release
-  version — the git tag, this CHANGELOG, and the app's own `--version`/About dialog — is unaffected. Linux
-  and Windows are untouched (jpackage accepts a leading-zero version there).
+  macOS legs of the release build with "The first number in an app-version cannot be zero or negative" —
+  on both the app-image build *and* the DMG wrap step, since jpackage enforces the rule on every
+  invocation. The macOS build now passes jpackage a bumped placeholder (a leading `0.` to `1.`, e.g.
+  `1.9.0`) purely to satisfy that CLI check, then immediately rewrites the built app's `Info.plist`
+  (`CFBundleVersion`/`CFBundleShortVersionString`) back to the true version before wrapping the DMG — so
+  the placeholder never reaches the delivered app: Finder "Get Info", `mdls`, System Settings, and the
+  app's own `--version`/About dialog all correctly show `0.9.0`. Linux and Windows are untouched (jpackage
+  accepts a leading-zero version there).
 
 
 - **AI connection check no longer hangs on a slow endpoint.** The Settings → AI Actions health check is

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -81,9 +81,18 @@ computes a bundle-metadata-only `jpackage.appVersion` via a `maven-antrun-plugin
 `loadresource`/`propertyresource`/`tokenfilter replaceregex`, `initialize` phase, `exportAntProperties`)
 that bumps a leading `0.` to `1.` (`0.9.0`→`1.9.0`); `os-windows`/`os-linux` just alias it to
 `${project.version}`. Both jpackage invocations — the `jpackage-app-image` execution and
-`aot_build.java`'s later DMG-wrap call — read `${jpackage.appVersion}`, not `${project.version}`, so the
-in-app `--version`/About dialog and the CI-renamed installer filename (via the `Resolve version` step
-above) stay the real semver regardless. A final job
+`aot_build.java`'s later DMG-wrap call — read `${jpackage.appVersion}` for their `--app-version` flag
+(confirmed empirically: the DMG-wrap bundler enforces the same zero/negative-first-number rule even in
+`--app-image <path>` mode, so the placeholder is unavoidable on *both* calls). But the placeholder must
+never reach the delivered app: `aot_build.java`'s **`fixMacBundleMetadata`** (which already rewrites
+`CFBundleDocumentTypes` for "Open With" — see below) also rewrites `CFBundleVersion`/
+`CFBundleShortVersionString` back to the TRUE version (passed as a separate `publicVersion` argument,
+`${project.version}`, distinct from the `appVersion` placeholder) right after the app-image build,
+*before* the DMG wrap runs — confirmed empirically that jpackage's DMG-wrap does **not** re-touch an
+already-correct `Info.plist` (it only uses `--app-version` for its own CLI validation and to name the raw
+`.dmg` file, which the `Resolve version`-based rename above replaces anyway), so the delivered `.app`'s
+Finder "Get Info" / `mdls` / System Settings, plus the in-app `--version`/About dialog, all show the real
+semver — never the placeholder. A final job
 hands them to **JReleaser** (`jreleaser.yml`, via `jreleaser/release-action`) which creates the
 GitHub release with all installers + fat jars + `checksums.txt` + a changelog. JReleaser only *orchestrates the release* — it does not
 build (the `dist` profile is reused as-is) and there is **no `pom.xml`/Maven change**, so the normal

--- a/jreleaser.yml
+++ b/jreleaser.yml
@@ -18,6 +18,9 @@ release:
   github:
     owner: adriandeleon
     name: Editora
+    # JReleaser defaults to "main" when unset; this repo's default branch is "master" — without this,
+    # the release job fails with "Could not checkout branch main".
+    branch: master
     tagName: 'v{{projectVersion}}'
     releaseName: 'Editora {{projectVersion}}'
     # Re-running on the same tag replaces the assets instead of failing.

--- a/pom.xml
+++ b/pom.xml
@@ -1080,16 +1080,17 @@
                  instead, which every text/source file conforms to. -->
             <build>
                 <plugins>
-                    <!-- jpackage's app-version flag sets CFBundleVersion/CFBundleShortVersionString on
-                         macOS, and jpackage REJECTS a version whose first component is zero/negative ("The
-                         first number in an app-version cannot be zero or negative"), so a pre-1.0
-                         project.version like 0.9.0 fails both the jpackage-maven-plugin app-image build
-                         below AND aot_build.java's later DMG-wrap invocation. Bump a leading "0." to "1."
-                         (0.9.0 to 1.9.0) into jpackage.appVersion, used by both instead of
-                         ${project.version} directly; cosmetic macOS bundle metadata only, the public
-                         release version (tag, CHANGELOG, About dialog, DMG filename via the CI "Resolve
-                         version" step) is unaffected. A version already >=1.x (no leading "0.") passes
-                         through unchanged. -->
+                    <!-- jpackage's own app-version flag REJECTS a version whose first component is
+                         zero/negative ("The first number in an app-version cannot be zero or negative"),
+                         on BOTH the jpackage-maven-plugin app-image build below AND aot_build.java's later
+                         DMG-wrap invocation — so a pre-1.0 project.version like 0.9.0 fails both. Bump a
+                         leading "0." to "1." (0.9.0 to 1.9.0) into jpackage.appVersion, passed to both
+                         jpackage calls instead of ${project.version} directly (a version already >=1.x
+                         passes through unchanged). This placeholder only satisfies jpackage's CLI
+                         validation — aot_build.java's fixMacBundleMetadata immediately rewrites the built
+                         app's Info.plist CFBundleVersion/CFBundleShortVersionString back to the TRUE
+                         ${project.version} (passed separately, see the aot-train-and-deliver execution
+                         below) before the DMG wrap runs, so the delivered app never shows the placeholder. -->
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-antrun-plugin</artifactId>
@@ -1357,6 +1358,7 @@
                                         <argument>${project.build.directory}/aot-image</argument>
                                         <argument>Editora</argument>
                                         <argument>${jpackage.appVersion}</argument>
+                                        <argument>${project.version}</argument>
                                         <argument>${jpackage.type}</argument>
                                         <argument>${jpackage.icon}</argument>
                                         <argument>${project.build.directory}/dist</argument>

--- a/scripts/aot_build.java
+++ b/scripts/aot_build.java
@@ -14,8 +14,15 @@
 // -XX:AOTCache file degrades gracefully to a normal, uncached start). Only the installer wrap, the
 // actual deliverable, fails the build on error.
 //
-// Args: <imageDir> <appName> <appVersion> <installerType> <iconPath|-> <destDir> <moduleMain>
-//   Run via:  java scripts/aot_build.java target/aot-image Editora 1.0.0 DMG branding/editora.icns target/dist com.editora/com.editora.App
+// Args: <imageDir> <appName> <appVersion> <publicVersion> <installerType> <iconPath|-> <destDir> <moduleMain>
+//   Run via:  java scripts/aot_build.java target/aot-image Editora 1.0.0 1.0.0 DMG branding/editora.icns target/dist com.editora/com.editora.App
+//
+// <appVersion> is what's handed to jpackage's own --app-version flag on BOTH jpackage invocations (the
+// app-image build, already done by the time this runs, and this file's own DMG/MSI/DEB wrap below) —
+// jpackage rejects a version whose first number is zero/negative, so on a pre-1.0 <publicVersion> (e.g.
+// 0.9.0) the caller (pom.xml's os-mac profile) passes a bumped placeholder here (e.g. 1.9.0) instead.
+// <publicVersion> is the TRUE release version; on macOS it's rewritten back into the app's Info.plist
+// (see fixMacBundleMetadata) before the DMG wrap, so the placeholder never reaches the delivered app.
 
 import java.io.IOException;
 import java.nio.file.*;
@@ -26,17 +33,19 @@ import java.util.stream.Stream;
 public class aot_build {
 
     public static void main(String[] rawArgs) throws Exception {
-        if (rawArgs.length < 7) {
-            System.err.println("[aot] usage: imageDir appName appVersion installerType iconPath destDir moduleMain");
+        if (rawArgs.length < 8) {
+            System.err.println(
+                    "[aot] usage: imageDir appName appVersion publicVersion installerType iconPath destDir moduleMain");
             System.exit(2);
         }
         Path imageDir   = Path.of(rawArgs[0]);
         String appName  = rawArgs[1];
         String appVer   = rawArgs[2];
-        String type     = rawArgs[3];
-        String icon     = rawArgs[4];
-        Path destDir    = Path.of(rawArgs[5]);
-        String module   = rawArgs[6];
+        String publicVer = rawArgs[3];
+        String type     = rawArgs[4];
+        String icon     = rawArgs[5];
+        Path destDir    = Path.of(rawArgs[6]);
+        String module   = rawArgs[7];
 
         if (!Files.isDirectory(imageDir)) {
             System.err.println("[aot] image dir not found: " + imageDir + " — skipping AOT step");
@@ -78,11 +87,14 @@ public class aot_build {
         Files.createDirectories(destDir);
         Path imageRoot = imageRoot(imageDir, appName, win); // Editora.app (mac) or Editora dir
 
-        // macOS "Open With": declare the SYSTEM UTIs public.text / public.source-code in the .app's
-        // Info.plist so Finder offers Editora for any text/source file (see fixMacDocumentTypes).
+        // macOS "Open With" + bundle version (see fixMacBundleMetadata): declares the SYSTEM UTIs
+        // public.text / public.source-code so Finder offers Editora for any text/source file, and
+        // rewrites the Info.plist version back to the true publicVer (jpackage's --app-version rejects a
+        // pre-1.0 version, so appVer may be a bumped placeholder baked into the plist by the app-image
+        // build above).
         boolean mac = System.getProperty("os.name", "").toLowerCase(Locale.ROOT).contains("mac");
         if (mac) {
-            fixMacDocumentTypes(imageRoot);
+            fixMacBundleMetadata(imageRoot, publicVer);
         }
 
         // Ensure the Linux app image carries OUR icon. The jpackage app-image phase can leave the
@@ -217,25 +229,41 @@ public class aot_build {
     // ---- helpers ----
 
     /**
-     * Rewrites the macOS app image's Info.plist so Editora appears in Finder's "Open With" menu for text
-     * and source files. jpackage's --file-associations would declare per-extension CUSTOM UTIs
+     * Rewrites the macOS app image's Info.plist for two things, sharing one re-codesign:
+     *
+     * <p><b>1. "Open With".</b> Declares CFBundleDocumentTypes so Editora appears in Finder's "Open With"
+     * menu for text/source files. jpackage's --file-associations would declare per-extension CUSTOM UTIs
      * (com.editora.txt, …) conforming to public.data — but Launch Services never offers an app for a file
      * already typed as a system UTI (a .txt is public.plain-text, which does not conform to com.editora.txt),
-     * so it wouldn't show up. Instead we declare a single CFBundleDocumentTypes entry using the SYSTEM UTIs
-     * public.text + public.source-code: every text/source file conforms to one of those, so the app becomes
-     * an eligible (Alternate-rank, so non-default) editor for all of them. Best-effort — a PlistBuddy failure
-     * logs and continues (the app still runs, just without the association).
+     * so it wouldn't show up. Instead we declare a single entry using the SYSTEM UTIs public.text +
+     * public.source-code: every text/source file conforms to one of those, so the app becomes an eligible
+     * (Alternate-rank, so non-default) editor for all of them.
      *
-     * <p><b>Must re-codesign afterward.</b> jpackage ad-hoc-signs the .app during the app-image build (before
-     * this runs); editing Info.plist invalidates that seal (its hash is part of the signature), and macOS then
-     * rejects the app as tampered ("could not verify … free of malware", spctl: "invalid Info.plist") and
-     * won't launch it. So we re-run `codesign --force --deep --sign -` to re-seal the bundle with the modified
-     * plist. (arm64 apps must be signed to run at all; ad-hoc is fine for a locally-built, un-notarized app.)
+     * <p><b>2. The true bundle version.</b> jpackage's own --app-version flag rejects a version whose first
+     * number is zero/negative ("The first number in an app-version cannot be zero or negative"), on BOTH
+     * the app-image build (already done by the time this runs) and this file's own DMG/MSI/DEB wrap below
+     * — so on a pre-1.0 publicVersion (e.g. 0.9.0) the app is necessarily built with a bumped placeholder
+     * (e.g. 1.9.0, computed by pom.xml's os-mac profile) baked into CFBundleVersion/
+     * CFBundleShortVersionString. This rewrites both back to the true publicVersion, so Finder "Get Info" /
+     * mdls / System Settings show the real release number, not the jpackage-safe placeholder. Verified
+     * empirically that jpackage's DMG-wrap (`--app-image <path> --app-version <placeholder>`) does NOT
+     * re-touch an already-correct Info.plist — it only uses --app-version for its own CLI validation and
+     * for naming the raw .dmg file (which the release workflow renames anyway) — so setting the true
+     * version here, before wrapInstaller runs below, survives untouched into the delivered installer's
+     * embedded .app.
+     *
+     * <p>Each half is best-effort — a PlistBuddy failure logs and continues (the app still runs, just
+     * without that fix). <b>Must re-codesign afterward</b> if either half succeeded: jpackage ad-hoc-signs
+     * the .app during the app-image build (before this runs); editing Info.plist invalidates that seal (its
+     * hash is part of the signature), and macOS then rejects the app as tampered ("could not verify … free
+     * of malware", spctl: "invalid Info.plist") and won't launch it. So we re-run
+     * `codesign --force --deep --sign -` to re-seal the bundle with the modified plist. (arm64 apps must be
+     * signed to run at all; ad-hoc is fine for a locally-built, un-notarized app.)
      */
-    private static void fixMacDocumentTypes(Path imageRoot) {
+    private static void fixMacBundleMetadata(Path imageRoot, String publicVersion) {
         Path plist = imageRoot.resolve("Contents").resolve("Info.plist");
         if (!Files.isRegularFile(plist)) {
-            System.out.println("[aot] no Info.plist at " + plist + " — skipping Open-With association");
+            System.out.println("[aot] no Info.plist at " + plist + " — skipping Open-With association + version fix");
             return;
         }
         String pb = "/usr/libexec/PlistBuddy";
@@ -243,7 +271,7 @@ public class aot_build {
         runQuiet(pb, "-c", "Delete :UTExportedTypeDeclarations", plist.toString());
         runQuiet(pb, "-c", "Delete :UTImportedTypeDeclarations", plist.toString());
         runQuiet(pb, "-c", "Delete :CFBundleDocumentTypes", plist.toString());
-        boolean ok = runQuiet(
+        boolean docTypesOk = runQuiet(
                 pb,
                 "-c", "Add :CFBundleDocumentTypes array",
                 "-c", "Add :CFBundleDocumentTypes:0 dict",
@@ -254,16 +282,25 @@ public class aot_build {
                 "-c", "Add :CFBundleDocumentTypes:0:LSItemContentTypes:0 string public.text",
                 "-c", "Add :CFBundleDocumentTypes:0:LSItemContentTypes:1 string public.source-code",
                 plist.toString());
-        if (!ok) {
-            System.out.println("[aot] Open-With: PlistBuddy edit failed — app ships without the file association");
-            return;
+        System.out.println(docTypesOk
+                ? "[aot] Open-With: declared CFBundleDocumentTypes (public.text, public.source-code)"
+                : "[aot] Open-With: PlistBuddy edit failed — app ships without the file association");
+        boolean versionOk = runQuiet(
+                pb,
+                "-c", "Set :CFBundleShortVersionString " + publicVersion,
+                "-c", "Set :CFBundleVersion " + publicVersion,
+                plist.toString());
+        System.out.println(versionOk
+                ? "[aot] bundle version -> " + publicVersion
+                : "[aot] bundle version rewrite FAILED — the app may show the internal jpackage placeholder version");
+        if (!docTypesOk && !versionOk) {
+            return; // nothing changed — the pre-existing signature is still valid
         }
-        System.out.println("[aot] Open-With: declared CFBundleDocumentTypes (public.text, public.source-code)");
-        // Re-seal the bundle: the plist edit broke jpackage's ad-hoc signature, which macOS would reject.
+        // Re-seal the bundle: either plist edit broke jpackage's ad-hoc signature, which macOS would reject.
         boolean signed = runQuiet("codesign", "--force", "--deep", "--sign", "-", imageRoot.toString());
         System.out.println(signed
-                ? "[aot] Open-With: re-codesigned the app image (ad-hoc)"
-                : "[aot] Open-With: codesign re-seal FAILED — the app may be rejected by Gatekeeper");
+                ? "[aot] re-codesigned the app image (ad-hoc)"
+                : "[aot] codesign re-seal FAILED — the app may be rejected by Gatekeeper");
     }
 
     /** Runs a command, discarding output; returns true on exit 0. Never throws. */


### PR DESCRIPTION
Follow-up to #333. Two issues found while watching the re-cut v0.9.0 release run.

## 1. Delivered app showed the jpackage app-version placeholder

That fix computed a jpackage-CLI-safe placeholder (`0.9.0` → `1.9.0`) for macOS's `--app-version`, but I'd assumed it would stay a transient build-time argument. It didn't — **the delivered app itself showed `1.9.0`** in `Info.plist` (Finder "Get Info", `mdls`, System Settings), not the real `0.9.0`.

**Root cause, confirmed empirically:** jpackage's "first number cannot be zero or negative" check isn't limited to the initial app-image build — the **DMG-wrap bundler** (`jpackage --app-image <path> --app-version <ver>`, used to wrap an already-built `.app` into an installer) enforces the exact same rule, even though it's just wrapping an existing bundle. So the placeholder got baked into the delivered app's `Info.plist` on both jpackage calls.

**Also confirmed empirically:** the DMG-wrap step does **not** re-touch an already-correct `Info.plist` — it only uses `--app-version` for its own CLI validation and to name the raw `.dmg` file (which the release workflow's rename step replaces anyway with the tag-derived version).

**Fix:** `aot_build.java`'s existing Info.plist-rewrite step (previously `fixMacDocumentTypes`, only handling the "Open With" file association) now *also* rewrites `CFBundleVersion`/`CFBundleShortVersionString` back to the true public version — passed as a new, separate `publicVersion` argument (`${project.version}`) — right after the app-image build and *before* the DMG wrap runs. Renamed to `fixMacBundleMetadata`; both edits share one PlistBuddy pass + one re-codesign.

**Verified end-to-end locally** with the real DMG build (`mvn clean -Pdist -DskipTests package`): jpackage received `--app-version 1.9.0` on both calls, but the delivered `Editora-1.9.0.dmg`'s embedded `Editora.app` shows `CFBundleShortVersionString`/`CFBundleVersion=0.9.0` and `--version` prints `Editora 0.9.0`.

## 2. JReleaser "Could not checkout branch main"

The v0.9.0 re-run after #333 actually **succeeded on all 5 platform builds**, including both macOS legs — confirming #333 fixed the real build failure. But the final "Release" (JReleaser) job failed separately:

```
java.io.IOException: Could not checkout branch main
```

JReleaser defaults to a branch named `main` when `release.github.branch` is unset; this repo's default branch is `master`. `jreleaser.yml` now sets it explicitly.

---

`./mvnw clean verify` green (1660 tests). No new dependency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)