### PR TITLE
Config durability: atomic writes for every store, keep torn files, fix backup + delete races

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **A crash or a full disk while saving can no longer wipe out your bookmarks, notes, breakpoints, or the
+  project list.** Those files were written by truncating them first and then streaming the new contents in, so
+  an interruption left a half-written file — which Editora then treated as *empty* on the next launch and
+  promptly overwrote. Every config store is now written to a temporary file and moved into place, so the real
+  file is only ever replaced by a complete one. A config file that still can't be read is kept as
+  `<name>.corrupt.bak` instead of being silently replaced.
+- **Running an older Editora twice no longer destroys a newer config.** A settings/session file from a newer
+  build is moved aside so the older build can't clobber it — but if a backup with that name already existed,
+  the move was skipped and the newer file was overwritten anyway, leaving only a stale backup. Backups are now
+  numbered.
+- **Deleting a project no longer risks it coming back.** A save queued moments earlier could re-create the
+  deleted project's session file, and because a project's identity is derived from its folder, re-adding that
+  folder later picked the old session right back up.
+
 - **Pressing Ctrl/Cmd-S on a very large file no longer destroys it.** A file of 50 MB or more is deliberately
   loaded only in part (the first 50 MB — or, for a log, the *last* 50 MB) and opened read-only. But read-only
   only blocks *typing*: Save needs neither an edit nor unsaved changes, and it wrote the buffer straight back

--- a/src/main/java/com/editora/config/AgentSessionHistory.java
+++ b/src/main/java/com/editora/config/AgentSessionHistory.java
@@ -113,7 +113,7 @@ public class AgentSessionHistory {
             Files.createDirectories(file.getParent());
             Stored stored = new Stored();
             stored.sessions = new ArrayList<>(sessions);
-            mapper.writeValue(file.toFile(), stored);
+            ConfigWriter.writeAtomic(file, mapper, stored);
         } catch (IOException e) {
             // Best effort.
         }

--- a/src/main/java/com/editora/config/ConfigWriter.java
+++ b/src/main/java/com/editora/config/ConfigWriter.java
@@ -37,6 +37,16 @@ public final class ConfigWriter {
     private final Object lock = new Object();
     private final Map<Path, byte[]> pending = new LinkedHashMap<>();
 
+    /**
+     * Drops any queued (not yet written) bytes for {@code file}. Used when the file is being <b>deleted</b> —
+     * a coalesced write still sitting in the queue would otherwise land afterwards and re-create it.
+     */
+    public void cancel(Path file) {
+        synchronized (lock) {
+            pending.remove(file);
+        }
+    }
+
     /** Queues {@code bytes} to be written to {@code file} off-thread; a newer write to the same file wins. */
     public void enqueue(Path file, byte[] bytes) {
         synchronized (lock) {
@@ -78,19 +88,40 @@ public final class ConfigWriter {
     /** Writes {@code bytes} to {@code file} via a temp file + atomic move (a crash never leaves a partial file). */
     static void writeAtomic(Path file, byte[] bytes) {
         try {
-            Path parent = file.getParent();
-            if (parent != null) {
-                Files.createDirectories(parent);
-            }
-            Path tmp = file.resolveSibling(file.getFileName() + ".tmp");
-            Files.write(tmp, bytes);
-            try {
-                Files.move(tmp, file, StandardCopyOption.REPLACE_EXISTING, StandardCopyOption.ATOMIC_MOVE);
-            } catch (IOException atomicUnsupported) {
-                Files.move(tmp, file, StandardCopyOption.REPLACE_EXISTING);
-            }
+            writeAtomicOrThrow(file, bytes);
         } catch (IOException e) {
             LOG.log(Level.SEVERE, "Failed to write config file " + file, e);
+        }
+    }
+
+    /**
+     * Serializes {@code value} with {@code mapper} and writes it to {@code file} atomically — <b>use this
+     * instead of {@code mapper.writeValue(file.toFile(), value)}</b> for any config store.
+     *
+     * <p>Jackson's {@code writeValue(File, …)} <b>truncates the target first</b> and streams into it. A crash,
+     * a full disk, or an I/O error partway through therefore leaves a <em>torn</em> file — and the read path
+     * ({@code ConfigMigrations.readVersioned}) treats an unparseable file as "absent" and loads an
+     * <em>empty</em> store, which the next save then writes back over the remains. One bad write and every
+     * bookmark, note, breakpoint, or the whole project index is gone, with nothing to recover from.
+     *
+     * <p>Temp-file-plus-atomic-move means the target is only ever replaced by a complete file.
+     */
+    public static void writeAtomic(Path file, com.fasterxml.jackson.databind.ObjectMapper mapper, Object value)
+            throws IOException {
+        writeAtomicOrThrow(file, mapper.writeValueAsBytes(value));
+    }
+
+    private static void writeAtomicOrThrow(Path file, byte[] bytes) throws IOException {
+        Path parent = file.getParent();
+        if (parent != null) {
+            Files.createDirectories(parent);
+        }
+        Path tmp = file.resolveSibling(file.getFileName() + ".tmp");
+        Files.write(tmp, bytes);
+        try {
+            Files.move(tmp, file, StandardCopyOption.REPLACE_EXISTING, StandardCopyOption.ATOMIC_MOVE);
+        } catch (IOException atomicUnsupported) {
+            Files.move(tmp, file, StandardCopyOption.REPLACE_EXISTING);
         }
     }
 

--- a/src/main/java/com/editora/config/ProjectManager.java
+++ b/src/main/java/com/editora/config/ProjectManager.java
@@ -88,7 +88,7 @@ public class ProjectManager {
     public void save() {
         try {
             Files.createDirectories(configDir);
-            json.writeValue(configDir.resolve(INDEX_FILE_NAME).toFile(), index);
+            ConfigWriter.writeAtomic(configDir.resolve(INDEX_FILE_NAME), json, index);
         } catch (IOException e) {
             throw new UncheckedIOException("Failed to write " + INDEX_FILE_NAME, e);
         }

--- a/src/main/java/com/editora/config/RecentFiles.java
+++ b/src/main/java/com/editora/config/RecentFiles.java
@@ -101,7 +101,7 @@ public class RecentFiles {
             Stored stored = new Stored();
             stored.files =
                     recents.stream().map(com.editora.vfs.Vfs::toStorableString).toList();
-            mapper.writeValue(file.toFile(), stored);
+            ConfigWriter.writeAtomic(file, mapper, stored);
         } catch (IOException e) {
             // Best effort.
         }

--- a/src/main/java/com/editora/config/SearchHistory.java
+++ b/src/main/java/com/editora/config/SearchHistory.java
@@ -81,7 +81,7 @@ public class SearchHistory {
             Files.createDirectories(file.getParent());
             Stored stored = new Stored();
             stored.queries = new ArrayList<>(queries);
-            mapper.writeValue(file.toFile(), stored);
+            ConfigWriter.writeAtomic(file, mapper, stored);
         } catch (IOException e) {
             // Best effort.
         }

--- a/src/main/java/com/editora/config/SharedConfig.java
+++ b/src/main/java/com/editora/config/SharedConfig.java
@@ -112,6 +112,11 @@ public class SharedConfig {
     }
 
     /** The shared off-thread writer (settings + session state route through it; see {@link ConfigWriter}). */
+    /** Drops any queued write for {@code file} (it's about to be deleted — see {@link ConfigWriter#cancel}). */
+    public void cancelPendingWrite(Path file) {
+        writer.cancel(file);
+    }
+
     ConfigWriter writer() {
         return writer;
     }
@@ -216,7 +221,7 @@ public class SharedConfig {
     public void savePlugins() {
         try {
             Files.createDirectories(configDir);
-            json.writeValue(getPluginsFile().toFile(), pluginStore);
+            ConfigWriter.writeAtomic(getPluginsFile(), json, pluginStore);
         } catch (IOException e) {
             throw new UncheckedIOException("Failed to write plugins to " + getPluginsFile(), e);
         }
@@ -239,7 +244,7 @@ public class SharedConfig {
     public void saveMacros() {
         try {
             Files.createDirectories(configDir);
-            json.writeValue(getMacrosFile().toFile(), macroStore);
+            ConfigWriter.writeAtomic(getMacrosFile(), json, macroStore);
         } catch (IOException e) {
             throw new UncheckedIOException("Failed to write macros to " + getMacrosFile(), e);
         }
@@ -269,7 +274,7 @@ public class SharedConfig {
 
     public void saveConnections() {
         try {
-            json.writeValue(getConnectionsFile().toFile(), connectionStore);
+            ConfigWriter.writeAtomic(getConnectionsFile(), json, connectionStore);
         } catch (IOException e) {
             throw new UncheckedIOException("Failed to write connections to " + getConnectionsFile(), e);
         }
@@ -443,7 +448,7 @@ public class SharedConfig {
     public void saveHistory() {
         try {
             Files.createDirectories(getHistoryFile().getParent());
-            json.writeValue(getHistoryFile().toFile(), historyStore);
+            ConfigWriter.writeAtomic(getHistoryFile(), json, historyStore);
         } catch (IOException e) {
             throw new UncheckedIOException("Failed to write history to " + getHistoryFile(), e);
         }
@@ -488,7 +493,7 @@ public class SharedConfig {
                 legacy.forEach(into::putIfAbsent);
             }
             obj.remove("bookmarks"); // drop the legacy node (even when empty) so it stops lingering
-            json.writeValue(file.toFile(), obj);
+            ConfigWriter.writeAtomic(file, json, obj);
         } catch (IOException | IllegalArgumentException e) {
             // a malformed legacy file simply contributes no bookmarks
         }
@@ -498,7 +503,7 @@ public class SharedConfig {
     public void saveBookmarks() {
         try {
             Files.createDirectories(configDir);
-            json.writeValue(getBookmarksFile().toFile(), bookmarkStore);
+            ConfigWriter.writeAtomic(getBookmarksFile(), json, bookmarkStore);
         } catch (IOException e) {
             throw new UncheckedIOException("Failed to write bookmarks to " + getBookmarksFile(), e);
         }
@@ -508,7 +513,7 @@ public class SharedConfig {
     public void saveBreakpoints() {
         try {
             Files.createDirectories(configDir);
-            json.writeValue(getBreakpointsFile().toFile(), breakpointStore);
+            ConfigWriter.writeAtomic(getBreakpointsFile(), json, breakpointStore);
         } catch (IOException e) {
             throw new UncheckedIOException("Failed to write breakpoints to " + getBreakpointsFile(), e);
         }
@@ -523,7 +528,7 @@ public class SharedConfig {
     public void saveNotes() {
         try {
             Files.createDirectories(configDir);
-            json.writeValue(getNotesFile().toFile(), noteStore);
+            ConfigWriter.writeAtomic(getNotesFile(), json, noteStore);
         } catch (IOException e) {
             throw new UncheckedIOException("Failed to write notes to " + getNotesFile(), e);
         }

--- a/src/main/java/com/editora/config/migration/ConfigMigrations.java
+++ b/src/main/java/com/editora/config/migration/ConfigMigrations.java
@@ -19,6 +19,12 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
  */
 public final class ConfigMigrations {
 
+    private static final java.util.logging.Logger LOG =
+            java.util.logging.Logger.getLogger(ConfigMigrations.class.getName());
+
+    /** Cap on how many numbered backups of one file we keep before reusing the last name. */
+    private static final int MAX_BACKUPS = 20;
+
     private ConfigMigrations() {}
 
     /**
@@ -83,10 +89,13 @@ public final class ConfigMigrations {
         try {
             tree = mapper.readTree(Files.readString(file));
         } catch (IOException e) {
+            // Unreadable, or not even valid JSON/TOML. Returning defaults means the next save writes an EMPTY
+            // store straight over it — so preserve what's there first (see keepCorrupt).
+            keepCorrupt(file);
             return defaults;
         }
         if (tree == null || tree.isMissingNode()) {
-            return defaults;
+            return defaults; // an empty file — nothing to preserve
         }
         try {
             ObjectNode migrated = upgrade(schema, tree, mapper);
@@ -95,17 +104,52 @@ public final class ConfigMigrations {
             backupQuietly(file, e.storedVersion());
             return defaults;
         } catch (IOException | RuntimeException e) {
-            // Malformed content or a misconfigured migration: fall back to defaults rather than crash.
+            // Malformed content or a misconfigured migration: fall back to defaults rather than crash — but
+            // keep a copy first, because the very next save overwrites the file.
+            keepCorrupt(file);
             return defaults;
         }
     }
 
-    /** Renames {@code file} to {@code <name>.v<storedVersion>.bak}, preserving any existing backup. */
+    /**
+     * Renames {@code file} out of the way as {@code <name>.v<storedVersion>.bak}. When that name is taken a
+     * counter is appended rather than <em>skipping the move</em> (the old behavior): the file being displaced
+     * is NEWER than this build understands, and we're about to load defaults over it — so skipping meant a
+     * second downgrade overwrote a re-customized config with defaults while the only backup on disk was the
+     * stale one from the first downgrade. The user's settings were lost with no copy at all.
+     */
     public static void backup(Path file, int storedVersion) throws IOException {
-        Path bak = file.resolveSibling(file.getFileName() + ".v" + storedVersion + ".bak");
-        if (!Files.exists(bak)) {
-            Files.move(file, bak);
+        Files.move(file, freeName(file, ".v" + storedVersion + ".bak"));
+    }
+
+    /**
+     * Keeps a copy of a config file we could not parse — overwhelmingly a torn write (a crash, a full disk, or
+     * a kill mid-save). The caller loads defaults, and the next save writes those defaults over the file, so
+     * without this the partially-written bookmarks/notes/projects are gone for good.
+     */
+    private static void keepCorrupt(Path file) {
+        try {
+            if (!Files.exists(file) || Files.size(file) == 0) {
+                return; // nothing worth keeping
+            }
+            Path kept = freeName(file, ".corrupt.bak");
+            Files.copy(file, kept);
+            LOG.log(
+                    java.util.logging.Level.WARNING,
+                    "Could not parse config file {0} — kept a copy at {1} and loaded defaults",
+                    new Object[] {file, kept});
+        } catch (IOException | RuntimeException ignored) {
+            // best effort — we still return defaults
         }
+    }
+
+    /** {@code file + suffix}, with a counter appended when that name is already taken. */
+    private static Path freeName(Path file, String suffix) {
+        Path candidate = file.resolveSibling(file.getFileName() + suffix);
+        for (int i = 2; Files.exists(candidate) && i <= MAX_BACKUPS; i++) {
+            candidate = file.resolveSibling(file.getFileName() + suffix + "." + i);
+        }
+        return candidate;
     }
 
     private static void backupQuietly(Path file, int storedVersion) {

--- a/src/main/java/com/editora/ui/MainController.java
+++ b/src/main/java/com/editora/ui/MainController.java
@@ -1119,6 +1119,7 @@ public class MainController implements com.editora.mcp.McpBridge {
 
     /** Releases this window's resources on close: language servers, debug session, and worker threads. */
     void disposeWindow() {
+        sessionClosed = true; // no further session writes from this window (see requestSave)
         for (Tab tab : tabPane.getTabs()) {
             EditorBuffer buffer = bufferOf(tab);
             if (buffer != null) {
@@ -1484,6 +1485,9 @@ public class MainController implements com.editora.mcp.McpBridge {
         if (windowManager != null && !windowManager.closeWindowForKey(p.id())) {
             return;
         }
+        // A write for this project's session may still be sitting in the config-writer queue; it would land
+        // after the delete below and re-create the file. Drop it first.
+        config.shared().cancelPendingWrite(projects.stateFile(p));
         projects.delete(p.id()); // drops it from the index + open set + deletes its state file
         projects.save();
         config.deleteBookmarksForProject(p.id()); // the project's bookmarks go with it
@@ -6657,15 +6661,26 @@ public class MainController implements com.editora.mcp.McpBridge {
      * after and clobber that durable one.
      */
     private void requestSave() {
-        if (configSavePending) {
+        if (configSavePending || sessionClosed) {
             return;
         }
         configSavePending = true;
         Platform.runLater(() -> {
             configSavePending = false;
-            config.saveAsync();
+            if (!sessionClosed) {
+                config.saveAsync(); // a window disposed in the meantime must not rewrite its session file
+            }
         });
     }
+
+    /**
+     * True once this window has been closed: its session was persisted and its services disposed, so nothing
+     * may write its session file again. Without this, a {@code requestSave()} coalesced earlier in the same FX
+     * pulse fires <em>after</em> the close/delete handler returns and re-creates the file — which, for a
+     * deleted project, silently <b>resurrects</b> it (ids are derived from the folder path, so re-adding that
+     * folder later picks the old state right back up).
+     */
+    private boolean sessionClosed;
 
     private void persistSession() {
         List<WorkspaceState.OpenFile> files = new ArrayList<>();

--- a/src/test/java/com/editora/config/ConfigDurabilityTest.java
+++ b/src/test/java/com/editora/config/ConfigDurabilityTest.java
@@ -1,0 +1,139 @@
+package com.editora.config;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+import com.editora.config.migration.ConfigMigrations;
+import com.editora.config.migration.ConfigSchema;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Durability of the config stores. The failure this guards against is quiet and total: Jackson's
+ * {@code writeValue(File, …)} truncates the target and then streams into it, so a crash / full disk / kill
+ * mid-save leaves a <b>torn</b> file — and the read path treats an unparseable file as "absent" and loads an
+ * <em>empty</em> store, which the next save writes straight back over the remains. One bad write and every
+ * bookmark, note, and breakpoint (or the whole project index) is gone, with nothing to recover from.
+ */
+class ConfigDurabilityTest {
+
+    @TempDir
+    Path dir;
+
+    @Test
+    void anAtomicWriteNeverLeavesAPartialFile() throws IOException {
+        Path file = dir.resolve("bookmarks.json");
+        ObjectMapper mapper = new ObjectMapper();
+        Files.writeString(file, "{\"schemaVersion\":1,\"old\":true}");
+
+        ConfigWriter.writeAtomic(file, mapper, java.util.Map.of("schemaVersion", 1, "fresh", true));
+
+        assertTrue(Files.readString(file).contains("fresh"), "the new content landed");
+        assertFalse(Files.exists(file.resolveSibling(file.getFileName() + ".tmp")), "the temp file is moved, not left");
+    }
+
+    @Test
+    void aTornFileIsKeptRatherThanSilentlyReplacedByAnEmptyStore() throws IOException {
+        // Exactly what a crash mid-`writeValue` leaves: a valid prefix, cut off. It holds most of the user's
+        // bookmarks — and the very next save is about to overwrite it.
+        Path file = dir.resolve("bookmarks.json");
+        String torn = "{\"schemaVersion\":1,\"byProject\":{\"\":{\"/src/Main.java\":[{\"line\":41,\"note\":\"here";
+        Files.writeString(file, torn);
+
+        BookmarkStore loaded =
+                ConfigMigrations.readVersioned(file, new ObjectMapper(), new BookmarkStore(), ConfigSchema.BOOKMARKS);
+
+        assertNotNull(loaded, "we still start up rather than crash");
+        assertTrue(loaded.getByProject().isEmpty(), "an unparseable store loads empty (that part is by design)");
+
+        // ...but the bytes must survive somewhere, or the user's bookmarks are gone for good.
+        Path kept = file.resolveSibling("bookmarks.json.corrupt.bak");
+        assertTrue(Files.exists(kept), "the unparseable file is preserved");
+        assertEquals(torn, Files.readString(kept), "byte-for-byte, so it can be recovered by hand");
+    }
+
+    @Test
+    void anEmptyFileIsNotBackedUp() throws IOException {
+        // Nothing to preserve — don't litter the config dir.
+        Path file = dir.resolve("notes.json");
+        Files.writeString(file, "");
+        ConfigMigrations.readVersioned(file, new ObjectMapper(), new NoteStore(), ConfigSchema.NOTES);
+        assertFalse(Files.exists(file.resolveSibling("notes.json.corrupt.bak")));
+    }
+
+    @Test
+    void aSecondDowngradeDoesNotDestroyTheNewerConfigWithoutABackup() throws IOException {
+        // A file NEWER than this build is backed up and defaults are loaded, so an older Editora can't clobber
+        // a newer config. But the backup used to be SKIPPED when one already existed — so on the second
+        // downgrade the newer file was left in place for the next save to overwrite, and the only copy on disk
+        // was the stale one from the first downgrade. Alternating beta/stable ate the user's settings.
+        Path file = dir.resolve("settings.toml");
+        Files.writeString(file, "first newer version");
+        ConfigMigrations.backup(file, 99);
+        assertEquals("first newer version", Files.readString(dir.resolve("settings.toml.v99.bak")));
+
+        Files.writeString(file, "second, re-customized newer version");
+        ConfigMigrations.backup(file, 99);
+
+        assertFalse(Files.exists(file), "the newer file was moved out of the way, not left to be overwritten");
+        assertEquals(
+                "first newer version",
+                Files.readString(dir.resolve("settings.toml.v99.bak")),
+                "the first backup is intact");
+        assertEquals(
+                "second, re-customized newer version",
+                Files.readString(dir.resolve("settings.toml.v99.bak.2")),
+                "and the second is kept alongside it, not dropped on the floor");
+    }
+
+    @Test
+    void aQueuedWriteForADeletedFileIsDropped() throws Exception {
+        // Deleting a project deletes its session file — but a coalesced write may still be in the queue, and
+        // it would land afterwards and re-create it. Project ids are derived from the folder path, so a
+        // resurrected file gets picked straight back up if the folder is ever re-added.
+        Path file = dir.resolve("projects").resolve("ghost.json");
+        ConfigWriter writer = new ConfigWriter();
+        writer.enqueue(file, "{\"resurrected\":true}".getBytes(java.nio.charset.StandardCharsets.UTF_8));
+        writer.cancel(file);
+        writer.flush();
+        assertFalse(Files.exists(file), "a cancelled write must not land");
+
+        // Sanity: without the cancel it does land (so the test proves the cancel, not a broken writer).
+        writer.enqueue(file, "{\"written\":true}".getBytes(java.nio.charset.StandardCharsets.UTF_8));
+        writer.flush();
+        assertTrue(Files.exists(file));
+        writer.shutdown();
+    }
+
+    @Test
+    void everyStoreIsWrittenAtomically() throws IOException {
+        // A regression net: no config store may go back to mapper.writeValue(File, …), which truncates first.
+        List<String> offenders = new java.util.ArrayList<>();
+        Path src = Path.of("src/main/java/com/editora/config");
+        try (var files = Files.walk(src)) {
+            for (Path f : files.filter(p -> p.toString().endsWith(".java")).toList()) {
+                String body = Files.readString(f);
+                for (String line : body.split("\n")) {
+                    String code = line.strip();
+                    if (code.startsWith("*") || code.startsWith("//")) {
+                        continue; // javadoc/comments may name the forbidden call
+                    }
+                    if (code.contains(".writeValue(") && code.contains(".toFile()")) {
+                        offenders.add(f.getFileName() + ": " + line.strip());
+                    }
+                }
+            }
+        }
+        assertTrue(
+                offenders.isEmpty(),
+                "these truncate the file before writing — use ConfigWriter.writeAtomic instead: " + offenders);
+    }
+}


### PR DESCRIPTION
2 of 4 from the audit (after #403). This one is about the config layer quietly destroying itself.

## 1. A crash mid-save wipes out every bookmark and note — permanently

`ConfigWriter` has a correct temp-file + `ATOMIC_MOVE` path, and its javadoc claims *"Every write is a temp-file-plus-atomic-move"*. But only **`settings.toml`** and the **session file** actually route through it. The other **12** writes — bookmarks, notes, breakpoints, `projects.json`, recent files, search history, macros, plugins, connections, the history index, agent sessions, and the legacy-bookmark strip — called:

```java
mapper.writeValue(file.toFile(), store);   // truncates the target, THEN streams into it
```

Now pair that with the read path: `ConfigMigrations.readVersioned()` catches a parse failure and **returns defaults**.

So: a file torn by a crash, a power loss, or a full disk parses as garbage → the store loads **empty** → the next save writes that empty store **over the remains**. One bad write and every bookmark, every personal note, every breakpoint — or the entire project index — is gone. No backup, no error, no hint.

The disk-full variant isn't even a race: `writeValue` truncates, throws partway through, and leaves `bookmarks.json` half-written on disk.

**Fix:** all 12 go through a new `ConfigWriter.writeAtomic(Path, ObjectMapper, Object)`. A test walks `com/editora/config` and fails if any store regresses to `writeValue(File, …)`.

## 2. An unparseable config file is now kept, not silently replaced

Loading defaults means the next save overwrites the file — and a torn file is precisely where most of the user's data still is. It's now preserved as `<name>.corrupt.bak` first. (An empty file isn't backed up; there's nothing to keep.)

## 3. Running an older build twice destroyed a newer config

`ConfigMigrations.backup()` **skipped the move** if a backup of that name already existed. But the file being displaced is *newer than this build* and we are about to load defaults over it. So:

1. Run new build → writes `settings.toml` v76.
2. Run old build → backs up to `.v76.bak`, loads defaults.
3. Run new build, re-customize everything → writes v76 again.
4. Run old build → **no backup taken** (the name is used), and the customized v76 file is overwritten with defaults. The only copy on disk is the *stale* one from step 2.

Alternating beta/stable — a normal thing to do — eats your settings. Backups are numbered now.

## 4. Deleting a project could resurrect it

`requestSave()` defers via `Platform.runLater`, so a save coalesced earlier **in the same FX pulse** fires *after* the delete handler returns and re-creates `projects/<id>.json`. `Stage.close()` is `hide()` and fires no close request, so nothing cancels it. And `ProjectManager.idFor` is deterministic (slug + hash of the folder path), so re-adding that folder later picks the ghost session straight back up — with its old tab set and layout.

Fixed at both ends: a disposed window never writes its session again, and any *queued* write for the file is cancelled before the delete.

## Verification

**1946 tests, 0 failures.** New `ConfigDurabilityTest` (6 cases); the two that pin the data-loss behavior fail on the old code:

```
aTornFileIsKeptRatherThanSilentlyReplacedByAnEmptyStore   expected: <true>  but was: <false>
aSecondDowngradeDoesNotDestroyTheNewerConfigWithoutABackup expected: <false> but was: <true>
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)