### PR TITLE
Fix resource leaks: viewer tabs, per-window services, and orphaned subprocesses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Closing an image, hex, or PDF tab now actually releases it.** Those tabs were only cleaned up when closed
+  by clicking the ✕ — closing them with Ctrl-W, "Close All"/"Close Others", or by closing the window leaked a
+  live thread and (for a PDF) kept the file open for as long as Editora was running. Open and close a few
+  dozen PDFs and it added up.
+- **Closing a window now shuts down everything it started.** The diff, external-tool and HTTP-client workers
+  were left running, and an SFTP connection stayed open on the remote host with its SSH client pinned in
+  memory for the rest of the session.
+- **Stopping (or quitting during) a run or a build now kills the whole process tree.** `npm run dev`, `mvn`
+  and `./gradlew` all launch a child process; only the wrapper was being killed, so a dev server kept holding
+  its port and a build JVM kept running. Those processes are now tracked, so they're also cleaned up if
+  Editora exits unexpectedly.
+
 - **Auto-save can no longer undo a manual save.** Hitting Ctrl/Cmd-S just as a queued auto-save fired let the
   auto-save land afterwards and put the *older* text back on disk — while the editor showed the file as saved.
   Writes to a file are now serialized, and a stale auto-save is dropped.

--- a/src/main/java/com/editora/build/BuildService.java
+++ b/src/main/java/com/editora/build/BuildService.java
@@ -60,6 +60,8 @@ public final class BuildService {
         Process process;
         try {
             process = pb.start();
+            com.editora.process.ProcessRegistry.track(process); // so the shutdown hook / reaper can kill it
+
         } catch (IOException e) {
             listener.onError(e.getMessage() == null ? e.toString() : e.getMessage());
             return;
@@ -88,14 +90,20 @@ public final class BuildService {
         waiter.start();
     }
 
-    /** Kills the running process (best effort); its waiter reports the exit. */
+    /**
+     * Kills the running process <b>and its descendants</b> (best effort); its waiter reports the exit.
+     *
+     * <p>{@code destroy()} on the root alone orphans the real work: {@code npm run dev}, {@code mvn}, and
+     * {@code ./gradlew} all fork a child, so SIGTERM-ing the wrapper leaves a dev server holding its port or a
+     * build JVM still running. {@code ProcessRegistry.killTree} kills children first (so a wrapper can't
+     * reparent-orphan its child) and escalates to a force-kill after a grace period, instead of the old
+     * {@code destroy(); if (isAlive()) destroyForcibly();} — where the {@code isAlive()} check right after an
+     * asynchronous SIGTERM is essentially always true, so the child was SIGKILLed with no grace period at all.
+     */
     public void stop() {
         Process p = current;
         if (p != null && p.isAlive()) {
-            p.destroy();
-            if (p.isAlive()) {
-                p.destroyForcibly();
-            }
+            com.editora.process.ProcessRegistry.killTree(p);
         }
     }
 

--- a/src/main/java/com/editora/http/HttpClientService.java
+++ b/src/main/java/com/editora/http/HttpClientService.java
@@ -292,4 +292,9 @@ public final class HttpClientService {
         String base = m == null || m.isBlank() ? e.getClass().getSimpleName() : m;
         return url.isBlank() ? base : base + "  (" + url + ")";
     }
+
+    /** Stops the daemon worker (window close). Without this, each closed window leaks its http-client thread. */
+    public void shutdown() {
+        exec.shutdownNow();
+    }
 }

--- a/src/main/java/com/editora/run/RunService.java
+++ b/src/main/java/com/editora/run/RunService.java
@@ -143,6 +143,9 @@ public final class RunService {
         Process process;
         try {
             process = pb.start();
+            // Track it: the JVM shutdown hook + the orphan reaper only know about tracked processes, so an
+            // untracked long-lived program (a dev server) outlived the app and wasn't reaped on the next launch.
+            com.editora.process.ProcessRegistry.track(process);
         } catch (IOException e) {
             listener.onError(e.getMessage() == null ? e.toString() : e.getMessage());
             return;
@@ -171,14 +174,20 @@ public final class RunService {
         waiter.start();
     }
 
-    /** Kills the running process (best effort); its waiter reports the exit. */
+    /**
+     * Kills the running process <b>and its descendants</b> (best effort); its waiter reports the exit.
+     *
+     * <p>{@code destroy()} on the root alone orphans the real work: {@code npm run dev}, {@code mvn}, and
+     * {@code ./gradlew} all fork a child, so SIGTERM-ing the wrapper leaves a dev server holding its port or a
+     * build JVM still running. {@code ProcessRegistry.killTree} kills children first (so a wrapper can't
+     * reparent-orphan its child) and escalates to a force-kill after a grace period, instead of the old
+     * {@code destroy(); if (isAlive()) destroyForcibly();} — where the {@code isAlive()} check right after an
+     * asynchronous SIGTERM is essentially always true, so the child was SIGKILLed with no grace period at all.
+     */
     public void stop() {
         Process p = current;
         if (p != null && p.isAlive()) {
-            p.destroy();
-            if (p.isAlive()) {
-                p.destroyForcibly();
-            }
+            com.editora.process.ProcessRegistry.killTree(p);
         }
     }
 

--- a/src/main/java/com/editora/ui/DiffCoordinator.java
+++ b/src/main/java/com/editora/ui/DiffCoordinator.java
@@ -559,4 +559,9 @@ final class DiffCoordinator {
                 });
         ops.addDiffTab(pane);
     }
+
+    /** Stops the diff worker thread (window close). */
+    public void shutdown() {
+        diffService.shutdown();
+    }
 }

--- a/src/main/java/com/editora/ui/ExternalToolCoordinator.java
+++ b/src/main/java/com/editora/ui/ExternalToolCoordinator.java
@@ -260,4 +260,9 @@ final class ExternalToolCoordinator {
         }
         return s;
     }
+
+    /** Stops the external-tool worker thread (window close). */
+    public void shutdown() {
+        service.shutdown();
+    }
 }

--- a/src/main/java/com/editora/ui/HttpClientCoordinator.java
+++ b/src/main/java/com/editora/ui/HttpClientCoordinator.java
@@ -332,4 +332,9 @@ final class HttpClientCoordinator {
             host.setStatus(tr("statusbar.tip.httpDisabled"));
         }
     }
+
+    /** Stops the HTTP-client worker thread (window close). */
+    public void shutdown() {
+        service.shutdown();
+    }
 }

--- a/src/main/java/com/editora/ui/MainController.java
+++ b/src/main/java/com/editora/ui/MainController.java
@@ -1124,6 +1124,8 @@ public class MainController implements com.editora.mcp.McpBridge {
             EditorBuffer buffer = bufferOf(tab);
             if (buffer != null) {
                 buffer.dispose();
+            } else {
+                disposeViewerTab(tab); // an image/hex/PDF tab holds a thread + file handle + GPU texture too
             }
         }
         lspManager.shutdownAll(); // don't orphan this window's external language servers
@@ -1152,7 +1154,32 @@ public class MainController implements com.editora.mcp.McpBridge {
             installCoordinator.shutdown();
         }
         autoSaveExecutor.shutdownNow();
+        diffCoordinator.shutdown(); // the diff-service worker thread
+        externalToolCoordinator.shutdown(); // the external-tool worker thread
+        httpClient.shutdown(); // the http-client worker thread
+        remoteCoordinator.shutdown(); // SFTP sessions + the SSH client (and un-pin the static Vfs hooks)
         projectPanel.dispose(); // stop the project tree's filesystem watcher + its daemon thread
+    }
+
+    /**
+     * Releases a non-buffer viewer tab (image / hex / PDF).
+     *
+     * <p>These panes were only released through {@code Tab.setOnClosed}, and JavaFX fires that from exactly one
+     * place — {@code TabPaneBehavior.closeTab()}, i.e. a click on the tab's ✕. Every one of the app's own close
+     * paths ({@code closeTab}, Close All / Others / Left / Right, and window close) removes the tab
+     * <em>programmatically</em>, which does not fire it. So closing a PDF with Ctrl-W leaked its {@code
+     * pdf-render} thread and left the document's file handle open for the life of the process (on Windows,
+     * holding a lock on the file), and an image tab kept its decoded texture pinned. Closing the same tab by
+     * clicking the ✕ leaked nothing — which is exactly why this survived manual testing.
+     */
+    private void disposeViewerTab(Tab tab) {
+        if (tab.getUserData() instanceof ImageViewerPane image) {
+            image.dispose();
+        } else if (tab.getUserData() instanceof HexViewerPane hex) {
+            hex.dispose();
+        } else if (tab.getUserData() instanceof PdfViewerPane pdf) {
+            pdf.dispose();
+        }
     }
 
     /**
@@ -1753,6 +1780,10 @@ public class MainController implements com.editora.mcp.McpBridge {
                             logViewer.onBufferClosed(closed); // cancel tail-follow + drop per-buffer state
                             csvCoordinator.onBufferClosed(closed); // drop the CSV grid's edit listener
                             closed.dispose();
+                        } else {
+                            // Tab.setOnClosed only fires for a click on the ✕ — never for a programmatic
+                            // remove (Ctrl-W, Close All/Others/Left/Right, window close). See disposeViewerTab.
+                            disposeViewerTab(removed);
                         }
                     }
                 }
@@ -5345,7 +5376,8 @@ public class MainController implements com.editora.mcp.McpBridge {
     private Tab openImageTab(Path file, boolean select) {
         ImageViewerPane pane = new ImageViewerPane(file);
         Tab tab = addContentTab(pane, select);
-        tab.setOnClosed(e -> pane.dispose()); // release the decoded image's GPU texture when the tab closes
+        // Disposal is driven by the tabs ListChangeListener (see disposeViewerTab) — setOnClosed here would
+        // only fire for a click on the ✕, never for Ctrl-W / Close All / window close.
         Platform.runLater(pane::relayout); // fit-to-window once the tab is laid out
         return tab;
     }
@@ -5359,7 +5391,6 @@ public class MainController implements com.editora.mcp.McpBridge {
     private Tab openHexTab(Path file, boolean select) {
         HexViewerPane pane = new HexViewerPane(file);
         Tab tab = addContentTab(pane, select);
-        tab.setOnClosed(e -> pane.dispose());
         return tab;
     }
 
@@ -5372,7 +5403,6 @@ public class MainController implements com.editora.mcp.McpBridge {
     private Tab openPdfTab(Path file, boolean select) {
         PdfViewerPane pane = new PdfViewerPane(file);
         Tab tab = addContentTab(pane, select);
-        tab.setOnClosed(e -> pane.dispose()); // close the document + release the page image when the tab closes
         Platform.runLater(pane::relayout); // fit-to-window once the tab is laid out
         return tab;
     }

--- a/src/main/java/com/editora/ui/RemoteCoordinator.java
+++ b/src/main/java/com/editora/ui/RemoteCoordinator.java
@@ -313,4 +313,16 @@ final class RemoteCoordinator {
         }
         host.setStatus(tr("status.remote.disconnected"));
     }
+
+    /**
+     * Closes every SFTP session and the SSH client, and releases the app-wide {@code Vfs} resolver this
+     * window installed. Without it a closed window's {@code RemoteFileSystems} stays strongly reachable from
+     * a static field forever — holding its SSH client, its NIO threads, and every open remote session.
+     */
+    public void shutdown() {
+        if (remoteFs != null) {
+            remoteFs.shutdown();
+            remoteFs = null;
+        }
+    }
 }

--- a/src/main/java/com/editora/vfs/RemoteFileSystems.java
+++ b/src/main/java/com/editora/vfs/RemoteFileSystems.java
@@ -54,6 +54,7 @@ public final class RemoteFileSystems {
         client.start();
         Vfs.setRemoteResolver(this::resolve); // remote sftp:// strings → live Paths
         Vfs.setRemoteStorable(this::storableFor); // remote Path → sftp:// string (Path.toUri() throws for SFTP)
+        Vfs.setRemoteOwner(this); // so shutdown() can un-pin these statics (see Vfs.clearRemoteHooksIf)
     }
 
     /** The {@code sftp://user@host:port/path} string for a remote Path, by finding its owning connection. */
@@ -150,8 +151,17 @@ public final class RemoteFileSystems {
         close(fs);
     }
 
-    /** Closes every connection + the client (called on app exit). */
+    /**
+     * Closes every connection + the client. Called when the owning window closes (and on app exit).
+     *
+     * <p>Also clears the app-wide {@link Vfs} resolver hooks this instance installed in its constructor — they
+     * are {@code static}, so without this a closed window's instance (its SSH client, NIO threads, and every
+     * open SFTP session) stays strongly reachable for the life of the process and can never be collected.
+     * Only clears them if they still point at <em>this</em> instance, so a newer window's hooks aren't
+     * unhooked from under it.
+     */
     public void shutdown() {
+        Vfs.clearRemoteHooksIf(this);
         byAuthority.values().forEach(RemoteFileSystems::close);
         byAuthority.clear();
         client.stop();

--- a/src/main/java/com/editora/vfs/Vfs.java
+++ b/src/main/java/com/editora/vfs/Vfs.java
@@ -22,6 +22,28 @@ public final class Vfs {
 
     private Vfs() {}
 
+    /** The object whose hooks are currently installed, so only it may clear them (see {@link #clearRemoteHooksIf}). */
+    private static volatile Object remoteOwner;
+
+    /**
+     * Clears the remote hooks if {@code owner} is the one that installed them. The hooks are static, so a
+     * closed window's {@code RemoteFileSystems} would otherwise be pinned here (with its SSH client and open
+     * sessions) for the rest of the process. Guarded by identity so a *newer* window's hooks survive an older
+     * window closing after it.
+     */
+    public static void clearRemoteHooksIf(Object owner) {
+        if (remoteOwner == owner) {
+            remoteResolver = null;
+            remoteStorable = null;
+            remoteOwner = null;
+        }
+    }
+
+    /** Records who installed the hooks (call with the owner right after setting them). */
+    public static void setRemoteOwner(Object owner) {
+        remoteOwner = owner;
+    }
+
     public static void setRemoteResolver(Function<String, Path> resolver) {
         remoteResolver = resolver;
     }

--- a/src/test/java/com/editora/ui/ViewerTabDisposalFxTest.java
+++ b/src/test/java/com/editora/ui/ViewerTabDisposalFxTest.java
@@ -1,0 +1,125 @@
+package com.editora.ui;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import javafx.scene.control.Tab;
+import javafx.scene.control.TabPane;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.io.TempDir;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * The image / hex / PDF viewer panes were released only through {@code Tab.setOnClosed} — and JavaFX fires
+ * that from exactly one place: {@code TabPaneBehavior.closeTab()}, i.e. a click on the tab's ✕. Every one of
+ * the app's own close paths (Ctrl-W, Close All / Others / Left / Right, and window close) removes the tab
+ * <b>programmatically</b>, which doesn't fire it.
+ *
+ * <p>So closing a PDF with Ctrl-W leaked its {@code pdf-render} thread — parked forever, a GC root — and left
+ * the document's file handle open for the life of the process. Closing the same tab by clicking the ✕ leaked
+ * nothing, which is precisely why it survived manual testing.
+ */
+@Tag("fx")
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class ViewerTabDisposalFxTest {
+
+    private FxWindowFixture fx;
+
+    @TempDir
+    Path tmp;
+
+    @BeforeAll
+    void setUp() throws Exception {
+        FxTestSupport.bootToolkit();
+        fx = FxWindowFixture.create();
+    }
+
+    @AfterAll
+    void tearDown() throws Exception {
+        if (fx != null) {
+            fx.dispose();
+        }
+    }
+
+    private static Set<String> threadNamesContaining(String fragment) {
+        return Thread.getAllStackTraces().keySet().stream()
+                .map(Thread::getName)
+                .filter(n -> n.contains(fragment))
+                .collect(Collectors.toSet());
+    }
+
+    /** A minimal one-page PDF, hand-built so the test needs no fixture file. */
+    private Path writePdf() throws Exception {
+        Path pdf = tmp.resolve("doc.pdf");
+        try (org.apache.pdfbox.pdmodel.PDDocument doc = new org.apache.pdfbox.pdmodel.PDDocument()) {
+            doc.addPage(new org.apache.pdfbox.pdmodel.PDPage());
+            doc.save(pdf.toFile());
+        }
+        return pdf;
+    }
+
+    @Test
+    void closingAPdfTabProgrammaticallyReleasesItsThread() throws Exception {
+        Path pdf = writePdf();
+        assertTrue(Files.exists(pdf));
+
+        int before = threadNamesContaining("pdf-render").size();
+
+        Tab tab = FxTestSupport.callOnFx(() -> (Tab)
+                FxTestSupport.call(fx.controller, "openPdfTab", new Class<?>[] {Path.class, boolean.class}, pdf, true));
+        assertTrue(tab.getUserData() instanceof PdfViewerPane, "a PDF opens in the PDF viewer");
+        assertTrue(threadNamesContaining("pdf-render").size() > before, "the pane started its render thread");
+
+        // Close it the way the app does — a programmatic remove (Ctrl-W / Close All / window close), NOT a
+        // click on the ✕. This is the path that leaked.
+        TabPane tabs = FxTestSupport.field(fx.controller, "tabPane");
+        FxTestSupport.runOnFx(() -> tabs.getTabs().remove(tab));
+        FxTestSupport.runOnFx(() -> {});
+
+        // The executor is shut down asynchronously; give the thread a moment to actually exit.
+        for (int i = 0; i < 50 && threadNamesContaining("pdf-render").size() > before; i++) {
+            Thread.sleep(20);
+        }
+        assertEquals(
+                before,
+                threadNamesContaining("pdf-render").size(),
+                "the pdf-render thread must be gone — it used to park forever, once per closed PDF tab");
+    }
+
+    @Test
+    void closingAnImageTabProgrammaticallyDisposesThePane() throws Exception {
+        // A decoded Image pins a Prism texture; the texture pool has a hard ceiling, and exhausting it is what
+        // produced the black-window bug. So an image tab must release it on close, not wait for GC.
+        Path png = tmp.resolve("pic.png");
+        Files.write(png, pngBytes());
+
+        Tab tab = FxTestSupport.callOnFx(() -> (Tab) FxTestSupport.call(
+                fx.controller, "openImageTab", new Class<?>[] {Path.class, boolean.class}, png, true));
+        ImageViewerPane pane = (ImageViewerPane) tab.getUserData();
+
+        TabPane tabs = FxTestSupport.field(fx.controller, "tabPane");
+        FxTestSupport.runOnFx(() -> tabs.getTabs().remove(tab));
+        FxTestSupport.runOnFx(() -> {});
+
+        assertTrue(
+                FxTestSupport.<javafx.scene.image.ImageView>field(pane, "imageView")
+                                .getImage()
+                        == null,
+                "the decoded image (and its GPU texture) is released on a programmatic close");
+    }
+
+    /** The smallest valid PNG: a 1x1 transparent pixel. */
+    private static byte[] pngBytes() {
+        return java.util.Base64.getDecoder()
+                .decode("iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII=");
+    }
+}


### PR DESCRIPTION
4 of 4 from the audit (after #403, #404, #405).

## 1. Closing a PDF tab leaked a thread and a file handle — unless you clicked the ✕

`ImageViewerPane` / `HexViewerPane` / `PdfViewerPane` were released **only** through `Tab.setOnClosed`. JavaFX fires that from exactly one place — `TabPaneBehavior.closeTab()`, i.e. **a click on the tab's ✕**. Every close path the app itself uses removes the tab *programmatically*, which does **not** fire it:

- `closeTab()` — Ctrl-W and the toolbar close button
- `closeTabs()` — Close All / Close Others / Close Unmodified / Close to Left / Close to Right
- `disposeWindow()` — closing the window (it only looks at `bufferOf(tab)`, skipping non-buffer tabs entirely)

So per PDF closed with Ctrl-W: a `pdf-render` thread parked **forever** (a GC root, so the pane never becomes collectable either) and the `PDDocument`'s file handle left open for the life of the process — on Windows, holding a lock on the file. Image tabs kept their decoded `Image` pinned, which is exactly the Prism-texture pattern behind the black-window bug CLAUDE.md warns about.

Closing the same tab by clicking the ✕ leaked nothing. That's why it survived manual testing.

Disposal now runs from the tabs `ListChangeListener` (which *does* fire on programmatic removal — it's already how `EditorBuffer`s get disposed) and from `disposeWindow`. The redundant `setOnClosed` handlers are removed, so there's exactly one path.

## 2. Closing a window left four services running

`disposeWindow()` shuts down ~18 things but missed these — and **none of them even had a `shutdown()`**:

| Coordinator | Leaked |
|---|---|
| `DiffCoordinator` | `diff-service` thread |
| `ExternalToolCoordinator` | `external-tool-service` thread |
| `HttpClientCoordinator` | `http-client` thread |
| `RemoteCoordinator` | **the whole SSH client + every open SFTP session** |

The remote one is the worst. `RemoteFileSystems.shutdown()` is javadoc'd *"called on app exit"* and had **zero callers anywhere in the repo** — while its constructor installs itself into `Vfs`'s **static** resolver hooks. So a closed window's `RemoteFileSystems` — SSH client, NIO threads, live SFTP sessions — stayed strongly reachable from a static field for the rest of the process, and the session stayed open on the remote host. `Vfs.clearRemoteHooksIf(owner)` now un-pins them, identity-guarded so a *newer* window's hooks survive an older window closing after it.

## 3. Run/build subprocesses orphaned their children and survived the app

`RunService` and `BuildService` never called `ProcessRegistry.track()`, so their processes were absent from **both** the JVM shutdown hook and the on-disk ledger the next launch reaps. And `stop()` did:

```java
p.destroy();
if (p.isAlive()) { p.destroyForcibly(); }
```

That kills only the **root**. `npm run dev`, `mvn`, and `./gradlew` all fork a real child — SIGTERM-ing the wrapper orphans it. **Repro:** start `npm run dev` from the Run window, quit Editora → the dev server keeps running and holding its port, and it isn't in `spawned-servers.txt` either, so the next launch won't reap it. (The `isAlive()` check immediately after an *asynchronous* SIGTERM is also all but always true, so the child was effectively SIGKILLed with no grace period — defeating the intended escalation.)

Both now `track()` and use `ProcessRegistry.killTree` — children first, so a wrapper can't reparent-orphan its child, with a real grace period before the force-kill. Combined with #403, quitting the app now kills them too.

## Verification

**1959 tests, 0 failures.** New `ViewerTabDisposalFxTest` counts live `pdf-render` threads across a programmatic tab close; it fails on the old code:

```
closingAPdfTabProgrammaticallyReleasesItsThread
  ==> the pdf-render thread must be gone — expected: <0> but was: <1>
```

## Deferred

The audit also found that the **language server is forked on the JavaFX Application Thread** (`LspCoordinator.syncBuffer` → `LspManager.sessionForRoot` → `session.start()` → `pb.start()` + `Files.createDirectories` + a synchronous ledger write). That's the "editor hangs for a beat when the LSP starts" stall. It's a real issue but it's a *responsiveness* fix with a different risk profile than these, so I'd rather do it on its own — filing separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)