### PR TITLE
Fix JReleaser "Cannot upload assets to an immutable release"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,15 @@ First tagged release.
   "Could not checkout branch main" even after every platform's installer build succeeded.
   `jreleaser.yml`'s `release.github` now sets `branch: master` explicitly.
 
+- **Release job failed with "Cannot upload assets to an immutable release."** GitHub's Immutable Releases
+  feature (GA October 2025) rejects any asset upload once a release is published, but JReleaser's default
+  flow publishes the release *before* uploading each installer — so every asset upload 422'd and the whole
+  release failed after all five platform builds had already succeeded. `jreleaser.yml`'s `release.github`
+  now sets `immutableRelease: true`, which makes JReleaser create the release as a draft, upload every
+  asset while it's still a mutable draft, then publish — the flow GitHub's own docs prescribe. This is
+  mutually exclusive with the previous `overwrite: true` (removed), so re-running on the same tag now
+  needs the prior release deleted first (`gh release delete v<version>`) rather than overwritten in place.
+
 - **AI connection check no longer hangs on a slow endpoint.** The Settings → AI Actions health check is
   now a **non-streaming** request whose 30 s timeout bounds the *entire* exchange — so a local server
   that sends response headers immediately but is slow to produce the first token (LM Studio warming up a

--- a/jreleaser.yml
+++ b/jreleaser.yml
@@ -23,8 +23,14 @@ release:
     branch: master
     tagName: 'v{{projectVersion}}'
     releaseName: 'Editora {{projectVersion}}'
-    # Re-running on the same tag replaces the assets instead of failing.
-    overwrite: true
+    # GitHub's Immutable Releases (GA Oct 2025) reject asset uploads once a release is published, so
+    # JReleaser's default create-then-upload-loop flow 422s on every asset ("Cannot upload assets to an
+    # immutable release"). This makes JReleaser create the release as a draft, upload every asset while
+    # it's still a (mutable) draft, then publish — the flow GitHub's own docs prescribe for immutable repos.
+    # Mutually exclusive with `overwrite` (JReleaser itself rejects the combination: an immutable release
+    # can't be overwritten by definition) — a re-run on the same tag now needs the prior release deleted
+    # first (`gh release delete v<version>`), not overwritten in place.
+    immutableRelease: true
     # Tags like v1.0.0-rc1 are published as pre-releases.
     prerelease:
       pattern: '.*-rc.*'


### PR DESCRIPTION
## Summary
- The v0.9.0 release run failed after all five platform builds succeeded, with JReleaser 422'ing on every asset upload: `Cannot upload assets to an immutable release`.
- GitHub's Immutable Releases feature (GA October 2025) rejects asset uploads once a release is published, but JReleaser's default flow publishes the release *before* uploading installers.
- Set `release.github.immutableRelease: true`, which makes JReleaser create the release as a draft, upload every asset while it's still mutable, then publish — the flow GitHub's own docs prescribe for immutable repos.
- Removed the previous `overwrite: true` (JReleaser's own config validation rejects having both set at once — an immutable release can't be overwritten by definition). Re-running on the same tag now needs the prior release deleted first (`gh release delete v<version>`) rather than overwritten in place.

## Verification
- Validated locally via `jreleaser config --config-file jreleaser.yml --basedir <repo>` against the Homebrew-installed 1.25.0 CLI (matching the version CI resolves) with dummy env vars — config resolves cleanly with `immutableRelease: true` applied and zero errors.
- `./mvnw -o -B clean verify` green (1660 tests, Spotless + JaCoCo).
- Deleted the broken, empty, immutable `v0.9.0` release object that the failed run left behind (`gh release delete v0.9.0`), so the tag can be re-cut cleanly once this merges.

## Test plan
- [x] Local `jreleaser config` validation
- [x] `mvn clean verify`
- [ ] Re-cut `v0.9.0` tag after merge and confirm the release workflow completes end-to-end with a real, non-empty GitHub Release

🤖 Generated with [Claude Code](https://claude.com/claude-code)