### PR TITLE
Bump release version to 0.9.2 (Windows hotfix)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.2] - 2026-07-08
+
 ### Added
 
 - **Maven support — a toolbar icon + actions popup that reads the active project's pom.xml, IntelliJ-style.**
@@ -59,6 +61,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   target easier to see and click.
 
 ### Fixed
+
+- **Windows installs failed to launch: "Failed to find JVM in ...\runtime directory".** The AOT-cache
+  build step (`scripts/aot_build.java`) strips the bundled runtime's `bin/` after training to reclaim
+  footprint — safe on macOS/Linux, where the JVM shared library lives in `runtime/lib/server/` and `bin/`
+  holds only launcher executables. But the Windows JDK layout puts the JVM itself *inside* `bin/`
+  (`runtime\bin\server\jvm.dll` plus the bootstrap `jli.dll`/`java.dll`/`jvm.cfg`), which `Editora.exe`
+  loads from there — so deleting `bin/` removed the JVM, and every Windows install since the AOT cache
+  landed failed to start. The `bin/` strip is now guarded to non-Windows only; the Windows `bin/` is kept
+  intact (its launcher exes are a negligible footprint).
 
 - **AI Agent header buttons (History / New Session / Stop) took up too much width.** They're now
   icon-only (matching the Debug panel's icon-only toolbar buttons), with the translated label moved to

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.editora</groupId>
     <artifactId>editora</artifactId>
-    <version>0.9.1</version>
+    <version>0.9.2</version>
     <packaging>jar</packaging>
 
     <name>Editora</name>

--- a/src/main/java/com/editora/AppInfo.java
+++ b/src/main/java/com/editora/AppInfo.java
@@ -11,7 +11,7 @@ import java.util.Properties;
 public final class AppInfo {
 
     public static final String NAME = "Editora";
-    public static final String VERSION = "0.9.1";
+    public static final String VERSION = "0.9.2";
     /** Project home page (the website's custom domain). */
     public static final String HOMEPAGE = "https://editora-project.dev";
     /** Copyright notice (matches the bundled {@code LICENSE} file). */


### PR DESCRIPTION
Cuts **0.9.2**, primarily to ship the Windows launch hotfix from #350.

`0.9.1` shipped a **broken Windows installer** — `Editora.exe` failed with *"Failed to find JVM in …\runtime directory"* because the AOT-cache build strips the runtime's `bin/`, which on Windows holds `jvm.dll` + the bootstrap DLLs. #350 fixed that (guarded the strip to non-Windows). This release also carries the Maven support (#349) and AI-settings (#347) work merged since 0.9.1.

## Changes

- `pom.xml`: `0.9.1` → `0.9.2`
- `AppInfo.VERSION`: `0.9.1` → `0.9.2`
- `CHANGELOG.md`: moved `[Unreleased]` under `## [0.9.2]` and added the Windows-JVM fix to *Fixed*.

## Release steps (after merge)

1. Merge this PR to `master`.
2. Tag the merge commit `v0.9.2` and push → triggers `release.yml` (5-platform matrix + JReleaser).
3. ⚠️ **Verify the Windows MSI actually launches** before announcing — the hotfix has not been device-tested (jpackage is host-specific; only the Windows runner build exercises it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)