### PR TITLE
Make --zen and --expert session-only, like --simple

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`--zen` and `--expert` are now genuinely session-only, like `--simple`.** Launching once with either flag
+  wrote the mode into the saved session, so *every* later launch came up in it — with no hint as to why. The
+  flags now apply the mode for the current run only and leave the saved session untouched (including the
+  docked tool windows the mode closes). Turning the mode on from inside the app still sticks, as before.
 - **Dragging a folder together with something inside it no longer pops an error dialog.** Selecting a folder
   *and* a file within it and dropping both on a target moved the folder first (contents and all), then failed
   trying to move the file from a path that no longer existed. Nested entries are now dropped from the move —

--- a/README.md
+++ b/README.md
@@ -610,8 +610,9 @@ editora [options] [FILE[:LINE[:COLUMN]] ...]
   --new-file[=name]     Open a new buffer instead of the Welcome page (optionally named, e.g. notes.md)
   --single-window[=project]  Open just one window (the named project, else the no-project window)
                         instead of restoring all windows; session-only, doesn't change the saved layout
-  --zen                 Start in Zen (distraction-free) mode
-  --expert              Start in Expert mode (like Zen, but keeps the editor view)
+  --zen                 Start in Zen (distraction-free) mode (session only)
+  --expert              Start in Expert mode: like Zen, but keeps the editor
+                        view (line numbers, status bar) (session only)
   --simple              Start in Simple UI mode (minimal chrome; session only)
   --version, -V         Print the version and exit
   --help, -h            Print help and exit

--- a/src/main/java/com/editora/App.java
+++ b/src/main/java/com/editora/App.java
@@ -260,8 +260,9 @@ public class App extends Application {
                   --new-file[=name]     Open a new buffer instead of the Welcome page (optionally named)
                   --single-window[=project]  Open just one window (the named project, else no-project)
                                         instead of restoring all windows; doesn't change the saved layout
-                  --zen                 Start in Zen (distraction-free) mode
-                  --expert              Start in Expert mode (like Zen, but keeps the editor view)
+                  --zen                 Start in Zen (distraction-free) mode (session only)
+                  --expert              Start in Expert mode: like Zen, but keeps the editor
+                                        view (line numbers, status bar) (session only)
                   --simple              Start in Simple UI mode (minimal chrome; session only)
                   --version, -V         Print the version and exit
                   --help, -h            Print this help and exit
@@ -282,7 +283,7 @@ public class App extends Application {
         return args != null && args.contains("--dev");
     }
 
-    /** True if {@code --zen} is present. */
+    /** True if {@code --zen} is present (a session-only Zen override — the saved session is untouched). */
     static boolean zenFlag(java.util.List<String> args) {
         return args != null && args.contains("--zen");
     }

--- a/src/main/java/com/editora/ui/MainController.java
+++ b/src/main/java/com/editora/ui/MainController.java
@@ -265,6 +265,18 @@ public class MainController implements com.editora.mcp.McpBridge {
             new com.editora.editor.MarkdownLintService();
     /** Session-only Simple-UI override from the {@code --simple} CLI flag; OR'd with the saved setting. */
     private boolean cliSimpleOverride;
+    /** Session-only Zen override from the {@code --zen} CLI flag; OR'd with this window's saved Zen state. */
+    private boolean cliZenOverride;
+    /** Session-only Expert override from the {@code --expert} CLI flag (the {@code --zen} twin). */
+    private boolean cliExpertOverride;
+    /**
+     * The open tool windows a {@code --zen}/{@code --expert} session override closed, as the persisted
+     * {left, right, bottom} ids. Entering a focus mode calls {@link ToolWindowManager#closeAllOpen()}, and
+     * {@code close()} persists "nothing open" — so without restoring these at quit, a session-only focus
+     * mode would silently lose the user's docked tool windows on the next launch. {@code null} = no CLI
+     * focus-mode override is in effect (including after an in-app toggle takes over from the flag).
+     */
+    private String[] cliFocusToolWindows;
     // --- Remote files (SFTP via MINA SSHD; off-thread connect/auth) — owned by RemoteCoordinator ---
     private RemoteCoordinator remoteCoordinator;
     // MCP server: a single app-wide loopback HTTP endpoint exposing live editor state + the command
@@ -735,14 +747,15 @@ public class MainController implements com.editora.mcp.McpBridge {
         return config.getSettings().isSimpleMode() || cliSimpleOverride;
     }
 
-    /** True when this window is in distraction-free Zen mode (per-window state, never a shared pref). */
+    /** True when this window is in distraction-free Zen mode — this window's saved state OR the session-only
+     *  {@code --zen} flag (which, like {@code --simple}, never touches the saved session). */
     private boolean zenActive() {
-        return config.getWorkspaceState().isZenMode();
+        return config.getWorkspaceState().isZenMode() || cliZenOverride;
     }
 
     /** True when this window is in Expert mode — like Zen, but keeps line numbers + the status bar. */
     private boolean expertActive() {
-        return config.getWorkspaceState().isExpertMode();
+        return config.getWorkspaceState().isExpertMode() || cliExpertOverride;
     }
 
     /** Snapshot of which optional features are effectively enabled, for {@link Chrome#paletteVisible}. */
@@ -901,8 +914,8 @@ public class MainController implements com.editora.mcp.McpBridge {
             return;
         }
         boolean show = !config.getSettings().isShowToolbar()
-                && !config.getWorkspaceState().isZenMode()
-                && !config.getWorkspaceState().isExpertMode(); // a focus mode hides the toolbar; its E/Z restores it
+                && !zenActive()
+                && !expertActive(); // a focus mode hides the toolbar; its E/Z restores it
         toolbarRestoreButton.setVisible(show);
         toolbarRestoreButton.setManaged(show);
     }
@@ -916,7 +929,7 @@ public class MainController implements com.editora.mcp.McpBridge {
         if (zenExitButton == null) {
             return;
         }
-        boolean zen = config.getWorkspaceState().isZenMode();
+        boolean zen = zenActive();
         zenExitButton.setVisible(zen);
         zenExitButton.setManaged(zen);
         EditorBuffer active = activeBuffer();
@@ -934,7 +947,7 @@ public class MainController implements com.editora.mcp.McpBridge {
         if (expertExitButton == null) {
             return;
         }
-        boolean expert = config.getWorkspaceState().isExpertMode();
+        boolean expert = expertActive();
         expertExitButton.setVisible(expert);
         expertExitButton.setManaged(expert);
         EditorBuffer active = activeBuffer();
@@ -4683,11 +4696,12 @@ public class MainController implements com.editora.mcp.McpBridge {
                 });
             }
         }
-        if (zen) {
-            setZenMode(true);
-        }
+        // --zen / --expert: session-only overrides (they don't change the saved session), like --simple.
+        // If both were given, Expert wins — the two are mutually exclusive.
         if (expert) {
-            setExpertMode(true); // like --zen; if both were given, Expert wins (the two are mutually exclusive)
+            applyCliFocusMode(true);
+        } else if (zen) {
+            applyCliFocusMode(false);
         }
     }
 
@@ -6632,7 +6646,31 @@ public class MainController implements com.editora.mcp.McpBridge {
         state.setActiveFile(activePath != null ? activePath.toAbsolutePath().toString() : "");
         persistWindowBounds(state);
         toolWindows.persistDividers(); // capture a divider dragged but left open (close() only saves on hide)
+        restoreCliFocusToolWindows(state);
         config.save(); // durable flush on quit — not coalesced
+    }
+
+    /**
+     * Undoes the persisted side-effects of a {@code --zen}/{@code --expert} session override, so the flag
+     * really is session-only: entering the mode closed the docked tool windows and {@code close()} persisted
+     * "nothing open", which would otherwise lose them on the next (flagless) launch. Only fills a side the
+     * user hasn't since reopened by hand, and leaves the pre-focus snapshots out of the saved file.
+     */
+    private void restoreCliFocusToolWindows(WorkspaceState state) {
+        if (cliFocusToolWindows == null) {
+            return;
+        }
+        if (state.getOpenLeftToolWindow().isEmpty()) {
+            state.setOpenLeftToolWindow(cliFocusToolWindows[0]);
+        }
+        if (state.getOpenRightToolWindow().isEmpty()) {
+            state.setOpenRightToolWindow(cliFocusToolWindows[1]);
+        }
+        if (state.getOpenBottomToolWindow().isEmpty()) {
+            state.setOpenBottomToolWindow(cliFocusToolWindows[2]);
+        }
+        state.getPreZenToolWindows().clear(); // a snapshot of a mode that was never saved as "on"
+        state.getPreExpertToolWindows().clear();
     }
 
     /** Records the main window's geometry. When maximized, keep the last normal bounds so
@@ -7610,7 +7648,7 @@ public class MainController implements com.editora.mcp.McpBridge {
     }
 
     private void toggleZen() {
-        setZenMode(!config.getWorkspaceState().isZenMode());
+        setZenMode(!zenActive());
     }
 
     /**
@@ -7621,20 +7659,25 @@ public class MainController implements com.editora.mcp.McpBridge {
      * {@link Settings}</em>. Leaving Zen therefore restores the user's saved prefs exactly (nothing was
      * changed), and one window being in Zen never affects another. Open tool windows are closed on enter
      * and reopened on leave (a per-window UI snapshot, not a pref). Idempotent.
+     *
+     * <p>An explicit toggle also <b>takes over from a {@code --zen}/{@code --expert} session flag</b> (as
+     * {@link #toggleSimpleMode} does for {@code --simple}): the CLI override is cleared and the real state is
+     * written, so entering the mode from a {@code --zen} launch makes it stick from then on.
      */
     void setZenMode(boolean on) {
         WorkspaceState ws = config.getWorkspaceState();
-        if (ws.isZenMode() == on) {
+        if (zenActive() == on) {
             return;
         }
-        if (on && ws.isExpertMode()) {
+        if (on && expertActive()) {
             setExpertMode(false); // the two focus modes are mutually exclusive
         }
         if (on) {
             ws.setPreZenToolWindows(toolWindows.closeAllOpen());
         }
+        clearCliFocusOverride(); // an explicit toggle takes over from the --zen/--expert session flag
         ws.setZenMode(on);
-        toolWindows.setZenStripesHidden(on || ws.isExpertMode());
+        toolWindows.setZenStripesHidden(on || expertActive());
         if (!on) {
             toolWindows.openByIds(ws.getPreZenToolWindows());
             ws.getPreZenToolWindows().clear();
@@ -7647,7 +7690,7 @@ public class MainController implements com.editora.mcp.McpBridge {
     }
 
     private void toggleExpert() {
-        setExpertMode(!config.getWorkspaceState().isExpertMode());
+        setExpertMode(!expertActive());
     }
 
     /**
@@ -7658,17 +7701,18 @@ public class MainController implements com.editora.mcp.McpBridge {
      */
     void setExpertMode(boolean on) {
         WorkspaceState ws = config.getWorkspaceState();
-        if (ws.isExpertMode() == on) {
+        if (expertActive() == on) {
             return;
         }
-        if (on && ws.isZenMode()) {
+        if (on && zenActive()) {
             setZenMode(false); // the two focus modes are mutually exclusive
         }
         if (on) {
             ws.setPreExpertToolWindows(toolWindows.closeAllOpen());
         }
+        clearCliFocusOverride(); // an explicit toggle takes over from the --zen/--expert session flag
         ws.setExpertMode(on);
-        toolWindows.setZenStripesHidden(on || ws.isZenMode());
+        toolWindows.setZenStripesHidden(on || zenActive());
         if (!on) {
             toolWindows.openByIds(ws.getPreExpertToolWindows());
             ws.getPreExpertToolWindows().clear();
@@ -7677,6 +7721,45 @@ public class MainController implements com.editora.mcp.McpBridge {
         applyViewSettingsToAllBuffers(config.getSettings());
         requestSave();
         setStatus(tr("status.toggle.expert", tr(on ? "common.on" : "common.off")));
+    }
+
+    /**
+     * Applies a {@code --zen} / {@code --expert} <b>session-only</b> focus mode: the same effect as the real
+     * mode, but nothing is written to the saved session — quit and relaunch without the flag and the window
+     * comes back normal. This mirrors {@code --simple} ({@link #cliSimpleOverride}).
+     *
+     * <p>Entering a focus mode closes the docked tool windows, and {@link ToolWindowManager#close} <em>persists</em>
+     * "nothing open" — so the ids are stashed in {@link #cliFocusToolWindows} and written back at quit
+     * ({@link #persistSession}); otherwise a session-only mode would still lose them for good.
+     *
+     * <p>No-op when this window's <em>saved</em> session already has a focus mode on (nothing to override).
+     */
+    private void applyCliFocusMode(boolean expert) {
+        if (zenActive() || expertActive()) {
+            return;
+        }
+        WorkspaceState ws = config.getWorkspaceState();
+        cliFocusToolWindows =
+                new String[] {ws.getOpenLeftToolWindow(), ws.getOpenRightToolWindow(), ws.getOpenBottomToolWindow()};
+        if (expert) {
+            cliExpertOverride = true;
+            ws.setPreExpertToolWindows(toolWindows.closeAllOpen()); // the in-app "E" exit reopens from here
+        } else {
+            cliZenOverride = true;
+            ws.setPreZenToolWindows(toolWindows.closeAllOpen()); // ditto for the "Z"
+        }
+        toolWindows.setZenStripesHidden(true);
+        applyChromeVisibility();
+        applyViewSettingsToAllBuffers(config.getSettings());
+        // Deliberately no requestSave(): the flag must leave the saved session untouched.
+    }
+
+    /** Drops a {@code --zen}/{@code --expert} session override — an in-app toggle now owns the state, so the
+     *  quit-time tool-window restore must not fire. */
+    private void clearCliFocusOverride() {
+        cliZenOverride = false;
+        cliExpertOverride = false;
+        cliFocusToolWindows = null;
     }
 
     private void toggleToolbar() {

--- a/src/test/java/com/editora/ui/CliFocusModeFxTest.java
+++ b/src/test/java/com/editora/ui/CliFocusModeFxTest.java
@@ -1,0 +1,158 @@
+package com.editora.ui;
+
+import javafx.scene.control.ToolBar;
+
+import com.editora.config.ConfigManager;
+import com.editora.config.WorkspaceState;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * {@code --zen} and {@code --expert} are <b>session-only</b> overrides, exactly like {@code --simple}: they
+ * put the window into the focus mode for this run, but must not write it into the saved session — launching
+ * once with the flag must not leave the user stuck in the mode on every later launch.
+ *
+ * <p>The subtle half is the tool windows: entering a focus mode closes the docked ones, and
+ * {@code ToolWindowManager.close()} <em>persists</em> "nothing open". So a session-only focus mode has to put
+ * those ids back at quit, or it would silently lose the user's docked tool windows for good — a worse bug
+ * than the one being fixed.
+ */
+@Tag("fx")
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class CliFocusModeFxTest {
+
+    private FxWindowFixture fx;
+
+    @BeforeAll
+    void setUp() throws Exception {
+        FxTestSupport.bootToolkit();
+        fx = FxWindowFixture.create();
+    }
+
+    @AfterAll
+    void tearDown() throws Exception {
+        if (fx != null) {
+            fx.dispose();
+        }
+    }
+
+    private WorkspaceState state() throws Exception {
+        ConfigManager config = FxTestSupport.field(fx.controller, "config");
+        return config.getWorkspaceState();
+    }
+
+    /** Applies the CLI flag exactly as {@code applyStartupTargets} does. */
+    private void applyCliFocusMode(boolean expert) throws Exception {
+        FxTestSupport.call(fx.controller, "applyCliFocusMode", new Class<?>[] {boolean.class}, expert);
+    }
+
+    private void persistSession() throws Exception {
+        FxTestSupport.invoke(fx.controller, "persistSession");
+    }
+
+    @Test
+    void zenFlagAppliesTheModeWithoutSavingIt() throws Exception {
+        ToolBar toolBar = FxTestSupport.field(fx.controller, "toolBar");
+        assertTrue(FxTestSupport.callOnFx(toolBar::isVisible), "toolbar visible by default");
+
+        FxTestSupport.runOnFx(() -> {
+            try {
+                applyCliFocusMode(false); // --zen
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        });
+
+        // The window IS in Zen for this session...
+        assertFalse(FxTestSupport.callOnFx(toolBar::isVisible), "--zen hides the chrome for this session");
+        assertTrue(
+                FxTestSupport.callOnFx(
+                        () -> (Boolean) FxTestSupport.call(fx.controller, "zenActive", new Class<?>[] {})),
+                "zenActive() reflects the flag");
+        // ...but nothing was written to the saved session, so the next flagless launch is normal.
+        assertFalse(state().isZenMode(), "--zen must not persist Zen into the saved session");
+
+        // Quitting keeps it that way.
+        FxTestSupport.runOnFx(() -> {
+            try {
+                persistSession();
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        });
+        assertFalse(state().isZenMode(), "still not saved after a quit");
+        assertFalse(state().isExpertMode(), "and Expert was never touched");
+
+        // Leave it, so the shared fixture isn't left in Zen for the next test.
+        FxTestSupport.runOnFx(() -> fx.controller.setZenMode(false));
+    }
+
+    @Test
+    void theFlagDoesNotEatYourDockedToolWindows() throws Exception {
+        ToolWindowManager toolWindows = FxTestSupport.field(fx.controller, "toolWindows");
+        WorkspaceState ws = state();
+
+        // A docked tool window, as a returning user would have.
+        ToolWindow project = FxTestSupport.field(fx.controller, "projectToolWindow");
+        FxTestSupport.runOnFx(() -> toolWindows.open(project));
+        String docked = ws.getOpenRightToolWindow(); // the Project window docks on the right by default
+        assertFalse(docked.isEmpty(), "a tool window is docked");
+
+        // --expert closes it, and close() persists "nothing open" — the trap.
+        FxTestSupport.runOnFx(() -> {
+            try {
+                applyCliFocusMode(true);
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        });
+        assertTrue(ws.getOpenRightToolWindow().isEmpty(), "entering the focus mode closed it");
+
+        // On quit the session-only override puts it back, so the next launch still has it.
+        FxTestSupport.runOnFx(() -> {
+            try {
+                persistSession();
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        });
+        assertEquals(docked, ws.getOpenRightToolWindow(), "the docked tool window survives a --expert session");
+        assertFalse(ws.isExpertMode(), "--expert still isn't saved");
+        assertTrue(ws.getPreExpertToolWindows().isEmpty(), "no stale snapshot of a mode that was never saved");
+
+        FxTestSupport.runOnFx(() -> fx.controller.setExpertMode(false));
+    }
+
+    @Test
+    void anInAppToggleTakesOverFromTheFlag() throws Exception {
+        // Launch with --zen, then turn Zen ON from inside the app (via the palette/keybinding). That's an
+        // explicit choice, so it must stick — mirroring how toggleSimpleMode() drops cliSimpleOverride.
+        FxTestSupport.runOnFx(() -> {
+            try {
+                applyCliFocusMode(false);
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        });
+        assertFalse(state().isZenMode(), "the flag alone doesn't save");
+
+        FxTestSupport.runOnFx(() -> fx.controller.setZenMode(false)); // exit: the override is dropped
+        assertFalse(
+                FxTestSupport.callOnFx(
+                        () -> (Boolean) FxTestSupport.call(fx.controller, "zenActive", new Class<?>[] {})),
+                "exiting the flag's Zen actually leaves Zen");
+
+        FxTestSupport.runOnFx(() -> fx.controller.setZenMode(true)); // now an explicit in-app enter
+        assertTrue(state().isZenMode(), "an explicit toggle IS saved");
+
+        FxTestSupport.runOnFx(() -> fx.controller.setZenMode(false));
+        assertFalse(state().isZenMode());
+    }
+}


### PR DESCRIPTION
Follow-up to the audit in #401, which turned this up.

## The bug

`--zen` and `--expert` are documented as session-only overrides, but both wrote the mode straight into the window's saved `WorkspaceState`. Launch **once** with `--zen` and **every** subsequent launch comes up in Zen — no toolbar, no tab bar, no status bar — with nothing on screen to explain why. The only way out is the floating "Z", which most people would never connect to a flag they used days ago.

`--simple` already got this right: a transient `cliSimpleOverride`, OR'd with the saved setting and never persisted. `--zen`/`--expert` now follow the same pattern.

## The fix

- `cliZenOverride` / `cliExpertOverride` are OR'd into `zenActive()` / `expertActive()`, so the mode is fully live for the session while `WorkspaceState` stays untouched. Every read of the two flags now goes through those accessors (several call sites still hit `isZenMode()` directly).
- An **in-app** toggle still takes over and persists — mirroring `toggleSimpleMode()`, which drops `cliSimpleOverride` on an explicit flip. So `--zen` then pressing the Zen keybinding makes it stick, which is what you'd want.

### The trap this had to avoid

Entering a focus mode calls `ToolWindowManager.closeAllOpen()`, and **`close()` persists "nothing open."** A naive session-only mode would therefore still eat the user's docked tool windows *permanently* — a worse bug than the one being fixed, and an easy one to ship without noticing. So the ids are stashed on entry and written back in `persistSession()`, skipping any side the user has since reopened by hand, and the stale pre-focus snapshots are dropped from the saved file.

## Verification

**Live, not just unit tests** — launched both builds against a scratch config dir with `--zen`, killed them, and read what actually landed in `workspace-state.json`:

| | `master` | this branch |
|---|---|---|
| `"zenMode"` after a `--zen` run | `true` ❌ | `false` ✅ |

Plus `CliFocusModeFxTest` (3 cases: the flag doesn't persist; the docked tool windows survive a `--expert` session; an in-app toggle takes over). All three **fail on the old code**:

```
zenFlagAppliesTheModeWithoutSavingIt:  --zen must not persist Zen  ==> expected: <false> but was: <true>
theFlagDoesNotEatYourDockedToolWindows: ==> expected: <project> but was: <>
anInAppToggleTakesOverFromTheFlag:     the flag alone doesn't save ==> expected: <false> but was: <true>
```

Full suite: **1936 tests, 0 failures**. `--help` text and the README's CLI section updated to match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)