### PR TITLE
Add CSV/TSV samples to the sample corpus

### DIFF
--- a/samples/README.md
+++ b/samples/README.md
@@ -78,6 +78,27 @@ Editor/Split/Preview toggle that renders the timeline). There is deliberately no
 - `samples/search/regex-cases.txt` — regex patterns plus a multibyte `é` to verify ripgrep
   byte→char column mapping.
 
+## csv/ — CSV/TSV grid, rainbow columns, delimiter detection
+
+Open any file and confirm: per-column **rainbow** editor coloring, the status-bar **"Field N of M"**
+segment (click it to copy as a Markdown table), and the **CSV grid** tool window (bottom stripe) with
+its row-count × column-count profiler and click-a-cell → jump. The delimiter is auto-detected from the
+first line, so the extension need not match the separator.
+
+- `samples/csv/people.csv` — plain comma CSV; mixed numeric (`id`/`salary`) and text columns exercise
+  the grid's type profiler (right-aligned numbers) and content-fit column widths.
+- `samples/csv/data.tsv` — **tab**-separated (real tabs); detected as TSV.
+- `samples/csv/european.csv` — **semicolon**-delimited (the European convention).
+- `samples/csv/pipe-delimited.csv` — **pipe**-delimited content in a `.csv` file (delimiter
+  auto-detection picks `|`).
+- `samples/csv/quoted.csv` — RFC-4180 edge cases: quoted fields with embedded commas, a `""` escaped
+  quote, a **leading-zero** ZIP (`07030` — stays text on export, not `7030`), and a field with an
+  **embedded line break** (a multi-line field, so the grid opens read-only — a data row no longer maps
+  1:1 to a physical line).
+- `samples/csv/ragged.csv` — deliberately **inconsistent** row widths (2–5 fields against a 4-column
+  header); the grid tints the ragged rows and the summary appends "· N inconsistent". Try **Align**
+  (`csv.align`) then **Shrink** (`csv.shrink`) — it refuses on a multi-line-field file but works here.
+
 ## editorconfig/ — EditorConfig overrides (hermetic)
 
 A self-contained tree with its own `root = true` so it does not inherit the repo's `.editorconfig`.

--- a/samples/csv/data.tsv
+++ b/samples/csv/data.tsv
@@ -1,0 +1,6 @@
+quarter	region	units	revenue
+Q1	North	1200	480000
+Q1	South	980	392000
+Q2	North	1350	540000
+Q2	South	1105	442000
+Q3	West	1420	568000

--- a/samples/csv/european.csv
+++ b/samples/csv/european.csv
@@ -1,0 +1,6 @@
+country;capital;population;area_km2
+France;Paris;67390000;551695
+Germany;Berlin;83240000;357022
+Spain;Madrid;47350000;505990
+Italy;Rome;59110000;301340
+Portugal;Lisbon;10300000;92212

--- a/samples/csv/people.csv
+++ b/samples/csv/people.csv
@@ -1,0 +1,7 @@
+id,name,department,salary,active
+1,Ada Lovelace,Engineering,145000,true
+2,Alan Turing,Research,152000,true
+3,Grace Hopper,Engineering,138000,true
+4,Katherine Johnson,Mathematics,141000,false
+5,Dennis Ritchie,Systems,149000,true
+6,Barbara Liskov,Research,156000,true

--- a/samples/csv/pipe-delimited.csv
+++ b/samples/csv/pipe-delimited.csv
@@ -1,0 +1,5 @@
+timestamp|level|service|message
+1720000001|INFO|auth|login ok
+1720000002|WARN|cache|near capacity
+1720000003|ERROR|db|connection refused
+1720000004|INFO|auth|logout

--- a/samples/csv/quoted.csv
+++ b/samples/csv/quoted.csv
@@ -1,0 +1,6 @@
+order_id,customer,notes,zip,amount
+1001,"Smith, John","Called it a ""must-have"" item",07030,1960
+1002,"Doe, Jane","Ship to office, not home",90210,349
+1003,"O'Brien, Pat","Contains a
+line break inside the quotes",02139,12500
+1004,"Nakamura, Kenji","Simple note",00501,75

--- a/samples/csv/ragged.csv
+++ b/samples/csv/ragged.csv
@@ -1,0 +1,6 @@
+sku,name,price,qty
+A100,Widget,9.99,50
+A101,Gadget,14.50
+A102,Gizmo,7.25,120,extra-column
+A103,Doohickey,3.00,0
+A104


### PR DESCRIPTION
## Summary
Adds six small fixtures under `samples/csv/` for manually exercising the CSV features (grid preview, rainbow columns, "Field N of M" status readout, delimiter auto-detection, align/shrink). All parse-verified against `CsvParser`.

| file | delimiter | notes |
|------|-----------|-------|
| `people.csv` | comma | numeric + text columns → type profiler / right-aligned numbers |
| `data.tsv` | tab (real `\t`) | detected as TSV |
| `european.csv` | semicolon | European convention |
| `pipe-delimited.csv` | pipe | `.csv` extension, `\|` auto-detected from content |
| `quoted.csv` | comma | RFC-4180: embedded commas, `""` escapes, leading-zero ZIPs, an embedded-line-break field (grid opens read-only) |
| `ragged.csv` | comma | inconsistent row widths → ragged-row tint + "· N inconsistent"; good for Align/Shrink |

Documented in `samples/README.md` under a new `## csv/` section.

## Test plan
- [x] Parse-verified all six against `CsvParser.detectDelimiter`/`parse`/`hasMultilineField` (comma/tab/semicolon/pipe detected correctly; `quoted.csv` flagged multiline)
- [x] `SamplesCorpusTest` green (manifest ↔ files in sync, no dangling references)
- Manual/demo aid only — no product code changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)