### PR TITLE
Clarify install banner: "language server" not "language support"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- The editor install banner for a missing **language server** now says "*X* language server isn't
+  installed" instead of "*X* language support isn't installed" — clearer that it offers the optional LSP
+  (code intelligence), not the language's render/run tool, which may already work (e.g. the Typst preview
+  renders via the typst CLI even when the tinymist language server isn't installed).
+
 ## [0.9.3] - 2026-07-10
 
 ### Added

--- a/src/main/java/com/editora/ui/MainController.java
+++ b/src/main/java/com/editora/ui/MainController.java
@@ -7028,17 +7028,25 @@ public class MainController implements com.editora.mcp.McpBridge {
             offerInstall(
                     buffer,
                     tr("install.lang." + l.name().toLowerCase(java.util.Locale.ROOT)),
+                    "install.banner.message",
                     cb -> installCoordinator.installSupport(l, cb));
             return;
         }
-        // …then the LSP-only servers (json/bash/yaml/dockerfile/toml/…).
+        // …then the LSP-only servers (json/bash/yaml/dockerfile/toml/typst/…). This offers the *language
+        // server* (code intelligence) — distinct from a language's render/run tool that may already work
+        // (e.g. the typst preview renders via the typst CLI even when tinymist isn't installed), so the
+        // banner says "language server", not "language support".
         String serverId = com.editora.lsp.LspServerRegistry.serverIdFor(buffer.getLanguage());
         if (serverId != null
                 && lspEnabled()
                 && lspCoordinator.isServerMissing(serverId)
                 && com.editora.install.InstallCatalog.installableServerIds().contains(serverId)) {
             String id = serverId;
-            offerInstall(buffer, installCoordinator.serverName(id), cb -> installCoordinator.installServer(id, cb));
+            offerInstall(
+                    buffer,
+                    installCoordinator.serverName(id),
+                    "install.banner.serverMessage",
+                    cb -> installCoordinator.installServer(id, cb));
             return;
         }
         buffer.showInstallBar(false);
@@ -7049,9 +7057,10 @@ public class MainController implements com.editora.mcp.McpBridge {
     private void offerInstall(
             EditorBuffer buffer,
             String displayName,
+            String messageKey,
             java.util.function.Consumer<java.util.function.Consumer<Boolean>> installer) {
         buffer.setInstallPrompt(
-                tr("install.banner.message", displayName),
+                tr(messageKey, displayName),
                 tr("install.banner.install"),
                 () -> {
                     buffer.setInstallBarBusy(true);

--- a/src/main/resources/com/editora/i18n/messages.properties
+++ b/src/main/resources/com/editora/i18n/messages.properties
@@ -3132,3 +3132,4 @@ command.typst.exportSvg.desc=Export the active Typst document to SVG (one file p
 install.lang.typst=Typst
 command.install.typstCli=Install Typst CLI
 command.install.typstCli.desc=Download and install the typst renderer binary for the document preview.
+install.banner.serverMessage={0} language server isn''t installed.

--- a/src/main/resources/com/editora/i18n/messages_de.properties
+++ b/src/main/resources/com/editora/i18n/messages_de.properties
@@ -3123,3 +3123,4 @@ command.typst.exportSvg.desc=Exportiert das aktive Typst-Dokument als SVG (eine 
 install.lang.typst=Typst
 command.install.typstCli=Typst-CLI installieren
 command.install.typstCli.desc=Lädt das typst-Renderer-Binary für die Dokumentvorschau herunter und installiert es.
+install.banner.serverMessage={0}-Sprachserver ist nicht installiert.

--- a/src/main/resources/com/editora/i18n/messages_es.properties
+++ b/src/main/resources/com/editora/i18n/messages_es.properties
@@ -3123,3 +3123,4 @@ command.typst.exportSvg.desc=Exporta el documento Typst activo a SVG (un archivo
 install.lang.typst=Typst
 command.install.typstCli=Instalar la CLI de Typst
 command.install.typstCli.desc=Descarga e instala el binario del renderizador typst para la vista previa del documento.
+install.banner.serverMessage=El servidor de lenguaje de {0} no está instalado.

--- a/src/main/resources/com/editora/i18n/messages_fr.properties
+++ b/src/main/resources/com/editora/i18n/messages_fr.properties
@@ -3123,3 +3123,4 @@ command.typst.exportSvg.desc=Exporte le document Typst actif en SVG (un fichier 
 install.lang.typst=Typst
 command.install.typstCli=Installer la CLI Typst
 command.install.typstCli.desc=Télécharge et installe le binaire du moteur de rendu typst pour l'aperçu du document.
+install.banner.serverMessage=Le serveur de langage {0} n''est pas installé.

--- a/src/main/resources/com/editora/i18n/messages_it.properties
+++ b/src/main/resources/com/editora/i18n/messages_it.properties
@@ -3123,3 +3123,4 @@ command.typst.exportSvg.desc=Esporta il documento Typst attivo in SVG (un file p
 install.lang.typst=Typst
 command.install.typstCli=Installa la CLI Typst
 command.install.typstCli.desc=Scarica e installa il binario del renderer typst per l'anteprima del documento.
+install.banner.serverMessage=Il language server {0} non è installato.

--- a/src/main/resources/com/editora/i18n/messages_pt.properties
+++ b/src/main/resources/com/editora/i18n/messages_pt.properties
@@ -3123,3 +3123,4 @@ command.typst.exportSvg.desc=Exporta o documento Typst ativo para SVG (um arquiv
 install.lang.typst=Typst
 command.install.typstCli=Instalar a CLI do Typst
 command.install.typstCli.desc=Baixa e instala o binário do renderizador typst para a pré-visualização do documento.
+install.banner.serverMessage=O servidor de linguagem de {0} não está instalado.


### PR DESCRIPTION
**Fixes a confusing message** reported after 0.9.3: with the Typst preview rendering fine (the `typst` CLI is installed) but the tinymist LSP absent, the editor banner said *"Typst language support isn't installed"* — implying the whole feature is broken.

The banner's LSP-server path (typst/json/bash/…/tinymist) offers the **language server** (completion/hover/diagnostics), which is distinct from a language's render/run tool. So it now reads *"Typst language server isn't installed"*, while the Java/Python/JS/Mermaid **bundle** path keeps *"language support"* (those install LSP+DAP / a CLI).

- `offerInstall()` gains a message-key param; the server path passes `install.banner.serverMessage`, the bundle path keeps `install.banner.message`.
- New `install.banner.serverMessage` i18n ×6.

`mvn verify` green — **1912 tests**, spotless + jacoco pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)