### PR TITLE
Add a portable Linux install tarball release target (.tar.gz + install.sh)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,6 +62,17 @@ jobs:
         shell: bash
         run: scripts/build-appimage.sh target/aot-image/Editora branding/editora.png target/dist
 
+      # Portable extract-and-install tarball from the same AOT-trained app-image (see
+      # scripts/build-tarball.sh): a jlink runtime + native bin/Editora launcher + a bundled install.sh
+      # that installs to /opt/editora (root) or ~/.local/editora (user) with an `editora` command + menu
+      # entry. The extract-and-install counterpart to the .AppImage — no jpackage installer, no FUSE.
+      # Best-effort: continue-on-error so it can't sink the .deb/.rpm/.AppImage/.jar release.
+      - name: Build install tarball (Linux)
+        if: runner.os == 'Linux'
+        continue-on-error: true
+        shell: bash
+        run: scripts/build-tarball.sh target/aot-image/Editora target/dist
+
       # Runnable fat jar for this runner's platform (JavaFX natives are host-specific, so each
       # runner produces its own jar — a single all-platforms jar isn't possible, see pom.xml).
       - name: Build fat jar (-Pfatjar)
@@ -90,7 +101,12 @@ jobs:
           mkdir -p staging
           for f in target/dist/*; do
             [ -f "$f" ] || continue
-            cp "$f" "staging/Editora-${VERSION}-${{ matrix.target }}.${f##*.}"
+            # Preserve compound extensions (.tar.gz) so the artifact isn't named "...-linux-x64.gz".
+            case "$f" in
+              *.tar.gz) ext="tar.gz" ;;
+              *)        ext="${f##*.}" ;;
+            esac
+            cp "$f" "staging/Editora-${VERSION}-${{ matrix.target }}.${ext}"
           done
           jar="$(ls target/Editora-*.jar | head -1)"
           cp "$jar" "staging/$(basename "$jar" .jar)-${{ matrix.target }}.jar"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Portable Linux install tarball** (`Editora-<version>-linux-<arch>.tar.gz`, x64 + arm64). A new release
+  artifact for systems without `.deb`/`.rpm`: it bundles the same self-contained, AOT-trained app image the
+  installers are built from (a jlink'd Java runtime + the native `bin/Editora` launcher — no system Java
+  needed) plus a POSIX `install.sh` that installs to **`/opt/editora`** when run as root or
+  **`~/.local/editora`** as a regular user, wiring up an `editora` command on `PATH` and an
+  application-menu entry (`StartupWMClass=com.editora.App` so the running window inherits the icon).
+  Supports `--system`/`--user`/`--prefix DIR`/`--uninstall`; the image also runs in place
+  (`./Editora/bin/Editora`) without installing. Built by the new `scripts/build-tarball.sh` from the
+  existing `target/aot-image/Editora` — the extract-and-install counterpart to the `.AppImage`, reusing the
+  jpackage `APP_IMAGE` output (jlink under the hood), so **no `pom.xml` change and no second build**.
 - **XML tree preview.** `.xml` files (xsd/xsl/fxml/pom/wsdl/rss/…) join the structured-data preview with a
   collapsible **DOM tree** in the 3-mode view — each element shows its tag + inline attributes, children in
   document order, and text-only elements inlined as `tag = "value"`. A *faithful* DOM model

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,8 +70,17 @@ old `macos-13` Intel runner was retired Dec 2025;
 each on its own GitHub-hosted runner) builds the native
 installer via the existing `-Pdist` profile — there is **no cross-building** (jpackage + JavaFX are
 host-specific), so each runner builds for itself. Each runner also builds a per-platform runnable
-fat jar via `-Pfatjar` (`Editora-<version>-<target>.jar`). Installers are renamed to
-`Editora-<version>-<target>.<ext>` per target — one consistent `Editora-<version>-<target>` prefix
+fat jar via `-Pfatjar` (`Editora-<version>-<target>.jar`). **Linux also ships two portable formats built
+from the same AOT-trained app-image the `.deb`/`.rpm` are wrapped from (`target/aot-image/Editora`, so no
+second `-Pdist` build):** a single-file **`.AppImage`** (`scripts/build-appimage.sh`) and an extract-and-install
+**`.tar.gz`** (`scripts/build-tarball.sh`) whose bundled `packaging/linux/tarball-install.sh` installs the
+image to `/opt/editora` (root) or `~/.local/editora` (user) with an `editora` command + a `.desktop`
+(`StartupWMClass=com.editora.App`), supporting `--system`/`--user`/`--prefix`/`--uninstall`. Both reuse the
+jpackage `APP_IMAGE` output (= jlink + the native launcher + `lib/app/editora.aot`, `$APPDIR`-relative so it's
+relocatable); both release steps are `continue-on-error` so a hiccup can't sink the installers. The
+`.tar.gz`/`.AppImage`/`.rpm` are attached to the GitHub release via `jreleaser.yml`'s file globs. Installers are renamed to
+`Editora-<version>-<target>.<ext>` per target (the Stage step preserves the compound `.tar.gz`
+extension) — one consistent `Editora-<version>-<target>` prefix
 across all artifacts (jpackage's DMG/MSI names omit the version + arch; the
 version comes from a `Resolve version` step — the tag minus `v`, else the pom version) and uploaded as
 artifacts alongside the fat jar. **macOS pre-1.0 app-version:** jpackage's `--app-version` (which becomes

--- a/README.md
+++ b/README.md
@@ -464,6 +464,22 @@ with arguments — e.g. `editora some/file.java:42` or `editora --new-file=notes
 command are removed when you uninstall the package. (The `.rpm` installs under `/opt/editora/` too; run
 `/opt/editora/bin/Editora` or add your own symlink.)
 
+Linux releases also ship a **portable install tarball** (`Editora-<version>-linux-<arch>.tar.gz`, x64 +
+arm64) for systems without `.deb`/`.rpm` (or where you'd rather not use a package manager). It bundles the
+same self-contained app image (its own jlink'd Java runtime — no system Java needed) plus an `install.sh`:
+
+```bash
+tar xzf Editora-<version>-linux-x64.tar.gz && cd editora-x86_64
+./install.sh          # per-user  -> ~/.local/editora  (+ ~/.local/bin/editora)
+sudo ./install.sh     # system    -> /opt/editora       (+ /usr/local/bin/editora)
+./install.sh --uninstall   # remove it again
+```
+
+Either way it adds an `editora` command and an application-menu entry (with the Editora icon). You can also
+run it in place without installing: `./Editora/bin/Editora`. Build one locally from an app-image with
+`./mvnw clean -Pdist -DskipTests -Djpackage.type=APP_IMAGE package` then
+`scripts/build-tarball.sh target/dist/Editora target/dist`.
+
 The `fatjar` profile produces a self-contained, runnable `target/Editora-<version>.jar` (no separate
 JavaFX install needed — `java -jar` is enough, on a JDK 25 runtime). It bundles JavaFX's classes and
 native libraries **for the build host's platform only**: a single jar can't be portable because

--- a/jreleaser.yml
+++ b/jreleaser.yml
@@ -40,11 +40,15 @@ release:
       contributors:
         enabled: false
 
-# Attach the installers and runnable fat jars gathered from the build matrix (downloaded under
-# ./artifacts). Both are renamed per target in CI, so names are unique across OS/arch.
+# Attach every artifact gathered from the build matrix (downloaded under ./artifacts): native installers
+# (.dmg/.msi/.deb/.rpm), the portable Linux builds (.AppImage single-file + .tar.gz extract-and-install),
+# and the per-platform runnable fat jars. All are renamed per target in CI, so names are unique across OS/arch.
 files:
   globs:
     - pattern: 'artifacts/**/*.dmg'
     - pattern: 'artifacts/**/*.msi'
     - pattern: 'artifacts/**/*.deb'
+    - pattern: 'artifacts/**/*.rpm'
+    - pattern: 'artifacts/**/*.AppImage'
+    - pattern: 'artifacts/**/*.tar.gz'
     - pattern: 'artifacts/**/Editora-*.jar'

--- a/packaging/linux/tarball-install.sh
+++ b/packaging/linux/tarball-install.sh
@@ -1,0 +1,143 @@
+#!/bin/sh
+#
+# Editora portable-tarball installer.
+#
+# This script ships INSIDE Editora-<version>-linux-<arch>.tar.gz, next to the self-contained `Editora/`
+# app-image (a jlink'd runtime + the native `bin/Editora` launcher + the AOT cache — the same relocatable
+# image the .deb/.rpm/.AppImage are built from). It installs that image and wires up an `editora` command
+# on PATH plus an application-menu entry, WITHOUT needing a package manager.
+#
+#   Run as root      -> installs system-wide to /opt/editora        (+ /usr/local/bin/editora)
+#   Run as a user    -> installs to ~/.local/editora                (+ ~/.local/bin/editora)
+#
+# Usage:
+#   ./install.sh                 # auto: system if root, else per-user
+#   sudo ./install.sh            # force system-wide (/opt/editora)
+#   ./install.sh --user          # force per-user (~/.local/editora)
+#   ./install.sh --system        # force system-wide (requires root)
+#   ./install.sh --prefix DIR    # install the app image into DIR/editora instead
+#   ./install.sh --uninstall     # remove a previous install (same mode/prefix rules)
+#   ./install.sh --help
+#
+# POSIX sh (no bashisms) so it runs under dash/busybox on minimal systems.
+set -eu
+
+PROG="Editora"
+WMCLASS="com.editora.App"   # JavaFX derives WM_CLASS from the module main; the menu entry must match it
+                            # exactly or the running window won't inherit the launcher icon (wmctrl -lx).
+
+# --- resolve the app-image that ships beside this script -----------------------------------------------
+SCRIPT_DIR=$(cd -- "$(dirname -- "$0")" >/dev/null 2>&1 && pwd -P)
+SRC="$SCRIPT_DIR/$PROG"
+
+MODE=""          # system | user
+PREFIX=""        # explicit install parent (overrides MODE's default location)
+ACTION="install" # install | uninstall
+
+die() { echo "editora-install: $*" >&2; exit 1; }
+
+usage() {
+    sed -n '3,26p' "$0" | sed 's/^# \{0,1\}//'
+    exit "${1:-0}"
+}
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --system)     MODE="system" ;;
+        --user)       MODE="user" ;;
+        --prefix)     shift; [ $# -gt 0 ] || die "--prefix needs a directory"; PREFIX="$1" ;;
+        --prefix=*)   PREFIX="${1#--prefix=}" ;;
+        --uninstall|--remove) ACTION="uninstall" ;;
+        -h|--help)    usage 0 ;;
+        *)            die "unknown option: $1 (try --help)" ;;
+    esac
+    shift
+done
+
+# Default mode: root -> system, otherwise per-user.
+if [ -z "$MODE" ]; then
+    if [ "$(id -u)" = "0" ]; then MODE="system"; else MODE="user"; fi
+fi
+[ "$MODE" = "system" ] && [ "$(id -u)" != "0" ] && \
+    die "--system needs root; re-run with sudo (or use --user for a per-user install)."
+
+# --- resolve install locations from the mode/prefix ----------------------------------------------------
+if [ -n "$PREFIX" ]; then
+    APPDIR="$PREFIX/editora"
+elif [ "$MODE" = "system" ]; then
+    APPDIR="/opt/editora"
+else
+    APPDIR="$HOME/.local/editora"   # self-contained app payload (kept out of ~/.local/share so it's
+                                    # easy to find/remove); the launcher resolves its runtime relatively.
+fi
+
+if [ "$MODE" = "system" ]; then
+    BINLINK="/usr/local/bin/editora"
+    DESKTOP_DIR="/usr/share/applications"
+else
+    BINLINK="$HOME/.local/bin/editora"
+    DESKTOP_DIR="${XDG_DATA_HOME:-$HOME/.local/share}/applications"
+fi
+DESKTOP="$DESKTOP_DIR/editora.desktop"
+LAUNCHER="$APPDIR/bin/$PROG"
+ICON="$APPDIR/lib/$PROG.png"
+
+refresh_menu() {
+    command -v update-desktop-database >/dev/null 2>&1 && \
+        update-desktop-database -q "$DESKTOP_DIR" 2>/dev/null || true
+}
+
+# --- uninstall -----------------------------------------------------------------------------------------
+if [ "$ACTION" = "uninstall" ]; then
+    rm -rf "$APPDIR"
+    # Only remove the symlink if it points into our app dir (don't clobber an unrelated `editora`).
+    if [ -L "$BINLINK" ] && [ "$(readlink "$BINLINK")" = "$LAUNCHER" ]; then rm -f "$BINLINK"; fi
+    rm -f "$DESKTOP"
+    refresh_menu
+    echo "editora-install: removed $APPDIR (and its command + menu entry)."
+    exit 0
+fi
+
+# --- install -------------------------------------------------------------------------------------------
+[ -x "$SRC/bin/$PROG" ] || die "app image not found next to this script (expected $SRC/bin/$PROG)."
+
+echo "editora-install: installing to $APPDIR ($MODE) ..."
+rm -rf "$APPDIR"                       # clean reinstall (idempotent; also drops a stale AOT cache)
+mkdir -p "$(dirname "$APPDIR")"
+cp -a "$SRC" "$APPDIR"                 # SRC is .../Editora -> APPDIR becomes its copy (bin/, lib/, ...)
+
+mkdir -p "$(dirname "$BINLINK")"
+ln -sf "$LAUNCHER" "$BINLINK"
+
+mkdir -p "$DESKTOP_DIR"
+{
+    echo "[Desktop Entry]"
+    echo "Type=Application"
+    echo "Name=Editora"
+    echo "GenericName=Text Editor"
+    echo "Comment=A keyboard-driven, cross-platform programmer's text editor"
+    echo "Exec=$LAUNCHER %F"
+    [ -f "$ICON" ] && echo "Icon=$ICON"
+    echo "Categories=Development;TextEditor;IDE;"
+    echo "Terminal=false"
+    echo "StartupNotify=true"
+    echo "StartupWMClass=$WMCLASS"
+    echo "MimeType=text/plain;"
+} > "$DESKTOP"
+chmod 0644 "$DESKTOP"
+refresh_menu
+
+echo "editora-install: installed."
+echo "  app image : $APPDIR"
+echo "  command   : $BINLINK  ->  $LAUNCHER"
+echo "  menu entry: $DESKTOP"
+
+# PATH hint (the per-user symlink dir isn't always on PATH).
+case ":${PATH}:" in
+    *":$(dirname "$BINLINK"):"*) : ;;
+    *) echo ""; echo "  NOTE: $(dirname "$BINLINK") is not on your PATH — add it, e.g.:"
+       echo "        echo 'export PATH=\"$(dirname "$BINLINK"):\$PATH\"' >> ~/.profile" ;;
+esac
+
+echo ""
+echo "Run 'editora' (or launch it from your applications menu). Uninstall with: $0 --uninstall"

--- a/scripts/build-tarball.sh
+++ b/scripts/build-tarball.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+#
+# Build a portable Linux install tarball from the jpackage app-image (Linux release leg only).
+#
+# The tarball is the extract-and-install counterpart to the .AppImage (see build-appimage.sh): it bundles
+# the same already-trained, AOT-cached, relocatable app-image that -Pdist produced at
+# target/aot-image/Editora — a jlink'd runtime + the native bin/Editora launcher — next to a self-contained
+# install.sh (packaging/linux/tarball-install.sh). Extracting + running install.sh drops the image into
+# /opt/editora (as root) or ~/.local/editora (as a user) and wires up an `editora` command + menu entry,
+# with no package manager and no jpackage installer. Editora spawns host tools (git, LSP/DAP servers,
+# python/node, ripgrep, ...) via the user's real PATH, so nothing here sandboxes.
+#
+# Usage:  scripts/build-tarball.sh <app-image-dir> <out-dir>
+#   e.g.  scripts/build-tarball.sh target/aot-image/Editora target/dist
+#
+# Best-effort in release.yml (continue-on-error), so a hiccup here never sinks the .deb/.rpm/.jar.
+set -euo pipefail
+
+APPIMG_DIR="${1:?app-image dir required}"   # the jpackage Linux app-image (has bin/Editora + lib/)
+OUTDIR="${2:?out dir required}"
+
+if [ ! -x "$APPIMG_DIR/bin/Editora" ]; then
+  echo "[tarball] launcher not found at $APPIMG_DIR/bin/Editora — skipping" >&2
+  exit 1
+fi
+
+ARCH="$(uname -m)"   # x86_64 on linux-x64, aarch64 on linux-arm64
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)"
+INSTALLER="$SCRIPT_DIR/../packaging/linux/tarball-install.sh"
+
+if [ ! -f "$INSTALLER" ]; then
+  echo "[tarball] installer template not found at $INSTALLER — skipping" >&2
+  exit 1
+fi
+
+WORK="$(mktemp -d)"
+STAGE="$WORK/editora-$ARCH"      # tarball's single top-level dir (avoids a tarbomb)
+mkdir -p "$STAGE"
+
+# The whole app-image (jlink runtime + lib/app/editora.aot ride along; bin/Editora stays executable).
+cp -a "$APPIMG_DIR" "$STAGE/Editora"
+cp "$INSTALLER" "$STAGE/install.sh"
+chmod +x "$STAGE/install.sh"
+
+cat > "$STAGE/README.txt" <<'EOF'
+Editora — portable Linux install
+=================================
+
+This archive contains a self-contained Editora app image (its own bundled Java
+runtime) plus an installer. No package manager, no root required.
+
+  Install for your user  (-> ~/.local/editora):
+      ./install.sh
+
+  Install system-wide    (-> /opt/editora):
+      sudo ./install.sh
+
+  Other options:
+      ./install.sh --prefix /some/dir     # install into /some/dir/editora
+      ./install.sh --uninstall            # remove a previous install
+      ./install.sh --help
+
+After installing, run 'editora' from a terminal or launch it from your
+applications menu. (A per-user install may need ~/.local/bin on your PATH —
+install.sh prints a hint if it isn't.)
+
+You can also run Editora in place without installing:
+      ./Editora/bin/Editora
+EOF
+
+mkdir -p "$OUTDIR"
+OUT="$OUTDIR/Editora-$ARCH.tar.gz"
+# GNU tar on the Linux runners; --owner/--group=0 keeps a clean root-owned tree regardless of the
+# building user, and a sorted listing makes the archive reproducible.
+tar --numeric-owner --owner=0 --group=0 -C "$WORK" -czf "$OUT" "editora-$ARCH"
+
+echo "[tarball] built $OUT"
+ls -la "$OUT"
+rm -rf "$WORK"


### PR DESCRIPTION
## What

A new Linux release artifact: **`Editora-<version>-linux-<arch>.tar.gz`** (x64 + arm64) — a portable, extract-and-install build for systems without `.deb`/`.rpm` (or where a package manager isn't wanted). The extract-and-install counterpart to the existing `.AppImage`.

It bundles the **same AOT-trained, relocatable app-image the installers are wrapped from** (a jlink'd Java runtime + the native `bin/Editora` launcher — no system Java needed) plus a bundled `install.sh`:

```bash
tar xzf Editora-<version>-linux-x64.tar.gz && cd editora-x86_64
./install.sh          # per-user  -> ~/.local/editora  (+ ~/.local/bin/editora)
sudo ./install.sh     # system    -> /opt/editora       (+ /usr/local/bin/editora)
./install.sh --uninstall
```

The installer adds an `editora` command on `PATH` and an application-menu `.desktop` entry (`StartupWMClass=com.editora.App` so the running window inherits the icon). Supports `--system` / `--user` / `--prefix DIR` / `--uninstall`. The image also runs in place without installing: `./Editora/bin/Editora`.

## On jpackage vs jlink

Reuses the existing `jpackage --type APP_IMAGE` output (`target/aot-image/Editora`) — which *is* jlink + a native launcher + the `$APPDIR`-relative AOT cache. No pure-jlink reimplementation (that would duplicate the moditect module descriptors, AOT training, and launcher). **No `pom.xml` change, no second build** — the tarball is packed from the image the `.deb`/`.rpm` build already produced, exactly like `build-appimage.sh`.

## Changes

- **`scripts/build-tarball.sh`** — stages `target/aot-image/Editora` + the installer into `editora-<arch>/` → `target/dist/Editora-<arch>.tar.gz`.
- **`packaging/linux/tarball-install.sh`** — the bundled POSIX-sh installer (root→`/opt`, user→`~/.local/editora`).
- **`release.yml`** — a `Build install tarball (Linux)` step (`continue-on-error`, like AppImage) + the Stage step now preserves the compound `.tar.gz` extension.
- **`jreleaser.yml`** — attach `.tar.gz`. ⚠️ **Scope note:** I also added `.rpm` and `.AppImage` globs. CI already builds + stages those, but they were missing from the release globs, so they were never attached to the GitHub release (a pre-existing gap — CLAUDE.md says the release "ships .deb AND .rpm"). Shipping the new tarball but not the AppImage/rpm you already build would be incoherent, so I fixed all three. **Happy to drop the rpm/AppImage lines if that omission was intentional.**
- **Docs** — CHANGELOG, README install section, CLAUDE.md release-pipeline note.

## Testing

- shellcheck clean on both scripts.
- Exercised on macOS against a **fake app-image**: `build-tarball.sh` staging + tar; `install.sh` `--help`, default (user → `~/.local/editora`), `--system` non-root rejection, `--prefix`, and `--uninstall` (clean reversal, symlink-guarded).
- ⚠️ **NOT yet device-tested on real Linux** (the actual Editora image launching post-install + desktop-menu/icon integration). Per the CLAUDE.md Linux-packaging convention this needs a device test — recommend a `workflow_dispatch` dry-run of the release and installing the produced tarball on an x64 + arm64 box before relying on it.

## Perf

None — build/release tooling only; no app code, no `pom.xml`/module change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)