### PR TITLE
In-app typst-CLI installer (download the typst renderer binary)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **In-app typst-CLI installer.** *Settings → Languages & Tools → Typst* gains an **Install…** button (and
+  the `install.typstCli` command) that downloads the `typst` renderer binary for your OS/arch from typst's
+  GitHub releases, extracts it (adds `.tar.xz` support — typst ships xz tarballs), and points
+  `Settings.typstPath` at it, so the document preview lights up without a restart. Distinct from the
+  tinymist LSP-server installer. The button shows **Installed** when `typst` is already detected.
+
 - **Typst editing conveniences.** For `.typ` files: **snippets** (a bundled `typst.json` — figure, table,
   grid, equation, import, outline, bibliography, …); **Insert Table** (a grid size-picker that drops a
   `#table(…)` skeleton with the caret in the first cell — on the format bar, right-click menu, and

--- a/TODO.md
+++ b/TODO.md
@@ -95,12 +95,13 @@ A backlog of planned features and improvements. Unordered within each section.
       preview); refs that escape the resolved root are blocked by typst's sandbox; an untitled buffer can't
       resolve any relative ref; uninstalled fonts fall back. **Editor conveniences shipped:** bundled
       snippets, `#table` insert (grid picker), `#outline()`/TOC insert, image paste/drop/drag → `assets/` +
-      `#image("…")`, and preview → PNG/SVG export (native `typst -f`). *Deferred: a ppi/quality setting; an
-      in-app **typst-CLI installer** (needs `.tar.xz` extraction + a distinct archive id from tinymist's +
-      an apply-to-`Settings.typstPath` path — the LSP-server installer already exists); **click-in-preview →
-      jump-to-source** (infeasible on the raster preview — needs tinymist's websocket preview protocol + a
-      `javafx.web` host Editora doesn't ship); and the generic "CLI → paginated image" seam (gnuplot,
-      asciidoc-via-PDF).*
+      `#image("…")`, and preview → PNG/SVG export (native `typst -f`). **In-app typst-CLI installer shipped:**
+      Settings → Typst **Install…** (+ `install.typstCli`) downloads the typst binary from GitHub releases
+      (added `.tar.xz` extraction via `tar -xf`; archive id `typst-cli` distinct from the tinymist server's
+      `typst`), applies it to `Settings.typstPath`, and re-detects — end-to-end verified against typst 0.15.
+      *Deferred: a ppi/quality setting; **click-in-preview → jump-to-source** (infeasible on the raster
+      preview — needs tinymist's websocket preview protocol + a `javafx.web` host Editora doesn't ship); and
+      the generic "CLI → paginated image" seam (gnuplot, asciidoc-via-PDF).*
 - [x] Typst language server (tinymist) — the 22nd LSP server: completion, hover, go-to-definition,
       find-references, document-symbol outline, push diagnostics (Problems window + squiggles), and Format
       Document for `.typ` files, complementing the rendered preview. One `ServerDef` in `LspServerRegistry`

--- a/src/main/java/com/editora/install/InstallCatalog.java
+++ b/src/main/java/com/editora/install/InstallCatalog.java
@@ -129,6 +129,12 @@ public final class InstallCatalog {
         return List.of("tar", "-xzf", archive.toString(), "-C", dest.toString());
     }
 
+    /** Like {@link #tarExtractArgv} but with {@code -xf} (auto-detect compression) — for {@code .tar.xz}
+     *  archives (bsdtar/GNU tar both sniff xz). */
+    public static List<String> tarExtractArgvAuto(Path archive, Path dest) {
+        return List.of("tar", "-xf", archive.toString(), "-C", dest.toString());
+    }
+
     /** The first substring of {@code text} matching {@code regex}, or {@code null}. Pure. */
     public static String firstMatch(String text, String regex) {
         if (text == null) {
@@ -315,6 +321,19 @@ public final class InstallCatalog {
                         "tinymist",
                         false,
                         " lsp"));
+            case "typst-cli" ->
+                java.util.Optional.of(new ArchiveSpec(
+                        "https://api.github.com/repos/typst/typst/releases/latest",
+                        // typst's own release binaries (.tar.xz on unix, .zip on Windows); musl = static/portable.
+                        java.util.Map.of(
+                                Platform.MAC_ARM, "typst-aarch64-apple-darwin",
+                                Platform.MAC_X64, "typst-x86_64-apple-darwin",
+                                Platform.LINUX_X64, "typst-x86_64-unknown-linux-musl",
+                                Platform.LINUX_ARM, "typst-aarch64-unknown-linux-musl",
+                                Platform.WIN_X64, "typst-x86_64-pc-windows-msvc"),
+                        "typst",
+                        false,
+                        ""));
             default -> java.util.Optional.empty();
         };
     }
@@ -372,6 +391,23 @@ public final class InstallCatalog {
                 false,
                 "plugins/lsp/" + id,
                 null);
+    }
+
+    /** The install step for the typst render CLI (the preview tool, distinct from the tinymist LSP server):
+     *  a per-OS binary archive from typst's GitHub releases, extracted to {@code plugins/typst}. Pure. */
+    public static List<Step> typstCliSteps() {
+        return List.of(new Step(
+                "typst-cli",
+                Kind.ARCHIVE,
+                Set.of(Prereq.TAR),
+                List.of(),
+                null,
+                null,
+                null,
+                null,
+                false,
+                "plugins/typst",
+                null));
     }
 
     // --- Step factories ------------------------------------------------------------------------

--- a/src/main/java/com/editora/install/InstallService.java
+++ b/src/main/java/com/editora/install/InstallService.java
@@ -191,6 +191,20 @@ public final class InstallService {
             } finally {
                 deleteQuietly(tmp);
             }
+        } else if (url.endsWith(".tar.xz") || url.endsWith(".txz")) {
+            // xz-compressed tarball (e.g. the typst CLI). System tar with -xf auto-detects xz (bsdtar/liblzma
+            // on macOS, GNU tar + xz on Linux); the TAR prereq covers it.
+            Path tmp = Files.createTempFile("editora-dl", ".tar.xz");
+            try {
+                Files.write(tmp, data);
+                ProcessRunner.Result r =
+                        ProcessRunner.run(null, CMD_TIMEOUT, InstallCatalog.tarExtractArgvAuto(tmp, dest));
+                if (!r.ok()) {
+                    throw new InstallException(s.id() + ": tar failed — " + r.message());
+                }
+            } finally {
+                deleteQuietly(tmp);
+            }
         } else {
             Unzip.extract(
                     new ByteArrayInputStream(data),

--- a/src/main/java/com/editora/typst/TypstService.java
+++ b/src/main/java/com/editora/typst/TypstService.java
@@ -40,6 +40,13 @@ public final class TypstService {
     }
 
     /** Probes {@code typst}'s presence off-thread (cached), posting the result on the FX thread. */
+    /** The last cached detection result ({@code false} if never probed) — a synchronous read for the
+     *  installer's "already installed?" pre-check. */
+    public boolean cachedAvailable() {
+        Boolean c = cached;
+        return c != null && c;
+    }
+
     public void detect(Consumer<Boolean> onResult) {
         Boolean hit = cached;
         if (hit != null) {

--- a/src/main/java/com/editora/ui/InstallCoordinator.java
+++ b/src/main/java/com/editora/ui/InstallCoordinator.java
@@ -44,6 +44,9 @@ final class InstallCoordinator {
         /** Whether the Mermaid {@code mmdc} CLI is currently detected. */
         boolean mmdcAvailable();
 
+        /** Whether the {@code typst} render CLI is currently detected (cached). */
+        boolean typstCliAvailable();
+
         /** Invalidates the cached tool detection and re-applies LSP/Debug/Mermaid support (+ persists). */
         void reapplyToolSupport();
     }
@@ -169,6 +172,64 @@ final class InstallCoordinator {
                             host.setStatus(tr("status.install.done", serverName(serverId)));
                         } else {
                             host.setStatus(tr("status.install.failed", serverName(serverId)));
+                            alert(Alert.AlertType.ERROR, result.message());
+                        }
+                        onResult.accept(result.ok());
+                    });
+        });
+    }
+
+    /**
+     * Installs the {@code typst} render CLI — a per-OS binary archive from typst's GitHub releases — and
+     * points {@code Settings.typstPath} at the extracted binary, then re-detects. This is the Typst
+     * <em>preview</em> tool (distinct from the tinymist LSP server, which has its own installer).
+     */
+    void installTypstCli() {
+        installTypstCli(ok -> {});
+    }
+
+    void installTypstCli(java.util.function.Consumer<Boolean> onResult) {
+        final String key = "typst-cli";
+        List<Step> steps = InstallCatalog.typstCliSteps();
+        if (steps.isEmpty()) {
+            onResult.accept(false);
+            return;
+        }
+        if (installingServers.contains(key)) {
+            host.setStatus(tr("status.install.inProgress"));
+            onResult.accept(false);
+            return;
+        }
+        if (ops.typstCliAvailable()) {
+            host.setStatus(tr("status.install.already", tr("install.lang.typst")));
+            onResult.accept(true);
+            return;
+        }
+        service.detectPrereqs(present -> {
+            Set<Prereq> needed = steps.stream()
+                    .flatMap(s -> s.prereqs().stream())
+                    .collect(Collectors.toCollection(() -> EnumSet.noneOf(Prereq.class)));
+            needed.removeAll(present);
+            if (!needed.isEmpty()) {
+                String names = needed.stream().map(this::prereqName).collect(Collectors.joining(", "));
+                host.setStatus(tr("status.install.needPrereq", names));
+                alert(Alert.AlertType.WARNING, tr("status.install.needPrereq", names));
+                onResult.accept(false);
+                return;
+            }
+            installingServers.add(key);
+            host.setStatus(tr("status.install.installing", tr("install.lang.typst")));
+            service.install(
+                    steps, ops.configDir(), id -> host.setStatus(tr("status.install.installingTool", id)), result -> {
+                        installingServers.remove(key);
+                        if (result.ok()) {
+                            if (result.installedCommand() != null) {
+                                host.settings().setTypstPath(result.installedCommand());
+                            }
+                            ops.reapplyToolSupport(); // re-applies Typst support (+ persists) → preview lights up
+                            host.setStatus(tr("status.install.done", tr("install.lang.typst")));
+                        } else {
+                            host.setStatus(tr("status.install.failed", tr("install.lang.typst")));
                             alert(Alert.AlertType.ERROR, result.message());
                         }
                         onResult.accept(result.ok());

--- a/src/main/java/com/editora/ui/MainController.java
+++ b/src/main/java/com/editora/ui/MainController.java
@@ -552,7 +552,11 @@ public class MainController implements com.editora.mcp.McpBridge {
         this.settingsWindow.setDictionaryActions(
                 this::openTechnicalDictionary, this::openPersonalDictionary); // Spell Check file links
         this.settingsWindow.setInstallActions(
-                key -> { // Settings LSP/Mermaid "Install…" buttons
+                key -> { // Settings LSP/Mermaid/Typst "Install…" buttons
+                    if ("typst".equals(key)) { // the typst CLI (renderer), not an LSP server
+                        installCoordinator.installTypstCli();
+                        return;
+                    }
                     com.editora.install.InstallCatalog.Lang lang =
                             switch (key) {
                                 case "python" -> com.editora.install.InstallCatalog.Lang.PYTHON;
@@ -2075,6 +2079,11 @@ public class MainController implements com.editora.mcp.McpBridge {
             @Override
             public boolean mmdcAvailable() {
                 return mermaid.mmdcAvailable();
+            }
+
+            @Override
+            public boolean typstCliAvailable() {
+                return typst.isTypstCliAvailable();
             }
 
             @Override
@@ -10561,6 +10570,7 @@ public class MainController implements com.editora.mcp.McpBridge {
         registry.register(Command.of(
                 "install.mermaidSupport",
                 () -> installCoordinator.installSupport(com.editora.install.InstallCatalog.Lang.MERMAID)));
+        registry.register(Command.of("install.typstCli", () -> installCoordinator.installTypstCli()));
         registry.register(Command.of("install.languageServer", this::chooseInstallServer));
         registry.register(Command.of("view.toggleColumnRuler", this::toggleColumnRuler));
         registry.register(Command.of("view.toggleToolStripe", this::toggleToolStripe));

--- a/src/main/java/com/editora/ui/SettingsWindow.java
+++ b/src/main/java/com/editora/ui/SettingsWindow.java
@@ -2726,6 +2726,7 @@ public class SettingsWindow {
                 null,
                 exePathRow(tr("settings.typst.path"), typstPathField),
                 "typst path executable render document");
+        row(p, Category.TYPST, null, installButton("typst"), "typst install download cli render");
         Label typstHint = note(tr("settings.typst.hint"));
         typstHint.setWrapText(true);
         typstHint.setMaxWidth(440);
@@ -2744,6 +2745,7 @@ public class SettingsWindow {
                     .getStyleClass()
                     .setAll("settings-git-status", present ? "settings-git-found" : "settings-git-missing");
             typstStatusLabel.setText(present ? tr("settings.typst.found") : tr("settings.typst.notFound"));
+            updateInstallButton("typst", present); // "Installed" + disabled when the typst CLI is found
         });
     }
 

--- a/src/main/java/com/editora/ui/TypstCoordinator.java
+++ b/src/main/java/com/editora/ui/TypstCoordinator.java
@@ -54,6 +54,11 @@ final class TypstCoordinator {
         return service;
     }
 
+    /** Whether the typst CLI was detected on the last probe (cached) — for the install "already?" pre-check. */
+    boolean isTypstCliAvailable() {
+        return service.cachedAvailable();
+    }
+
     /** Whether the Typst feature is enabled in Settings (default on). */
     boolean isEnabled() {
         return host.settings().isTypstSupport();

--- a/src/main/resources/com/editora/i18n/messages.properties
+++ b/src/main/resources/com/editora/i18n/messages.properties
@@ -3116,3 +3116,6 @@ command.typst.exportPng=Typst: Export as PNG
 command.typst.exportPng.desc=Export the active Typst document to PNG (one file per page).
 command.typst.exportSvg=Typst: Export as SVG
 command.typst.exportSvg.desc=Export the active Typst document to SVG (one file per page).
+install.lang.typst=Typst
+command.install.typstCli=Install Typst CLI
+command.install.typstCli.desc=Download and install the typst renderer binary for the document preview.

--- a/src/main/resources/com/editora/i18n/messages_de.properties
+++ b/src/main/resources/com/editora/i18n/messages_de.properties
@@ -3107,3 +3107,6 @@ command.typst.exportPng=Typst: Als PNG exportieren
 command.typst.exportPng.desc=Exportiert das aktive Typst-Dokument als PNG (eine Datei pro Seite).
 command.typst.exportSvg=Typst: Als SVG exportieren
 command.typst.exportSvg.desc=Exportiert das aktive Typst-Dokument als SVG (eine Datei pro Seite).
+install.lang.typst=Typst
+command.install.typstCli=Typst-CLI installieren
+command.install.typstCli.desc=Lädt das typst-Renderer-Binary für die Dokumentvorschau herunter und installiert es.

--- a/src/main/resources/com/editora/i18n/messages_es.properties
+++ b/src/main/resources/com/editora/i18n/messages_es.properties
@@ -3107,3 +3107,6 @@ command.typst.exportPng=Typst: Exportar como PNG
 command.typst.exportPng.desc=Exporta el documento Typst activo a PNG (un archivo por página).
 command.typst.exportSvg=Typst: Exportar como SVG
 command.typst.exportSvg.desc=Exporta el documento Typst activo a SVG (un archivo por página).
+install.lang.typst=Typst
+command.install.typstCli=Instalar la CLI de Typst
+command.install.typstCli.desc=Descarga e instala el binario del renderizador typst para la vista previa del documento.

--- a/src/main/resources/com/editora/i18n/messages_fr.properties
+++ b/src/main/resources/com/editora/i18n/messages_fr.properties
@@ -3107,3 +3107,6 @@ command.typst.exportPng=Typst : Exporter en PNG
 command.typst.exportPng.desc=Exporte le document Typst actif en PNG (un fichier par page).
 command.typst.exportSvg=Typst : Exporter en SVG
 command.typst.exportSvg.desc=Exporte le document Typst actif en SVG (un fichier par page).
+install.lang.typst=Typst
+command.install.typstCli=Installer la CLI Typst
+command.install.typstCli.desc=Télécharge et installe le binaire du moteur de rendu typst pour l'aperçu du document.

--- a/src/main/resources/com/editora/i18n/messages_it.properties
+++ b/src/main/resources/com/editora/i18n/messages_it.properties
@@ -3107,3 +3107,6 @@ command.typst.exportPng=Typst: Esporta come PNG
 command.typst.exportPng.desc=Esporta il documento Typst attivo in PNG (un file per pagina).
 command.typst.exportSvg=Typst: Esporta come SVG
 command.typst.exportSvg.desc=Esporta il documento Typst attivo in SVG (un file per pagina).
+install.lang.typst=Typst
+command.install.typstCli=Installa la CLI Typst
+command.install.typstCli.desc=Scarica e installa il binario del renderer typst per l'anteprima del documento.

--- a/src/main/resources/com/editora/i18n/messages_pt.properties
+++ b/src/main/resources/com/editora/i18n/messages_pt.properties
@@ -3107,3 +3107,6 @@ command.typst.exportPng=Typst: Exportar como PNG
 command.typst.exportPng.desc=Exporta o documento Typst ativo para PNG (um arquivo por página).
 command.typst.exportSvg=Typst: Exportar como SVG
 command.typst.exportSvg.desc=Exporta o documento Typst ativo para SVG (um arquivo por página).
+install.lang.typst=Typst
+command.install.typstCli=Instalar a CLI do Typst
+command.install.typstCli.desc=Baixa e instala o binário do renderizador typst para a pré-visualização do documento.

--- a/src/test/java/com/editora/install/InstallCatalogTest.java
+++ b/src/test/java/com/editora/install/InstallCatalogTest.java
@@ -197,6 +197,29 @@ class InstallCatalogTest {
     }
 
     @Test
+    void typstCliIsABinaryArchiveForEveryPlatform() {
+        var steps = InstallCatalog.typstCliSteps();
+        assertEquals(1, steps.size());
+        assertEquals(Kind.ARCHIVE, steps.get(0).kind());
+        assertEquals("typst-cli", steps.get(0).id());
+        assertEquals("plugins/typst", steps.get(0).destSubpath());
+        ArchiveSpec spec = InstallCatalog.archiveSpec("typst-cli").orElseThrow();
+        assertEquals("typst", spec.binaryName());
+        assertEquals("", spec.commandSuffix()); // the bare typst binary (renderer adds "compile …")
+        for (Platform p : Platform.values()) {
+            assertNotNull(spec.assetByPlatform().get(p), "typst-cli missing asset for " + p);
+        }
+        assertEquals("typst-aarch64-apple-darwin", spec.assetByPlatform().get(Platform.MAC_ARM));
+    }
+
+    @Test
+    void tarExtractArgvAutoDetectsCompression() {
+        assertEquals(
+                java.util.List.of("tar", "-xf", "/tmp/x.tar.xz", "-C", "/tmp/out"),
+                InstallCatalog.tarExtractArgvAuto(Path.of("/tmp/x.tar.xz"), Path.of("/tmp/out")));
+    }
+
+    @Test
     void installableServerIdsAreAllServiceable() {
         for (String id : InstallCatalog.installableServerIds()) {
             assertTrue(InstallCatalog.serverInstall(id).isPresent(), id + " should have install steps");


### PR DESCRIPTION
Closes the last deferred Typst item: an in-app installer for the **typst renderer CLI** (the preview tool), distinct from the tinymist LSP-server installer. **No new Maven dependency.**

## What it does
*Settings → Languages & Tools → Typst* gets an **Install…** button (and the `install.typstCli` command) that:
1. Downloads the `typst` binary for the host OS/arch from **typst's GitHub releases**,
2. Extracts it (this adds **`.tar.xz` support** — typst ships xz tarballs), and
3. Points `Settings.typstPath` at the extracted binary + re-detects, so the document preview lights up **without a restart**.

The button shows **Installed** when `typst` is already on the system.

## How
- **`InstallService`** — new `.tar.xz`/`.txz` branch using system `tar -xf` (auto-detects xz: bsdtar/liblzma on macOS, GNU tar + xz on Linux; covered by the existing `TAR` prereq).
- **`InstallCatalog`** — `typstCliSteps()` + `archiveSpec("typst-cli")` → `typst/typst` releases (musl on Linux for a static binary). Archive id `typst-cli` is deliberately distinct from the tinymist server's `typst` id.
- **`InstallCoordinator.installTypstCli()`** — prereq-check → download/extract → apply the resolved binary to `Settings.typstPath` → `reapplyToolSupport()` (already re-applies Typst support + persists). `Ops.typstCliAvailable()` (cached, via `TypstService.cachedAvailable()`) handles the already-installed case.
- **`SettingsWindow`** — reuses the shared `installButton("typst")`; `refreshTypstStatus` flips it to *Installed* when detected.

## Verification
- `mvn verify` green: **1906 tests**, spotless + jacoco pass. New `InstallCatalogTest` cases (typst-cli archive spec/step, `tarExtractArgvAuto`).
- **End-to-end against typst 0.15** (real release): the archiveSpec substring `typst-aarch64-apple-darwin` matched the real asset, `tar -xf` extracted the `.tar.xz`, `findBinary` located `./typst`, `chmod +x` + run → `typst 0.15.0`.

Docs: CHANGELOG.md, TODO.md. With this, the only remaining deferred Typst item is click-in-preview → jump-to-source (architecturally infeasible on the raster preview — documented).

🤖 Generated with [Claude Code](https://claude.com/claude-code)