### PR TITLE
Pin structured/XML tree preview token colors on row selection (no recolor flash)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -97,6 +97,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Structured / XML tree preview no longer recolors its text when you select a row.** The JSON/YAML/TOML
+  and XML preview rows are `TextFlow`s of colored `Text` runs, whose fill AtlantaFX flips to the selection
+  foreground on a selected cell — so clicking a line made the syntax-colored tokens visibly flash to the
+  selection color and back (a "redraw"). Added selected-state CSS rules pinning each token's `-fx-fill` to
+  its normal color (the same fix `.completion-list` already uses for its `TextFlow` labels), so selection
+  only changes the row background now. CSS-only.
 - **Spell-check and Personal-Notes overlays no longer pin an idle full-viewport GPU texture.** Both
   `SpellCheckOverlay` and `NoteHighlightOverlay` kept their `Canvas` sized to the whole viewport whenever
   the feature was on (the default), even on a buffer with zero visible misspellings/notes — retaining a

--- a/src/main/resources/com/editora/styles/app.css
+++ b/src/main/resources/com/editora/styles/app.css
@@ -535,6 +535,25 @@
 .xml-punct { -fx-fill: -color-fg-muted; }
 .xml-comment { -fx-fill: -color-fg-muted; -fx-font-style: italic; }
 
+/* Keep the tree token colors stable when a row is selected. The rows are TextFlows of Text runs, whose
+   -fx-fill AtlantaFX flips to the selection foreground (-color-cell-fg-selected) on a selected cell — so
+   without these the colored tokens visibly recolor on select/deselect (a "redraw" flash). Restating each
+   token's fill at the selected-cell specificity pins it, exactly as .completion-list does above. */
+.structured-tree .tree-cell:filled:selected .structured-key { -fx-fill: -color-fg-default; }
+.structured-tree .tree-cell:filled:selected .structured-punct,
+.structured-tree .tree-cell:filled:selected .structured-count,
+.structured-tree .tree-cell:filled:selected .structured-null { -fx-fill: -color-fg-muted; }
+.structured-tree .tree-cell:filled:selected .structured-string { -fx-fill: -color-success-fg; }
+.structured-tree .tree-cell:filled:selected .structured-number { -fx-fill: -color-accent-fg; }
+.structured-tree .tree-cell:filled:selected .structured-boolean { -fx-fill: -color-warning-fg; }
+
+.xml-tree .tree-cell:filled:selected .xml-tag { -fx-fill: -color-accent-fg; }
+.xml-tree .tree-cell:filled:selected .xml-attr-name { -fx-fill: -color-warning-fg; }
+.xml-tree .tree-cell:filled:selected .xml-attr-value { -fx-fill: -color-success-fg; }
+.xml-tree .tree-cell:filled:selected .xml-text { -fx-fill: -color-fg-default; }
+.xml-tree .tree-cell:filled:selected .xml-punct,
+.xml-tree .tree-cell:filled:selected .xml-comment { -fx-fill: -color-fg-muted; }
+
 /* OpenAPI/Swagger docs preview. */
 .openapi-scroll { -fx-background-color: -color-bg-default; }
 .openapi-doc { -fx-padding: 16; -fx-spacing: 6; -fx-background-color: -color-bg-default; }


### PR DESCRIPTION
## Problem

In the XML (and JSON/YAML/TOML) 3-mode tree preview, **selecting a row makes the text visibly recolor/flash** ("the text redraws").

## Cause

The tree rows are `TextFlow`s of colored `Text` runs (`.xml-tag`, `.xml-attr-value`, `.structured-string`, …). AtlantaFX's selected-cell rule sets `-color-cell-fg: -color-cell-fg-selected`, which cascades to those `Text` runs' `-fx-fill` — so on selection the syntax-colored tokens flip to the selection foreground and revert on deselect. The token classes had no selected-state handling, so the theme won. (The cell graphic is **not** rebuilt on selection — `updateItem` only runs on scroll-virtualization, and there's no selection listener re-rendering the tree — so this is purely the CSS recolor.)

## Fix

CSS-only. Added selected-state rules that restate each token's `-fx-fill` at `.<tree> .tree-cell:filled:selected .<token>` specificity, so the colors stay put and selection only changes the row background. This mirrors the identical `TextFlow`-in-a-selected-cell fix `.completion-list` already uses (app.css:1552). Applied to both `.xml-tree` (the reported case) and `.structured-tree` (same pattern → same flash).

## Safety / testing

- Harmless if the mechanism ever differs: the rules just re-assert the normal colors, so worst case they're no-ops (and on a theme that doesn't recolor selected-cell text, they're inert).
- CSS isn't unit-testable meaningfully in the headless FX harness (cells render lazily; looked-up colors), and this is a desktop app, so **the definitive check is visual**: open an `.xml`/`.json` file in Split/Preview and click rows — the token colors should now stay stable while only the row background highlights.

🤖 Generated with [Claude Code](https://claude.com/claude-code)