### PR TITLE
LSP: disable jdtls's own workspace build (java.autobuild)

### DIFF
--- a/src/main/java/com/editora/lsp/LspManager.java
+++ b/src/main/java/com/editora/lsp/LspManager.java
@@ -240,14 +240,14 @@ public final class LspManager {
                 }
             }
             // Per-server initializationOptions:
-            //  - jdtls gets the java-debug plugin bundle (when debugging is on) so it registers the
-            //    vscode.java.* debug commands.
+            //  - jdtls gets `settings.java.autobuild.enabled=false` always, plus the java-debug plugin
+            //    bundle when debugging is on (see javaInitOptions).
             //  - gopls ships semantic tokens DISABLED and only advertises semanticTokensProvider when its
             //    `semanticTokens` option is set at initialize (confirmed: the flat key works, `ui.` doesn't);
             //    enabling it is free — gopls computes tokens only when we request them.
             Object initOptions = null;
-            if ("java".equals(serverId) && !debugBundles.isEmpty()) {
-                initOptions = Map.of("bundles", debugBundles);
+            if ("java".equals(serverId)) {
+                initOptions = javaInitOptions(debugBundles);
             } else if ("go".equals(serverId)) {
                 initOptions = Map.of("semanticTokens", true);
             }
@@ -724,6 +724,26 @@ public final class LspManager {
             }
         }
         return out;
+    }
+
+    /**
+     * jdtls's {@code initializationOptions}: {@code settings.java.autobuild.enabled=false} always, plus
+     * the java-debug plugin {@code bundles} when {@code debugBundles} is non-empty. Editora only needs
+     * jdtls for per-file diagnostics/completion/hover/nav — never its on-disk build output — but by
+     * default jdtls runs a full incremental Eclipse workspace <em>build</em> on save/change, which m2e
+     * points at the project's own configured Maven/Gradle output directory (e.g. {@code target/classes}
+     * for a Maven project — the exact same directory {@code mvn}/{@code gradle} CLI builds write to).
+     * Racing jdtls's ECJ builder against a CLI build there can leave that directory missing classes (most
+     * visibly javac's synthetic enum-switch-map inner classes, since ECJ doesn't regenerate them in
+     * lockstep) even right after a clean CLI build. Disabling autobuild stops jdtls from ever touching
+     * that directory; live per-file diagnostics still work via reconcile-on-type, which isn't gated by it.
+     * Pure + package-private so it's directly unit-tested.
+     */
+    static Map<String, Object> javaInitOptions(List<String> debugBundles) {
+        Map<String, Object> autobuildOff = Map.of("java", Map.of("autobuild", Map.of("enabled", false)));
+        return debugBundles.isEmpty()
+                ? Map.of("settings", autobuildOff)
+                : Map.of("bundles", debugBundles, "settings", autobuildOff);
     }
 
     /**

--- a/src/test/java/com/editora/lsp/LspManagerTest.java
+++ b/src/test/java/com/editora/lsp/LspManagerTest.java
@@ -1,6 +1,7 @@
 package com.editora.lsp;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 import org.eclipse.lsp4j.CompletionOptions;
@@ -15,7 +16,8 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-/** Unit tests for {@link LspManager}'s pure capability helpers (trigger chars, semantic-tokens gate). */
+/** Unit tests for {@link LspManager}'s pure capability helpers (trigger chars, semantic-tokens gate,
+ *  jdtls initializationOptions). */
 class LspManagerTest {
 
     private static SemanticTokensWithRegistrationOptions stProvider(boolean withLegend, Boolean range, Boolean full) {
@@ -100,5 +102,28 @@ class LspManagerTest {
         ServerCapabilities noLegend = new ServerCapabilities();
         noLegend.setSemanticTokensProvider(stProvider(false, true, true));
         assertNull(LspManager.semanticTokensProvider(noLegend)); // can't decode without a legend
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    void javaInitOptionsAlwaysDisablesAutobuildNoDebugBundles() {
+        Map<String, Object> opts = LspManager.javaInitOptions(List.of());
+        assertFalse(opts.containsKey("bundles"));
+        Map<String, Object> settings = (Map<String, Object>) opts.get("settings");
+        Map<String, Object> java = (Map<String, Object>) settings.get("java");
+        Map<String, Object> autobuild = (Map<String, Object>) java.get("autobuild");
+        assertEquals(Boolean.FALSE, autobuild.get("enabled"));
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    void javaInitOptionsIncludesBundlesWhenDebugging() {
+        List<String> jars = List.of("/path/to/java-debug.jar");
+        Map<String, Object> opts = LspManager.javaInitOptions(jars);
+        assertEquals(jars, opts.get("bundles"));
+        Map<String, Object> settings = (Map<String, Object>) opts.get("settings");
+        Map<String, Object> java = (Map<String, Object>) settings.get("java");
+        Map<String, Object> autobuild = (Map<String, Object>) java.get("autobuild");
+        assertEquals(Boolean.FALSE, autobuild.get("enabled")); // autobuild stays off even while debugging
     }
 }


### PR DESCRIPTION
## Summary
- Root-caused a reproducible bug: dogfooding Editora's own source (editing it inside a running Editora with the Java LSP on) crashes it later with `NoClassDefFoundError` for various synthetic classes (`KeyDispatcher$1`, `Minimap$1`, `AgentCoordinator$1`, `LspDiagnosticOverlay$1`, ...) — even immediately after `mvn clean`.
- Confirmed via a live jdtls workspace's `org.eclipse.m2e.core/workspacestate.properties`: `com.editora:editora:jar::0.9.1=/home/adl/src/adl/Editora/target/classes` — m2e (bundled in jdtls) maps the imported project's build output straight to the real Maven `target/classes`, the same directory `mvn`/CLI builds use.
- jdtls's own incremental Eclipse build (ECJ) writes into that directory in the background. ECJ doesn't regenerate things in lockstep with javac (e.g. synthetic enum-switch-map inner classes), so racing it against a CLI build — or simply having it run recently — can leave `target/classes` missing classes even right after a clean rebuild, regardless of which Maven goal you run (`javafx:run`, `-Pdist`, etc.).
- Fix: send `settings.java.autobuild.enabled=false` in jdtls's `initializationOptions` always (alongside the existing java-debug `bundles` when debugging is on). This stops jdtls from ever running its own workspace build / touching the project's output directory. Live per-file diagnostics/completion/hover still work via reconcile-on-type, which isn't gated by the workspace build.

## Test plan
- [x] `mvn compile`
- [x] `mvn spotless:apply`
- [x] `mvn test -DexcludedGroups=fx` (full pure suite, including two new `LspManagerTest` cases for `javaInitOptions`)
- [ ] Manual: edit Editora's own source inside Editora with Java LSP on for a while, then run `mvn clean javafx:run` (or `-Pdist`) and confirm no more `NoClassDefFoundError` crashes, while diagnostics/completion for the open Java file still work live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)