### PR TITLE
Light syntax highlighting on AI chat tool lines + Send/Stop toggle

### DIFF
--- a/src/main/java/com/editora/ui/AgentCommandHighlighter.java
+++ b/src/main/java/com/editora/ui/AgentCommandHighlighter.java
@@ -1,0 +1,94 @@
+package com.editora.ui;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Light shell-command tokenizer for the AI Agent chat's tool-call lines (the {@code ⚙ …} rows). Splits a
+ * command string into colored {@link Span}s reusing the editor's {@code .text.<class>} token classes, so
+ * the coloring tracks the active editor theme with no dedicated CSS. Deliberately "light": it colors the
+ * leading command word, option flags, quoted strings, shell operators, {@code $variables}, and trailing
+ * {@code #comments}, leaving plain arguments/paths in the default foreground.
+ *
+ * <p>Pure + directly unit-tested (the {@link AgentPanel#glyphFor} idiom); {@link AgentPanel} turns each
+ * span into a styled JavaFX {@code Text} run.
+ */
+final class AgentCommandHighlighter {
+
+    private AgentCommandHighlighter() {}
+
+    /** A run of text and the token style class to pair with {@code text} ({@code null} = default foreground,
+     *  no {@code .text} class). */
+    record Span(String text, String styleClass) {}
+
+    /** Tokenizes {@code command} into ordered spans whose concatenated {@link Span#text} equals the input. */
+    static List<Span> spans(String command) {
+        List<Span> out = new ArrayList<>();
+        if (command == null || command.isEmpty()) {
+            return out;
+        }
+        int n = command.length();
+        int i = 0;
+        boolean atCommandStart = true; // the first word of the line / of each pipeline segment
+        while (i < n) {
+            char c = command.charAt(i);
+            if (Character.isWhitespace(c)) {
+                int start = i;
+                while (i < n && Character.isWhitespace(command.charAt(i))) {
+                    i++;
+                }
+                out.add(new Span(command.substring(start, i), null));
+            } else if (c == '#') {
+                // A '#' at a token boundary starts a comment to end of line (mid-word '#' stays in the word).
+                out.add(new Span(command.substring(i), "comment"));
+                break;
+            } else if (c == '\'' || c == '"') {
+                int start = i;
+                char quote = c;
+                i++;
+                while (i < n && command.charAt(i) != quote) {
+                    i++;
+                }
+                if (i < n) {
+                    i++; // include the closing quote
+                }
+                out.add(new Span(command.substring(start, i), "string"));
+                atCommandStart = false;
+            } else if (isOperator(c)) {
+                int start = i;
+                while (i < n && isOperator(command.charAt(i))) {
+                    i++;
+                }
+                out.add(new Span(command.substring(start, i), "operator"));
+                atCommandStart = true; // the next word begins a new command
+            } else {
+                int start = i;
+                while (i < n && !isWordBreak(command.charAt(i))) {
+                    i++;
+                }
+                String word = command.substring(start, i);
+                String cls;
+                if (atCommandStart) {
+                    cls = "function"; // the command / subcommand name
+                    atCommandStart = false;
+                } else if (word.charAt(0) == '-') {
+                    cls = "constant"; // an option flag (-x / --long)
+                } else if (word.charAt(0) == '$') {
+                    cls = "constant"; // a variable reference
+                } else {
+                    cls = null; // an argument / path — kept plain
+                }
+                out.add(new Span(word, cls));
+            }
+        }
+        return out;
+    }
+
+    private static boolean isOperator(char c) {
+        return c == '|' || c == '&' || c == ';' || c == '<' || c == '>';
+    }
+
+    private static boolean isWordBreak(char c) {
+        return Character.isWhitespace(c) || isOperator(c) || c == '\'' || c == '"';
+    }
+}

--- a/src/main/java/com/editora/ui/AgentCoordinator.java
+++ b/src/main/java/com/editora/ui/AgentCoordinator.java
@@ -656,7 +656,7 @@ final class AgentCoordinator implements AcpClient.Host {
         Platform.runLater(() -> {
             switch (update.kind()) {
                 case AGENT_MESSAGE -> panel().appendChunk(update.text());
-                case TOOL_CALL -> panel().appendLine("⚙ " + update.text());
+                case TOOL_CALL -> panel().appendToolLine(update.text());
                 case TOOL_CALL_UPDATE -> {
                     if ("failed".equals(update.text())) {
                         panel().appendLine("⚙ ✗ " + tr("agent.toolFailed"));

--- a/src/main/java/com/editora/ui/AgentPanel.java
+++ b/src/main/java/com/editora/ui/AgentPanel.java
@@ -18,6 +18,8 @@ import javafx.scene.layout.HBox;
 import javafx.scene.layout.Priority;
 import javafx.scene.layout.Region;
 import javafx.scene.layout.VBox;
+import javafx.scene.text.Text;
+import javafx.scene.text.TextFlow;
 import javafx.util.Duration;
 
 import com.editora.agent.AcpJson;
@@ -70,6 +72,10 @@ public final class AgentPanel extends VBox implements ToolWindowContent {
     private final Button historyButton = new Button();
     /** Receives the prompt text when the user sends (coordinator → agent). */
     private Consumer<String> onSend;
+    /** Cancels the in-flight turn (the header ■ + the Send→Stop toggle + Esc all run this). */
+    private final Runnable onStop;
+    /** True while a prompt turn is in flight (drives the Send↔Stop toggle + the Esc-stops shortcut). */
+    private boolean busy;
     /** Receives a clicked inline-code span's raw text that looks like a file path (coordinator resolves +
      *  opens it, or reports it doesn't exist). */
     private final Consumer<String> onOpenPath;
@@ -93,6 +99,7 @@ public final class AgentPanel extends VBox implements ToolWindowContent {
             Runnable onResumeSession,
             Consumer<String> onOpenPath) {
         this.onOpenPath = onOpenPath;
+        this.onStop = onStop;
         getStyleClass().add("agent-panel");
         getProperties().put("editora.ownsKeys", Boolean.TRUE);
         setSpacing(6);
@@ -128,16 +135,28 @@ public final class AgentPanel extends VBox implements ToolWindowContent {
         input.setWrapText(true);
         input.setPrefRowCount(3);
         input.getStyleClass().add("agent-input");
-        // Chat convention: Enter sends, Shift+Enter inserts a newline.
+        // Chat convention: Enter sends, Shift+Enter inserts a newline; Esc stops an in-flight turn.
         input.addEventFilter(javafx.scene.input.KeyEvent.KEY_PRESSED, e -> {
             if (e.getCode() == KeyCode.ENTER && !e.isShiftDown()) {
                 e.consume();
                 send();
+            } else if (e.getCode() == KeyCode.ESCAPE && busy) {
+                e.consume();
+                onStop.run();
             }
         });
         sendButton.setText(tr("agent.send"));
         sendButton.setDefaultButton(false);
-        sendButton.setOnAction(e -> send());
+        // The Send button doubles as Stop while a turn runs (ChatGPT/Claude convention — far more visible
+        // than the header ■), so it's never disabled; it just switches action + label + danger styling.
+        sendButton.getStyleClass().add("agent-send-button");
+        sendButton.setOnAction(e -> {
+            if (busy) {
+                onStop.run();
+            } else {
+                send();
+            }
+        });
         HBox inputRow = new HBox(6, input, sendButton);
         inputRow.setAlignment(Pos.BOTTOM_RIGHT);
         HBox.setHgrow(input, Priority.ALWAYS);
@@ -154,7 +173,7 @@ public final class AgentPanel extends VBox implements ToolWindowContent {
 
     private void send() {
         String text = input.getText() == null ? "" : input.getText().strip();
-        if (text.isEmpty() || onSend == null || !stopButton.isDisable()) {
+        if (text.isEmpty() || onSend == null || busy) {
             return; // empty, unwired, or a turn is already running
         }
         input.clear();
@@ -195,9 +214,41 @@ public final class AgentPanel extends VBox implements ToolWindowContent {
         trimIfNeeded();
     }
 
+    /** Appends a tool-call / command line ({@code command}, glyph-prefixed) with light shell syntax
+     *  highlighting — the command word, flags, quoted strings, operators, variables, and trailing comments
+     *  get the editor's token colors (via {@link AgentCommandHighlighter}); plain args/paths stay default.
+     *  Finalizes any streaming agent message first, like {@link #appendLine}. */
+    public void appendToolLine(String command) {
+        finalizeCurrentMessage();
+        TextFlow flow = new TextFlow();
+        flow.getStyleClass().add("agent-line");
+        Text glyph = new Text("⚙ ");
+        glyph.getStyleClass().add("agent-tool-glyph");
+        applyRunFont(glyph);
+        flow.getChildren().add(glyph);
+        for (AgentCommandHighlighter.Span span : AgentCommandHighlighter.spans(command == null ? "" : command)) {
+            Text run = new Text(span.text());
+            if (span.styleClass() != null) {
+                run.getStyleClass().addAll("text", span.styleClass()); // reuse .text.<class> token colors
+            } else {
+                run.getStyleClass().add("agent-cmd-plain"); // default foreground (theme-aware)
+            }
+            applyRunFont(run);
+            flow.getChildren().add(run);
+        }
+        transcriptBox.getChildren().add(flow);
+        trimIfNeeded();
+    }
+
     private void applyLineFont(Label label) {
         if (lineFontFamily != null) {
             label.setFont(javafx.scene.text.Font.font(lineFontFamily, lineFontSize));
+        }
+    }
+
+    private void applyRunFont(Text run) {
+        if (lineFontFamily != null) {
+            run.setFont(javafx.scene.text.Font.font(lineFontFamily, lineFontSize));
         }
     }
 
@@ -295,8 +346,14 @@ public final class AgentPanel extends VBox implements ToolWindowContent {
      *  the just-completed turn's streaming message so its last chunk renders immediately rather than
      *  waiting out the debounce after the status has already flipped back to "Idle". */
     public void setBusy(boolean busy) {
-        stopButton.setDisable(!busy);
-        sendButton.setDisable(busy);
+        this.busy = busy;
+        stopButton.setDisable(!busy); // the header ■ still enables only while running
+        // The Send button becomes a red "Stop" while running (and back to "Send" when idle); never disabled.
+        sendButton.setText(tr(busy ? "agent.stop" : "agent.send"));
+        sendButton.getStyleClass().remove("danger");
+        if (busy) {
+            sendButton.getStyleClass().add("danger");
+        }
         status.setText(tr(busy ? "agent.running" : "agent.idle"));
         if (!busy) {
             finalizeCurrentMessage();

--- a/src/main/resources/com/editora/styles/app.css
+++ b/src/main/resources/com/editora/styles/app.css
@@ -1790,6 +1790,11 @@
     -fx-background-insets: 0;
 }
 
+/* AI Agent tool-call lines: the ⚙ glyph is muted; the command's plain (untokenized) runs use the theme
+   foreground. Highlighted runs reuse the editor's `.text.<class>` token colors from syntax.css. */
+.agent-panel .agent-tool-glyph { -fx-fill: -color-fg-muted; }
+.agent-panel .agent-cmd-plain { -fx-fill: -color-fg-default; }
+
 /* AI Agent: an inline-code span in a reply that looks like a file path is clickable (opens it). */
 .agent-code-path {
     -fx-cursor: hand;

--- a/src/test/java/com/editora/ui/AgentCommandHighlighterTest.java
+++ b/src/test/java/com/editora/ui/AgentCommandHighlighterTest.java
@@ -1,0 +1,104 @@
+package com.editora.ui;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/** Pure tests for the AI Agent chat's light shell-command tokenizer. */
+class AgentCommandHighlighterTest {
+
+    private static List<AgentCommandHighlighter.Span> spans(String s) {
+        return AgentCommandHighlighter.spans(s);
+    }
+
+    /** The concatenated span texts must always reconstruct the input exactly (no dropped/added chars). */
+    private static void assertRoundTrips(String s) {
+        StringBuilder sb = new StringBuilder();
+        for (AgentCommandHighlighter.Span span : spans(s)) {
+            sb.append(span.text());
+        }
+        assertEquals(s, sb.toString());
+    }
+
+    /** The style class of the first span whose text equals {@code token} (may be {@code null} = default
+     *  foreground); {@code "<absent>"} when no span has that exact text. */
+    private static String classOf(String command, String token) {
+        for (AgentCommandHighlighter.Span sp : spans(command)) {
+            if (sp.text().equals(token)) {
+                return sp.styleClass();
+            }
+        }
+        return "<absent>";
+    }
+
+    @Test
+    void emptyOrNullYieldsNoSpans() {
+        assertTrue(spans("").isEmpty());
+        assertTrue(spans(null).isEmpty());
+    }
+
+    @Test
+    void commandWordIsFunction() {
+        assertEquals("function", classOf("grep -n plugins ~/.bashrc", "grep"));
+    }
+
+    @Test
+    void flagsAreConstant() {
+        assertEquals("constant", classOf("grep -n plugins ~/.bashrc", "-n"));
+        assertEquals("constant", classOf("ls --all", "--all"));
+    }
+
+    @Test
+    void argumentsAndPathsStayPlain() {
+        assertEquals(null, classOf("grep -n plugins ~/.bashrc", "plugins"));
+        assertEquals(null, classOf("grep -n plugins ~/.bashrc", "~/.bashrc"));
+    }
+
+    @Test
+    void quotedStringsAreStrings() {
+        assertEquals("string", classOf("git commit -m \"a message\"", "\"a message\""));
+        assertEquals("string", classOf("echo 'hi there'", "'hi there'"));
+    }
+
+    @Test
+    void operatorsAndPipelineRestartCommandColor() {
+        // After a pipe, the next word is a new command → function again.
+        List<AgentCommandHighlighter.Span> s = spans("cat f | grep x");
+        assertEquals("function", classOf("cat f | grep x", "cat"));
+        assertEquals("operator", classOf("cat f | grep x", "|"));
+        assertEquals("function", classOf("cat f | grep x", "grep"));
+        assertRoundTrips("cat f | grep x");
+    }
+
+    @Test
+    void trailingCommentIsComment() {
+        assertEquals(
+                "# note",
+                spans("make all # note").stream()
+                        .reduce((a, b) -> b)
+                        .map(AgentCommandHighlighter.Span::text)
+                        .orElse(""));
+        assertEquals("comment", classOf("make all # note", "# note"));
+    }
+
+    @Test
+    void hashInsideAWordIsNotAComment() {
+        // A '#' not at a token boundary stays part of the word (e.g. a fragment/anchor).
+        assertRoundTrips("curl http://x/a#frag");
+        assertEquals("<absent>", classOf("curl http://x/a#frag", "#frag"));
+    }
+
+    @Test
+    void variablesAreConstant() {
+        assertEquals("constant", classOf("echo $HOME", "$HOME"));
+    }
+
+    @Test
+    void roundTripsPreserveWhitespaceAndOperators() {
+        assertRoundTrips("bash -n /home/adl/.dotfiles/shell/functions.sh && echo \"Syntax OK\"");
+        assertRoundTrips("  leading   spaces  ");
+    }
+}


### PR DESCRIPTION
Two AI Agent chat improvements.

## 1. Light syntax highlighting on tool-call lines

The `⚙ …` command/tool-activity rows were flat monospace. They now get light shell coloring:

- New pure, unit-tested **`ui/AgentCommandHighlighter`** — tokenizes a command into spans: command word → *function*, flags (`-x`/`--long`) → *constant*, quoted strings → *string*, operators/pipes → *operator*, `$vars` → *constant*, trailing `# comments` → *comment*. Plain args/paths stay default (deliberately light). **10-case test.**
- **`AgentPanel.appendToolLine`** renders each span as a `Text` run reusing the editor's `.text.<class>` token classes, so the coloring **tracks the active editor theme** — only 2 tiny new CSS rules (muted `⚙` glyph + theme-aware default runs). `AgentCoordinator` routes `TOOL_CALL` through it.

(The agent's prose replies already render via `MarkdownRenderer`, so *fenced* code blocks were already highlighted — this covers the remaining plain surface.)

## 2. Send → Stop toggle + Esc

Stop was only a small header ■ that's easy to miss. Now:

- While a turn runs, the **Send button becomes a red "Stop"** (never disabled — switches action/label/`danger` styling), and **Esc** in the input stops the turn.
- Both reuse the existing `session/cancel`; the header ■ stays as a redundant control.

## Testing

- `mvn verify` green: **1755 tests, 0 failures** (+10 new; incl. Spotless, coverage gates, FX harness that builds the real window/panel).
- ⚠️ Not visually confirmed (headless env) — builds, tokenizes correctly, and passes window-building FX tests, but the rendered colors/toggle should get an eyeball.

🤖 Generated with [Claude Code](https://claude.com/claude-code)