### PR TITLE
Make the gutter Run play glyph 20% bigger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   finishes. `EditorBuffer` gained a centered spinner + message overlay (`setPreviewLoading`), shown from
   just before the request starts until it ends (success or error).
 
+### Changed
+
+- **The gutter Run play glyph is 20% bigger** (scale 1.014 → 1.217), making the clickable green run
+  target easier to see and click.
+
 ### Fixed
 
 - **AI Agent header buttons (History / New Session / Stop) took up too much width.** They're now

--- a/src/main/java/com/editora/editor/FoldManager.java
+++ b/src/main/java/com/editora/editor/FoldManager.java
@@ -786,8 +786,8 @@ public final class FoldManager {
         SVGPath svg = new SVGPath();
         svg.setContent(RUN_GLYPH_PATH);
         svg.getStyleClass().add("run-marker");
-        svg.setScaleX(1.014); // 30% larger than before (0.78) so the Run target is easier to click; still fits the slot
-        svg.setScaleY(1.014);
+        svg.setScaleX(1.217); // 20% bigger than before (1.014) so the Run target is easier to click
+        svg.setScaleY(1.217);
         return new Group(svg);
     }
 


### PR DESCRIPTION
## Summary
- Bumps the gutter Run play-triangle glyph's scale from `1.014` to `1.217` — a 20% increase — so the clickable green run marker is bigger and easier to click.
- Adds a CHANGELOG entry.

## Test plan
- [x] `./mvnw -o -q spotless:apply` — clean
- [x] `./mvnw -o -B clean verify` — all tests pass, coverage checks pass, spotless check clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)