### PR TITLE
Save path: fix autosave races, silent charset corruption, EOL ratchet, non-atomic writes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Auto-save can no longer undo a manual save.** Hitting Ctrl/Cmd-S just as a queued auto-save fired let the
+  auto-save land afterwards and put the *older* text back on disk — while the editor showed the file as saved.
+  Writes to a file are now serialized, and a stale auto-save is dropped.
+- **Auto-save no longer overwrites a file that changed on disk.** A dirty buffer in a *background* tab was
+  never checked for outside modification (that check only looks at the tab you're on), so a timer could
+  silently overwrite a file that a `git checkout` or a generator had just rewritten. Auto-save now skips such a
+  file and leaves the usual "changed on disk" prompt to handle it.
+- **Saving a file is now crash-safe.** Files were written by truncating them first, so an interruption
+  (a crash, a full disk) could leave the document truncated or half-written. The new content is written to a
+  temporary file and moved into place — and the file keeps its permissions (an executable script stays
+  executable) and stays a symlink if it was one.
+- **A character your file's encoding can't represent is no longer silently turned into `?`.** With an
+  `.editorconfig` setting `charset = latin1`, an em dash, a curly quote, `€`, or an emoji was written to disk
+  as a question mark — and the editor kept showing the real character until you reopened the file. Editora now
+  saves as UTF-8 instead and tells you why.
+- **Trimming trailing whitespace no longer flips a whole file to Windows line endings.** A mostly-LF file
+  containing a single stray CRLF was rewritten *entirely* as CRLF the first time it was saved with
+  `trim_trailing_whitespace` on. The file's dominant line ending is now what's preserved.
+- **Save-As now applies the destination's `.editorconfig`**, instead of writing with the previous location's
+  charset, line endings, and trim rules (and continuing to do so on every later save).
+
 - **A crash or a full disk while saving can no longer wipe out your bookmarks, notes, breakpoints, or the
   project list.** Those files were written by truncating them first and then streaming the new contents in, so
   an interruption left a half-written file — which Editora then treated as *empty* on the next launch and

--- a/src/main/java/com/editora/editorconfig/EditorConfigCharset.java
+++ b/src/main/java/com/editora/editorconfig/EditorConfigCharset.java
@@ -90,6 +90,20 @@ public final class EditorConfigCharset {
         return out;
     }
 
+    /**
+     * True when {@code text} can be written in charset {@code name} <b>without loss</b>.
+     *
+     * <p>{@code String.getBytes(Charset)} silently replaces anything the charset can't represent with
+     * {@code '?'}. With an {@code .editorconfig} saying {@code charset = latin1}, every em dash, curly quote,
+     * {@code €}, emoji or CJK character the user typed or pasted was written to disk as a question mark — and
+     * the editor kept showing the real character until the file was reopened, so the corruption was invisible
+     * until it was permanent. Callers check this first and fall back to UTF-8 rather than mangle the text.
+     */
+    public static boolean canEncode(String text, String name) {
+        java.nio.charset.CharsetEncoder encoder = charsetFor(name).newEncoder();
+        return encoder.canEncode(text);
+    }
+
     /** A human-readable label for the status bar (e.g. {@code "UTF-8 BOM"}, {@code "UTF-16 LE"}). */
     public static String displayName(String name) {
         return switch (name == null ? "" : name) {

--- a/src/main/java/com/editora/editorconfig/EditorConfigTransform.java
+++ b/src/main/java/com/editora/editorconfig/EditorConfigTransform.java
@@ -23,13 +23,12 @@ public final class EditorConfigTransform {
             return content; // nothing to do — leave the bytes (and existing EOLs) untouched
         }
 
-        String contentEol = content.contains("\r\n") ? "\r\n" : content.indexOf('\r') >= 0 ? "\r" : "\n";
         String target =
                 switch (eol == null ? "" : eol) {
                     case "crlf" -> "\r\n";
                     case "cr" -> "\r";
                     case "lf" -> "\n";
-                    default -> contentEol; // EOL not specified → keep the file's dominant style
+                    default -> dominantEol(content); // EOL not specified → keep the file's dominant style
                 };
 
         String lf = content.replace("\r\n", "\n").replace("\r", "\n");
@@ -48,6 +47,41 @@ public final class EditorConfigTransform {
             lf = lf.substring(0, end);
         }
         return "\n".equals(target) ? lf : lf.replace("\n", target);
+    }
+
+    /**
+     * The file's <b>dominant</b> line ending — the one that occurs most often, ties going to LF.
+     *
+     * <p>This used to be "does the text contain a CRLF <em>anywhere</em>". Mixed-EOL files are common (a
+     * Windows-touched repo, a pasted snippet, a test fixture), so a predominantly-LF file with a single stray
+     * CRLF was rewritten <b>entirely as CRLF</b> the first time {@code trim_trailing_whitespace} or
+     * {@code insert_final_newline} was set with no {@code end_of_line} — every line of the file changed, with
+     * no user action and no indication. And it only ever ratcheted toward CRLF, never back.
+     */
+    static String dominantEol(String content) {
+        int crlf = 0;
+        int cr = 0;
+        int lf = 0;
+        for (int i = 0; i < content.length(); i++) {
+            char c = content.charAt(i);
+            if (c == '\r') {
+                if (i + 1 < content.length() && content.charAt(i + 1) == '\n') {
+                    crlf++;
+                    i++; // consumed the pair
+                } else {
+                    cr++;
+                }
+            } else if (c == '\n') {
+                lf++;
+            }
+        }
+        if (crlf > lf && crlf >= cr) {
+            return "\r\n";
+        }
+        if (cr > lf && cr > crlf) {
+            return "\r";
+        }
+        return "\n"; // LF wins, including on a tie and for a file with no line endings at all
     }
 
     /** Removes trailing spaces/tabs from every line (operating on {@code \n}-normalized text). */

--- a/src/main/java/com/editora/io/AtomicFileWrite.java
+++ b/src/main/java/com/editora/io/AtomicFileWrite.java
@@ -1,0 +1,96 @@
+package com.editora.io;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.LinkOption;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.nio.file.attribute.PosixFileAttributeView;
+import java.nio.file.attribute.PosixFilePermission;
+import java.util.Set;
+
+/**
+ * Writes a <b>document</b> (the user's file) as safely as the platform allows: to a temp file in the same
+ * directory, then moved into place — so the real file is only ever replaced by a complete one.
+ *
+ * <p>{@code Files.write(file, bytes)} truncates the target and then streams into it: a crash, a full disk, or
+ * any I/O error partway through leaves the user's file truncated or half-written, with no copy to recover
+ * from. The editor still holds the text in memory, but a power cut doesn't care.
+ *
+ * <p>Two things a naive temp-and-move gets wrong, both of which would be worse than the bug it fixes:
+ *
+ * <ul>
+ *   <li><b>Symlinks.</b> Moving over a symlink <em>replaces the link with a regular file</em>. Editing a
+ *       dotfile that's symlinked into a dotfiles repo (a very normal setup) would quietly detach it. So the
+ *       link is resolved first and the target is written.
+ *   <li><b>Permissions.</b> A fresh temp file gets default permissions, so a shell script would silently lose
+ *       its executable bit and any group/other access. The existing file's POSIX permissions are copied onto
+ *       the temp file before the move.
+ * </ul>
+ *
+ * <p>If the platform can't do any of that (a filesystem without atomic move, a directory we can't create a
+ * temp file in — e.g. a read-only dir holding a writable file), it falls back to a plain in-place write, which
+ * is what the editor did before: no worse than the status quo, and the save still happens.
+ */
+public final class AtomicFileWrite {
+
+    private AtomicFileWrite() {}
+
+    /** Writes {@code bytes} to {@code file}, replacing it atomically where the platform supports it. */
+    public static void write(Path file, byte[] bytes) throws IOException {
+        Path target = resolveLink(file);
+        Path dir = target.getParent();
+        if (dir == null || !Files.isDirectory(dir)) {
+            Files.write(target, bytes); // no directory to stage in — write in place
+            return;
+        }
+        Path tmp;
+        try {
+            tmp = Files.createTempFile(dir, "." + target.getFileName() + ".", ".editora-tmp");
+        } catch (IOException cannotStage) {
+            Files.write(target, bytes); // e.g. a read-only directory holding a writable file
+            return;
+        }
+        try {
+            Files.write(tmp, bytes);
+            copyPermissions(target, tmp);
+            try {
+                Files.move(tmp, target, StandardCopyOption.REPLACE_EXISTING, StandardCopyOption.ATOMIC_MOVE);
+            } catch (IOException atomicUnsupported) {
+                Files.move(tmp, target, StandardCopyOption.REPLACE_EXISTING);
+            }
+        } catch (IOException e) {
+            Files.deleteIfExists(tmp); // never leave litter next to the user's file
+            throw e;
+        }
+    }
+
+    /**
+     * The real file behind {@code file} when it is a symlink — writing through the link keeps it a link.
+     * A broken link, or any resolution failure, falls back to the path as given.
+     */
+    static Path resolveLink(Path file) {
+        try {
+            return Files.isSymbolicLink(file) ? file.toRealPath() : file;
+        } catch (IOException brokenLink) {
+            return file;
+        }
+    }
+
+    /** Copies {@code from}'s POSIX permissions onto {@code to}, so the saved file keeps its mode (e.g. +x). */
+    private static void copyPermissions(Path from, Path to) {
+        try {
+            if (!Files.exists(from, LinkOption.NOFOLLOW_LINKS)) {
+                return; // a brand-new file: the temp file's defaults are correct
+            }
+            PosixFileAttributeView view = Files.getFileAttributeView(from, PosixFileAttributeView.class);
+            if (view == null) {
+                return; // not a POSIX filesystem (Windows) — nothing to carry over
+            }
+            Set<PosixFilePermission> perms = view.readAttributes().permissions();
+            Files.setPosixFilePermissions(to, perms);
+        } catch (IOException | UnsupportedOperationException | SecurityException ignored) {
+            // Best effort: a save that keeps the wrong mode still beats a save that doesn't happen.
+        }
+    }
+}

--- a/src/main/java/com/editora/ui/MainController.java
+++ b/src/main/java/com/editora/ui/MainController.java
@@ -5871,6 +5871,11 @@ public class MainController implements com.editora.mcp.McpBridge {
     /** Points {@code buffer} at {@code file}, refreshes its previews/tab/breadcrumb, and writes it. */
     private boolean applySaveAsTarget(EditorBuffer buffer, Path file) {
         buffer.setPath(file);
+        // The buffer's EditorConfig properties + charset were resolved against the OLD path. Without
+        // re-resolving, a Save-As into another tree writes with the previous project's charset/EOL/trim rules
+        // (and keeps doing so on every later save), while an untitled buffer saved INTO a project with an
+        // .editorconfig gets none of its rules.
+        applyEditorConfig(buffer);
         ensurePreviewControls(buffer); // a new untitled saved as .md/.mmd now gets the preview toggle
         htmlPreview.ensureControl(buffer); // a save-as to .html now gets the "open in browser" globe
         logViewer.ensureControl(buffer); // a save-as to .log now gets the log control + level overlay
@@ -5962,12 +5967,26 @@ public class MainController implements com.editora.mcp.McpBridge {
                 ? buffer.getEditorConfigProps()
                 : com.editora.editorconfig.EditorConfigProperties.EMPTY;
         String text = com.editora.editorconfig.EditorConfigTransform.transform(buffer.getContent(), p);
-        return com.editora.editorconfig.EditorConfigCharset.encode(text, buffer.getEffectiveCharset());
+        String charset = buffer.getEffectiveCharset();
+        // A charset that can't represent what the user typed (an em dash / curly quote / emoji under
+        // `charset = latin1`) would be written as '?' by String.getBytes — and the editor keeps showing the
+        // real character until the file is reopened, so the corruption is invisible until it's permanent.
+        // Fall back to UTF-8 and say so: a changed encoding is recoverable, mangled text is not.
+        if (!com.editora.editorconfig.EditorConfigCharset.canEncode(text, charset)) {
+            setStatus(tr("status.charsetFallback", com.editora.editorconfig.EditorConfigCharset.displayName(charset)));
+            charset = com.editora.editorconfig.EditorConfigCharset.UTF_8;
+        }
+        return com.editora.editorconfig.EditorConfigCharset.encode(text, charset);
     }
 
     private boolean writeBuffer(EditorBuffer buffer, Path file) {
         try {
-            Files.write(file, saveBytes(buffer));
+            byte[] bytes = saveBytes(buffer);
+            // Serialized against auto-save (see autoSaveBuffer): a queued auto-save holding an OLDER snapshot
+            // must not land after this write and rewind the file.
+            synchronized (fileWriteLock) {
+                com.editora.io.AtomicFileWrite.write(file, bytes);
+            }
             historyCoordinator.record(buffer, HistoryRevision.REASON_SAVE); // snapshot the just-saved version
             buffer.markClean();
             buffer.setDiskSnapshot(lastModifiedMillis(file), fileSize(file)); // our own write isn't "external"
@@ -6019,13 +6038,27 @@ public class MainController implements com.editora.mcp.McpBridge {
      * (so we never mark clean over edits made after the snapshot).
      */
     private void autoSaveBuffer(EditorBuffer buffer) {
+        Path file = buffer.getPath();
+        // Never auto-save over a file that changed underneath us. checkExternalChanges() only inspects the
+        // ACTIVE tab, so a dirty background buffer whose file was rewritten (a git checkout, a generator)
+        // would otherwise be silently overwritten by a timer, with no prompt and no way back.
+        if (buffer.diskChangedFrom(lastModifiedMillis(file), fileSize(file))) {
+            return; // leave it dirty: the external-change prompt handles it when the user comes back to it
+        }
         String content = buffer.getContent();
         byte[] bytes = saveBytes(buffer); // transform + encode on the FX thread (pure); write off-thread
-        Path file = buffer.getPath();
         historyCoordinator.record(buffer, HistoryRevision.REASON_AUTOSAVE); // snapshot before the off-thread write
         autoSaveExecutor.submit(() -> {
             try {
-                Files.write(file, bytes);
+                // Take the same lock a manual save takes, and re-check the buffer is still dirty inside it:
+                // a Ctrl-S landing between the snapshot above and this write has already written NEWER bytes,
+                // and writing our stale snapshot on top would silently rewind the user's file.
+                synchronized (fileWriteLock) {
+                    if (!buffer.isDirty()) {
+                        return; // already saved (manually) — our snapshot is stale
+                    }
+                    com.editora.io.AtomicFileWrite.write(file, bytes);
+                }
                 Platform.runLater(() -> {
                     if (content.equals(buffer.getContent())) {
                         buffer.markClean();
@@ -6039,6 +6072,13 @@ public class MainController implements com.editora.mcp.McpBridge {
             }
         });
     }
+
+    /**
+     * Serializes writes to the user's files. A manual save writes synchronously on the FX thread while
+     * auto-save writes an earlier snapshot on its own executor — without this, the queued auto-save could land
+     * after the manual save and put the older content back on disk, while the buffer showed "saved".
+     */
+    private final Object fileWriteLock = new Object();
 
     private void toggleAutoSave() {
         String next =

--- a/src/main/resources/com/editora/i18n/messages.properties
+++ b/src/main/resources/com/editora/i18n/messages.properties
@@ -825,6 +825,7 @@ status.recentCleared=Recent files cleared
 status.saved=Saved {0}
 status.failedSave=Failed to save: {0}
 status.truncatedNoSave = Not saved: this file is too large to load fully, so only part of it is open. Saving would truncate the file on disk.
+status.charsetFallback = Saved as UTF-8: {0} cannot represent some characters in this file.
 status.autoSaved=Auto-saved {0}
 status.autoSaveFailed=Auto-save failed: {0}
 status.autoSave=Auto save: {0}

--- a/src/main/resources/com/editora/i18n/messages_de.properties
+++ b/src/main/resources/com/editora/i18n/messages_de.properties
@@ -821,6 +821,7 @@ status.recentCleared=Zuletzt verwendete Dateien gelöscht
 status.saved=Gespeichert {0}
 status.failedSave=Speichern fehlgeschlagen: {0}
 status.truncatedNoSave = Nicht gespeichert: Die Datei ist zu groß, um vollständig geladen zu werden, daher ist nur ein Teil geöffnet. Ein Speichern würde die Datei auf der Festplatte abschneiden.
+status.charsetFallback = Als UTF-8 gespeichert: {0} kann einige Zeichen dieser Datei nicht darstellen.
 status.autoSaved=Automatisch gespeichert: {0}
 status.autoSaveFailed=Automatisches Speichern fehlgeschlagen: {0}
 status.autoSave=Automatisches Speichern: {0}

--- a/src/main/resources/com/editora/i18n/messages_es.properties
+++ b/src/main/resources/com/editora/i18n/messages_es.properties
@@ -821,6 +821,7 @@ status.recentCleared=Archivos recientes borrados
 status.saved=Guardado {0}
 status.failedSave=Error al guardar: {0}
 status.truncatedNoSave = No se guardó: el archivo es demasiado grande para cargarse por completo, así que solo hay una parte abierta. Guardarlo truncaría el archivo en el disco.
+status.charsetFallback = Guardado como UTF-8: {0} no puede representar algunos caracteres de este archivo.
 status.autoSaved=Guardado automático: {0}
 status.autoSaveFailed=Error en el guardado automático: {0}
 status.autoSave=Guardado automático: {0}

--- a/src/main/resources/com/editora/i18n/messages_fr.properties
+++ b/src/main/resources/com/editora/i18n/messages_fr.properties
@@ -821,6 +821,7 @@ status.recentCleared=Fichiers récents effacés
 status.saved=Enregistré {0}
 status.failedSave=Échec de l'enregistrement : {0}
 status.truncatedNoSave = Non enregistré : le fichier est trop volumineux pour être chargé entièrement, seule une partie est ouverte. L’enregistrer tronquerait le fichier sur le disque.
+status.charsetFallback = Enregistré en UTF-8 : {0} ne peut pas représenter certains caractères de ce fichier.
 status.autoSaved=Enregistré automatiquement : {0}
 status.autoSaveFailed=Échec de l'enregistrement automatique : {0}
 status.autoSave=Enregistrement automatique : {0}

--- a/src/main/resources/com/editora/i18n/messages_it.properties
+++ b/src/main/resources/com/editora/i18n/messages_it.properties
@@ -821,6 +821,7 @@ status.recentCleared=File recenti cancellati
 status.saved=Salvato {0}
 status.failedSave=Salvataggio non riuscito: {0}
 status.truncatedNoSave = Non salvato: il file è troppo grande per essere caricato per intero, quindi ne è aperta solo una parte. Salvarlo troncherebbe il file su disco.
+status.charsetFallback = Salvato come UTF-8: {0} non può rappresentare alcuni caratteri di questo file.
 status.autoSaved=Salvato automaticamente: {0}
 status.autoSaveFailed=Salvataggio automatico non riuscito: {0}
 status.autoSave=Salvataggio automatico: {0}

--- a/src/main/resources/com/editora/i18n/messages_pt.properties
+++ b/src/main/resources/com/editora/i18n/messages_pt.properties
@@ -821,6 +821,7 @@ status.recentCleared=Arquivos recentes limpos
 status.saved=Salvo {0}
 status.failedSave=Falha ao salvar: {0}
 status.truncatedNoSave = Não salvo: o arquivo é grande demais para ser carregado por completo, então apenas parte dele está aberta. Salvar truncaria o arquivo no disco.
+status.charsetFallback = Salvo como UTF-8: {0} não consegue representar alguns caracteres deste arquivo.
 status.autoSaved=Salvo automaticamente: {0}
 status.autoSaveFailed=Falha no salvamento automático: {0}
 status.autoSave=Salvamento automático: {0}

--- a/src/test/java/com/editora/editorconfig/EditorConfigCharsetTest.java
+++ b/src/test/java/com/editora/editorconfig/EditorConfigCharsetTest.java
@@ -4,7 +4,9 @@ import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class EditorConfigCharsetTest {
 
@@ -61,5 +63,27 @@ class EditorConfigCharsetTest {
         assertEquals("ISO-8859-1", EditorConfigCharset.displayName("latin1"));
         assertEquals("UTF-16 LE", EditorConfigCharset.displayName("utf-16le"));
         assertEquals("UTF-8", EditorConfigCharset.displayName(null));
+    }
+
+    @Test
+    void latin1CannotEncodeWhatTheUserActuallyTypes() {
+        // String.getBytes(Charset) replaces these with '?' — silently, and the editor keeps showing the real
+        // character until the file is reopened. The save path checks this and falls back to UTF-8 instead.
+        assertFalse(EditorConfigCharset.canEncode("an em dash — here", "latin1"));
+        assertFalse(EditorConfigCharset.canEncode("curly \u201cquotes\u201d", "latin1"));
+        assertFalse(EditorConfigCharset.canEncode("\u20ac 100", "latin1"), "the euro sign is not in ISO-8859-1");
+        assertFalse(EditorConfigCharset.canEncode("emoji \ud83d\ude80", "latin1"));
+        assertFalse(EditorConfigCharset.canEncode("\u65e5\u672c\u8a9e", "latin1"));
+    }
+
+    @Test
+    void latin1EncodesWhatItCan() {
+        assertTrue(EditorConfigCharset.canEncode("plain ascii", "latin1"));
+        assertTrue(EditorConfigCharset.canEncode("caf\u00e9 na\u00efve", "latin1"), "accented Latin-1 is fine");
+    }
+
+    @Test
+    void utf8EncodesEverything() {
+        assertTrue(EditorConfigCharset.canEncode("— \u201c\u201d \u20ac \ud83d\ude80 \u65e5\u672c\u8a9e", "utf-8"));
     }
 }

--- a/src/test/java/com/editora/editorconfig/EditorConfigTransformTest.java
+++ b/src/test/java/com/editora/editorconfig/EditorConfigTransformTest.java
@@ -3,6 +3,7 @@ package com.editora.editorconfig;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 class EditorConfigTransformTest {
 
@@ -46,5 +47,32 @@ class EditorConfigTransformTest {
         String once = EditorConfigTransform.transform("x  \r\ny   ", p);
         assertEquals("x\ny\n", once);
         assertEquals(once, EditorConfigTransform.transform(once, p)); // idempotent
+    }
+
+    @Test
+    void aMostlyLfFileWithOneStrayCrlfStaysLf() {
+        // Mixed-EOL files are ordinary (a Windows-touched repo, a pasted snippet). Trimming trailing
+        // whitespace with no end_of_line set used to flip the WHOLE file to CRLF because a single CRLF
+        // existed somewhere — every line changed, silently, and it only ever ratcheted toward CRLF.
+        String mixed = "a  \nb\r\nc\nd\n";
+        String out = EditorConfigTransform.transform(mixed, props(true, null, null));
+        assertFalse(out.contains("\r"), "LF is dominant, so the file stays LF: " + out.replace("\r", "<CR>"));
+        assertEquals("a\nb\nc\nd\n", out);
+    }
+
+    @Test
+    void aMostlyCrlfFileStaysCrlf() {
+        String mostlyCrlf = "a  \r\nb\r\nc\r\nd\n";
+        String out = EditorConfigTransform.transform(mostlyCrlf, props(true, null, null));
+        assertEquals("a\r\nb\r\nc\r\nd\r\n", out, "CRLF is dominant here, so CRLF is preserved");
+    }
+
+    @Test
+    void dominantEolCountsRatherThanMerelyDetecting() {
+        assertEquals("\n", EditorConfigTransform.dominantEol("a\nb\nc\r\n"));
+        assertEquals("\r\n", EditorConfigTransform.dominantEol("a\r\nb\r\nc\n"));
+        assertEquals("\r", EditorConfigTransform.dominantEol("a\rb\rc\n"));
+        assertEquals("\n", EditorConfigTransform.dominantEol("no line endings at all"));
+        assertEquals("\n", EditorConfigTransform.dominantEol("a\nb\r\n"), "a tie goes to LF");
     }
 }

--- a/src/test/java/com/editora/io/AtomicFileWriteTest.java
+++ b/src/test/java/com/editora/io/AtomicFileWriteTest.java
@@ -1,0 +1,108 @@
+package com.editora.io;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.LinkOption;
+import java.nio.file.Path;
+import java.nio.file.attribute.PosixFilePermission;
+import java.nio.file.attribute.PosixFilePermissions;
+import java.util.Set;
+
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Saving a document must replace it atomically — but the two obvious ways to get that wrong would each be
+ * worse than the truncating write it replaces: following a symlink turns the link into a regular file, and a
+ * fresh temp file loses the original's permissions (a shell script silently stops being executable).
+ */
+class AtomicFileWriteTest {
+
+    @TempDir
+    Path dir;
+
+    private static byte[] bytes(String s) {
+        return s.getBytes(java.nio.charset.StandardCharsets.UTF_8);
+    }
+
+    @Test
+    void writesTheContentAndLeavesNoTempFileBehind() throws IOException {
+        Path file = dir.resolve("a.txt");
+        Files.writeString(file, "old\n");
+
+        AtomicFileWrite.write(file, bytes("new\n"));
+
+        assertEquals("new\n", Files.readString(file));
+        try (var entries = Files.list(dir)) {
+            assertEquals(1, entries.count(), "the temp file was moved into place, not left lying around");
+        }
+    }
+
+    @Test
+    void createsAFileThatDidNotExist() throws IOException {
+        Path file = dir.resolve("new.txt");
+        AtomicFileWrite.write(file, bytes("hello\n"));
+        assertEquals("hello\n", Files.readString(file));
+    }
+
+    @Test
+    void savingThroughASymlinkKeepsItASymlink() throws IOException {
+        // The dotfiles case: ~/.zshrc is a symlink into a git repo. Moving a temp file over the LINK would
+        // replace it with a regular file and quietly detach it from the repo.
+        Path real = dir.resolve("real.txt");
+        Files.writeString(real, "original\n");
+        Path link = dir.resolve("link.txt");
+        try {
+            Files.createSymbolicLink(link, real);
+        } catch (UnsupportedOperationException | IOException noSymlinks) {
+            Assumptions.abort("symlinks not supported here");
+        }
+
+        AtomicFileWrite.write(link, bytes("edited\n"));
+
+        assertTrue(Files.isSymbolicLink(link), "still a symlink");
+        assertEquals("edited\n", Files.readString(real), "and the edit landed in the real file");
+    }
+
+    @Test
+    void anExecutableFileStaysExecutable() throws IOException {
+        // Editing a shell script must not silently drop its +x bit.
+        Path script = dir.resolve("run.sh");
+        Files.writeString(script, "#!/bin/sh\necho old\n");
+        try {
+            Files.setPosixFilePermissions(script, PosixFilePermissions.fromString("rwxr-xr-x"));
+        } catch (UnsupportedOperationException notPosix) {
+            Assumptions.abort("not a POSIX filesystem");
+        }
+
+        AtomicFileWrite.write(script, bytes("#!/bin/sh\necho new\n"));
+
+        Set<PosixFilePermission> perms = Files.getPosixFilePermissions(script, LinkOption.NOFOLLOW_LINKS);
+        assertTrue(perms.contains(PosixFilePermission.OWNER_EXECUTE), "owner can still run it");
+        assertTrue(perms.contains(PosixFilePermission.GROUP_EXECUTE), "and so can the group");
+        assertTrue(perms.contains(PosixFilePermission.OTHERS_READ), "other permissions carried over too");
+        assertEquals("#!/bin/sh\necho new\n", Files.readString(script));
+    }
+
+    @Test
+    void aFailedWriteLeavesTheOriginalIntact() throws IOException {
+        // The whole point: an interrupted save must not leave a truncated file. Simulate the failure by
+        // writing to a path whose parent is a FILE, so staging fails and the original is never touched.
+        Path file = dir.resolve("keep.txt");
+        Files.writeString(file, "precious\n");
+        Path bogus = file.resolve("child.txt"); // keep.txt/child.txt — not a directory
+
+        assertFalse(Files.isDirectory(bogus.getParent().getParent().resolve("nope")));
+        try {
+            AtomicFileWrite.write(bogus, bytes("junk"));
+        } catch (IOException expected) {
+            // fine — what matters is the original
+        }
+        assertEquals("precious\n", Files.readString(file), "the existing file is untouched by a failed write");
+    }
+}


### PR DESCRIPTION
3 of 4 from the audit (after #403, #404). Everything here can corrupt or lose the user's **actual documents**.

## 1. Auto-save could rewind a manual save

`autoSaveBuffer` snapshots the bytes on the FX thread and writes on its executor. A `Cmd-S` in between writes **newer** bytes synchronously — and then the queued task lands and puts the **older** snapshot back.

The existing content-equality check only guards the *dirty flag*, not the file: it skipped `markClean()` while the stale `Files.write` had **already happened**, and `setDiskSnapshot()` then re-baselined external-change detection onto the stale write. Net result: the buffer shows *saved*, the disk holds the older text, and nothing warns you.

Both writers now take one lock, and the auto-save re-checks `isDirty()` **inside** it.

## 2. Auto-save clobbered externally-modified files

`checkExternalChanges()` only inspects the **active** tab. A dirty buffer in a *background* tab was therefore never checked — and `autoSaveBuffer` never consulted `diskChangedFrom` at all. So a timer could silently overwrite a file that a `git checkout` or a code generator had just rewritten, with no prompt and no way back. Auto-save now skips such a file and leaves it dirty for the normal "changed on disk" prompt.

## 3. Document writes were not atomic

`Files.write(file, bytes)` truncates the target and then streams into it: a crash or a full disk leaves the user's file **truncated or half-written**, with no copy.

New `com.editora.io.AtomicFileWrite` does temp-file + `ATOMIC_MOVE`, and handles the two traps that would make a naive version **worse than the bug**:

- **Symlinks.** Moving over a symlink *replaces the link with a regular file*. Editing a `~/.zshrc` that's symlinked into a dotfiles repo would quietly detach it. The link is resolved first.
- **Permissions.** A fresh temp file gets default permissions — a shell script would silently lose its `+x` bit. The original's POSIX permissions are copied onto the temp file before the move.

Falls back to an in-place write where the platform can't do it (no worse than today).

## 4. `charset = latin1` silently turned characters into `?`

`String.getBytes(Charset)` uses `CodingErrorAction.REPLACE`. With an `.editorconfig` saying `charset = latin1`, every em dash, curly quote, `€`, emoji, or CJK character you typed or pasted was written to disk as a **question mark** — and the editor kept showing the real character until the file was reopened, so the corruption was invisible until it was permanent.

`saveBytes` now checks `canEncode()` and falls back to UTF-8, saying so in the status bar. A changed encoding is recoverable; mangled text is not.

## 5. Trimming whitespace flipped whole files to CRLF

`EditorConfigTransform` picked the file's EOL with `content.contains("\r\n")` — **any** occurrence, despite the comment claiming "dominant style". A mostly-LF file with a *single* stray CRLF (utterly normal in a Windows-touched repo) was rewritten **entirely as CRLF** the first time `trim_trailing_whitespace` fired with no `end_of_line` set. Every line of the file changed, with no user action, and it only ever ratcheted *toward* CRLF. Now a real majority count, ties to LF.

## 6. Save-As kept the *old* file's `.editorconfig`

`applySaveAsTarget` set the new path but never re-resolved EditorConfig, so `saveBytes` still used the previous location's charset / EOL / trim rules — for that save and **every later one**. And an untitled buffer saved *into* a project with an `.editorconfig` got none of its rules.

## Verification

**1957 tests, 0 failures.** New `AtomicFileWriteTest` (symlink survival, `+x` preservation, no temp litter, failed-write leaves the original intact), plus EOL-dominance and `canEncode` cases on the existing pure suites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)