### PR TITLE
Bump release version to 0.9.1 — v0.9.0 tag is permanently unusable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,21 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.9.0] - 2026-07-06
+## [0.9.1] - 2026-07-06
 
-First tagged release.
+First tagged release. (`v0.9.0` was cut and pushed first, but a JReleaser misconfiguration published it
+as an immutable GitHub Release before the asset uploads failed; GitHub permanently reserves a tag once
+it has backed an immutable release, even after both the release and the tag are deleted, so `v0.9.0`
+itself can never be reused on this repository — see the fixes below. This release ships as `0.9.1`
+instead.)
 
 ### Fixed
 
 - **macOS release build failure on a pre-1.0 version.** jpackage rejects an `--app-version` whose first
-  number is zero or negative, so a `0.x.y` `pom.xml` version (like this release's `0.9.0`) failed the
+  number is zero or negative, so a `0.x.y` `pom.xml` version (like this release's `0.9.1`) failed the
   macOS legs of the release build with "The first number in an app-version cannot be zero or negative" —
   on both the app-image build *and* the DMG wrap step, since jpackage enforces the rule on every
   invocation. The macOS build now passes jpackage a bumped placeholder (a leading `0.` to `1.`, e.g.
-  `1.9.0`) purely to satisfy that CLI check, then immediately rewrites the built app's `Info.plist`
+  `1.9.1`) purely to satisfy that CLI check, then immediately rewrites the built app's `Info.plist`
   (`CFBundleVersion`/`CFBundleShortVersionString`) back to the true version before wrapping the DMG — so
   the placeholder never reaches the delivered app: Finder "Get Info", `mdls`, System Settings, and the
-  app's own `--version`/About dialog all correctly show `0.9.0`. Linux and Windows are untouched (jpackage
+  app's own `--version`/About dialog all correctly show `0.9.1`. Linux and Windows are untouched (jpackage
   accepts a leading-zero version there).
 
 - **Release job failed to check out branch `main`.** JReleaser defaults to a branch named `main` when none

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.editora</groupId>
     <artifactId>editora</artifactId>
-    <version>0.9.0</version>
+    <version>0.9.1</version>
     <packaging>jar</packaging>
 
     <name>Editora</name>

--- a/src/main/java/com/editora/AppInfo.java
+++ b/src/main/java/com/editora/AppInfo.java
@@ -11,7 +11,7 @@ import java.util.Properties;
 public final class AppInfo {
 
     public static final String NAME = "Editora";
-    public static final String VERSION = "0.9.0";
+    public static final String VERSION = "0.9.1";
     /** Project home page (the website's custom domain). */
     public static final String HOMEPAGE = "https://editora-project.dev";
     /** Copyright notice (matches the bundled {@code LICENSE} file). */


### PR DESCRIPTION
## Summary
- The `v0.9.0` release run published an immutable GitHub Release before the asset uploads failed with `422`s (fixed in #335, merged).
- GitHub's Immutable Releases feature **permanently reserves a tag** once it has backed an immutable release — per [GitHub's docs](https://docs.github.com/en/code-security/concepts/supply-chain-security/immutable-releases): "If you delete the immutable release, you can delete the tag, but you cannot reuse the same tag name." This is deliberate (anti repository-resurrection protection), not a bug, and there is no config workaround.
- Confirmed empirically: pushing a differently-named throwaway tag succeeded immediately, while re-pushing `v0.9.0` at the exact same commit fails with `Cannot create ref due to creations being restricted` — isolating the block to that one specific ref, not tag creation in general.
- So `v0.9.0` can never be released on this repository. Bumps `pom.xml` and `AppInfo.VERSION` to `0.9.1`, which becomes the actual first tagged release, and updates `CHANGELOG.md` accordingly.

## Test plan
- [x] `./mvnw -o -B clean verify` (1660 tests, Spotless + JaCoCo)
- [ ] Cut `v0.9.1` tag after merge and confirm the release workflow completes end-to-end with a real, non-empty GitHub Release

🤖 Generated with [Claude Code](https://claude.com/claude-code)