### PR TITLE
CI: fix macOS release staging (no-fat-jar aborts the step)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -119,7 +119,9 @@ jobs:
             cp "$f" "staging/Editora-${VERSION}-${{ matrix.target }}.${ext}"
           done
           # The fat jar isn't built for macOS (see the -Pfatjar step's condition), so guard the copy.
-          jar="$(ls target/Editora-*.jar 2>/dev/null | head -1)"
+          # The `|| true` is required: GitHub's `shell: bash` runs with `set -eo pipefail`, so a no-match
+          # `ls` (macOS: no jar) would abort the whole step before the `-n` guard below could skip it.
+          jar="$(ls target/Editora-*.jar 2>/dev/null | head -1 || true)"
           if [ -n "$jar" ]; then
             cp "$jar" "staging/$(basename "$jar" .jar)-${{ matrix.target }}.jar"
           fi


### PR DESCRIPTION
## Problem

Both macOS legs of the **v0.9.4 release** failed at "Stage artifacts" (the `.dmg` built fine first). The step's

```bash
jar="$(ls target/Editora-*.jar 2>/dev/null | head -1)"
```

aborts the whole step: PR #386 stopped building the fat jar for macOS, so `ls` finds nothing and — under GitHub's `shell: bash` (`set -eo pipefail`) — the pipeline's non-zero exit kills the step **before** the `if [ -n "$jar" ]` guard can skip it. The `2>/dev/null` hid the message, so it surfaced as a bare "exit code 1". Linux/Windows (which do build a jar) were unaffected.

## Fix

Add `|| true` so the no-jar case yields an empty string and the existing guard skips the copy, as intended.

No release was published (the `Release`/JReleaser job needs all builds green, so it never ran) — so this can be re-tagged cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)