### PR TITLE
AI Agent: open a newly-written file as a background tab

### DIFF
--- a/src/main/java/com/editora/ui/AgentCoordinator.java
+++ b/src/main/java/com/editora/ui/AgentCoordinator.java
@@ -58,6 +58,11 @@ final class AgentCoordinator implements AcpClient.Host {
         /** Refreshes the Project tree after the agent wrote a file the editor doesn't have open. */
         void refreshProjectTree();
 
+        /** Opens {@code target} as a new, unfocused background tab (creating the {@link EditorBuffer} and
+         *  loading its just-written content) — so a brand-new file the agent created is immediately
+         *  visible, without stealing focus from the chat. FX-thread only. */
+        EditorBuffer openBackgroundBuffer(Path target);
+
         /** Records a prompt in {@code sessionId} in the persisted resume history (title set once from
          *  {@code candidateLabel}; position/timestamp bumped on every call). FX-thread only. */
         void rememberSession(String sessionId, String cwd, String candidateLabel, long updatedAt);
@@ -567,7 +572,13 @@ final class AgentCoordinator implements AcpClient.Host {
             Files.createDirectories(file.getParent());
         }
         Files.writeString(file, body);
-        Platform.runLater(ops::refreshProjectTree);
+        // No open buffer matched this path (a brand-new file, or an unsaved/untitled buffer the agent
+        // couldn't have targeted since it has no path yet) — open it as a background tab so the user
+        // actually sees what the agent wrote, instead of it only landing on disk with no visible tab.
+        Platform.runLater(() -> {
+            ops.refreshProjectTree();
+            ops.openBackgroundBuffer(file);
+        });
     }
 
     @Override

--- a/src/main/java/com/editora/ui/MainController.java
+++ b/src/main/java/com/editora/ui/MainController.java
@@ -2510,15 +2510,7 @@ public class MainController implements com.editora.mcp.McpBridge {
 
                 @Override
                 public EditorBuffer openBackgroundBuffer(Path target) {
-                    try {
-                        EditorBuffer buffer = new EditorBuffer();
-                        buffer.setPath(target);
-                        loadInto(buffer, target);
-                        addBuffer(buffer, false); // background: keep the diff tab focused
-                        return buffer;
-                    } catch (IOException e) {
-                        return null;
-                    }
+                    return MainController.this.openBackgroundBuffer(target);
                 }
 
                 @Override
@@ -2956,6 +2948,11 @@ public class MainController implements com.editora.mcp.McpBridge {
         @Override
         public void refreshProjectTree() {
             projectPanel.refreshTree();
+        }
+
+        @Override
+        public EditorBuffer openBackgroundBuffer(Path target) {
+            return MainController.this.openBackgroundBuffer(target);
         }
 
         @Override
@@ -3640,6 +3637,21 @@ public class MainController implements com.editora.mcp.McpBridge {
             }
         }
         return null;
+    }
+
+    /** Opens {@code target} (assumed not already open — callers check {@link #openBufferFor} first) as a
+     *  new, unfocused background tab. Used when something other than the user opens a file the editor
+     *  doesn't have a tab for yet (a diff's compare-with-local target, an AI agent's newly-written file). */
+    private EditorBuffer openBackgroundBuffer(Path target) {
+        try {
+            EditorBuffer buffer = new EditorBuffer();
+            buffer.setPath(target);
+            loadInto(buffer, target);
+            addBuffer(buffer, false); // background: keep the caller's current tab focused
+            return buffer;
+        } catch (IOException e) {
+            return null;
+        }
     }
 
     /** Toggles the IntelliJ-style branch dropdown, fetching local + remote branches off-thread first. */


### PR DESCRIPTION
## Summary
- Reported symptom: asked the AI Agent chat to write a Python script; it correctly wrote the file to disk, but no tab in Editora showed it — the currently-open tab (an untitled/unsaved buffer created from a template, displaying a name like `script.py` but with no real path yet) stayed showing its old stub content.
- Root cause: the agent's `fs/write_text_file` target didn't match any *open* buffer's path (an untitled buffer has `getPath() == null`, so it can never match — the agent has no way to "fill in" an unsaved buffer, since its own tools only operate on file paths, and the context header gives it just the display name, not "this file has no path yet"). So the write correctly took the direct-disk-write branch — but nothing then surfaced the new file as a tab.
- Fix: `AgentCoordinator.writeTextFile`'s direct-disk-write branch now also opens the freshly-written file as a new, unfocused background tab (same pattern `DiffCoordinator`'s compare-with-local flow already used — extracted into a shared `MainController.openBackgroundBuffer` so both reuse it). Doesn't steal focus from the chat, mirroring how editing an *already-open* buffer only marks it dirty rather than jumping to it.

## Test plan
- [x] `mvn compile`
- [x] `mvn spotless:apply`
- [x] `mvn test -DexcludedGroups=fx` (full pure suite)
- [ ] Manual: with an untitled/template-stub buffer open, ask the AI Agent to write a new file with no explicit path — confirm the newly-written file now opens as a background tab (visible without switching away from the chat), and that a *second* prompt writing to that same path now goes through the undoable in-buffer edit path instead of creating another tab.

🤖 Generated with [Claude Code](https://claude.com/claude-code)