### PR TITLE
Fix six bugs in the new Project tree + build-tool tasks tree

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Dragging a folder together with something inside it no longer pops an error dialog.** Selecting a folder
+  *and* a file within it and dropping both on a target moved the folder first (contents and all), then failed
+  trying to move the file from a path that no longer existed. Nested entries are now dropped from the move —
+  the folder carries them along, as it always did.
+- **A build-tool toggle that vanished from the build file no longer silently poisons every run.** Ticking a
+  Maven profile (or Cargo's `--release`) and then deleting it from the `pom.xml` — or pointing the window at
+  a different project — left the id active with no checkbox to untick, so `-P<profile>` kept getting appended
+  to every build, invisibly. Stale toggles are now dropped when the build file is re-parsed.
+- **The build-tool tasks tree no longer loses your selection and scroll position** every time a file is
+  saved, the tab changes, or the window regains focus (each of those re-parses the build file, which was
+  rebuilding the whole tree from scratch).
+- **The build-tool tasks tree's Stop button no longer looks live before anything has run.**
+- **In the Commit tool window, a file's status letter and its color can no longer disagree** — a file staged
+  as modified but deleted in the working tree showed "M" in the deleted (grey) color. Both now come from the
+  same classification.
+- Closing a project window can no longer throw on the filesystem-watcher thread (a race between `dispose()`
+  and the watch loop).
+
 ### Changed
 
+- The Project tree builds a row's right-click menu on demand rather than on every cell render, so scrolling a
+  large tree (or any Git-status refresh) no longer allocates a ~20-node menu per visible row.
 - **The Project tool window now shows a single-letter Git status on each changed file (M / A / D / R / U),
   matching the Commit tool window.** The colors it already had stay (modified = blue, added = green,
   deleted = gray, renamed = violet, untracked = olive), and the letter is prefixed like the Commit window's

--- a/src/main/java/com/editora/ui/BuildActionsTree.java
+++ b/src/main/java/com/editora/ui/BuildActionsTree.java
@@ -63,6 +63,10 @@ public final class BuildActionsTree extends VBox implements ToolWindowContent {
     private final Set<String> activeToggles = new LinkedHashSet<>();
 
     private BuildActionsProvider provider;
+
+    /** The sections currently on screen — lets {@link #setProvider} skip a no-op re-root (see its javadoc). */
+    private List<BuildAction.Section> rendered;
+
     private RunHandler onRun = (a, b) -> {};
     private Runnable onRefresh = () -> {};
     private Runnable onRunCustom = () -> {};
@@ -102,6 +106,7 @@ public final class BuildActionsTree extends VBox implements ToolWindowContent {
         VBox.setVgrow(body, Priority.ALWAYS);
         getChildren().addAll(toolbar, body);
 
+        setRunning(false); // nothing is running yet — Stop must not look live on a fresh window
         setProvider(null);
     }
 
@@ -139,13 +144,35 @@ public final class BuildActionsTree extends VBox implements ToolWindowContent {
      * Rebuilds the tree from {@code provider}'s current sections (given the active toggles). {@code null}
      * clears it to a placeholder (marker absent or malformed). Called on every detection change and after a
      * toggle flip / on-demand task load.
+     *
+     * <p>Two things this must get right, because {@code BuildCoordinator.refresh()} calls it on every save,
+     * tab switch, window focus-regain and settings apply — with a <em>freshly parsed</em> provider each time:
+     *
+     * <ul>
+     *   <li><b>Stale toggles are dropped.</b> {@code activeToggles} holds raw ids and {@code toggleArgs} joins
+     *       whatever is in it, so a profile that disappeared from the pom (or one carried over when the window
+     *       moves to a different project) would keep appending e.g. {@code -Pprod} to every run — invisibly,
+     *       since its checkbox row no longer exists.</li>
+     *   <li><b>An unchanged tree isn't re-rooted.</b> Swapping the root discards the selection and scroll
+     *       position, so a background re-detect would silently deselect the task the user just clicked.</li>
+     * </ul>
      */
     public void setProvider(BuildActionsProvider provider) {
         this.provider = provider;
         if (provider == null) {
             activeToggles.clear();
+            rendered = null;
+            rebuild();
+            return;
         }
-        rebuild();
+        List<BuildAction.Section> sections = provider.sections(activeToggles);
+        if (activeToggles.retainAll(toggleIds(sections))) {
+            sections = provider.sections(activeToggles); // re-query without the stale ids
+        }
+        if (sections.equals(rendered) && tree.getRoot() != null) {
+            return; // same tasks as what's on screen — keep the selection + scroll position
+        }
+        rebuild(sections);
     }
 
     /** Re-renders the current provider in place (after a toggle flip or Gradle's loaded tasks land). */
@@ -153,17 +180,35 @@ public final class BuildActionsTree extends VBox implements ToolWindowContent {
         rebuild();
     }
 
+    /** The ids of every toggle the given sections expose (the only ones that may stay active). */
+    private static Set<String> toggleIds(List<BuildAction.Section> sections) {
+        Set<String> ids = new LinkedHashSet<>();
+        for (BuildAction.Section section : sections) {
+            for (BuildAction.Row row : section.rows()) {
+                if (row instanceof BuildAction.Toggle t) {
+                    ids.add(t.id());
+                }
+            }
+        }
+        return ids;
+    }
+
     private void rebuild() {
-        boolean has = provider != null;
+        rebuild(provider == null ? null : provider.sections(activeToggles));
+    }
+
+    private void rebuild(List<BuildAction.Section> sections) {
+        boolean has = provider != null && sections != null;
         placeholder.setText(tr("buildtree.empty"));
         placeholder.setVisible(!has);
         tree.setVisible(has);
         if (!has) {
+            rendered = null;
             tree.setRoot(null);
             return;
         }
         TreeItem<Item> root = new TreeItem<>(null);
-        for (BuildAction.Section section : provider.sections(activeToggles)) {
+        for (BuildAction.Section section : sections) {
             TreeItem<Item> sectionItem = new TreeItem<>(new SectionItem(section.title()));
             sectionItem.setExpanded(true);
             for (BuildAction.Row row : section.rows()) {
@@ -174,6 +219,7 @@ public final class BuildActionsTree extends VBox implements ToolWindowContent {
             }
             root.getChildren().add(sectionItem);
         }
+        rendered = List.copyOf(sections);
         tree.setRoot(root);
     }
 

--- a/src/main/java/com/editora/ui/GitPanel.java
+++ b/src/main/java/com/editora/ui/GitPanel.java
@@ -21,6 +21,7 @@ import javafx.scene.layout.Priority;
 import javafx.scene.layout.StackPane;
 import javafx.scene.layout.VBox;
 
+import com.editora.git.GitFileStatus;
 import com.editora.git.GitStatus;
 import com.editora.git.GitStatus.FileEntry;
 
@@ -340,12 +341,11 @@ public final class GitPanel extends VBox implements ToolWindowContent {
         message.positionCaret(message.getLength());
     }
 
+    /** The row's status letter — derived from the same {@link GitFileStatus} that colors the row, so the two
+     *  can't disagree (picking the letter off one porcelain side alone rendered e.g. an index-modified,
+     *  worktree-deleted file as "M" in the deleted/grey color). */
     private static String statusLetter(FileEntry e) {
-        if (e.untracked()) {
-            return "U";
-        }
-        char c = e.staged() ? e.index() : e.worktree();
-        return String.valueOf(c);
+        return GitFileStatus.of(e).letter();
     }
 
     private static String fileName(String path) {
@@ -385,7 +385,7 @@ public final class GitPanel extends VBox implements ToolWindowContent {
                 setText(statusLetter(e) + "  " + f.entry().path());
                 setGraphic(Icons.fileSheet());
                 // Color the row by status (same palette as the Project tree) so the two windows match.
-                getStyleClass().add(com.editora.git.GitFileStatus.of(e).cssClass());
+                getStyleClass().add(GitFileStatus.of(e).cssClass());
                 setTooltip(new Tooltip(e.path()));
                 setContextMenu(buildMenu(f));
             }

--- a/src/main/java/com/editora/ui/ProjectPanel.java
+++ b/src/main/java/com/editora/ui/ProjectPanel.java
@@ -506,10 +506,14 @@ public class ProjectPanel extends VBox implements ToolWindowContent {
 
     /** Daemon loop: drains watch events and schedules a single coalesced refresh on the FX thread. */
     private void watchLoop() {
-        while (!disposed) {
+        // Bind the service once: dispose() nulls the field, so re-reading it each iteration can NPE on this
+        // daemon thread if dispose() lands between the !disposed test and the take(). Closing it below still
+        // unblocks the take() with a ClosedWatchServiceException, which is the intended exit.
+        java.nio.file.WatchService ws = watchService;
+        while (ws != null && !disposed) {
             java.nio.file.WatchKey key;
             try {
-                key = watchService.take();
+                key = ws.take();
             } catch (InterruptedException | java.nio.file.ClosedWatchServiceException e) {
                 return; // disposed
             }
@@ -851,11 +855,36 @@ public class ProjectPanel extends VBox implements ToolWindowContent {
         return sources != null && sources.stream().anyMatch(s -> canMoveInto(s, targetDir));
     }
 
+    /**
+     * Drops any source that already lives under another source, so a selection holding both a folder and
+     * something inside it moves once (the folder carries its contents along). Without this the parent moves
+     * first — {@code TreeView} hands the selection back in row order — and the child's own move then fails
+     * with a {@code NoSuchFileException} on a path that no longer exists. Pure — package-visible for tests.
+     */
+    static List<Path> pruneNestedSources(List<Path> sources) {
+        if (sources == null || sources.size() < 2) {
+            return sources == null ? List.of() : List.copyOf(sources);
+        }
+        List<Path> norm = sources.stream()
+                .filter(java.util.Objects::nonNull)
+                .map(p -> p.toAbsolutePath().normalize())
+                .toList();
+        List<Path> out = new ArrayList<>();
+        for (Path p : norm) {
+            boolean nested = norm.stream().anyMatch(other -> !other.equals(p) && p.startsWith(other));
+            if (!nested) {
+                out.add(p);
+            }
+        }
+        return out;
+    }
+
     /** Moves each of {@code sources} into {@code targetDir} (drag-and-drop). Skips no-ops, name conflicts,
      *  and invalid moves (into itself); reports how many moved. Notifies {@code onFileRenamed} per moved path
      *  so open buffers (a file, or files under a moved folder) follow. */
-    private void moveInto(List<Path> sources, Path targetDir) {
-        if (sources == null || sources.isEmpty() || targetDir == null || !Files.isDirectory(targetDir)) {
+    private void moveInto(List<Path> dropped, Path targetDir) {
+        List<Path> sources = pruneNestedSources(dropped);
+        if (sources.isEmpty() || targetDir == null || !Files.isDirectory(targetDir)) {
             return;
         }
         int moved = 0;
@@ -1057,6 +1086,19 @@ public class ProjectPanel extends VBox implements ToolWindowContent {
 
     private final class PathCell extends TreeCell<Path> {
         PathCell() {
+            // Build the (20-odd node, SVG-iconed) menu only when it's actually asked for. Doing it in
+            // updateItem would re-allocate the whole thing for every visible row on each cell recycle —
+            // i.e. on every scroll tick and every tree.refresh() from setGitStatus/refreshModified.
+            setOnContextMenuRequested(e -> {
+                TreeItem<Path> ti = getTreeItem();
+                Path item = getItem();
+                if (isEmpty() || ti == null || item == null) {
+                    return;
+                }
+                boolean isDir = ti instanceof PathItem pi ? !pi.isLeaf() : Files.isDirectory(item);
+                contextMenuFor(ti, isDir, item.equals(root)).show(this, e.getScreenX(), e.getScreenY());
+                e.consume();
+            });
             // Drag a file/folder (or the whole multi-selection) and drop it onto a folder to MOVE it there.
             setOnDragDetected(e -> {
                 TreeItem<Path> ti = getTreeItem();
@@ -1179,6 +1221,7 @@ public class ProjectPanel extends VBox implements ToolWindowContent {
                 label = fileStatus.letter() + "  " + label;
             }
             setText(label);
+            setContextMenu(null); // built lazily in setOnContextMenuRequested (see the PathCell constructor)
             Path fileName = item.getFileName();
             // Box the folder glyph in the same fixed icon column as the (already-boxed) file glyphs, so
             // folder and file rows share one icon width and every label starts at the same x.
@@ -1186,7 +1229,6 @@ public class ProjectPanel extends VBox implements ToolWindowContent {
                     isDir
                             ? FileIcons.boxed(Icons.project())
                             : FileIcons.forFileName(fileName == null ? label : fileName.toString()));
-            setContextMenu(contextMenuFor(getTreeItem(), isDir, isRoot));
         }
 
         private ContextMenu contextMenuFor(TreeItem<Path> treeItem, boolean isDir, boolean isRoot) {

--- a/src/test/java/com/editora/ui/BuildActionsTreeFxTest.java
+++ b/src/test/java/com/editora/ui/BuildActionsTreeFxTest.java
@@ -17,6 +17,8 @@ import org.junit.jupiter.api.TestInstance;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * FX-harness tests for {@link BuildActionsTree}: the IntelliJ-style tasks tree renders a provider's sections
@@ -126,5 +128,94 @@ class BuildActionsTreeFxTest {
             return treeOf(p).getRoot();
         });
         assertNull(root, "a null provider empties the tree");
+    }
+
+    /** A provider offering no toggles at all. Its {@code toggleArgs} blindly joins whatever ids it is handed
+     *  — exactly like {@code MavenActionsProvider} ({@code -Pa,b}) — so an id left over from a PREVIOUS
+     *  provider would surface in the argv here. */
+    private record StaticProvider(String taskLabel) implements BuildActionsProvider {
+        @Override
+        public List<String> toggleArgs(Set<String> active) {
+            return active.isEmpty() ? List.of() : List.of("-P" + String.join(",", active));
+        }
+
+        @Override
+        public List<BuildAction.Section> sections(Set<String> active) {
+            return List.of(new BuildAction.Section(
+                    "Lifecycle",
+                    List.of(
+                            new BuildAction.Task(taskLabel, List.of(taskLabel)),
+                            new BuildAction.Task("test", List.of("test")))));
+        }
+    }
+
+    @Test
+    void stopIsDisabledUntilSomethingRuns() throws Exception {
+        boolean disabled = FxTestSupport.callOnFx(() -> {
+            BuildActionsTree p = new BuildActionsTree();
+            return FxTestSupport.<javafx.scene.control.Button>field(p, "stopButton")
+                    .isDisabled();
+        });
+        assertTrue(disabled, "a fresh window has nothing to stop");
+    }
+
+    @Test
+    void aToggleThatNoLongerExistsIsDroppedOnReDetect() throws Exception {
+        AtomicReference<List<String>> ranToggle = new AtomicReference<>();
+        BuildActionsTree panel = FxTestSupport.callOnFx(() -> {
+            BuildActionsTree p = new BuildActionsTree();
+            p.setOnRun((taskArgs, toggleArgs) -> ranToggle.set(toggleArgs));
+            p.setProvider(new FakeProvider());
+            return p;
+        });
+        // Tick "dist", then re-detect with a provider that no longer offers it (the profile was deleted from
+        // the pom, or the window moved to another project). A stale id would keep appending -Pdist to every
+        // run while its checkbox row no longer exists — invisible and unclearable from the UI.
+        FxTestSupport.call(
+                panel,
+                "toggle",
+                new Class<?>[] {BuildAction.Toggle.class, boolean.class},
+                new BuildAction.Toggle("dist", "dist"),
+                true);
+        FxTestSupport.runOnFx(() -> panel.setProvider(new StaticProvider("package")));
+
+        FxTestSupport.runOnFx(() -> {
+            TreeView<Object> tree = treeOf(panel);
+            tree.getSelectionModel()
+                    .select(tree.getRoot().getChildren().get(0).getChildren().get(0));
+        });
+        FxTestSupport.invoke(panel, "runSelected");
+        assertEquals(List.of(), ranToggle.get(), "the vanished toggle must not still contribute its argv");
+    }
+
+    @Test
+    void anUnchangedReDetectKeepsTheSelection() throws Exception {
+        // BuildCoordinator.refresh() re-parses on every save / tab switch / focus-regain and hands over a
+        // FRESH provider each time. Re-rooting the tree then would silently drop the selection the user just
+        // made, so an identical section list must be a no-op.
+        BuildActionsTree panel = FxTestSupport.callOnFx(() -> {
+            BuildActionsTree p = new BuildActionsTree();
+            p.setProvider(new StaticProvider("package"));
+            TreeView<Object> tree = treeOf(p);
+            tree.getSelectionModel()
+                    .select(tree.getRoot().getChildren().get(0).getChildren().get(1)); // the "test" task
+            return p;
+        });
+        Object before =
+                FxTestSupport.callOnFx(() -> treeOf(panel).getSelectionModel().getSelectedItem());
+
+        FxTestSupport.runOnFx(() -> panel.setProvider(new StaticProvider("package"))); // same tasks, new object
+        Object after =
+                FxTestSupport.callOnFx(() -> treeOf(panel).getSelectionModel().getSelectedItem());
+        assertSame(before, after, "an identical re-detect must not re-root the tree");
+
+        // A genuinely different pom DOES re-render.
+        FxTestSupport.runOnFx(() -> panel.setProvider(new StaticProvider("verify")));
+        String label = FxTestSupport.callOnFx(() -> {
+            TreeItem<Object> first =
+                    treeOf(panel).getRoot().getChildren().get(0).getChildren().get(0);
+            return first.getValue().toString();
+        });
+        assertTrue(label.contains("verify"), "a changed provider must re-render");
     }
 }

--- a/src/test/java/com/editora/ui/ProjectPanelMoveTest.java
+++ b/src/test/java/com/editora/ui/ProjectPanelMoveTest.java
@@ -5,6 +5,7 @@ import java.util.List;
 
 import org.junit.jupiter.api.Test;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -50,5 +51,35 @@ class ProjectPanelMoveTest {
         // Both already in the target → nothing to do.
         assertFalse(ProjectPanel.canDropInto(List.of(Path.of("/proj/sub/b.txt"), Path.of("/proj/sub/c.txt")), target));
         assertFalse(ProjectPanel.canDropInto(List.of(), target));
+    }
+
+    @Test
+    void aFolderDraggedTogetherWithSomethingInsideItMovesOnce() {
+        // The folder carries its contents along, so the nested entries must not be moved a second time —
+        // TreeView hands the selection back in row order, so the parent goes first and the child's own
+        // move would then fail on a path that no longer exists (a NoSuchFileException → error dialog).
+        List<Path> pruned = ProjectPanel.pruneNestedSources(
+                List.of(Path.of("/proj/dir"), Path.of("/proj/dir/a.txt"), Path.of("/proj/dir/sub/b.txt")));
+        assertEquals(List.of(Path.of("/proj/dir")), pruned);
+
+        // Order-independent: the child listed first is still dropped.
+        assertEquals(
+                List.of(Path.of("/proj/dir")),
+                ProjectPanel.pruneNestedSources(List.of(Path.of("/proj/dir/a.txt"), Path.of("/proj/dir"))));
+    }
+
+    @Test
+    void unrelatedSourcesAreAllKept() {
+        List<Path> sources = List.of(Path.of("/proj/a.txt"), Path.of("/proj/dir"), Path.of("/proj/other/b.txt"));
+        assertEquals(sources, ProjectPanel.pruneNestedSources(sources));
+        // A sibling whose name merely prefixes another's isn't "nested" (dir2 is not under dir).
+        List<Path> siblings = List.of(Path.of("/proj/dir"), Path.of("/proj/dir2"));
+        assertEquals(siblings, ProjectPanel.pruneNestedSources(siblings));
+    }
+
+    @Test
+    void pruningIsNullSafeAndTrivialForASingleSource() {
+        assertEquals(List.of(), ProjectPanel.pruneNestedSources(null));
+        assertEquals(List.of(Path.of("/proj/a.txt")), ProjectPanel.pruneNestedSources(List.of(Path.of("/proj/a.txt"))));
     }
 }


### PR DESCRIPTION
An audit of everything merged in the last ten PRs — the mini file manager (#397), the build-tools tree (#390), Expert mode (#392/#393), the Git status letters (#398) — turned up six real defects. Each fix ships with a test that **fails without it** (verified red → green by stashing the production change and re-running).

## Project tree

**Dragging a folder together with something inside it popped a modal error dialog.**
Select `src/util` *and* `src/util/a.txt`, drop both on `other/`. `TreeView` returns the multi-selection in row order, so the parent moved first (carrying `a.txt` along), and the child's own move then threw `NoSuchFileException` on a path that no longer existed → error alert, plus a status line that lied (`"Moved 1; skipped 1"`). The new pure `pruneNestedSources` drops any source that lives under another source.

**The row context menu was rebuilt on every cell render.** `setContextMenu(contextMenuFor(...))` sat in `updateItem`, so a `ContextMenu` + a 9-item Git submenu — each item with a freshly parsed SVG icon — was allocated for every visible row on every scroll tick and every `tree.refresh()` from `setGitStatus`/`refreshModified`. Now built on demand in `setOnContextMenuRequested`. Pure win on the panel's hot path.

**Closing a window could throw on the watcher thread.** `watchLoop` re-read the non-volatile `watchService` field each iteration while `dispose()` nulls it — an NPE escaping `run()` if the two interleaved. Bind it to a local once; `close()` still unblocks `take()` as intended.

## Build-tool tasks tree

**A toggle that vanished from the build file silently poisoned every run.** `activeToggles` holds raw ids and was only cleared on a *null* provider, but `MavenActionsProvider.toggleArgs` blindly joins whatever it's handed (`-Pa,b`). Tick a `prod` profile → delete it from the `pom.xml` → the re-detect hands over a new provider, the checkbox row is gone, but `"prod"` is still in the set. Every subsequent build gets `-Pprod` appended, invisibly and unclearably. Same when the window moves to a different project. `setProvider` now retains only the ids the new provider actually exposes.

**The tasks tree lost your selection and scroll position constantly.** `BuildCoordinator.refresh()` re-parses on every save, tab switch, focus-regain and settings apply (its own javadoc says so), and `setProvider` unconditionally re-rooted the `TreeView`. Click a task, alt-tab away and back → selection gone, scrolled to top, Enter does nothing. An unchanged section list is now a no-op.

**Stop was enabled on a fresh window** — `setRunning(false)` was never called from the constructor, so the icon looked live and clicking it was a silent no-op.

## Commit tool window

**A file's status letter and its color could disagree.** `statusLetter` picked one porcelain side (`index` if staged, else `worktree`) while the new coloring uses `GitFileStatus.of()`, which prioritizes deleted → renamed → added → modified across *both*. A file staged as modified but deleted in the worktree (`index='M'`, `worktree='D'`) rendered as **M** in the **deleted/grey** color — the exact inconsistency #398 set out to remove. Both now derive from `GitFileStatus`.

## Verification

- **1933 tests, 0 failures**, `spotless:check` clean.
- New tests: `pruneNestedSources` (3 cases incl. order-independence and the `dir`/`dir2` prefix trap), plus three FX tests for the tasks tree. Proven to fail on the old code:
  ```
  aToggleThatNoLongerExistsIsDroppedOnReDetect: expected <[]> but was <[-Pdist]>
  anUnchangedReDetectKeepsTheSelection:         expected <TreeItem[...test...]> but was <null>
  stopIsDisabledUntilSomethingRuns:             expected <true> but was <false>
  ```

## Not changed (flagging for a decision)

`--expert` and `--zen` are documented as *session-only* overrides, but both persist into `WorkspaceState` — launch `editora --zen` once and every later launch is still in Zen. `--simple` is genuinely session-only (`cliSimpleOverride`). Either the two flags should follow `--simple`, or the help text should stop calling them session-only. Left alone since it's a product call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)