### PR TITLE
Make Markdown preview links clickable (opens system browser)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Clickable links in the Markdown preview.** A rendered link now shows a hand cursor and opens in the
+  system default browser on click (the same `Consumer<String>` already used by Ctrl/Cmd-click-in-source
+  and the Welcome page's links), rather than being inert. `MarkdownRenderer.renderDocument` gained an
+  overload taking an optional click handler; the print/PDF writers and the hover/completion-doc popups
+  keep using the existing no-handler path, so only the interactive live preview is affected.
+
 ### Fixed
 
 - **CSV grid preview could stay open on a non-CSV file after a restart.** If the CSV/TSV grid tool

--- a/README.md
+++ b/README.md
@@ -182,7 +182,8 @@ Editora is built with the help of AI coding tools.
   strikethrough, autolinks, plus **YAML front matter**, **footnotes**, **heading anchors**, and
   **`++inserted++`** text) with **GitHub-style** output — task-list checkboxes, inline-code pills,
   underlined h1/h2, and **images** (local and remote). Live-updating and theme-matched; the mode is
-  remembered per file. In Split mode the editor and preview scroll together (the pane under the mouse
+  remembered per file. **Links are clickable** — a hand cursor + click opens the destination in the
+  system default browser. In Split mode the editor and preview scroll together (the pane under the mouse
   drives the other). Zoom the preview text with its `−`/`+` control or, in Preview mode,
   **Ctrl + mouse wheel**. The **Structure** tool window shows the document's heading outline.
 - **Markdown authoring** — **paste or drag-drop images** into a saved Markdown file (saved into a sibling

--- a/TODO.md
+++ b/TODO.md
@@ -3,6 +3,11 @@
 A backlog of planned features and improvements. Unordered within each section.
 
 ## Recently shipped
+- [x] Clickable links in the Markdown preview — a rendered link shows a hand cursor and opens in the
+      system default browser on click (previously inert). `MarkdownRenderer.renderDocument` gained an
+      overload taking an optional click handler, threaded through the block/inline render chain
+      alongside `baseDir`; only the live interactive preview wires one — print/PDF and the
+      hover/completion-doc popups keep the no-handler path.
 - [x] Auto Close Tags (VS Code parity) — typing the `>` completing an HTML/XML open tag inserts
       `</name>` after the caret. Pure/unit-tested `editops/TagAutoClose` (one forward pass over a
       bounded pre-caret window; quote state tracked only inside tags so apostrophes in text and

--- a/src/main/java/com/editora/editor/EditorBuffer.java
+++ b/src/main/java/com/editora/editor/EditorBuffer.java
@@ -3463,7 +3463,7 @@ public class EditorBuffer implements TabContent {
                     return; // a newer render superseded this one
                 }
                 double v = previewPane().getVvalue();
-                previewPane().setContent(MarkdownRenderer.renderDocument(ast, baseDir));
+                previewPane().setContent(MarkdownRenderer.renderDocument(ast, baseDir, openUrlHandler));
                 applyPreviewScale(); // keep the current zoom on the freshly rendered content
                 Platform.runLater(() -> previewPane().setVvalue(v)); // best-effort scroll preserve
             });

--- a/src/main/java/com/editora/editor/MarkdownRenderer.java
+++ b/src/main/java/com/editora/editor/MarkdownRenderer.java
@@ -119,12 +119,24 @@ public final class MarkdownRenderer {
 
     /** Builds a JavaFX node tree from a parsed AST. MUST run on the FX thread (creates Text/ImageView). */
     public static Node renderDocument(org.commonmark.node.Node ast, Path baseDir) {
+        return renderDocument(ast, baseDir, null);
+    }
+
+    /**
+     * Overload that also wires links to a click handler — invoked with the link's raw destination
+     * (as written in the Markdown; never resolved/normalized) when a rendered link is clicked. Used by the
+     * live, interactive preview so a link opens in the system browser; pass {@code null} for
+     * non-interactive renders (print/PDF don't build this JavaFX tree at all, and the hover/completion-doc
+     * popups pass null since they're ephemeral display surfaces, not meant to be clicked through).
+     */
+    public static Node renderDocument(
+            org.commonmark.node.Node ast, Path baseDir, java.util.function.Consumer<String> onLinkClick) {
         VBox content = new VBox();
         content.getStyleClass().add("markdown-preview");
         // Cap the readable column width so long lines don't stretch across a wide window (GitHub-style).
         content.setMaxWidth(MAX_CONTENT_WIDTH);
         if (ast != null) {
-            appendBlocks(ast, content, baseDir);
+            appendBlocks(ast, content, new RenderContext(baseDir, onLinkClick));
         }
         // Center the capped-width column within the (fit-to-width) preview pane. A StackPane clamps the
         // content to the available width when the viewport is narrower than the cap, so it never overflows.
@@ -134,20 +146,25 @@ public final class MarkdownRenderer {
         return wrap;
     }
 
+    /** Threaded through every block/inline renderer alongside {@code baseDir} (for image resolution) so a
+     *  link's click handler reaches the {@code Link} node without a parameter per call — the pure-{@code
+     *  baseDir} idiom this file already used, extended to carry one more per-render input. */
+    private record RenderContext(Path baseDir, java.util.function.Consumer<String> onLinkClick) {}
+
     // --- block level ---------------------------------------------------------------------------
 
-    private static void appendBlocks(org.commonmark.node.Node parent, Pane container, Path baseDir) {
+    private static void appendBlocks(org.commonmark.node.Node parent, Pane container, RenderContext ctx) {
         for (org.commonmark.node.Node n = parent.getFirstChild(); n != null; n = n.getNext()) {
-            Node fx = renderBlock(n, baseDir);
+            Node fx = renderBlock(n, ctx);
             if (fx != null) {
                 container.getChildren().add(fx);
             }
         }
     }
 
-    private static Node renderBlock(org.commonmark.node.Node node, Path baseDir) {
+    private static Node renderBlock(org.commonmark.node.Node node, RenderContext ctx) {
         if (node instanceof Heading h) {
-            TextFlow tf = inlineFlow(h, baseDir);
+            TextFlow tf = inlineFlow(h, ctx);
             tf.getStyleClass().add("md-h" + Math.min(6, Math.max(1, h.getLevel())));
             return tf;
         }
@@ -163,24 +180,24 @@ public final class MarkdownRenderer {
             }
             // A paragraph that is just an image renders as a block image (not squeezed into a TextFlow).
             if (p.getFirstChild() instanceof org.commonmark.node.Image img && img.getNext() == null) {
-                return imageNode(img, baseDir);
+                return imageNode(img, ctx.baseDir());
             }
-            TextFlow tf = inlineFlow(p, baseDir);
+            TextFlow tf = inlineFlow(p, ctx);
             tf.getStyleClass().add("md-paragraph");
             return tf;
         }
         if (node instanceof BlockQuote) {
             VBox box = new VBox();
             box.getStyleClass().add("md-quote");
-            appendBlocks(node, box, baseDir);
+            appendBlocks(node, box, ctx);
             return box;
         }
         if (node instanceof BulletList bl) {
-            return renderList(bl, baseDir, false, 1);
+            return renderList(bl, ctx, false, 1);
         }
         if (node instanceof OrderedList ol) {
             Integer start = ol.getMarkerStartNumber();
-            return renderList(ol, baseDir, true, start == null ? 1 : start);
+            return renderList(ol, ctx, true, start == null ? 1 : start);
         }
         if (node instanceof FencedCodeBlock f) {
             if (isMermaidInfo(f.getInfo()) && MermaidImages.isEnabled()) {
@@ -204,17 +221,17 @@ public final class MarkdownRenderer {
             return codeBlock(hb.getLiteral()); // other raw HTML shown as text (no interpretation)
         }
         if (node instanceof TableBlock tb) {
-            return renderTable(tb, baseDir);
+            return renderTable(tb, ctx);
         }
         if (node instanceof YamlFrontMatterBlock fm) {
             return frontMatterBlock(fm);
         }
         if (node instanceof FootnoteDefinition def) {
-            return footnoteDefinition(def, baseDir);
+            return footnoteDefinition(def, ctx);
         }
         // Unknown block container: render its children.
         VBox box = new VBox();
-        appendBlocks(node, box, baseDir);
+        appendBlocks(node, box, ctx);
         return box.getChildren().isEmpty() ? null : box;
     }
 
@@ -223,7 +240,7 @@ public final class MarkdownRenderer {
         return literal != null && literal.strip().startsWith("<!--");
     }
 
-    private static Node renderList(org.commonmark.node.Node list, Path baseDir, boolean ordered, int start) {
+    private static Node renderList(org.commonmark.node.Node list, RenderContext ctx, boolean ordered, int start) {
         VBox box = new VBox();
         box.getStyleClass().add("md-list");
         int n = start;
@@ -249,7 +266,7 @@ public final class MarkdownRenderer {
             VBox content = new VBox();
             content.getStyleClass().add("md-list-content");
             HBox.setHgrow(content, Priority.ALWAYS);
-            appendBlocks(item, content, baseDir);
+            appendBlocks(item, content, ctx);
             row.getChildren().addAll(marker, content);
             box.getChildren().add(row);
             n++;
@@ -263,7 +280,7 @@ public final class MarkdownRenderer {
 
     private static final int MAX_COL_WEIGHT = 40;
 
-    private static Node renderTable(TableBlock tb, Path baseDir) {
+    private static Node renderTable(TableBlock tb, RenderContext ctx) {
         GridPane grid = new GridPane();
         grid.getStyleClass().add("md-table");
         // Fill the preview column so the percent-based ColumnConstraints below have a definite width to
@@ -283,7 +300,7 @@ public final class MarkdownRenderer {
                     if (!(c instanceof TableCell cell)) {
                         continue;
                     }
-                    TextFlow tf = inlineFlow(cell, baseDir);
+                    TextFlow tf = inlineFlow(cell, ctx);
                     tf.getStyleClass().add(header ? "md-table-header" : "md-table-cell");
                     tf.setMaxWidth(Double.MAX_VALUE);
                     if (cell.getAlignment() == TableCell.Alignment.CENTER) {
@@ -481,7 +498,7 @@ public final class MarkdownRenderer {
     }
 
     /** A footnote definition: its label marker followed by the definition's block content. */
-    private static Node footnoteDefinition(FootnoteDefinition def, Path baseDir) {
+    private static Node footnoteDefinition(FootnoteDefinition def, RenderContext ctx) {
         HBox row = new HBox();
         row.getStyleClass().add("md-footnote-def");
         Label marker = new Label("[" + def.getLabel() + "]");
@@ -489,7 +506,7 @@ public final class MarkdownRenderer {
         VBox content = new VBox();
         content.getStyleClass().add("md-footnote-def-content");
         HBox.setHgrow(content, Priority.ALWAYS);
-        appendBlocks(def, content, baseDir);
+        appendBlocks(def, content, ctx);
         row.getChildren().addAll(marker, content);
         return row;
     }
@@ -512,20 +529,20 @@ public final class MarkdownRenderer {
 
     // --- inline level --------------------------------------------------------------------------
 
-    private static TextFlow inlineFlow(org.commonmark.node.Node block, Path baseDir) {
+    private static TextFlow inlineFlow(org.commonmark.node.Node block, RenderContext ctx) {
         TextFlow flow = new TextFlow();
-        appendInline(block, flow, List.of(), baseDir);
+        appendInline(block, flow, List.of(), ctx);
         return flow;
     }
 
     private static void appendInline(
-            org.commonmark.node.Node parent, TextFlow flow, List<String> styles, Path baseDir) {
+            org.commonmark.node.Node parent, TextFlow flow, List<String> styles, RenderContext ctx) {
         for (org.commonmark.node.Node n = parent.getFirstChild(); n != null; n = n.getNext()) {
-            emitInline(n, flow, styles, baseDir);
+            emitInline(n, flow, styles, ctx);
         }
     }
 
-    private static void emitInline(org.commonmark.node.Node n, TextFlow flow, List<String> styles, Path baseDir) {
+    private static void emitInline(org.commonmark.node.Node n, TextFlow flow, List<String> styles, RenderContext ctx) {
         if (n instanceof org.commonmark.node.Text t) {
             if (MathImages.isEnabled()) {
                 appendTextWithMath(t.getLiteral(), flow, styles);
@@ -535,23 +552,24 @@ public final class MarkdownRenderer {
         } else if (n instanceof Code c) {
             flow.getChildren().add(inlineCode(c.getLiteral()));
         } else if (n instanceof Emphasis) {
-            appendInline(n, flow, with(styles, "md-italic"), baseDir);
+            appendInline(n, flow, with(styles, "md-italic"), ctx);
         } else if (n instanceof StrongEmphasis) {
-            appendInline(n, flow, with(styles, "md-bold"), baseDir);
+            appendInline(n, flow, with(styles, "md-bold"), ctx);
         } else if (n instanceof Strikethrough) {
-            appendInline(n, flow, with(styles, "md-strike"), baseDir);
+            appendInline(n, flow, with(styles, "md-strike"), ctx);
         } else if (n instanceof Ins) {
-            appendInline(n, flow, with(styles, "md-ins"), baseDir);
+            appendInline(n, flow, with(styles, "md-ins"), ctx);
         } else if (n instanceof FootnoteReference ref) {
             flow.getChildren().add(footnoteRef(ref.getLabel()));
         } else if (n instanceof InlineFootnote) {
-            appendInline(n, flow, with(styles, "md-footnote-ref"), baseDir);
+            appendInline(n, flow, with(styles, "md-footnote-ref"), ctx);
         } else if (n instanceof Link link) {
             int from = flow.getChildren().size();
-            appendInline(n, flow, with(styles, "md-link"), baseDir);
+            appendInline(n, flow, with(styles, "md-link"), ctx);
             installLinkTooltip(flow, from, link.getDestination());
+            installLinkClick(flow, from, link.getDestination(), ctx.onLinkClick());
         } else if (n instanceof org.commonmark.node.Image img) {
-            flow.getChildren().add(imageNode(img, baseDir));
+            flow.getChildren().add(imageNode(img, ctx.baseDir()));
         } else if (n instanceof SoftLineBreak) {
             flow.getChildren().add(new Text(" "));
         } else if (n instanceof HardLineBreak) {
@@ -563,7 +581,7 @@ public final class MarkdownRenderer {
         } else if (n instanceof TaskListItemMarker) {
             // rendered as a CheckBox by renderList — skip here
         } else {
-            appendInline(n, flow, styles, baseDir); // unknown inline: descend
+            appendInline(n, flow, styles, ctx); // unknown inline: descend
         }
     }
 
@@ -633,6 +651,21 @@ public final class MarkdownRenderer {
         Tooltip tip = new Tooltip(dest);
         for (int i = from; i < flow.getChildren().size(); i++) {
             Tooltip.install(flow.getChildren().get(i), tip);
+        }
+    }
+
+    /** Wires a rendered link's run of nodes to {@code onLinkClick} (hand cursor + click → the link's raw
+     *  destination, unresolved — matching the existing Ctrl/Cmd-click-in-source behavior). No-op when
+     *  there's no handler (print/PDF/popups) or the link has no destination. */
+    private static void installLinkClick(
+            TextFlow flow, int from, String dest, java.util.function.Consumer<String> onLinkClick) {
+        if (onLinkClick == null || dest == null || dest.isBlank()) {
+            return;
+        }
+        for (int i = from; i < flow.getChildren().size(); i++) {
+            Node child = flow.getChildren().get(i);
+            child.setCursor(javafx.scene.Cursor.HAND);
+            child.setOnMouseClicked(e -> onLinkClick.accept(dest));
         }
     }
 

--- a/src/test/java/com/editora/ui/MarkdownRendererFxTest.java
+++ b/src/test/java/com/editora/ui/MarkdownRendererFxTest.java
@@ -3,9 +3,11 @@ package com.editora.ui;
 import java.util.ArrayList;
 import java.util.List;
 
+import javafx.scene.Cursor;
 import javafx.scene.Node;
 import javafx.scene.Parent;
 import javafx.scene.control.Label;
+import javafx.scene.text.Text;
 import javafx.scene.text.TextFlow;
 
 import com.editora.editor.MarkdownRenderer;
@@ -14,7 +16,9 @@ import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
@@ -75,5 +79,30 @@ class MarkdownRendererFxTest {
                 .anyMatch(f -> f.getStyleClass().contains("md-code-block"));
         assertTrue(plainLabel, "no language ⇒ plain Label code block");
         assertFalse(highlightedFlow, "no language ⇒ not a highlighted TextFlow");
+    }
+
+    @Test
+    void linkGetsClickHandlerAndHandCursorWhenWired() throws Exception {
+        List<String> clicked = new ArrayList<>();
+        Node root = FxTestSupport.callOnFx(() -> MarkdownRenderer.renderDocument(
+                MarkdownRenderer.parseToDocument("[example](https://example.com)"), null, clicked::add));
+        Text link = collect(root, Text.class).stream()
+                .filter(t -> t.getStyleClass().contains("md-link"))
+                .findFirst()
+                .orElseThrow();
+        assertEquals(Cursor.HAND, link.getCursor(), "a clickable link shows the hand cursor");
+        link.getOnMouseClicked().handle(null); // the handler ignores its event arg
+        assertEquals(List.of("https://example.com"), clicked, "click fires with the link's raw destination");
+    }
+
+    @Test
+    void linkHasNoClickHandlerWithoutOneWired() throws Exception {
+        // Non-interactive renders (print/PDF/popups) pass no handler — links must stay inert.
+        Node root = render("[example](https://example.com)");
+        Text link = collect(root, Text.class).stream()
+                .filter(t -> t.getStyleClass().contains("md-link"))
+                .findFirst()
+                .orElseThrow();
+        assertNull(link.getOnMouseClicked(), "no handler wired ⇒ link isn't clickable");
     }
 }


### PR DESCRIPTION
## Summary
- Rendered links in the live Markdown preview were inert — no cursor change, no click handler — while Ctrl/Cmd-click already opened a link from the raw source, and the Welcome page's links already worked.
- `MarkdownRenderer.renderDocument` gained an overload taking an optional `Consumer<String> onLinkClick`, threaded through the block/inline render chain via a small private `RenderContext(baseDir, onLinkClick)` record — the same idiom `baseDir` already used for image resolution, extended to carry one more per-render input.
- A link's rendered `Text` runs get a hand cursor + an `onMouseClicked` firing the link's raw destination (unresolved, matching the existing Ctrl/Cmd-click-in-source behavior).
- Only `EditorBuffer`'s live preview wires a handler, reusing the existing `openUrlHandler` field already used for Ctrl/Cmd-click — no new `MainController` wiring needed. The five other `renderDocument` call sites (print/PDF-adjacent paths, note-body tooltip, completion-doc popup, Agent chat, LSP hover) are unaffected: they call the pre-existing 2-arg overload, which now just delegates with a `null` handler, so links stay inert there as before (correct — those are non-interactive/ephemeral surfaces).

## Test plan
- [x] New FX-harness tests in `MarkdownRendererFxTest`: a link gets the hand cursor + fires the click handler with its raw destination when one is wired; stays inert (no handler at all) when none is passed.
- [x] `./mvnw -o -B clean verify` (full suite, Spotless + JaCoCo) — green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)