### PR TITLE
AI Agent header: icon-only History/New Session/Stop buttons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **AI Agent header buttons (History / New Session / Stop) took up too much width.** They're now
+  icon-only (matching the Debug panel's icon-only toolbar buttons), with the translated label moved to
+  a tooltip instead of being lost — hover to see what each does.
+
 - **CSV grid preview could stay open on a non-CSV file after a restart.** If the CSV/TSV grid tool
   window was left open in the previous session, it was force-reopened at startup (session restore) before
   the first real buffer loaded — at that point every buffer-gated tool window is provisionally marked

--- a/src/main/java/com/editora/ui/AgentPanel.java
+++ b/src/main/java/com/editora/ui/AgentPanel.java
@@ -105,13 +105,10 @@ public final class AgentPanel extends VBox implements ToolWindowContent {
         modelLabel.setOnMouseClicked(e -> onPickModel.run());
         modeLabel.getStyleClass().add("agent-header-label");
         modeLabel.setOnMouseClicked(e -> onPickMode.run());
-        stopButton.setText(tr("agent.stop"));
+        iconButton(historyButton, Icons.history(), "agent.history", onResumeSession);
+        iconButton(newSessionButton, Icons.newFile(), "agent.newSession", onNewSession);
+        iconButton(stopButton, Icons.debugStop(), "agent.stop", onStop);
         stopButton.setDisable(true);
-        stopButton.setOnAction(e -> onStop.run());
-        historyButton.setText(tr("agent.history"));
-        historyButton.setOnAction(e -> onResumeSession.run());
-        newSessionButton.setText(tr("agent.newSession"));
-        newSessionButton.setOnAction(e -> onNewSession.run());
         HBox header = new HBox(
                 8, status, agentLabel, modelLabel, modeLabel, spacer(), historyButton, newSessionButton, stopButton);
         header.setAlignment(Pos.CENTER_LEFT);
@@ -362,5 +359,15 @@ public final class AgentPanel extends VBox implements ToolWindowContent {
         Region r = new Region();
         HBox.setHgrow(r, Priority.ALWAYS);
         return r;
+    }
+
+    /** Icon-only header button (mirrors {@code DebugPanel.btn}): the {@code key}'s translated string
+     *  becomes the tooltip instead of the button's (now absent) text, keeping the header compact. */
+    private static void iconButton(Button b, Node icon, String key, Runnable action) {
+        b.setGraphic(icon);
+        b.setTooltip(new Tooltip(tr(key)));
+        b.getStyleClass().addAll("flat", "agent-toolbar-button");
+        b.setFocusTraversable(false);
+        b.setOnAction(e -> action.run());
     }
 }

--- a/src/main/resources/com/editora/styles/app.css
+++ b/src/main/resources/com/editora/styles/app.css
@@ -1770,6 +1770,9 @@
     -fx-background-color: -color-bg-inset;
     -fx-cursor: hand;
 }
+/* History / New Session / Stop are icon-only (see AgentPanel.iconButton) — narrow padding keeps the
+   header compact, matching the Debug panel's icon-only toolbar buttons. */
+.agent-panel .agent-toolbar-button { -fx-padding: 3 6 3 6; }
 
 /* AI Agent plan checklist rows — muted by default; completed dims further, in-progress reads as active. */
 .plan-entry-pending { -fx-text-fill: -color-fg-default; }


### PR DESCRIPTION
## Summary
- The AI Agent panel's header buttons (History / New Session / Stop) were text-labeled, making the header too wide.
- Converted to icon-only buttons — `Icons.history()` / `Icons.newFile()` / `Icons.debugStop()` — mirroring the Debug panel's existing icon-only toolbar (`DebugPanel.btn`), with the previous translated label moved to a `Tooltip` instead of being lost.
- New `.agent-toolbar-button` CSS rule (narrow padding, matching `.debug-toolbar-button`).

## Test plan
- [x] `./mvnw -o -B clean verify` (full suite, Spotless + JaCoCo) — green.
- [ ] Manual: open the AI Agent tool window and confirm the header is narrower, with each icon showing its label as a tooltip on hover.

🤖 Generated with [Claude Code](https://claude.com/claude-code)