### PR TITLE
AI Agent: render chat replies as Markdown by default

### DIFF
--- a/src/main/java/com/editora/ui/AgentPanel.java
+++ b/src/main/java/com/editora/ui/AgentPanel.java
@@ -3,18 +3,23 @@ package com.editora.ui;
 import java.util.List;
 import java.util.function.Consumer;
 
+import javafx.animation.PauseTransition;
 import javafx.geometry.Insets;
 import javafx.geometry.Pos;
+import javafx.scene.Node;
 import javafx.scene.control.Button;
 import javafx.scene.control.Label;
+import javafx.scene.control.ScrollPane;
 import javafx.scene.control.TextArea;
 import javafx.scene.input.KeyCode;
 import javafx.scene.layout.HBox;
 import javafx.scene.layout.Priority;
 import javafx.scene.layout.Region;
 import javafx.scene.layout.VBox;
+import javafx.util.Duration;
 
 import com.editora.agent.AcpJson;
+import com.editora.editor.MarkdownRenderer;
 
 import static com.editora.i18n.Messages.tr;
 
@@ -22,20 +27,34 @@ import static com.editora.i18n.Messages.tr;
  * The "AI Agent" tool window: a chat transcript streaming the ACP agent's replies + tool activity, a
  * multi-line prompt input (Enter sends, Shift+Enter inserts a newline), and Stop / New Session actions.
  * A {@link ToolWindowContent} modeled on {@link RunPanel}; {@link AgentCoordinator} drives it via
- * {@code appendChunk/appendLine/setBusy} on the FX thread. The transcript is a read-only wrapped
- * {@link TextArea} (cheap and robust for streaming text), capped so a long session can't grow memory
- * without bound.
+ * {@code appendChunk/appendLine/setBusy} on the FX thread.
+ *
+ * <p>The transcript is a {@link VBox} of entries, not a single control: a user prompt / tool-activity /
+ * status line ({@link #appendLine}) is a plain {@link Label}, but the agent's own reply
+ * ({@link #appendChunk}) is rendered as <b>Markdown</b> via {@link MarkdownRenderer} (the same renderer
+ * the Markdown preview uses) — so code blocks, lists, bold, tables, and even Mermaid/math in a reply
+ * render properly instead of showing raw markup. A reply streams in one chunk at a time; each chunk
+ * accumulates into that message's own raw-text buffer and a debounced ({@link #RENDER_DEBOUNCE}) re-parse
+ * replaces that message's single rendered node in place, so a long response isn't re-parsed on every
+ * chunk. {@link #appendLine} (a new prompt, a tool-call line, an error) finalizes — flushes any pending
+ * render synchronously — whatever agent message was streaming, so the next chunk starts a fresh message
+ * rather than continuing the previous one. Capped at {@link #MAX_ENTRIES} transcript nodes (oldest
+ * dropped first) so a long session can't grow memory without bound.
  */
 public final class AgentPanel extends VBox implements ToolWindowContent {
 
-    /** Trim the transcript once it exceeds this many characters (keeps the most recent output). */
-    private static final int MAX_CHARS = 400_000;
+    /** Trim the transcript once it exceeds this many entries (keeps the most recent messages/lines). */
+    private static final int MAX_ENTRIES = 2000;
+
+    /** Coalesces rapid streaming chunks into one Markdown re-parse+re-render per pause. */
+    private static final Duration RENDER_DEBOUNCE = Duration.millis(150);
 
     private final Label status = new Label();
     private final Label modelLabel = new Label();
     private final Label modeLabel = new Label();
     private final VBox planBox = new VBox(2);
-    private final TextArea transcript = new TextArea();
+    private final VBox transcriptBox = new VBox(4);
+    private final ScrollPane transcriptScroll = new ScrollPane(transcriptBox);
     private final TextArea input = new TextArea();
     private final Button sendButton = new Button();
     private final Button stopButton = new Button();
@@ -43,6 +62,16 @@ public final class AgentPanel extends VBox implements ToolWindowContent {
     private final Button historyButton = new Button();
     /** Receives the prompt text when the user sends (coordinator → agent). */
     private Consumer<String> onSend;
+    /** The plain-text line font, applied to each new {@code agent-line} Label ({@link #setPanelFont}). */
+    private String lineFontFamily;
+
+    private double lineFontSize = -1;
+    /** The currently-streaming agent message's single-child wrapper, or null between messages. */
+    private VBox currentAgentWrapper;
+    /** Raw Markdown accumulated so far for {@link #currentAgentWrapper}. */
+    private final StringBuilder currentAgentMarkdown = new StringBuilder();
+
+    private PauseTransition renderPause;
 
     public AgentPanel(
             Runnable onStop,
@@ -73,9 +102,13 @@ public final class AgentPanel extends VBox implements ToolWindowContent {
         planBox.setManaged(false);
         planBox.setVisible(false);
 
-        transcript.setEditable(false);
-        transcript.setWrapText(true);
-        transcript.getStyleClass().add("agent-transcript");
+        transcriptBox.getStyleClass().add("agent-transcript");
+        transcriptScroll.setContent(transcriptBox);
+        transcriptScroll.setFitToWidth(true);
+        transcriptScroll.getStyleClass().add("agent-transcript-scroll");
+        // Always-scroll-to-bottom on new/updated content (matches the old TextArea's behavior); height
+        // changes on every append and every debounced re-render of the in-progress message.
+        transcriptBox.heightProperty().addListener((obs, oldV, newV) -> transcriptScroll.setVvalue(1.0));
 
         input.setPromptText(tr("agent.inputPrompt"));
         input.setWrapText(true);
@@ -95,8 +128,8 @@ public final class AgentPanel extends VBox implements ToolWindowContent {
         inputRow.setAlignment(Pos.BOTTOM_RIGHT);
         HBox.setHgrow(input, Priority.ALWAYS);
 
-        VBox.setVgrow(transcript, Priority.ALWAYS);
-        getChildren().addAll(header, planBox, transcript, inputRow);
+        VBox.setVgrow(transcriptScroll, Priority.ALWAYS);
+        getChildren().addAll(header, planBox, transcriptScroll, inputRow);
         setBusy(false);
         status.setText(tr("agent.idle"));
     }
@@ -114,45 +147,113 @@ public final class AgentPanel extends VBox implements ToolWindowContent {
         onSend.accept(text);
     }
 
-    /** Matches the transcript/input font family to the editor's (size stays the UI default). */
+    /** Matches the input + plain transcript lines to the editor's font family/size (rendered Markdown
+     *  replies keep their own typography — Inter for prose, JetBrains Mono for code — matching the app's
+     *  Markdown preview everywhere else, so it isn't overridden here). */
     public void setPanelFont(String family, int size) {
-        transcript.setFont(javafx.scene.text.Font.font(family, size));
         input.setFont(javafx.scene.text.Font.font(family, size));
+        lineFontFamily = family;
+        lineFontSize = size;
     }
 
-    /** Appends streaming text verbatim (agent message chunks arrive without trailing newlines). */
+    /** Appends one streaming chunk of the agent's reply (arrives without trailing newlines). Starts a new
+     *  message on the first chunk after a line/finalize; later chunks accumulate into the same message and
+     *  schedule a debounced Markdown re-render. */
     public void appendChunk(String text) {
-        appendRaw(text);
-    }
-
-    /** Appends {@code line} on its own line (tool activity, prompts, status notes). */
-    public void appendLine(String line) {
-        String text = transcript.getText();
-        appendRaw((text.isEmpty() || text.endsWith("\n") ? "" : "\n") + line + "\n");
-    }
-
-    private void appendRaw(String text) {
-        transcript.appendText(text);
-        int len = transcript.getLength();
-        if (len > MAX_CHARS) {
-            String kept = transcript.getText(len - MAX_CHARS, len);
-            int nl = kept.indexOf('\n');
-            transcript.replaceText(0, len, nl >= 0 ? kept.substring(nl + 1) : kept);
+        if (currentAgentWrapper == null) {
+            currentAgentWrapper = new VBox();
+            transcriptBox.getChildren().add(currentAgentWrapper);
+            trimIfNeeded();
         }
-        transcript.positionCaret(transcript.getLength());
-        transcript.setScrollTop(Double.MAX_VALUE);
+        currentAgentMarkdown.append(text);
+        scheduleMarkdownRender();
+    }
+
+    /** Appends {@code line} as its own plain-text entry (tool activity, prompts, status notes) — finalizes
+     *  (flushes) whatever agent message was streaming first, so the next chunk starts a fresh message. */
+    public void appendLine(String line) {
+        finalizeCurrentMessage();
+        Label label = new Label(line);
+        label.getStyleClass().add("agent-line");
+        label.setWrapText(true);
+        applyLineFont(label);
+        transcriptBox.getChildren().add(label);
+        trimIfNeeded();
+    }
+
+    private void applyLineFont(Label label) {
+        if (lineFontFamily != null) {
+            label.setFont(javafx.scene.text.Font.font(lineFontFamily, lineFontSize));
+        }
+    }
+
+    private void trimIfNeeded() {
+        while (transcriptBox.getChildren().size() > MAX_ENTRIES) {
+            transcriptBox.getChildren().remove(0);
+        }
+    }
+
+    private void scheduleMarkdownRender() {
+        if (renderPause == null) {
+            renderPause = new PauseTransition(RENDER_DEBOUNCE);
+            renderPause.setOnFinished(e -> renderCurrentMarkdown());
+        }
+        renderPause.stop();
+        renderPause.playFromStart();
+    }
+
+    /** Flushes any pending debounced render synchronously and stops streaming the current message
+     *  (the next {@link #appendChunk} starts a new one). A no-op when nothing is streaming. */
+    private void finalizeCurrentMessage() {
+        if (renderPause != null) {
+            renderPause.stop();
+        }
+        if (currentAgentWrapper != null) {
+            renderCurrentMarkdown();
+            currentAgentWrapper = null;
+            currentAgentMarkdown.setLength(0);
+        }
+    }
+
+    /** Re-parses {@link #currentAgentMarkdown} and replaces {@link #currentAgentWrapper}'s content —
+     *  MUST run on the FX thread ({@link MarkdownRenderer#renderDocument} builds FX nodes). Falls back to
+     *  a plain wrapped label if rendering throws (malformed input should never break the chat). */
+    private void renderCurrentMarkdown() {
+        if (currentAgentWrapper == null) {
+            return;
+        }
+        String md = currentAgentMarkdown.toString();
+        Node rendered;
+        try {
+            rendered = MarkdownRenderer.renderDocument(MarkdownRenderer.parseToDocument(md), null);
+        } catch (RuntimeException ex) {
+            Label fallback = new Label(md);
+            fallback.setWrapText(true);
+            rendered = fallback;
+        }
+        currentAgentWrapper.getChildren().setAll(rendered);
     }
 
     /** Clears the transcript (a new session). */
     public void clearTranscript() {
-        transcript.clear();
+        transcriptBox.getChildren().clear();
+        if (renderPause != null) {
+            renderPause.stop();
+        }
+        currentAgentWrapper = null;
+        currentAgentMarkdown.setLength(0);
     }
 
-    /** Toggles the running state: Stop enabled + status while a prompt turn is in flight. */
+    /** Toggles the running state: Stop enabled + status while a prompt turn is in flight. Also finalizes
+     *  the just-completed turn's streaming message so its last chunk renders immediately rather than
+     *  waiting out the debounce after the status has already flipped back to "Idle". */
     public void setBusy(boolean busy) {
         stopButton.setDisable(!busy);
         sendButton.setDisable(busy);
         status.setText(tr(busy ? "agent.running" : "agent.idle"));
+        if (!busy) {
+            finalizeCurrentMessage();
+        }
     }
 
     /** Sets the model-picker label's text (e.g. "Model: Claude Opus"); {@code null}/blank shows a placeholder. */

--- a/src/main/resources/com/editora/styles/app.css
+++ b/src/main/resources/com/editora/styles/app.css
@@ -1770,6 +1770,17 @@
 .plan-entry-in_progress { -fx-text-fill: -color-accent-fg; -fx-font-weight: bold; }
 .plan-entry-completed { -fx-text-fill: -color-fg-muted; }
 
+/* AI Agent transcript: transparent scroll container (each rendered Markdown reply draws its own
+   -color-bg-default background via .markdown-preview) — no separate border/viewport box. */
+.agent-transcript-scroll,
+.agent-transcript-scroll > .viewport {
+    -fx-background-color: transparent;
+}
+.agent-transcript-scroll {
+    -fx-padding: 0;
+    -fx-background-insets: 0;
+}
+
 /* Green play glyph for the gutter Run marker (compact source main line) + the right-click Run item. */
 .run-marker { -fx-fill: #3fb950; }
 .fold-gutter .run-slot:hover .run-marker { -fx-fill: #56d364; }


### PR DESCRIPTION
## Summary
- The AI Agent chat transcript was a single plain `TextArea`, so a reply's raw markdown (code fences, **bold**, lists, tables) showed as literal syntax instead of being rendered.
- The transcript is now a `VBox` of entries: user-prompt / tool-activity / status lines stay plain `Label`s, but the agent's own reply streams into a per-message buffer that's rendered via the same `MarkdownRenderer` the Markdown preview uses — so code blocks, lists, tables, and even Mermaid/math in a reply render properly.
- Streaming chunks are debounced (150ms) into one re-parse+re-render rather than re-parsing on every token, and flushed synchronously whenever a line event (new prompt, tool call, turn end) finalizes the in-progress message.
- No new setting/toggle — matches the precedent set by the model/mode header + plan checklist (also unconditional display, not an optional feature).

## Test plan
- [x] `mvn compile`
- [x] `mvn spotless:apply`
- [x] `mvn test -DexcludedGroups=fx` (full pure suite; `AgentPanelGlyphTest` unaffected)
- [ ] Manual smoke test with a real `claude-code-acp` on PATH: ask the agent something that returns a code block / list / table and confirm it renders instead of showing raw markdown; confirm scrolling stays pinned to the bottom while streaming; confirm a new prompt/tool call cleanly ends the previous reply's rendering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)