### PR TITLE
Release idle viewport texture in Spell/Note overlays when nothing is visible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -97,6 +97,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Spell-check and Personal-Notes overlays no longer pin an idle full-viewport GPU texture.** Both
+  `SpellCheckOverlay` and `NoteHighlightOverlay` kept their `Canvas` sized to the whole viewport whenever
+  the feature was on (the default), even on a buffer with zero visible misspellings/notes — retaining a
+  viewport-sized RTTexture that other overlays (Todo/Search/LSP/…) already release. They now shrink the
+  canvas to 1×1 when there's nothing visible to paint and grow it back on demand (with no per-scroll size
+  flapping), matching the established overlay convention — trimming idle Prism-texture footprint on every
+  spell-checked/annotated buffer. Purely a resource fix; no visible behavior change.
 - **Structured / XML tree preview no longer blanks silently on a render error.** The off-thread
   `PREVIEW_POOL.submit(...)` tasks that parse a JSON/YAML/TOML/XML buffer now catch `Throwable` (not just
   the parser's `Exception`), so an `Error` such as a `NoClassDefFoundError`/`LinkageError` while loading a

--- a/src/main/java/com/editora/editor/NoteHighlightOverlay.java
+++ b/src/main/java/com/editora/editor/NoteHighlightOverlay.java
@@ -34,6 +34,10 @@ final class NoteHighlightOverlay extends Region {
     private Supplier<List<int[]>> spans = List::of;
     private boolean active;
     private boolean redrawPending;
+    // Whether the last redraw had visible note spans to paint. When false the canvas is shrunk to 1x1 to
+    // release its viewport-sized RTTexture — a buffer with no visible notes shouldn't pin a full-viewport
+    // texture (the convention the other overlays follow). layoutChildren re-grows only while this is set.
+    private boolean hasContent;
 
     NoteHighlightOverlay(CodeArea area) {
         this.area = area;
@@ -60,7 +64,7 @@ final class NoteHighlightOverlay extends Region {
         if (active) {
             scheduleRedraw();
         } else {
-            clear();
+            releaseCanvas(); // off → drop the texture, not just clear it
         }
     }
 
@@ -70,13 +74,17 @@ final class NoteHighlightOverlay extends Region {
 
     @Override
     protected void layoutChildren() {
-        double w = CanvasGuards.clampDim(getWidth());
-        double h = CanvasGuards.clampDim(getHeight());
-        if (canvas.getWidth() != w || canvas.getHeight() != h) {
-            canvas.setWidth(w);
-            canvas.setHeight(h);
-        }
         canvas.relocate(0, 0);
+        // Track the viewport size only while there's something to paint; an idle overlay stays 1x1 (see
+        // hasContent). redraw() grows the canvas on demand when a note span becomes visible.
+        if (hasContent) {
+            double w = CanvasGuards.clampDim(getWidth());
+            double h = CanvasGuards.clampDim(getHeight());
+            if (canvas.getWidth() != w || canvas.getHeight() != h) {
+                canvas.setWidth(w);
+                canvas.setHeight(h);
+            }
+        }
         scheduleRedraw();
     }
 
@@ -91,19 +99,33 @@ final class NoteHighlightOverlay extends Region {
         });
     }
 
-    private void clear() {
+    /** Grows the canvas to the viewport (only when there's content to paint) and clears it. */
+    private void ensureCanvasSized() {
+        double w = CanvasGuards.clampDim(getWidth());
+        double h = CanvasGuards.clampDim(getHeight());
+        if (canvas.getWidth() != w || canvas.getHeight() != h) {
+            canvas.setWidth(w); // resizing a Canvas also clears it
+            canvas.setHeight(h);
+        }
+        canvas.relocate(0, 0);
+        hasContent = true;
         canvas.getGraphicsContext2D().clearRect(0, 0, canvas.getWidth(), canvas.getHeight());
     }
 
+    /** Shrinks the canvas to 1x1, releasing its RTTexture (no visible note spans / overlay off). */
+    private void releaseCanvas() {
+        hasContent = false;
+        if (canvas.getWidth() != 1 || canvas.getHeight() != 1) {
+            canvas.setWidth(1);
+            canvas.setHeight(1);
+        }
+    }
+
     private void redraw() {
-        GraphicsContext g = canvas.getGraphicsContext2D();
-        double w = canvas.getWidth();
-        double h = canvas.getHeight();
-        g.clearRect(0, 0, w, h);
         if (!active || !CanvasGuards.paintable(getWidth(), getHeight())) {
+            releaseCanvas();
             return;
         }
-        g.setLineWidth(1);
         try {
             int firstVisible = area.firstVisibleParToAllParIndex();
             int lastVisible = area.lastVisibleParToAllParIndex();
@@ -114,10 +136,23 @@ final class NoteHighlightOverlay extends Region {
             int lastVis = Math.min(total - 1, lastVisible);
             int lastOffset = area.getAbsolutePosition(
                     lastVis, area.getParagraph(lastVis).getText().length());
+            List<int[]> visible = new java.util.ArrayList<>();
             for (int[] span : spans.get()) {
                 if (span[1] < firstOffset || span[0] > lastOffset) {
                     continue;
                 }
+                visible.add(span);
+            }
+            if (visible.isEmpty()) {
+                releaseCanvas(); // no visible note spans → drop the viewport texture
+                return;
+            }
+            ensureCanvasSized();
+            GraphicsContext g = canvas.getGraphicsContext2D();
+            double w = canvas.getWidth();
+            double h = canvas.getHeight();
+            g.setLineWidth(1);
+            for (int[] span : visible) {
                 paintSpan(g, span[0], span[1], firstVisible, lastVisible, w, h);
             }
         } catch (RuntimeException ignored) {

--- a/src/main/java/com/editora/editor/SpellCheckOverlay.java
+++ b/src/main/java/com/editora/editor/SpellCheckOverlay.java
@@ -36,6 +36,11 @@ final class SpellCheckOverlay extends Region {
     private boolean markdown;
     private boolean active;
     private boolean redrawPending;
+    // Whether the last redraw actually had visible misspellings to paint. When false the canvas is shrunk
+    // to 1x1 to release its (viewport-sized) RTTexture — a spell-checked buffer with no visible squiggles
+    // shouldn't pin a full-viewport texture (the convention every other overlay follows). layoutChildren
+    // only re-grows the canvas while this is set, so a clean viewport never flaps between sizes on scroll.
+    private boolean hasContent;
 
     /** Lines (0-based) inside a Markdown fenced ``` code block — never spell-checked. Their content is
      *  the embedded language (or unstyled), so the per-char "code" style class can't catch them; this
@@ -136,7 +141,7 @@ final class SpellCheckOverlay extends Region {
             recomputeCodeLines(); // pick up the current text (it may have changed while inactive)
             scheduleRedraw();
         } else {
-            clear();
+            releaseCanvas(); // off → drop the texture, not just clear it
         }
     }
 
@@ -152,13 +157,17 @@ final class SpellCheckOverlay extends Region {
 
     @Override
     protected void layoutChildren() {
-        double w = CanvasGuards.clampDim(getWidth());
-        double h = CanvasGuards.clampDim(getHeight());
-        if (canvas.getWidth() != w || canvas.getHeight() != h) {
-            canvas.setWidth(w);
-            canvas.setHeight(h);
-        }
         canvas.relocate(0, 0);
+        // Only track the viewport size while there's something to paint; an idle overlay stays 1x1 (see
+        // hasContent). redraw() grows the canvas on demand when it finds visible misspellings.
+        if (hasContent) {
+            double w = CanvasGuards.clampDim(getWidth());
+            double h = CanvasGuards.clampDim(getHeight());
+            if (canvas.getWidth() != w || canvas.getHeight() != h) {
+                canvas.setWidth(w);
+                canvas.setHeight(h);
+            }
+        }
         scheduleRedraw();
     }
 
@@ -173,39 +182,79 @@ final class SpellCheckOverlay extends Region {
         });
     }
 
-    private void clear() {
+    /** Grows the canvas to the viewport (only when there's content to paint) and clears it. */
+    private void ensureCanvasSized() {
+        double w = CanvasGuards.clampDim(getWidth());
+        double h = CanvasGuards.clampDim(getHeight());
+        if (canvas.getWidth() != w || canvas.getHeight() != h) {
+            canvas.setWidth(w); // resizing a Canvas also clears it
+            canvas.setHeight(h);
+        }
+        canvas.relocate(0, 0);
+        hasContent = true;
         canvas.getGraphicsContext2D().clearRect(0, 0, canvas.getWidth(), canvas.getHeight());
     }
 
+    /** Shrinks the canvas to 1x1, releasing its RTTexture (nothing visible to draw / overlay off). */
+    private void releaseCanvas() {
+        hasContent = false;
+        if (canvas.getWidth() != 1 || canvas.getHeight() != 1) {
+            canvas.setWidth(1);
+            canvas.setHeight(1);
+        }
+    }
+
     private void redraw() {
-        GraphicsContext g = canvas.getGraphicsContext2D();
-        double w = canvas.getWidth();
-        double h = canvas.getHeight();
-        g.clearRect(0, 0, w, h);
         if (!active || checker == null || !checker.ready() || !CanvasGuards.paintable(getWidth(), getHeight())) {
+            releaseCanvas();
             return;
         }
         try {
             int total = area.getParagraphs().size();
             if (total == 0) {
+                releaseCanvas();
                 return;
             }
             int first = Math.max(0, area.firstVisibleParToAllParIndex());
             int last = Math.min(total - 1, area.lastVisibleParToAllParIndex());
-            g.setStroke(SQUIGGLE);
-            g.setLineWidth(1.0);
+            // Phase 1 — collect the visible misspelled spans (the cheap, cached scan; for a clean viewport
+            // this makes zero getCharacterBoundsOnScreen calls, exactly as before).
+            List<int[]> hits = new java.util.ArrayList<>();
             for (int p = first; p <= last; p++) {
                 if (area.isFolded(p) || (markdown && codeLines.get(p))) {
                     continue; // skip folded lines and Markdown fenced code blocks
                 }
-                drawParagraph(g, p, w, h);
+                collectParagraph(p, hits);
+            }
+            if (hits.isEmpty()) {
+                releaseCanvas(); // no visible squiggles → drop the viewport texture
+                return;
+            }
+            // Phase 2 — size the canvas to the viewport and paint the collected spans.
+            ensureCanvasSized();
+            GraphicsContext g = canvas.getGraphicsContext2D();
+            double w = canvas.getWidth();
+            double h = canvas.getHeight();
+            g.setStroke(SQUIGGLE);
+            g.setLineWidth(1.0);
+            for (int[] hit : hits) {
+                Bounds b =
+                        toLocal(area.getCharacterBoundsOnScreen(hit[0], hit[1]).orElse(null));
+                if (b == null) {
+                    continue;
+                }
+                if (b.getMaxX() < 0 || b.getMinX() > w || b.getMaxY() < 0 || b.getMinY() > h) {
+                    continue; // off-screen (horizontal scroll)
+                }
+                squiggle(g, b.getMinX(), b.getMaxX(), b.getMaxY() - 1);
             }
         } catch (RuntimeException ignored) {
             // Viewport mid-layout — skip this frame; a later event will redraw.
         }
     }
 
-    private void drawParagraph(GraphicsContext g, int paragraph, double w, double h) {
+    /** Adds each misspelled, eligible word in {@code paragraph} to {@code hits} as {@code {absStart, absEnd}}. */
+    private void collectParagraph(int paragraph, List<int[]> hits) {
         String line = area.getParagraph(paragraph).getText();
         if (line.isEmpty()) {
             return;
@@ -232,15 +281,7 @@ final class SpellCheckOverlay extends Region {
             if (!eligible(abs)) {
                 continue; // eligibility is style-dependent (inline/fenced code) → evaluated fresh
             }
-            Bounds b =
-                    toLocal(area.getCharacterBoundsOnScreen(abs, parBase + end).orElse(null));
-            if (b == null) {
-                continue;
-            }
-            if (b.getMaxX() < 0 || b.getMinX() > w || b.getMaxY() < 0 || b.getMinY() > h) {
-                continue; // off-screen
-            }
-            squiggle(g, b.getMinX(), b.getMaxX(), b.getMaxY() - 1);
+            hits.add(new int[] {abs, parBase + end});
         }
     }
 


### PR DESCRIPTION
## What

Found via a performance audit of the per-buffer overlays. `SpellCheckOverlay` and `NoteHighlightOverlay` sized their `Canvas` to the **full viewport** whenever the feature was active — and both spell-check and Personal Notes are **on by default**. So a buffer with **zero visible misspellings/notes** still pinned a viewport-sized `RTTexture`, unlike every other overlay (Todo/Search/LSP/Mermaid/MarkdownLint), which shrink their canvas to 1×1 when there's nothing to draw. Across many ever-viewed buffers this needlessly grows the Prism texture pool — a documented constraint in this codebase (why the caps are raised to 2 GB).

## Change

Both overlays now follow the established convention:
- a `hasContent` flag gates `layoutChildren`'s canvas sizing,
- `redraw()` collects the visible spans first, then `releaseCanvas()` (shrink to 1×1) when the visible set is empty, else `ensureCanvasSized()` (grow to the viewport) + paint.

Because `layoutChildren` only re-grows while `hasContent` is set and `redraw()` grows on demand, a clean viewport **never flaps between sizes on scroll**. `SpellCheckOverlay.redraw` is split into a *collect* phase (the cheap, cached eligibility/spell scan — zero `getCharacterBoundsOnScreen` calls for a clean viewport, exactly as before) and a *paint* phase, so **which words get squiggled is unchanged**.

Purely a resource/texture fix — no visible behavior change.

## Testing

- `spotless:apply` + `compile` clean.
- `SpellCheckOverlayTest` (5) + `EditorBufferFxTest` (9, builds both overlays in a real buffer scene graph) pass.
- Note: the *grow* path can't be meaningfully asserted headlessly (no real layout → `getCharacterBoundsOnScreen` is empty), so verification is compile + existing tests + the logic mirroring the reviewed Todo/Whitespace convention.

## Perf

The intended win: idle spell/note buffers drop a ~viewport-sized texture each (2 per buffer when truly empty). No hot-path cost added — the collect phase does the same cached scan as before; the only new per-redraw work is building a small `ArrayList` of visible hits (bounded by visible paragraphs).

## Audit result

The broader audit (edit/scroll/caret hot paths, preview cluster, overlays/textures) found **no other issues** — everything else is already well-bounded (debounced/off-thread/coalesced/LRU-capped/disposed-on-close). This was the only actionable finding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)