### PR TITLE
Fix buffer-gated tool windows staying open on restore when unavailable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **CSV grid preview could stay open on a non-CSV file after a restart.** If the CSV/TSV grid tool
+  window was left open in the previous session, it was force-reopened at startup (session restore) before
+  the first real buffer loaded — at that point every buffer-gated tool window is provisionally marked
+  "unavailable", so the reopened window's tracked availability and its actual open state diverged. The
+  very next gating pass (on the restored tab) saw the tracked flag as already matching and skipped
+  closing it, leaving the grid visibly open over a file that wasn't CSV until some other state change
+  happened to flip it. `ToolWindowManager.setAvailable` now always reconciles the actual open/closed +
+  stripe-button state instead of short-circuiting when its tracked flag already matches, so it self-heals
+  regardless of how it got out of sync (mirrors the same gating used by the Commit/Markdown-Lint/TODO
+  windows).
+
 ## [0.9.1] - 2026-07-06
 
 First tagged release. (`v0.9.0` was cut and pushed first, but a JReleaser misconfiguration published it

--- a/src/main/java/com/editora/ui/ToolWindowManager.java
+++ b/src/main/java/com/editora/ui/ToolWindowManager.java
@@ -279,13 +279,15 @@ public class ToolWindowManager {
      * Context-driven availability (NOT persisted, unlike {@link #setVisible}): hides the tool window's
      * stripe button + closes it when {@code available} is false, restoring it (subject to the user's
      * {@link #isVisible} preference) when true. Used to hide the Commit window outside a Git repo without
-     * disturbing the user's show/hide setting.
+     * disturbing the user's show/hide setting. Always reconciles the actual open/closed + button state to
+     * match {@code available} — it does NOT short-circuit when the tracked flag already matches, because
+     * {@link #open}/{@link #restore} can force a window open while it's still marked unavailable (a
+     * previously-open tool window is restored at startup before the first real buffer loads, when every
+     * buffer-gated window is provisionally unavailable): without reconciling every call, that divergence
+     * between "tracked unavailable" and "actually open" would make the very next {@code setAvailable(tw,
+     * false)} look like a no-op and skip the {@link #close} it should perform.
      */
     public void setAvailable(ToolWindow tw, boolean available) {
-        boolean wasAvailable = !unavailable.contains(tw);
-        if (available == wasAvailable) {
-            return;
-        }
         if (available) {
             unavailable.remove(tw);
         } else {


### PR DESCRIPTION
## Summary
- Reported symptom: the CSV/TSV grid preview tool window stayed open once, after switching to a non-CSV file — but only once, not consistently.
- Root cause is in `ToolWindowManager`, shared by every buffer-gated tool window (CSV grid, Markdown Lint, TODO, Commit, ...), not CSV-specific:
  1. `setupToolWindows()` runs `updateBufferToolWindows()` before any buffer loads, marking every buffer-gated window "unavailable" — correct at that moment, there's no buffer yet.
  2. `toolWindows.restore()` runs right after and force-reopens whatever tool window was left open in the previous session, via `open()`/`openById()` — which never consults the `unavailable` set. So a previously-open window gets reopened even though step 1 just marked it unavailable, leaving its tracked flag and its actual open state diverged.
  3. Once the real active buffer loads and `updateBufferToolWindows()` recomputes availability, `setAvailable(tw, false)` short-circuited on "the tracked flag already says unavailable" and skipped the `close()` it should have performed — because the divergence from step 2 made it look like nothing had changed.
- Fix: `ToolWindowManager.setAvailable()` no longer short-circuits on the tracked flag; it always reconciles the actual open/closed + stripe-button state to match the requested availability, so it self-heals regardless of how the state got out of sync. `close()`/`addButtonOrdered()` are already internally guarded against redundant no-op calls, so this is safe to call unconditionally — the only added cost is `updateStripeVisibility()`'s three cheap boolean checks, negligible next to a tab switch.

## Test plan
- [x] `./mvnw -o -B clean verify` (full suite incl. the FX-harness tool-window/chrome tests, Spotless + JaCoCo) — green, no regressions from removing the short-circuit.
- [ ] Manual: leave the CSV grid open on a `.csv` file, quit, relaunch with a non-CSV file active — confirm it no longer stays open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)