### PR TITLE
Typst LSP (tinymist): completion, hover, goto, diagnostics, format, outline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Typst language server (tinymist).** `.typ` files now get full LSP code intelligence via
+  [tinymist](https://github.com/Myriad-Dreamin/tinymist) — completion, hover docs, go-to-definition,
+  find-references, a precise document-symbol outline, diagnostics (squiggles + the Problems window), and
+  **Format Document** — the 22nd server in Editora's LSP layer (one `ServerDef`, root markers `typst.toml`).
+  It complements the existing Typst rendered preview. Off until the global LSP feature is on; auto-detected
+  on `PATH` (`tinymist lsp`), with a per-server enable + command field and a one-click **Install…** button
+  (downloads the tinymist binary from GitHub releases) under *Settings → LSP*. `Settings.typstLspEnabled`/
+  `typstLspCommand` (schema 72→73).
+
 - **fstab mount preview.** An `/etc/fstab` file (already syntax-highlighted) gains the same 3-mode
   Editor/Split/Preview view. The preview decodes each mount line into plain English — the device spec
   (`UUID=…` → "the filesystem with UUID …", `LABEL=`, `//nas/share` → SMB/CIFS, `host:/export` → NFS), the

--- a/README.md
+++ b/README.md
@@ -132,9 +132,9 @@ Editora is built with the help of AI coding tools.
   **technical-terms dictionary** (`config`, `async`, `middleware`, `kubernetes`, …) keeps code-adjacent
   prose from being flagged — toggle it in Settings → Spell Check (default on). Pure-Java (Apache Lucene
   Hunspell).
-- **Code intelligence (LSP)** _(Beta)_ — language smarts via the Language Server Protocol, with **21 servers**
+- **Code intelligence (LSP)** _(Beta)_ — language smarts via the Language Server Protocol, with **22 servers**
   auto-detected on `PATH` (Java/JDT LS, TypeScript/JavaScript, Python/Pyright, Go, Rust, C/C++/clangd,
-  C#, PHP, Ruby, Kotlin, Lua, Bash, XML, JSON, YAML, HTML, CSS, Dockerfile, SQL, Terraform, TOML).
+  C#, PHP, Ruby, Kotlin, Lua, Bash, XML, JSON, YAML, HTML, CSS, Dockerfile, SQL, Terraform, TOML, Typst/tinymist).
   Inline diagnostics + a Problems tool window (`M-8`) + minimap/scrollbar stripes, go-to-definition
   (`M-.`), find references (`M-?`), hover docs (`C-c h`), LSP-backed completion, auto-imports, and
   **Format Document** (whole-file reformat via the server, when it advertises formatting — palette or the

--- a/TODO.md
+++ b/TODO.md
@@ -83,9 +83,18 @@ A backlog of planned features and improvements. Unordered within each section.
       to an isolated temp root, so a self-contained one still renders. **Inherent typst constraints
       (documented, not bugs):** `@preview` packages need a network fetch (offline → the doc errors in the
       preview); refs that escape the resolved root are blocked by typst's sandbox; an untitled buffer can't
-      resolve any relative ref; uninstalled fonts fall back. *Deferred: a ppi/quality setting, live linting
-      (typst compile diagnostics), autocomplete, `#table`/`#outline` insertion + image paste, an in-app
-      installer entry, and the generic "CLI → paginated image" seam (gnuplot, asciidoc-via-PDF).*
+      resolve any relative ref; uninstalled fonts fall back. *Deferred: a ppi/quality setting,
+      `#table`/`#outline` insertion + image paste, and the generic "CLI → paginated image" seam (gnuplot,
+      asciidoc-via-PDF).*
+- [x] Typst language server (tinymist) — the 22nd LSP server: completion, hover, go-to-definition,
+      find-references, document-symbol outline, push diagnostics (Problems window + squiggles), and Format
+      Document for `.typ` files, complementing the rendered preview. One `ServerDef` in `LspServerRegistry`
+      (`tinymist lsp`, root markers `typst.toml`/`.git`) + the served `typst` language id + a Settings
+      enable/command pair (data-driven LSP page) + an install-catalog binary archive entry (tinymist GitHub
+      releases) so Settings → LSP + the editor banner offer a one-click install. Live-verified: `tinymist lsp`
+      answers `initialize` advertising completion/hover/definition/references/symbols/formatting/semantic
+      tokens (tinymist 0.15.2). `Settings.typstLspEnabled`/`typstLspCommand` (schema 72→73). Supersedes the
+      Typst preview's deferred "live linting / autocomplete". *Deferred: bundled `snippets/typst.json`.*
 - [x] CSV/TSV grid preview moved into the editor as an IntelliJ-style Editor/Split/Preview view (mirroring
       the Markdown preview), replacing the bottom `csvGrid` tool window. The floating top-right toggle drives
       Editor (source), Split (source + live grid), and Preview (grid only); the mode is remembered per file.

--- a/src/main/java/com/editora/config/Settings.java
+++ b/src/main/java/com/editora/config/Settings.java
@@ -10,7 +10,7 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 public class Settings {
 
     /** Current on-disk schema version of {@code settings.toml}; bump when the format changes (+ a migration). */
-    public static final int SCHEMA_VERSION = 72;
+    public static final int SCHEMA_VERSION = 73;
 
     private int schemaVersion = SCHEMA_VERSION;
 
@@ -338,6 +338,7 @@ public class Settings {
     private String terraformLspCommand = "";
     private String tomlLspCommand = "";
     private String csharpLspCommand = "";
+    private String typstLspCommand = "";
     private boolean javaLspEnabled = true;
     private boolean typescriptLspEnabled = true;
     private boolean pythonLspEnabled = true;
@@ -359,6 +360,7 @@ public class Settings {
     private boolean terraformLspEnabled = true;
     private boolean tomlLspEnabled = true;
     private boolean csharpLspEnabled = true;
+    private boolean typstLspEnabled = true;
     /** PDF export: include the line-number gutter (code PDFs). */
     private boolean pdfLineNumbers = true;
     /** PDF export: apply syntax-highlighting colors (code PDFs); off = plain monospace. */
@@ -1737,6 +1739,22 @@ public class Settings {
 
     public void setCsharpLspEnabled(boolean csharpLspEnabled) {
         this.csharpLspEnabled = csharpLspEnabled;
+    }
+
+    public String getTypstLspCommand() {
+        return typstLspCommand == null ? "" : typstLspCommand;
+    }
+
+    public void setTypstLspCommand(String typstLspCommand) {
+        this.typstLspCommand = typstLspCommand == null ? "" : typstLspCommand;
+    }
+
+    public boolean isTypstLspEnabled() {
+        return typstLspEnabled;
+    }
+
+    public void setTypstLspEnabled(boolean typstLspEnabled) {
+        this.typstLspEnabled = typstLspEnabled;
     }
 
     public boolean isPdfLineNumbers() {

--- a/src/main/java/com/editora/config/migration/ConfigSchema.java
+++ b/src/main/java/com/editora/config/migration/ConfigSchema.java
@@ -120,7 +120,9 @@ public enum ConfigSchema {
                             ConfigMigrations::identity), // v69→70: + cargoSupport/cargoCommand (additive)
                     Map.entry(70, (Migration) ConfigMigrations::identity), // v70→71: + goSupport/goCommand (additive)
                     Map.entry(71, (Migration)
-                            ConfigMigrations::identity))), // v71→72: + gradleSupport/gradleCommand (additive)
+                            ConfigMigrations::identity), // v71→72: + gradleSupport/gradleCommand (additive)
+                    Map.entry(72, (Migration)
+                            ConfigMigrations::identity))), // v72→73: + typstLspCommand/typstLspEnabled (additive)
     WORKSPACE(WorkspaceState.SCHEMA_VERSION, 1, Map.of()),
     BOOKMARKS(BookmarkStore.SCHEMA_VERSION, 1, Map.of()),
     BREAKPOINTS(BreakpointStore.SCHEMA_VERSION, 1, Map.of()),

--- a/src/main/java/com/editora/editor/EditorBuffer.java
+++ b/src/main/java/com/editora/editor/EditorBuffer.java
@@ -2593,7 +2593,8 @@ public class EditorBuffer implements TabContent {
             "sql",
             "terraform",
             "toml",
-            "csharp");
+            "csharp",
+            "typst");
 
     /** Whether this buffer's language has a language server. */
     public boolean isLspLanguage() {

--- a/src/main/java/com/editora/install/InstallCatalog.java
+++ b/src/main/java/com/editora/install/InstallCatalog.java
@@ -188,7 +188,8 @@ public final class InstallCatalog {
                 "kotlin",
                 "lua",
                 "xml",
-                "terraform");
+                "terraform",
+                "typst");
     }
 
     /** The install steps for an LSP-only server id (empty if it has no installer). Pure. */
@@ -224,13 +225,14 @@ public final class InstallCatalog {
                 java.util.Optional.of(List.of(toolStep(
                         "phpactor", Prereq.COMPOSER, List.of("composer", "global", "require", "phpactor/phpactor"))));
             // --- per-OS/arch binary archives (download + extract into the config dir) ---
-            case "clangd", "kotlin", "lua", "xml", "terraform" -> java.util.Optional.of(List.of(archiveStep(serverId)));
+            case "clangd", "kotlin", "lua", "xml", "terraform", "typst" ->
+                java.util.Optional.of(List.of(archiveStep(serverId)));
             default -> java.util.Optional.empty();
         };
     }
 
     /**
-     * The per-OS binary-archive recipe for a server id (clangd/kotlin/lua/xml/terraform), or empty.
+     * The per-OS binary-archive recipe for a server id (clangd/kotlin/lua/xml/terraform/typst), or empty.
      * {@code apiUrl} returns JSON whose asset/download URLs we match by the per-{@link Platform} substring;
      * the extracted tree is searched for {@code binaryName} (a prefix when {@code binaryPrefix}) and the
      * server's command is set to that path + {@code commandSuffix}. Pure.
@@ -300,6 +302,19 @@ public final class InstallCatalog {
                         "terraform-ls",
                         false,
                         " serve"));
+            case "typst" ->
+                java.util.Optional.of(new ArchiveSpec(
+                        "https://api.github.com/repos/Myriad-Dreamin/tinymist/releases/latest",
+                        // The bare "tinymist-<triple>" binary — distinct from tinymist-docs-tool/-viewer/typlite.
+                        java.util.Map.of(
+                                Platform.MAC_ARM, "tinymist-aarch64-apple-darwin",
+                                Platform.MAC_X64, "tinymist-x86_64-apple-darwin",
+                                Platform.LINUX_X64, "tinymist-x86_64-unknown-linux-gnu",
+                                Platform.LINUX_ARM, "tinymist-aarch64-unknown-linux-gnu",
+                                Platform.WIN_X64, "tinymist-x86_64-pc-windows-msvc"),
+                        "tinymist",
+                        false,
+                        " lsp"));
             default -> java.util.Optional.empty();
         };
     }

--- a/src/main/java/com/editora/lsp/LspServerRegistry.java
+++ b/src/main/java/com/editora/lsp/LspServerRegistry.java
@@ -13,14 +13,15 @@ import java.util.Set;
  * {@code javascript}/{@code javascriptreact}/{@code typescript}/{@code typescriptreact}), so the
  * {@link LspManager} keys a single session per {@code (serverId, root)} and all four share one process.
  *
- * <p>Ships twenty-one servers — <b>Java</b> (Eclipse JDT LS), <b>TypeScript</b> (typescript-language-server,
+ * <p>Ships twenty-two servers — <b>Java</b> (Eclipse JDT LS), <b>TypeScript</b> (typescript-language-server,
  * which also covers JavaScript/JSX/TSX), <b>Python</b> (Pyright), <b>XML</b> (lemminx), <b>JSON</b>
  * (vscode-json-language-server), <b>Bash</b> (bash-language-server, for shell scripts), <b>YAML</b>
  * (yaml-language-server), <b>Go</b> (gopls), <b>Rust</b> (rust-analyzer), <b>PHP</b> (phpactor),
  * <b>Ruby</b> (ruby-lsp), <b>C/C++</b> (clangd — one server, both language ids), <b>HTML</b> and
  * <b>CSS</b> (vscode-html/css-language-server), <b>Kotlin</b> (kotlin-language-server), <b>Lua</b>
  * (lua-language-server), <b>Dockerfile</b> (docker-langserver), <b>SQL</b> (sqls),
- * <b>Terraform</b> (terraform-ls), <b>TOML</b> (taplo), and <b>C#</b> (csharp-ls). Commands are
+ * <b>Terraform</b> (terraform-ls), <b>TOML</b> (taplo), <b>C#</b> (csharp-ls), and <b>Typst</b>
+ * (tinymist). Commands are
  * user-configurable (Settings) and never bundled. All methods are static + pure (no process launch, no I/O) so they are
  * unit-testable. Adding a server later = one more {@link ServerDef} entry.
  */
@@ -127,6 +128,9 @@ public final class LspServerRegistry {
     /** Markers for a C# project root (a global.json, else the repo; csharp-ls finds the .sln/.csproj). */
     public static final List<String> CSHARP_ROOT_MARKERS = List.of("global.json", ".git");
 
+    /** Markers for a Typst project root (a typst.toml package manifest, else the repo). */
+    public static final List<String> TYPST_ROOT_MARKERS = List.of("typst.toml", ".git");
+
     /** Default server commands when the user leaves the Settings field blank. */
     public static final String DEFAULT_JAVA_COMMAND = "jdtls";
 
@@ -150,6 +154,7 @@ public final class LspServerRegistry {
     public static final String DEFAULT_TERRAFORM_COMMAND = "terraform-ls serve";
     public static final String DEFAULT_TOML_COMMAND = "taplo lsp stdio";
     public static final String DEFAULT_CSHARP_COMMAND = "csharp-ls";
+    public static final String DEFAULT_TYPST_COMMAND = "tinymist lsp";
 
     /** A known language server: its id, default command, root markers, and the language ids it serves. */
     private enum ServerDef {
@@ -178,7 +183,8 @@ public final class LspServerRegistry {
         SQL("sql", DEFAULT_SQL_COMMAND, SHELL_ROOT_MARKERS, Set.of("sql")),
         TERRAFORM("terraform", DEFAULT_TERRAFORM_COMMAND, TERRAFORM_ROOT_MARKERS, Set.of("terraform")),
         TOML("toml", DEFAULT_TOML_COMMAND, SHELL_ROOT_MARKERS, Set.of("toml")),
-        CSHARP("csharp", DEFAULT_CSHARP_COMMAND, CSHARP_ROOT_MARKERS, Set.of("csharp"));
+        CSHARP("csharp", DEFAULT_CSHARP_COMMAND, CSHARP_ROOT_MARKERS, Set.of("csharp")),
+        TYPST("typst", DEFAULT_TYPST_COMMAND, TYPST_ROOT_MARKERS, Set.of("typst"));
 
         final String id;
         final String defaultCommand;

--- a/src/main/java/com/editora/ui/LspCoordinator.java
+++ b/src/main/java/com/editora/ui/LspCoordinator.java
@@ -127,7 +127,8 @@ final class LspCoordinator {
         "sql",
         "terraform",
         "toml",
-        "csharp"
+        "csharp",
+        "typst"
     };
 
     /** Lines of over-scan above/below the viewport when requesting semantic tokens (small scrolls stay covered). */
@@ -276,7 +277,8 @@ final class LspCoordinator {
                         Map.entry("sql", s.getSqlLspCommand()),
                         Map.entry("terraform", s.getTerraformLspCommand()),
                         Map.entry("toml", s.getTomlLspCommand()),
-                        Map.entry("csharp", s.getCsharpLspCommand())));
+                        Map.entry("csharp", s.getCsharpLspCommand()),
+                        Map.entry("typst", s.getTypstLspCommand())));
         updateProblemsAvailability();
         // The Run affordance (compact source files) is gated by the LSP feature: toggle every buffer's
         // Run detection, then refresh the active buffer's Run tool-window availability.
@@ -338,6 +340,7 @@ final class LspCoordinator {
             case "terraform" -> s.isTerraformLspEnabled();
             case "toml" -> s.isTomlLspEnabled();
             case "csharp" -> s.isCsharpLspEnabled();
+            case "typst" -> s.isTypstLspEnabled();
             default -> s.isJavaLspEnabled();
         };
     }
@@ -366,6 +369,7 @@ final class LspCoordinator {
             case "terraform" -> s.getTerraformLspCommand();
             case "toml" -> s.getTomlLspCommand();
             case "csharp" -> s.getCsharpLspCommand();
+            case "typst" -> s.getTypstLspCommand();
             default -> s.getJavaLspCommand();
         };
     }
@@ -394,6 +398,7 @@ final class LspCoordinator {
             case "terraform" -> s.setTerraformLspEnabled(on);
             case "toml" -> s.setTomlLspEnabled(on);
             case "csharp" -> s.setCsharpLspEnabled(on);
+            case "typst" -> s.setTypstLspEnabled(on);
             default -> s.setJavaLspEnabled(on);
         }
     }
@@ -422,6 +427,7 @@ final class LspCoordinator {
             case "terraform" -> s.setTerraformLspCommand(command);
             case "toml" -> s.setTomlLspCommand(command);
             case "csharp" -> s.setCsharpLspCommand(command);
+            case "typst" -> s.setTypstLspCommand(command);
             default -> s.setJavaLspCommand(command);
         }
     }

--- a/src/main/java/com/editora/ui/SettingsWindow.java
+++ b/src/main/java/com/editora/ui/SettingsWindow.java
@@ -4664,7 +4664,18 @@ public class SettingsWindow {
                         v -> config.getSettings().setCsharpLspEnabled(v),
                         () -> config.getSettings().isCsharpLspEnabled(),
                         v -> config.getSettings().setCsharpLspCommand(v),
-                        () -> config.getSettings().getCsharpLspCommand()));
+                        () -> config.getSettings().getCsharpLspCommand()),
+                new LspServerUi(
+                        "typst",
+                        com.editora.lsp.LspServerRegistry.DEFAULT_TYPST_COMMAND,
+                        "settings.lsp.enableTypst",
+                        "settings.lsp.typstCommand",
+                        "settings.lsp.typstStatus",
+                        "lsp typst tinymist language server found installed not found command path executable",
+                        v -> config.getSettings().setTypstLspEnabled(v),
+                        () -> config.getSettings().isTypstLspEnabled(),
+                        v -> config.getSettings().setTypstLspCommand(v),
+                        () -> config.getSettings().getTypstLspCommand()));
     }
 
     /** A "[label] [path field] [Browse…]" row for picking a CLI executable. */
@@ -4831,7 +4842,8 @@ public class SettingsWindow {
                         java.util.Map.entry("sql", cs.getSqlLspCommand()),
                         java.util.Map.entry("terraform", cs.getTerraformLspCommand()),
                         java.util.Map.entry("toml", cs.getTomlLspCommand()),
-                        java.util.Map.entry("csharp", cs.getCsharpLspCommand())));
+                        java.util.Map.entry("csharp", cs.getCsharpLspCommand()),
+                        java.util.Map.entry("typst", cs.getTypstLspCommand())));
         for (LspServerUi srv : lspServerUis()) {
             Label status = lspStatusLabels.get(srv.id());
             if (status == null) {

--- a/src/main/resources/com/editora/i18n/messages.properties
+++ b/src/main/resources/com/editora/i18n/messages.properties
@@ -3087,3 +3087,6 @@ command.gradle.refresh=Gradle: Refresh build file
 command.gradle.refresh.desc=Force re-detect the Gradle project now (e.g. after an external edit).
 command.view.toggleGradleSupport=Toggle Gradle Support
 command.view.toggleGradleSupport.desc=Enable or disable the Gradle toolbar icon, actions popup, and console.
+settings.lsp.enableTypst=Enable Typst (tinymist)
+settings.lsp.typstCommand=Typst server command
+settings.lsp.typstStatus=Typst language server (tinymist): {0}

--- a/src/main/resources/com/editora/i18n/messages_de.properties
+++ b/src/main/resources/com/editora/i18n/messages_de.properties
@@ -3078,3 +3078,6 @@ command.gradle.refresh=Gradle: build file aktualisieren
 command.gradle.refresh.desc=Erzwingt eine sofortige erneute Erkennung des Gradle-Projekts (z. B. nach einer externen Änderung).
 command.view.toggleGradleSupport=Gradle-Unterstützung umschalten
 command.view.toggleGradleSupport.desc=Aktiviert oder deaktiviert das Gradle-Symbol in der Symbolleiste, das Aktionen-Popup und die Konsole.
+settings.lsp.enableTypst=Typst (tinymist) aktivieren
+settings.lsp.typstCommand=Typst-Server-Befehl
+settings.lsp.typstStatus=Typst-Sprachserver (tinymist): {0}

--- a/src/main/resources/com/editora/i18n/messages_es.properties
+++ b/src/main/resources/com/editora/i18n/messages_es.properties
@@ -3078,3 +3078,6 @@ command.gradle.refresh=Gradle: actualizar build file
 command.gradle.refresh.desc=Fuerza una nueva detección del proyecto de Gradle (por ejemplo, tras una edición externa).
 command.view.toggleGradleSupport=Alternar compatibilidad con Gradle
 command.view.toggleGradleSupport.desc=Habilita o deshabilita el icono de Gradle en la barra de herramientas, el menú de acciones y la consola.
+settings.lsp.enableTypst=Habilitar Typst (tinymist)
+settings.lsp.typstCommand=Comando del servidor Typst
+settings.lsp.typstStatus=Servidor de lenguaje Typst (tinymist): {0}

--- a/src/main/resources/com/editora/i18n/messages_fr.properties
+++ b/src/main/resources/com/editora/i18n/messages_fr.properties
@@ -3078,3 +3078,6 @@ command.gradle.refresh=Gradle : actualiser build file
 command.gradle.refresh.desc=Force une nouvelle détection du projet Gradle (par exemple après une modification externe).
 command.view.toggleGradleSupport=Activer/désactiver la prise en charge de Gradle
 command.view.toggleGradleSupport.desc=Active ou désactive l'icône Gradle de la barre d'outils, le menu d'actions et la console.
+settings.lsp.enableTypst=Activer Typst (tinymist)
+settings.lsp.typstCommand=Commande du serveur Typst
+settings.lsp.typstStatus=Serveur de langage Typst (tinymist) : {0}

--- a/src/main/resources/com/editora/i18n/messages_it.properties
+++ b/src/main/resources/com/editora/i18n/messages_it.properties
@@ -3078,3 +3078,6 @@ command.gradle.refresh=Gradle: aggiorna build file
 command.gradle.refresh.desc=Forza un nuovo rilevamento del progetto Gradle (ad es. dopo una modifica esterna).
 command.view.toggleGradleSupport=Attiva/disattiva supporto Gradle
 command.view.toggleGradleSupport.desc=Abilita o disabilita l'icona Gradle nella barra degli strumenti, il popup delle azioni e la console.
+settings.lsp.enableTypst=Abilita Typst (tinymist)
+settings.lsp.typstCommand=Comando server Typst
+settings.lsp.typstStatus=Language server Typst (tinymist): {0}

--- a/src/main/resources/com/editora/i18n/messages_pt.properties
+++ b/src/main/resources/com/editora/i18n/messages_pt.properties
@@ -3078,3 +3078,6 @@ command.gradle.refresh=Gradle: atualizar build file
 command.gradle.refresh.desc=Força uma nova deteção do projeto Gradle (por exemplo, após uma edição externa).
 command.view.toggleGradleSupport=Alternar suporte ao Gradle
 command.view.toggleGradleSupport.desc=Ativa ou desativa o ícone do Gradle na barra de ferramentas, o menu de ações e a consola.
+settings.lsp.enableTypst=Ativar Typst (tinymist)
+settings.lsp.typstCommand=Comando do servidor Typst
+settings.lsp.typstStatus=Servidor de linguagem Typst (tinymist): {0}

--- a/src/test/java/com/editora/lsp/LspServerRegistryTest.java
+++ b/src/test/java/com/editora/lsp/LspServerRegistryTest.java
@@ -168,6 +168,17 @@ class LspServerRegistryTest {
     }
 
     @Test
+    void typstServerDefaultsAndMarkers() {
+        assertTrue(LspServerRegistry.isSupported("typst"));
+        assertEquals("typst", LspServerRegistry.serverIdFor("typst"));
+        assertEquals(
+                List.of("tinymist", "lsp"),
+                LspServerRegistry.specFor("typst", Map.of()).command());
+        assertTrue(LspServerRegistry.specFor("typst", Map.of()).rootMarkers().contains("typst.toml"));
+        assertTrue(LspServerRegistry.specFor("typst", Map.of()).rootMarkers().contains(".git"));
+    }
+
+    @Test
     void configuredCommandIsTokenizedPerServer() {
         var java = LspServerRegistry.specFor("java", Map.of("java", "java -jar /opt/jdtls/launcher.jar -data ws"));
         assertEquals(List.of("java", "-jar", "/opt/jdtls/launcher.jar", "-data", "ws"), java.command());


### PR DESCRIPTION
Adds **tinymist** as the 22nd server in Editora's LSP layer, giving `.typ` files full code intelligence alongside the rendered preview shipped in #374. **No new Maven dependency** (tinymist is an external server the user installs).

## What you get
- **Completion**, **hover docs**, **go-to-definition** (`M-.`), **find-references** (`M-?`), a precise **document-symbol outline** (Structure window), **diagnostics** (squiggles + Problems `M-8`), and **Format Document** — everything Editora's LSP layer already exposes.

## Wiring (the standard "add a server" surface)
- One `ServerDef` in `LspServerRegistry` (`tinymist lsp`, root markers `typst.toml`/`.git`).
- Served `typst` language id in `EditorBuffer.LSP_LANGUAGES`.
- `LspCoordinator` `SERVER_IDS` + configure-map + the enable/command/get/set switches.
- `Settings.typstLspEnabled`/`typstLspCommand` (schema **72→73** additive) + the data-driven **Settings → LSP** row + i18n ×6.
- **Install-catalog** binary-archive entry (per-OS/arch from tinymist's GitHub releases) → a one-click **Install…** in Settings → LSP and the editor install banner (`tinymist lsp` command wired via the ` lsp` suffix).

Off until the global LSP feature is on; auto-detected on `PATH`.

## Verification
- `mvn verify` green: **1885 tests**, spotless + jacoco pass. New `LspServerRegistryTest.typstServerDefaultsAndMarkers`.
- **Live-verified against tinymist 0.15.2**: `tinymist lsp` answers `initialize` advertising `completionProvider`, `hoverProvider`, `definitionProvider`, `referencesProvider`, `documentSymbolProvider`, `documentFormattingProvider`, `semanticTokensProvider`. (`diagnosticProvider: false` → tinymist *pushes* diagnostics via `publishDiagnostics`, which Editora handles.)

Docs: CHANGELOG.md, README.md (21→22 servers), TODO.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)