### PR TITLE
Release 0.9.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.3] - 2026-07-10
+
 ### Added
 
 - **In-app typst-CLI installer.** *Settings → Languages & Tools → Typst* gains an **Install…** button (and

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.editora</groupId>
     <artifactId>editora</artifactId>
-    <version>0.9.2</version>
+    <version>0.9.3</version>
     <packaging>jar</packaging>
 
     <name>Editora</name>


### PR DESCRIPTION
Version bump **0.9.2 → 0.9.3** + CHANGELOG dating. Merging this, then pushing the `v0.9.3` tag triggers the release matrix.

- `pom.xml` `<version>` → `0.9.3` (the single source; `AppInfo.VERSION` derives from it via the Maven-filtered `build-info.properties` — verified `build.version=0.9.3`).
- `CHANGELOG.md`: `[Unreleased]` → `[0.9.3] - 2026-07-10` + a fresh empty `[Unreleased]`.

**0.9.3 highlights:** first-class **Typst** (multi-page preview, Markdown-parity editing, tinymist LSP, snippets/table/outline/image-paste/PNG-SVG export, in-app installer) and plain-English **config previews** (systemd, SSH config, Dockerfile, fstab, GitHub Actions, crontab).

No code changes beyond the version string.

🤖 Generated with [Claude Code](https://claude.com/claude-code)