### PR TITLE
Harden structured/XML tree preview against silently-swallowed render errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,6 +85,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   were retired; the Settings → Editor → CSV toggle and the `view.toggleCsvGrid` palette command now gate
   the in-editor preview.
 
+### Fixed
+
+- **Structured / XML tree preview no longer blanks silently on a render error.** The off-thread
+  `PREVIEW_POOL.submit(...)` tasks that parse a JSON/YAML/TOML/XML buffer now catch `Throwable` (not just
+  the parser's `Exception`), so an `Error` such as a `NoClassDefFoundError`/`LinkageError` while loading a
+  Jackson format factory on the pool thread is surfaced as a visible error label in the preview + a
+  `WARNING` in the Debug Log, instead of being swallowed into the task's `Future` and leaving a blank pane.
+  Aligns these two branches with the project's "catch `Throwable` in `exec.submit` tasks" convention.
+
 ## [0.9.2] - 2026-07-08
 
 ### Added

--- a/src/main/java/com/editora/editor/EditorBuffer.java
+++ b/src/main/java/com/editora/editor/EditorBuffer.java
@@ -3713,13 +3713,18 @@ public class EditorBuffer implements TabContent {
             String src = area.getText();
             long gen = ++previewGen;
             PREVIEW_POOL.submit(() -> {
-                StructuredParser.Parsed parsed = StructuredParser.parse(src, sfmt);
-                Platform.runLater(() -> {
-                    if (gen != previewGen) {
-                        return;
-                    }
-                    renderStructured(parsed);
-                });
+                try {
+                    StructuredParser.Parsed parsed = StructuredParser.parse(src, sfmt);
+                    Platform.runLater(() -> {
+                        if (gen == previewGen) {
+                            renderStructured(parsed);
+                        }
+                    });
+                } catch (Throwable t) {
+                    // submit() would swallow a Throwable (e.g. a NoClassDefFoundError while loading a Jackson
+                    // format factory on this pool thread) into its Future — a silent blank preview. Surface it.
+                    surfaceTreePreviewError(gen, t);
+                }
             });
             return;
         }
@@ -3729,13 +3734,16 @@ public class EditorBuffer implements TabContent {
             String src = area.getText();
             long gen = ++previewGen;
             PREVIEW_POOL.submit(() -> {
-                XmlParser.Parsed parsed = XmlParser.parse(src);
-                Platform.runLater(() -> {
-                    if (gen != previewGen) {
-                        return;
-                    }
-                    renderXml(parsed);
-                });
+                try {
+                    XmlParser.Parsed parsed = XmlParser.parse(src);
+                    Platform.runLater(() -> {
+                        if (gen == previewGen) {
+                            renderXml(parsed);
+                        }
+                    });
+                } catch (Throwable t) {
+                    surfaceTreePreviewError(gen, t);
+                }
             });
             return;
         }
@@ -3925,6 +3933,27 @@ public class EditorBuffer implements TabContent {
             node = XmlTree.build(parsed.root());
         }
         structuredContentHolder().getChildren().setAll(node);
+    }
+
+    /**
+     * Surfaces a Throwable from a {@code PREVIEW_POOL.submit(...)} tree-preview task (structured/XML) that the
+     * task's {@code Future} would otherwise swallow into a silent blank — the {@code exec.submit}
+     * Error-swallowing trap the project conventions warn about — as a logged warning + a visible error label
+     * in the shared holder, so a failed render is diagnosable rather than a blank pane.
+     */
+    private void surfaceTreePreviewError(long gen, Throwable t) {
+        java.util.logging.Logger.getLogger(EditorBuffer.class.getName())
+                .log(java.util.logging.Level.WARNING, "tree preview render failed", t);
+        String msg = t.getMessage() != null ? t.getMessage() : t.toString();
+        Platform.runLater(() -> {
+            if (gen != previewGen) {
+                return;
+            }
+            Label err = new Label(msg);
+            err.getStyleClass().add("structured-error");
+            err.setWrapText(true);
+            structuredContentHolder().getChildren().setAll(err);
+        });
     }
 
     /** The self-scrolling structured preview node holder — used directly as the Split preview side. */


### PR DESCRIPTION
## What

The off-thread `PREVIEW_POOL.submit(...)` tasks that parse a JSON/YAML/TOML/XML buffer for the 3-mode tree preview only caught the parser's `Exception`. An `Error` (e.g. a `NoClassDefFoundError`/`LinkageError` while loading a Jackson format factory on the pool thread) escaped into the task's `Future` and was **swallowed** — leaving a **blank preview pane** with no log. This is the exact `exec.submit()` Error-swallowing trap the project conventions warn about (`PdfExportService`/`OfficeExportService` already catch `Throwable` for this reason); the structured/XML preview branches were the outliers still catching only `Exception`.

## Change

Wrap both the structured and XML submit tasks in `catch (Throwable)` and surface it via a new `surfaceTreePreviewError()`:
- a `WARNING` in the Debug Log, and
- a visible `.structured-error` label in the preview holder (`previewGen`-guarded like the render itself),

so a failed tree render is **diagnosable** instead of a silent blank pane. No success-path behavior change.

## Context

Prompted by a "YAML/TOML preview seems blank" report that turned out to be a stale-`target/classes` build on the reporter's side (a fresh compile fixed it). The code renders JSON/YAML/TOML/XML correctly in every test — verified via classpath + module-path parse and the real `openPath` → preview flow in the headless-FX harness. This change is the robustness net so a *future* such failure self-diagnoses rather than presenting as a mystery blank.

## Testing

- `StructuredParserTest`, `XmlParserTest`, `EditorBufferFxTest` pass.
- `spotless:apply` clean; `compile` clean.

## Perf

None. The `try`/`catch` adds no work on the hot/success path (a `catch` clause has zero cost unless a `Throwable` is actually thrown); the error path was previously a swallowed exception.

🤖 Generated with [Claude Code](https://claude.com/claude-code)