### PR TITLE
Project tree: add a right-click menu to the project root

### DIFF
--- a/src/main/java/com/editora/ui/ProjectPanel.java
+++ b/src/main/java/com/editora/ui/ProjectPanel.java
@@ -966,10 +966,10 @@ public class ProjectPanel extends VBox implements ToolWindowContent {
                     isDir
                             ? FileIcons.boxed(Icons.project())
                             : FileIcons.forFileName(fileName == null ? label : fileName.toString()));
-            setContextMenu(isRoot ? null : contextMenuFor(getTreeItem(), isDir));
+            setContextMenu(contextMenuFor(getTreeItem(), isDir, isRoot));
         }
 
-        private ContextMenu contextMenuFor(TreeItem<Path> treeItem, boolean isDir) {
+        private ContextMenu contextMenuFor(TreeItem<Path> treeItem, boolean isDir, boolean isRoot) {
             ContextMenu menu = new ContextMenu();
             if (isDir) {
                 MenuItem newFolder = new MenuItem(tr("project.menu.newFolder"));
@@ -983,10 +983,14 @@ public class ProjectPanel extends VBox implements ToolWindowContent {
                 newFromTemplate.setOnAction(e -> onNewFromTemplate.accept(treeItem.getValue()));
                 menu.getItems().add(newFromTemplate);
             }
-            MenuItem rename = new MenuItem(tr("project.menu.rename"));
-            rename.setGraphic(Icons.edit());
-            rename.setOnAction(e -> renameItem(treeItem));
-            menu.getItems().add(rename);
+            // Rename is offered on every file/folder EXCEPT the project root — renaming that would move the
+            // whole project folder on disk and leave the project pointing at a path that no longer exists.
+            if (!isRoot) {
+                MenuItem rename = new MenuItem(tr("project.menu.rename"));
+                rename.setGraphic(Icons.edit());
+                rename.setOnAction(e -> renameItem(treeItem));
+                menu.getItems().add(rename);
+            }
             if (!isDir) {
                 MenuItem delete = new MenuItem(tr("project.menu.delete"));
                 delete.setGraphic(Icons.trash());


### PR DESCRIPTION
## What

The top-level project folder in the Project tool window had **no context menu** — it was explicitly given `null`, so right-clicking the root did nothing (reported by the user).

It now shows the same menu as any folder, since it's a directory:

- **New Folder…**
- **New From Template…**
- **Reveal in File Manager** / **Open Terminal Here**
- **Local History**
- **Git** submenu → Stage / Revert of the whole subtree

## Deliberate omission: Rename

**Rename is not offered on the project root.** Renaming it would move the whole project folder on disk and leave the project pointing at a path that no longer exists. Rename stays available on every other file/folder; Delete was already folder-excluded.

## Change

One spot in `ProjectPanel`: `PathCell.updateItem` now always builds the menu (`contextMenuFor(item, isDir, isRoot)`) instead of `isRoot ? null`, and `contextMenuFor` guards the Rename item with `!isRoot`.

## Verification

Compiles, Spotless-clean. Launched the app with a project open — the Project tool window rendered the root cell (which now builds this menu) with no errors. (Didn't drive an actual right-click — screen-control was declined earlier — but the root menu builds through the same path every other folder already uses.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)