### PR TITLE
Add build-tool sample projects (Maven, Gradle, npm, Cargo)

### DIFF
--- a/samples/README.md
+++ b/samples/README.md
@@ -210,6 +210,31 @@ A self-contained tree with its own `root = true` so it does not inherit the repo
 - `samples/run/hello.py` — a Python script; the ▶ sits on the `if __name__ == "__main__":` guard
   (needs `python3` on `PATH`).
 
+## build-tools/ — Maven / Gradle / npm / Cargo toolbar button + actions popup
+
+Four tiny, self-contained projects — one per build tool. Open a file under a project's folder and
+its build-tool toolbar button appears (each button stays hidden until its marker file is detected);
+click it for the sectioned actions popup. The projects are **standalone** — the repo's own build
+never picks them up (the Maven sample isn't a `<module>` of the root pom, the Gradle sample has its
+own `settings.gradle`), and every command is harmless (an `@echo`/`println`, or a lifecycle phase you
+choose to run). Each needs its tool on `PATH` to actually run (`mvn`/`gradle`/`npm`/`cargo`); the
+button + popup show regardless. (Build Tools are disabled in Simple UI mode and for remote files.)
+
+- `samples/build-tools/maven/pom.xml` + `samples/build-tools/maven/src/main/java/com/example/App.java`
+  — the popup lists the Lifecycle phases (a Task each), the `release` **profile** (a checkable
+  toggle → `-Prelease`), and the surefire `integration-tests` execution goal under Plugins.
+- `samples/build-tools/gradle/build.gradle` + `samples/build-tools/gradle/settings.gradle` — the
+  popup shows the static Common section (build/clean/test/assemble/check/jar/run/bootRun) plus
+  **Load all tasks…** (runs `gradle tasks --all` to list the rest, including the custom `hello` task).
+- `samples/build-tools/npm/package.json` + `samples/build-tools/npm/index.js` — the popup lists the
+  `scripts` (`start`/`build`/`test`/`lint`, each `npm run <name>`) + a Common `install`/`ci`; the
+  `packageManager` field would switch the runner (npm/yarn/pnpm/bun).
+- `samples/build-tools/cargo/Cargo.toml` + `samples/build-tools/cargo/src/main.rs` — the popup shows
+  the standard subcommands, the explicit `cargo-demo` binary under Targets (`cargo run --bin
+  cargo-demo`), and a `--release` toggle.
+
+(Go is also supported — `go.mod`/`go.work` markers — but isn't included here.)
+
 ## images/ — image viewer
 
 - `samples/images/sample.png` — opens in the read-only image viewer (zoom out/in/fit/actual, Ctrl+wheel)

--- a/samples/build-tools/cargo/Cargo.toml
+++ b/samples/build-tools/cargo/Cargo.toml
@@ -1,0 +1,13 @@
+# Sample Cargo project for exercising Editora's Cargo build-tool support.
+# The actions popup shows the standard subcommands (build/run/test/check/…), the
+# explicit "cargo-demo" binary under Targets, and a "--release" toggle.
+[package]
+name = "cargo-demo"
+version = "0.1.0"
+edition = "2021"
+
+[[bin]]
+name = "cargo-demo"
+path = "src/main.rs"
+
+[dependencies]

--- a/samples/build-tools/cargo/src/main.rs
+++ b/samples/build-tools/cargo/src/main.rs
@@ -1,0 +1,3 @@
+fn main() {
+    println!("Hello from the Cargo sample project.");
+}

--- a/samples/build-tools/gradle/build.gradle
+++ b/samples/build-tools/gradle/build.gradle
@@ -1,0 +1,20 @@
+// Sample Gradle project for exercising Editora's Gradle build-tool support.
+// Gradle's DSL can't be parsed statically, so the actions popup shows the static
+// Common section (build/clean/test/assemble/check/jar/run/bootRun) plus a
+// "Load all tasks…" action that runs `gradle tasks --all` to list the rest.
+plugins {
+    id 'java'
+}
+
+group = 'com.example'
+version = '1.0.0'
+
+repositories {
+    mavenCentral()
+}
+
+tasks.register('hello') {
+    doLast {
+        println 'Hello from the Gradle sample project.'
+    }
+}

--- a/samples/build-tools/gradle/settings.gradle
+++ b/samples/build-tools/gradle/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'gradle-demo'

--- a/samples/build-tools/maven/pom.xml
+++ b/samples/build-tools/maven/pom.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Sample Maven project for exercising Editora's Maven build-tool support.
+     Opening any file under this folder should show the Maven toolbar button; its
+     actions popup lists the Lifecycle phases, the "release" profile (a checkable
+     toggle), and the surefire "integration-tests" execution goal. Standalone — the
+     repo's own build never picks it up (it isn't a <module> of the root pom). -->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.example</groupId>
+    <artifactId>maven-demo</artifactId>
+    <version>1.0.0</version>
+    <packaging>jar</packaging>
+
+    <properties>
+        <maven.compiler.release>21</maven.compiler.release>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.2.5</version>
+                <executions>
+                    <execution>
+                        <id>integration-tests</id>
+                        <phase>verify</phase>
+                        <goals>
+                            <goal>test</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+    <profiles>
+        <profile>
+            <id>release</id>
+        </profile>
+    </profiles>
+</project>

--- a/samples/build-tools/maven/src/main/java/com/example/App.java
+++ b/samples/build-tools/maven/src/main/java/com/example/App.java
@@ -1,0 +1,8 @@
+package com.example;
+
+/** Trivial entry point so the Maven sample looks like a real project. */
+public class App {
+    public static void main(String[] args) {
+        System.out.println("Hello from the Maven sample project.");
+    }
+}

--- a/samples/build-tools/npm/index.js
+++ b/samples/build-tools/npm/index.js
@@ -1,0 +1,1 @@
+console.log("Hello from the npm sample project.");

--- a/samples/build-tools/npm/package.json
+++ b/samples/build-tools/npm/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "npm-demo",
+  "version": "1.0.0",
+  "description": "Sample npm project for exercising Editora's npm build-tool support.",
+  "packageManager": "npm@10.0.0",
+  "scripts": {
+    "start": "node index.js",
+    "build": "echo \"build step\"",
+    "test": "echo \"no tests yet\"",
+    "lint": "echo \"lint step\""
+  },
+  "license": "MIT"
+}


### PR DESCRIPTION
## What

Four tiny, self-contained projects under `samples/build-tools/` — one per build tool — for manually exercising the build-tool **toolbar button + actions popup**. Opening a file under a project's folder shows that tool's button; the popup lists its parsed actions.

| Tool | Files | Popup shows |
|------|-------|-------------|
| **Maven** | `maven/pom.xml`, `maven/src/main/java/com/example/App.java` | Lifecycle phases, `release` profile toggle (`-Prelease`), surefire `integration-tests` goal |
| **Gradle** | `gradle/build.gradle`, `gradle/settings.gradle` | Common section + "Load all tasks…" (finds the custom `hello` task) |
| **npm** | `npm/package.json`, `npm/index.js` | scripts `start`/`build`/`test`/`lint`, `install`/`ci` |
| **Cargo** | `cargo/Cargo.toml`, `cargo/src/main.rs` | subcommands, `cargo-demo` bin target, `--release` toggle |

## Notes

- **Standalone** — the repo's own build never picks them up (the sample pom isn't a `<module>` of the root pom; the Gradle sample has its own `settings.gradle`). Every command is harmless (`@echo`/`println` or a chosen lifecycle phase).
- Each needs its tool on `PATH` (`mvn`/`gradle`/`npm`/`cargo`) to actually run; the button + popup show regardless.
- Verified the markers parse via the app's own `PomParser`/`NpmProject`/`CargoProject`; documented in `samples/README.md`; the `SamplesCorpusTest` guard passes.
- Go is supported too (`go.mod`/`go.work`) but left out — say the word to add a `go/` sample.

🤖 Generated with [Claude Code](https://claude.com/claude-code)