### PR TITLE
Fix two data-loss bugs: huge-file save truncation, and quit dropping other windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Pressing Ctrl/Cmd-S on a very large file no longer destroys it.** A file of 50 MB or more is deliberately
+  loaded only in part (the first 50 MB — or, for a log, the *last* 50 MB) and opened read-only. But read-only
+  only blocks *typing*: Save needs neither an edit nor unsaved changes, and it wrote the buffer straight back
+  over the file — truncating it on disk to whichever slice happened to be loaded, irreversibly. Every write
+  path now refuses a partially-loaded file and says why.
+- **Quitting no longer discards the unsaved work and the session of every window except the one you quit
+  from.** Quitting from inside the app never ran the other windows' close handling, so their dirty buffers
+  were dropped with no save prompt and their sessions (open tabs, carets, window bounds) reverted to whatever
+  they were at launch. Quit now prompts and persists each window in turn, and any window's prompt can cancel
+  the quit. Each window's services and subprocesses are shut down properly too.
+
 - **`--zen` and `--expert` are now genuinely session-only, like `--simple`.** Launching once with either flag
   wrote the mode into the saved session, so *every* later launch came up in it — with no hint as to why. The
   flags now apply the mode for the current run only and leave the saved session untouched (including the

--- a/src/main/java/com/editora/editor/EditorBuffer.java
+++ b/src/main/java/com/editora/editor/EditorBuffer.java
@@ -292,6 +292,8 @@ public class EditorBuffer implements TabContent {
     private boolean heavyFile;
     /** Huge-file mode: implies large-file mode plus read-only (no undo, not editable). */
     private boolean hugeFile;
+    /** The loader could only read part of this file (huge-file cap / log tail) — saving would truncate it. */
+    private boolean truncatedLoad;
     /** User "View mode": non-editable but keeps all normal editor features (separate from huge-file). */
     private boolean viewMode;
     /** The most recently focused view (primary or secondary); drives "active area" for commands. */
@@ -5971,6 +5973,21 @@ public class EditorBuffer implements TabContent {
         } else {
             applyUndoMode();
         }
+    }
+
+    /**
+     * Marks that the loader could only read <b>part</b> of the file — the huge-file cap (first
+     * {@link #HUGE_FILE_BYTES}) or a log's tail (the <em>last</em> chunk). The buffer's content is then not
+     * the file, and writing it back would <b>truncate the user's file on disk</b>, so the save path refuses.
+     * Set by the loader on every load (cleared for a normal, complete read).
+     */
+    public void setTruncatedLoad(boolean truncated) {
+        this.truncatedLoad = truncated;
+    }
+
+    /** True when this buffer holds only a slice of its file — see {@link #setTruncatedLoad}. Never save it. */
+    public boolean isTruncatedLoad() {
+        return truncatedLoad;
     }
 
     /**

--- a/src/main/java/com/editora/ui/MainController.java
+++ b/src/main/java/com/editora/ui/MainController.java
@@ -1118,7 +1118,7 @@ public class MainController implements com.editora.mcp.McpBridge {
     }
 
     /** Releases this window's resources on close: language servers, debug session, and worker threads. */
-    private void disposeWindow() {
+    void disposeWindow() {
         for (Tab tab : tabPane.getTabs()) {
             EditorBuffer buffer = bufferOf(tab);
             if (buffer != null) {
@@ -5428,6 +5428,9 @@ public class MainController implements com.editora.mcp.McpBridge {
         }
         buffer.setDiskSnapshot(mtime, size); // baseline for external-change detection
         boolean isLog = logViewer.handlesLogFile(file);
+        // A huge file is read only PARTIALLY below. Flag that, so the save path can refuse: writing a
+        // partial buffer back would truncate the user's file on disk (see EditorBuffer.setTruncatedLoad).
+        buffer.setTruncatedLoad(size >= EditorBuffer.HUGE_FILE_BYTES);
         if (size >= EditorBuffer.HUGE_FILE_BYTES) {
             if (isLog) {
                 // A huge log opens at its END (the tail is what matters) instead of the first chunk.
@@ -5722,7 +5725,27 @@ public class MainController implements com.editora.mcp.McpBridge {
         }
     }
 
+    /**
+     * Blocks every write path for a buffer the loader could only read <em>part</em> of (a file at/over
+     * {@link EditorBuffer#HUGE_FILE_BYTES}: the first 50 MB, or a log's <em>last</em> 50 MB). Such a buffer is
+     * a slice, not the file — writing it back with {@code Files.write} would truncate the real file on disk
+     * and destroy everything outside the slice. The buffer is read-only, but that only stops <em>typing</em>:
+     * {@code file.save} (Ctrl/Cmd-S) needs no edit and no dirty flag to fire, so it has to be refused here.
+     *
+     * @return true when the save was refused (the caller must not write).
+     */
+    private boolean refuseTruncatedSave(EditorBuffer buffer) {
+        if (buffer == null || !buffer.isTruncatedLoad()) {
+            return false;
+        }
+        setStatus(tr("status.truncatedNoSave"));
+        return true;
+    }
+
     private boolean save(EditorBuffer buffer) {
+        if (refuseTruncatedSave(buffer)) {
+            return false;
+        }
         if (buffer.getPath() == null) {
             return saveAs(buffer);
         }
@@ -5820,6 +5843,9 @@ public class MainController implements com.editora.mcp.McpBridge {
     }
 
     private boolean saveAs(EditorBuffer buffer) {
+        if (refuseTruncatedSave(buffer)) {
+            return false;
+        }
         if (com.editora.vfs.Vfs.isRemote(buffer.getPath())) {
             // A remote buffer always opens with a path, so plain Save writes it back over SFTP; choosing a
             // new remote destination (an async prompt) isn't supported yet.
@@ -5864,7 +5890,7 @@ public class MainController implements com.editora.mcp.McpBridge {
      * overwriting a different existing file.
      */
     private void saveAsPrompt(EditorBuffer buffer) {
-        if (buffer == null) {
+        if (buffer == null || refuseTruncatedSave(buffer)) {
             return;
         }
         if (buffer.getPath() != null && com.editora.vfs.Vfs.isRemote(buffer.getPath())) {
@@ -6569,9 +6595,19 @@ public class MainController implements com.editora.mcp.McpBridge {
         return com.editora.config.PathKeys.canonical(p);
     }
 
+    /**
+     * In-app quit. {@code Platform.exit()} fires no {@code Stage.onCloseRequest}, so the per-window close
+     * handler never runs — every window has to be prompted + persisted here, or the other windows lose their
+     * unsaved buffers and their whole session. {@link WindowManager#confirmCloseAllWindows} does that (and
+     * disposes each window's services); the null case is the unit-test/standalone controller.
+     */
     @FXML
     private void onQuit() {
-        if (confirmQuit() && confirmCloseAllBuffers()) {
+        if (!confirmQuit()) {
+            return;
+        }
+        boolean ok = windowManager != null ? windowManager.confirmCloseAllWindows() : confirmCloseAllBuffers();
+        if (ok) {
             Platform.exit();
         }
     }
@@ -6590,8 +6626,9 @@ public class MainController implements com.editora.mcp.McpBridge {
         return result.isPresent() && result.get() == quit;
     }
 
-    /** Walks every tab and prompts to save/discard each dirty buffer. False = user cancelled. */
-    private boolean confirmCloseAllBuffers() {
+    /** Walks every tab and prompts to save/discard each dirty buffer, then persists this window's session.
+     *  False = the user cancelled. Package-visible: the quit path drives it for every window. */
+    boolean confirmCloseAllBuffers() {
         for (Tab tab : new ArrayList<>(tabPane.getTabs())) {
             EditorBuffer buffer = bufferOf(tab);
             if (buffer == null || !buffer.isDirty()) {

--- a/src/main/java/com/editora/ui/WindowManager.java
+++ b/src/main/java/com/editora/ui/WindowManager.java
@@ -347,6 +347,41 @@ public class WindowManager {
     }
 
     /**
+     * The in-app quit path ({@code app.quit} / the toolbar Quit button / {@code C-x C-c}) ends in
+     * {@code Platform.exit()} — which fires <b>no</b> {@code Stage.onCloseRequest}, so the per-window close
+     * handler that prompts for unsaved buffers and persists the window's session never runs. Quitting
+     * therefore used to silently discard the dirty buffers <em>and</em> the whole session (tabs, carets,
+     * bounds) of every window except the one quit from.
+     *
+     * <p>So walk them all here: bring each to the front, let it prompt for its own dirty buffers and persist
+     * its session, then dispose its services (which also kills that window's Run/build subprocesses). Any
+     * window's prompt can cancel the quit.
+     *
+     * <p>Deliberately does <b>not</b> call {@link #onWindowClosed} — that would drain the persisted
+     * open-window set (see {@link #reconcileOpenSet}), and a quit must leave every window to reopen.
+     *
+     * @return false if the user cancelled at some window's save prompt (the quit is off).
+     */
+    boolean confirmCloseAllWindows() {
+        for (Holder h : new ArrayList<>(windows)) {
+            h.stage().toFront(); // make it obvious which window is asking about unsaved changes
+            h.stage().requestFocus();
+            if (!h.controller().confirmCloseAllBuffers()) {
+                return false; // cancelled — the app keeps running and nothing was disposed
+            }
+        }
+        for (Holder h : new ArrayList<>(windows)) {
+            try {
+                h.controller().disposeWindow(); // shut this window's services + kill its subprocesses
+            } catch (RuntimeException | Error t) {
+                java.util.logging.Logger.getLogger(WindowManager.class.getName())
+                        .log(java.util.logging.Level.WARNING, "disposeWindow failed during quit", t);
+            }
+        }
+        return true;
+    }
+
+    /**
      * Persists the set of currently-open windows as the restore set. Debounced (see {@link #openSetReconcile})
      * so a burst of closes settles to a single write, and — crucially — so it cannot run <em>during</em> a
      * quit. The two ends:

--- a/src/main/resources/com/editora/i18n/messages.properties
+++ b/src/main/resources/com/editora/i18n/messages.properties
@@ -824,6 +824,7 @@ status.failedReload=Failed to reload {0}: {1}
 status.recentCleared=Recent files cleared
 status.saved=Saved {0}
 status.failedSave=Failed to save: {0}
+status.truncatedNoSave = Not saved: this file is too large to load fully, so only part of it is open. Saving would truncate the file on disk.
 status.autoSaved=Auto-saved {0}
 status.autoSaveFailed=Auto-save failed: {0}
 status.autoSave=Auto save: {0}

--- a/src/main/resources/com/editora/i18n/messages_de.properties
+++ b/src/main/resources/com/editora/i18n/messages_de.properties
@@ -820,6 +820,7 @@ status.failedReload=Neuladen von {0} fehlgeschlagen: {1}
 status.recentCleared=Zuletzt verwendete Dateien gelöscht
 status.saved=Gespeichert {0}
 status.failedSave=Speichern fehlgeschlagen: {0}
+status.truncatedNoSave = Nicht gespeichert: Die Datei ist zu groß, um vollständig geladen zu werden, daher ist nur ein Teil geöffnet. Ein Speichern würde die Datei auf der Festplatte abschneiden.
 status.autoSaved=Automatisch gespeichert: {0}
 status.autoSaveFailed=Automatisches Speichern fehlgeschlagen: {0}
 status.autoSave=Automatisches Speichern: {0}

--- a/src/main/resources/com/editora/i18n/messages_es.properties
+++ b/src/main/resources/com/editora/i18n/messages_es.properties
@@ -820,6 +820,7 @@ status.failedReload=Error al recargar {0}: {1}
 status.recentCleared=Archivos recientes borrados
 status.saved=Guardado {0}
 status.failedSave=Error al guardar: {0}
+status.truncatedNoSave = No se guardó: el archivo es demasiado grande para cargarse por completo, así que solo hay una parte abierta. Guardarlo truncaría el archivo en el disco.
 status.autoSaved=Guardado automático: {0}
 status.autoSaveFailed=Error en el guardado automático: {0}
 status.autoSave=Guardado automático: {0}

--- a/src/main/resources/com/editora/i18n/messages_fr.properties
+++ b/src/main/resources/com/editora/i18n/messages_fr.properties
@@ -820,6 +820,7 @@ status.failedReload=Échec du rechargement de {0} : {1}
 status.recentCleared=Fichiers récents effacés
 status.saved=Enregistré {0}
 status.failedSave=Échec de l'enregistrement : {0}
+status.truncatedNoSave = Non enregistré : le fichier est trop volumineux pour être chargé entièrement, seule une partie est ouverte. L’enregistrer tronquerait le fichier sur le disque.
 status.autoSaved=Enregistré automatiquement : {0}
 status.autoSaveFailed=Échec de l'enregistrement automatique : {0}
 status.autoSave=Enregistrement automatique : {0}

--- a/src/main/resources/com/editora/i18n/messages_it.properties
+++ b/src/main/resources/com/editora/i18n/messages_it.properties
@@ -820,6 +820,7 @@ status.failedReload=Ricaricamento di {0} non riuscito: {1}
 status.recentCleared=File recenti cancellati
 status.saved=Salvato {0}
 status.failedSave=Salvataggio non riuscito: {0}
+status.truncatedNoSave = Non salvato: il file è troppo grande per essere caricato per intero, quindi ne è aperta solo una parte. Salvarlo troncherebbe il file su disco.
 status.autoSaved=Salvato automaticamente: {0}
 status.autoSaveFailed=Salvataggio automatico non riuscito: {0}
 status.autoSave=Salvataggio automatico: {0}

--- a/src/main/resources/com/editora/i18n/messages_pt.properties
+++ b/src/main/resources/com/editora/i18n/messages_pt.properties
@@ -820,6 +820,7 @@ status.failedReload=Falha ao recarregar {0}: {1}
 status.recentCleared=Arquivos recentes limpos
 status.saved=Salvo {0}
 status.failedSave=Falha ao salvar: {0}
+status.truncatedNoSave = Não salvo: o arquivo é grande demais para ser carregado por completo, então apenas parte dele está aberta. Salvar truncaria o arquivo no disco.
 status.autoSaved=Salvo automaticamente: {0}
 status.autoSaveFailed=Falha no salvamento automático: {0}
 status.autoSave=Salvamento automático: {0}

--- a/src/test/java/com/editora/ui/HugeFileSaveFxTest.java
+++ b/src/test/java/com/editora/ui/HugeFileSaveFxTest.java
@@ -1,0 +1,117 @@
+package com.editora.ui;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import com.editora.command.CommandRegistry;
+import com.editora.editor.EditorBuffer;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.io.TempDir;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+/**
+ * A file at or over {@link EditorBuffer#HUGE_FILE_BYTES} is loaded <b>partially</b> — the first 50 MB, or (for
+ * a log) the <em>last</em> 50 MB. The buffer is read-only, but read-only only stops <em>typing</em>:
+ * {@code file.save} (Ctrl/Cmd-S) needs neither an edit nor a dirty flag, and it went straight to
+ * {@code Files.write(file, bufferContent)} — truncating the user's file on disk to whichever slice happened to
+ * be loaded, irreversibly. This pins that every write path refuses such a buffer.
+ *
+ * <p>The buffers here are marked truncated directly rather than by loading a real 50 MB file: pushing 50 M
+ * characters into a {@code CodeArea} takes far longer than an FX test may block the toolkit for. The flag is
+ * set by the loader from exactly the condition that decides the partial read
+ * ({@code setTruncatedLoad(size >= HUGE_FILE_BYTES)} in {@code loadInto}), and everything downstream of it —
+ * the part that actually destroyed files — is what these tests drive, through the real command.
+ */
+@Tag("fx")
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class HugeFileSaveFxTest {
+
+    private FxWindowFixture fx;
+
+    @TempDir
+    Path tmp;
+
+    @BeforeAll
+    void setUp() throws Exception {
+        FxTestSupport.bootToolkit();
+        fx = FxWindowFixture.create();
+    }
+
+    @AfterAll
+    void tearDown() throws Exception {
+        if (fx != null) {
+            fx.dispose();
+        }
+    }
+
+    /** A buffer standing in for a partially-loaded huge file: it holds a slice, its path is the whole file. */
+    private EditorBuffer openTruncated(Path file, String loadedSlice) throws Exception {
+        return FxTestSupport.callOnFx(() -> {
+            EditorBuffer buffer = new EditorBuffer();
+            buffer.setPath(file);
+            buffer.setContent(loadedSlice);
+            buffer.setReadOnly(true); // what loadInto does for a huge file
+            buffer.setTruncatedLoad(true); // ...and the flag that says the content is only a slice
+            FxTestSupport.call(
+                    fx.controller, "addBuffer", new Class<?>[] {EditorBuffer.class, boolean.class}, buffer, true);
+            return buffer;
+        });
+    }
+
+    @Test
+    void ctrlSOnAPartiallyLoadedHugeFileDoesNotTruncateItOnDisk() throws Exception {
+        Path file = tmp.resolve("huge.txt");
+        String whole = "line one\nline two\nline three — the part beyond the load cap\n";
+        Files.writeString(file, whole);
+        openTruncated(file, "line one\n"); // the loader only got the first slice
+
+        // The reflex: Ctrl/Cmd-S. No edit, not dirty — this used to overwrite the file with the slice.
+        CommandRegistry registry = FxTestSupport.field(fx.controller, "registry");
+        FxTestSupport.runOnFx(() -> registry.run("file.save"));
+        FxTestSupport.runOnFx(() -> {});
+
+        assertEquals(whole, Files.readString(file), "the file on disk must be untouched — a save would destroy it");
+    }
+
+    @Test
+    void saveAsOfAPartiallyLoadedFileIsAlsoRefused() throws Exception {
+        Path file = tmp.resolve("huge2.txt");
+        Files.writeString(file, "aaa\nbbb\nccc\n");
+        EditorBuffer buffer = openTruncated(file, "aaa\n");
+
+        // Save-As wouldn't destroy the original, but it would write a SLICE of the file to a new path and
+        // present it as a copy — a corrupt file the user has no reason to distrust. Refused too.
+        boolean wrote = FxTestSupport.callOnFx(() ->
+                (Boolean) FxTestSupport.call(fx.controller, "saveAs", new Class<?>[] {EditorBuffer.class}, buffer));
+        assertFalse(wrote, "Save-As is refused for a partially-loaded buffer");
+        assertEquals("aaa\nbbb\nccc\n", Files.readString(file), "and the original is untouched");
+    }
+
+    @Test
+    void aNormalFileStillSaves() throws Exception {
+        // The guard must not break the ordinary path.
+        Path file = tmp.resolve("small.txt");
+        Files.writeString(file, "hello\n");
+
+        EditorBuffer buffer = FxTestSupport.callOnFx(() -> {
+            EditorBuffer b = new EditorBuffer();
+            b.setPath(file);
+            b.setContent("hello\nworld\n");
+            FxTestSupport.call(fx.controller, "addBuffer", new Class<?>[] {EditorBuffer.class, boolean.class}, b, true);
+            return b;
+        });
+        assertFalse(buffer.isTruncatedLoad(), "a normal buffer is not a truncated load");
+
+        CommandRegistry registry = FxTestSupport.field(fx.controller, "registry");
+        FxTestSupport.runOnFx(() -> registry.run("file.save"));
+        FxTestSupport.runOnFx(() -> {});
+
+        assertEquals("hello\nworld\n", Files.readString(file), "a normal save still writes");
+    }
+}

--- a/src/test/java/com/editora/ui/QuitAllWindowsFxTest.java
+++ b/src/test/java/com/editora/ui/QuitAllWindowsFxTest.java
@@ -1,0 +1,87 @@
+package com.editora.ui;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+import com.editora.config.ConfigManager;
+import com.editora.config.WorkspaceState;
+import com.editora.editor.EditorBuffer;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.io.TempDir;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * The in-app quit ({@code app.quit} / the toolbar Quit button / {@code C-x C-c}) ends in
+ * {@code Platform.exit()}, which fires <b>no</b> {@code Stage.onCloseRequest} — so the per-window close
+ * handler, the only thing that prompts for unsaved buffers and persists a window's session, never runs. It
+ * used to prompt + persist only the window you happened to quit <em>from</em>: every other window's dirty
+ * buffers were discarded with no prompt, and its session (tabs, carets, bounds) silently reverted to whatever
+ * it was at launch.
+ *
+ * <p>This drives the fix, {@link WindowManager#confirmCloseAllWindows}, with a clean (non-dirty) buffer in the
+ * second window — a dirty one would open a modal save prompt, which a headless test can't answer. The session
+ * half is the half that regresses silently; the prompt half is the same {@code confirmCloseAllBuffers} call
+ * the per-window close handler already makes.
+ */
+@Tag("fx")
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class QuitAllWindowsFxTest {
+
+    @TempDir
+    Path tmp;
+
+    @BeforeAll
+    void setUp() throws Exception {
+        FxTestSupport.bootToolkit();
+    }
+
+    @Test
+    void quittingPersistsTheSessionOfEveryWindowNotJustTheOneYouQuitFrom() throws Exception {
+        FxWindowFixture fx = FxWindowFixture.create(); // window A
+        WindowManager wm = fx.windowManager;
+
+        // A second window, as "New Window" (C-x 5 2) creates. It gets its own session file.
+        MainController b = FxTestSupport.callOnFx(() -> {
+            wm.newWindow();
+            List<?> holders = FxTestSupport.field(wm, "windows");
+            Object holder = holders.get(holders.size() - 1);
+            return (MainController) FxTestSupport.call(holder, "controller", new Class<?>[] {});
+        });
+        assertTrue(b != fx.controller, "a genuinely second window");
+
+        // Open a file in window B only.
+        Path file = tmp.resolve("in-window-b.txt");
+        Files.writeString(file, "work in the other window\n");
+        FxTestSupport.runOnFx(() -> {
+            EditorBuffer buffer = new EditorBuffer();
+            buffer.setPath(file);
+            buffer.setContent("work in the other window\n");
+            FxTestSupport.call(b, "addBuffer", new Class<?>[] {EditorBuffer.class, boolean.class}, buffer, true);
+        });
+
+        ConfigManager configB = FxTestSupport.field(b, "config");
+        WorkspaceState stateB = configB.getWorkspaceState();
+        assertTrue(stateB.getOpenFiles().isEmpty(), "B's session hasn't been persisted yet");
+
+        // Quit. (onQuit() itself opens a confirm dialog, which a headless test can't answer — this is the
+        // step it performs once confirmed, and the step that was missing.)
+        boolean ok = FxTestSupport.callOnFx(
+                () -> (Boolean) FxTestSupport.call(wm, "confirmCloseAllWindows", new Class<?>[] {}));
+        assertTrue(ok, "nothing was dirty, so nothing cancelled the quit");
+
+        assertEquals(
+                1,
+                stateB.getOpenFiles().size(),
+                "window B's session must be persisted on quit — it used to be silently dropped");
+        assertEquals(
+                file.toAbsolutePath().toString(),
+                stateB.getOpenFiles().get(0).getPath(),
+                "and it must be B's own file");
+    }
+}


### PR DESCRIPTION
Two bugs that destroy the user's data. Found by auditing the file-I/O and config/session layers; neither is recent — both predate everything merged this week. 1 of 4 PRs from that audit (config durability, save-path correctness, and resource leaks to follow).

---

## 1. Ctrl/Cmd-S on a huge file **destroys** it

A file >= 50 MB is loaded **partially on purpose** — `readCapped()` takes the first 50 MB, and a huge *log* takes the **last** 50 MB (`LogTail.readTail`) — and the buffer is set read-only.

But read-only only stops **typing**. `file.save` needs neither an edit nor a dirty flag, and `save()` checked neither `isEditable()` nor `isDirty()` before:

```java
Files.write(file, saveBytes(buffer));   // buffer holds 50 MB of a 500 MB file
```

**Repro:** open a 500 MB log. The status bar says "very large log ... read-only, showing last 50 MB". Press Cmd-S — a reflex, no edit required. **The file is now 50 MB: its own tail. 450 MB are gone.** For a plain text file you keep the first 50 MB and lose the rest.

The controller *has* the guard — `activeEditable()` gates every editing command, and `autoSaveAllDirty()` checks `isEditable()`. The save path was the one place that skipped it.

**Fix:** `EditorBuffer` carries an explicit `truncatedLoad` flag, set by `loadInto` from the same condition that decides the partial read. `save` / `saveAs` / `saveAsPrompt` all refuse such a buffer and say why. Save-As is refused too — it wouldn't destroy the original, but it would write a *slice* to a new path and present it as a faithful copy.

---

## 2. Quit throws away every **other** window's unsaved work and session

`onQuit()` prompted for dirty buffers and called `persistSession()` for **this** window's tabs, then `Platform.exit()` — which fires **no** `Stage.onCloseRequest`. `WindowManager`'s own javadoc says as much: *"app.quit uses Platform.exit() and fires none"*.

So the per-window close handler — the only thing that prompts to save dirty buffers and persists a window's session — **never ran for any other window**. And `persistSession()` is the *sole* writer of the open-file list.

**Repro:** open two windows. In window B, open some files and type without saving. Focus window A, hit Cmd-Q, confirm. **Window B's unsaved edits are gone with no prompt**, and on relaunch B reopens with the tab set it had at *launch* — a session's worth of opened/closed tabs, carets and bounds silently lost.

**Fix:** `WindowManager.confirmCloseAllWindows()` walks every window — fronts it, lets it prompt for its own dirty buffers and persist its session, then disposes its services (which also kills that window's Run/build subprocesses, which used to **survive the quit**). Any window's prompt can cancel. It deliberately does *not* call `onWindowClosed()`, which would drain the persisted open-window set and stop the windows reopening next launch.

---

## Verification

**1940 tests, 0 failures.** Both fixes have a test that fails without them (verified by reverting the guard and re-running):

```
ctrlSOnAPartiallyLoadedHugeFileDoesNotTruncateItOnDisk
  ==> the file on disk must be untouched — expected <line one\nline two\nline three...> but was <line one\n>

quittingPersistsTheSessionOfEveryWindowNotJustTheOneYouQuitFrom
  ==> window B's session must be persisted on quit — expected: <1> but was: <0>
```

Note on the first: it marks the buffer truncated directly rather than materializing a real 50 MB file — pushing 50 M characters into a `CodeArea` takes far longer than an FX test may block the toolkit (my first attempt timed out at exactly that). The flag comes from the same condition as the partial read, and everything downstream of it — the part that actually destroyed files — is driven through the real `file.save` command.

🤖 Generated with [Claude Code](https://claude.com/claude-code)