### PR TITLE
Harden pure parsers against pathological input (ReDoS, numeric overflow)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **A pathological regex in Find no longer freezes the editor.** Typing a valid-but-catastrophic pattern
+  (the classic ReDoS case) with regex search on could send the find bar backtracking for many seconds — on the
+  UI thread, so the whole editor locked up with no way out. Regex search is now time-bounded and abandons a
+  runaway match instead.
+- **A hostile or fat-fingered `.editorconfig` no longer throws when you open a file.** An enormous numeric
+  glob range like `[{1..99999999999999999999}]` crashed the read of any file it governed. It now degrades to
+  matching any number.
+- **The systemd unit preview no longer throws on an out-of-range time value.** A directive like
+  `RestartSec=99999999999999999999` (or one that overflows when converted to seconds) now shows the raw value
+  instead of failing to render.
+
 - **Closing an image, hex, or PDF tab now actually releases it.** Those tabs were only cleaned up when closed
   by clicking the ✕ — closing them with Ctrl-W, "Close All"/"Close Others", or by closing the window leaked a
   live thread and (for a PDF) kept the file open for as long as Editora was running. Open and close a few

--- a/src/main/java/com/editora/editor/SearchMatcher.java
+++ b/src/main/java/com/editora/editor/SearchMatcher.java
@@ -106,21 +106,90 @@ public final class SearchMatcher {
         }
     }
 
+    /** Wall-clock budget for a single regex search before it's abandoned (see {@link Deadline}). */
+    static final long DEFAULT_MATCH_BUDGET_NANOS = 1_000_000_000L; // 1 s
+
     private static List<int[]> regexMatches(String text, String query, boolean caseSensitive, boolean wholeWord) {
+        return regexMatches(text, query, caseSensitive, wholeWord, DEFAULT_MATCH_BUDGET_NANOS);
+    }
+
+    /**
+     * Regex matches, but bounded in time. {@code java.util.regex} is a backtracking engine with no timeout, so
+     * a <b>valid</b> but pathological pattern — the classic {@code (a+)+$} against a long run of {@code a}s
+     * ending in a non-match — backtracks for effectively forever. The in-editor find bar runs this
+     * <em>synchronously on the JavaFX thread</em> (a debounce only delays it), so such a pattern froze the whole
+     * editor with no way out ({@code regexError} only catches <em>syntax</em> errors, and a pathological pattern
+     * compiles fine). The input is wrapped in a {@link Deadline} sequence whose {@code charAt} aborts the match
+     * once the budget passes — the engine touches {@code charAt} on every backtrack step, so it unwinds
+     * promptly — and we return whatever was found so far rather than hang. Package-visible budget overload for
+     * tests.
+     */
+    static List<int[]> regexMatches(
+            String text, String query, boolean caseSensitive, boolean wholeWord, long budgetNanos) {
         Pattern p = compileRegex(query, caseSensitive, wholeWord);
         if (p == null) {
             return List.of();
         }
         List<int[]> out = new ArrayList<>();
-        Matcher matcher = p.matcher(text);
+        Matcher matcher = p.matcher(new Deadline(text, budgetNanos));
         int from = 0;
-        while (from <= text.length() && matcher.find(from)) {
-            int start = matcher.start();
-            int end = matcher.end();
-            out.add(new int[] {start, end});
-            from = end > start ? end : end + 1; // advance past a zero-width match
+        try {
+            while (from <= text.length() && matcher.find(from)) {
+                int start = matcher.start();
+                int end = matcher.end();
+                out.add(new int[] {start, end});
+                from = end > start ? end : end + 1; // advance past a zero-width match
+            }
+        } catch (MatchAbortedException aborted) {
+            return out; // budget exceeded — partial results beat freezing the UI
         }
         return out;
+    }
+
+    /** Thrown by {@link Deadline} to unwind a runaway backtracking match; caught in {@link #regexMatches}. */
+    private static final class MatchAbortedException extends RuntimeException {
+        MatchAbortedException() {
+            super(null, null, false, false); // no message/stacktrace — it's control flow, not an error
+        }
+    }
+
+    /**
+     * A read-only {@link CharSequence} view of the text that throws {@link MatchAbortedException} from
+     * {@code charAt} once {@code deadlineNanos} passes. The clock is only sampled every 1024th access (a bit
+     * mask) so the common fast path stays a plain array read.
+     */
+    private static final class Deadline implements CharSequence {
+        private final CharSequence text;
+        private final long deadlineNanos;
+        private int ticks;
+
+        Deadline(CharSequence text, long budgetNanos) {
+            this.text = text;
+            this.deadlineNanos = System.nanoTime() + budgetNanos;
+        }
+
+        @Override
+        public char charAt(int index) {
+            if ((++ticks & 0x3FF) == 0 && System.nanoTime() > deadlineNanos) {
+                throw new MatchAbortedException();
+            }
+            return text.charAt(index);
+        }
+
+        @Override
+        public int length() {
+            return text.length();
+        }
+
+        @Override
+        public CharSequence subSequence(int start, int end) {
+            return text.subSequence(start, end);
+        }
+
+        @Override
+        public String toString() {
+            return text.toString();
+        }
     }
 
     private static boolean isWordBounded(String text, int start, int end) {

--- a/src/main/java/com/editora/editorconfig/EditorConfigGlob.java
+++ b/src/main/java/com/editora/editorconfig/EditorConfigGlob.java
@@ -31,13 +31,22 @@ public final class EditorConfigGlob {
         } else if (g.startsWith("/")) {
             g = g.substring(1); // leading slash → anchored to the .editorconfig directory
         }
-        StringBuilder re = new StringBuilder("^");
-        appendPattern(re, g);
-        re.append('$');
         try {
+            StringBuilder re = new StringBuilder("^");
+            appendPattern(re, g); // also inside the try: a malformed glob must never throw out of matches()
+            re.append('$');
             return Pattern.compile(re.toString()).matcher(relPath).matches();
         } catch (RuntimeException e) {
             return false;
+        }
+    }
+
+    /** A brace-range bound as a long, or null when it doesn't fit (so the caller degrades to "any integer"). */
+    private static Long parseBound(String s) {
+        try {
+            return Long.parseLong(s);
+        } catch (NumberFormatException overflow) {
+            return null;
         }
     }
 
@@ -116,7 +125,13 @@ public final class EditorConfigGlob {
     private static void appendBrace(StringBuilder re, String inner) {
         Matcher m = NUM_RANGE.matcher(inner);
         if (m.matches()) {
-            re.append(numericRange(Long.parseLong(m.group(1)), Long.parseLong(m.group(2))));
+            // NUM_RANGE accepts any digit count, so a bound past Long.MAX (e.g. `{1..99999999999999999999}` in
+            // a hostile .editorconfig) overflows Long.parseLong. The MAX_RANGE cap only fires once BOTH bounds
+            // parse, so the throw escaped — and matches()' try/catch is after this call. A bound we can't hold
+            // in a long can't be a small enumerable range anyway, so fall back to "match any integer".
+            Long lo = parseBound(m.group(1));
+            Long hi = parseBound(m.group(2));
+            re.append(lo == null || hi == null ? "-?\\d+" : numericRange(lo, hi));
             return;
         }
         List<String> parts = splitTopLevelCommas(inner);

--- a/src/main/java/com/editora/systemd/TimeSpan.java
+++ b/src/main/java/com/editora/systemd/TimeSpan.java
@@ -56,7 +56,12 @@ public final class TimeSpan {
             if (m.start() != matchedTo && !s.substring(matchedTo, m.start()).isBlank()) {
                 return -1; // junk between tokens
             }
-            long n = Long.parseLong(m.group(1));
+            long n;
+            try {
+                n = Long.parseLong(m.group(1)); // TOKEN accepts any digit count; a huge value overflows a long
+            } catch (NumberFormatException overflow) {
+                return -1;
+            }
             String unit = m.group(2);
             long per = unit.isEmpty()
                     ? 1L
@@ -64,7 +69,11 @@ public final class TimeSpan {
             if (per < 0) {
                 return -1;
             }
-            total += n * per;
+            try {
+                total = Math.addExact(total, Math.multiplyExact(n, per)); // a large-but-parseable span overflows
+            } catch (ArithmeticException overflow) {
+                return -1;
+            }
             matchedTo = m.end();
             any = true;
         }

--- a/src/test/java/com/editora/editor/SearchMatcherTest.java
+++ b/src/test/java/com/editora/editor/SearchMatcherTest.java
@@ -91,4 +91,39 @@ class SearchMatcherTest {
         assertEquals(1, SearchMatcher.indexAt(ms, 10));
         assertEquals(-1, SearchMatcher.indexAt(ms, 6));
     }
+
+    // A pattern + input that catastrophically backtracks on this JDK: `(.*a){30}` over 30 'a's runs ~9 s
+    // unbounded (`{32}` ~38 s), which is a total UI freeze since the find bar matches on the FX thread.
+    private static final String EVIL_RE = "(.*a){30}";
+    private static final String EVIL_IN = "a".repeat(30);
+
+    @Test
+    void aPathologicalRegexIsAbandonedRatherThanHangingForever() {
+        // java.util.regex has no timeout and the pattern is VALID, so regexError() doesn't catch it — it used
+        // to spin ~9 s (much longer as the input grows) on the FX thread. The default budget must bound it.
+        long start = System.nanoTime();
+        List<int[]> out = SearchMatcher.matches(EVIL_IN, EVIL_RE, true, true, false);
+        long elapsedMs = (System.nanoTime() - start) / 1_000_000;
+        assertTrue(elapsedMs < 4_000, "must abandon the runaway match near the ~1s budget, took " + elapsedMs + "ms");
+        assertNotNull(out); // returned at all — that's the point
+    }
+
+    @Test
+    void aTinyBudgetBoundsItAlmostImmediately() {
+        // A 1 ms budget aborts the same catastrophic match right away — proves the deadline actually fires,
+        // not that the input happened to be tractable.
+        long start = System.nanoTime();
+        List<int[]> out = SearchMatcher.regexMatches(EVIL_IN, EVIL_RE, true, false, 1_000_000L); // 1 ms
+        assertTrue((System.nanoTime() - start) / 1_000_000 < 1_000, "bounded by the tiny budget");
+        assertNotNull(out);
+    }
+
+    @Test
+    void ordinaryRegexSearchStillWorks() {
+        // The bounding must not change normal results.
+        List<int[]> out = SearchMatcher.matches("foo bar foo", "foo", true, true, false);
+        assertEquals(2, out.size());
+        assertEquals(0, out.get(0)[0]);
+        assertEquals(8, out.get(1)[0]);
+    }
 }

--- a/src/test/java/com/editora/editorconfig/EditorConfigGlobTest.java
+++ b/src/test/java/com/editora/editorconfig/EditorConfigGlobTest.java
@@ -68,4 +68,21 @@ class EditorConfigGlobTest {
         assertTrue(EditorConfigGlob.matches("/Makefile", "Makefile"));
         assertFalse(EditorConfigGlob.matches("/Makefile", "sub/Makefile"));
     }
+
+    @Test
+    void anOversizedNumericRangeDoesNotThrow() {
+        // A hostile .editorconfig section like [{1..99999999999999999999}] overflowed Long.parseLong and the
+        // exception escaped matches() (its try/catch was after the pattern build), throwing all the way out of
+        // EditorConfig.resolveFor — so merely OPENING any file it governed threw. It must degrade to matching
+        // any integer instead.
+        assertTrue(EditorConfigGlob.matches("file{1..99999999999999999999}.txt", "file7.txt"));
+        assertTrue(EditorConfigGlob.matches("v{0..99999999999999999999}", "v12345"));
+        assertFalse(EditorConfigGlob.matches("v{0..99999999999999999999}", "vNaN"));
+    }
+
+    @Test
+    void anInRangeNumericRangeStillEnumerates() {
+        assertTrue(EditorConfigGlob.matches("f{1..3}.txt", "f2.txt"));
+        assertFalse(EditorConfigGlob.matches("f{1..3}.txt", "f9.txt"));
+    }
 }

--- a/src/test/java/com/editora/systemd/TimeSpanTest.java
+++ b/src/test/java/com/editora/systemd/TimeSpanTest.java
@@ -1,0 +1,45 @@
+package com.editora.systemd;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * {@link TimeSpan} parses systemd time spans ({@code RestartSec=}, {@code OnActiveSec=}, …). A hostile or
+ * fat-fingered unit file can hand it a number that overflows a {@code long}; that must degrade to "can't
+ * parse" (the method's {@code -1} sentinel), not throw out of the systemd preview.
+ */
+class TimeSpanTest {
+
+    @Test
+    void ordinarySpansParse() {
+        assertEquals(90, TimeSpan.seconds("1min 30s"));
+        assertEquals(3600, TimeSpan.seconds("1h"));
+        assertEquals(45, TimeSpan.seconds("45"));
+    }
+
+    @Test
+    void aHugeNumberDoesNotThrow() {
+        // Long.parseLong would throw on 20 digits; describe() had no guard, so rendering the preview threw.
+        assertEquals(-1, TimeSpan.seconds("99999999999999999999"));
+        assertEquals(-1, TimeSpan.seconds("99999999999999999999s"));
+        // describe() falls back to the raw text rather than throwing.
+        assertEquals(
+                "99999999999999999999",
+                TimeSpan.describe("99999999999999999999").strip());
+    }
+
+    @Test
+    void aParseableButOverflowingProductDoesNotWrapToGarbage() {
+        // Long.MAX weeks * 604800 s/week overflows the multiply; without Math.multiplyExact this silently
+        // produced a negative/wrong "describe" instead of admitting it can't represent it.
+        assertEquals(-1, TimeSpan.seconds("9223372036854775807w"));
+    }
+
+    @Test
+    void junkIsRejected() {
+        assertEquals(-1, TimeSpan.seconds("1min garbage"));
+        assertEquals(-1, TimeSpan.seconds("abc"));
+        assertEquals(-1, TimeSpan.seconds(""));
+    }
+}


### PR DESCRIPTION
From a fuzz-the-cores audit — the PR #308 lens: feed the pure parsers legal-but-nasty input and see what throws, hangs, or corrupts. Three confirmed defects; the rest of the cores traced clean.

## 1. A pathological regex in Find froze the whole editor (ReDoS)

`java.util.regex` is a backtracking engine with **no timeout**, and the in-editor find bar runs it **synchronously on the JavaFX thread** (the 150 ms debounce only delays it). `regexError()` only catches `PatternSyntaxException` — a *valid* catastrophic pattern compiles fine, so nothing guarded it.

**Repro:** regex search on, type `(.*a){30}`, against a line of ~30 `a`s. Backtracks **~9 s** here (`{32}` ≈ 38 s, `{34}` didn't finish in 2 min) — the entire UI is locked with no way out.

`regexMatches` now wraps the text in a `Deadline` `CharSequence` whose `charAt` aborts once a 1 s budget passes. The engine touches `charAt` on every backtrack step, so it unwinds promptly; partial results are returned rather than hanging. Measured on the catastrophic input: **9170 ms → 1003 ms**; ordinary searches are unchanged.

## 2. A hostile `.editorconfig` threw when you opened a file

`EditorConfigGlob.matches` parsed a `{n..m}` numeric-range bound with `Long.parseLong`. The `MAX_RANGE` cap only fires once *both* bounds parse, and the `try/catch` in `matches()` sat **after** the pattern build — so a bound past `Long.MAX` (e.g. `[{1..99999999999999999999}]`) threw `NumberFormatException` all the way out of `EditorConfig.resolveFor`. **Opening any file that `.editorconfig` governed threw.** Bounds that don't fit a `long` now degrade to "match any integer" (they can't be a small enumerable range anyway), and `appendPattern` moved inside the `try`.

## 3. The systemd preview threw on an out-of-range time value

`TimeSpan.seconds` did an unguarded `Long.parseLong`, reached from the systemd unit preview with no surrounding catch — so `RestartSec=99999999999999999999` threw rather than rendering. And `total += n * per` silently overflowed to a wrong/negative value for a large-but-parseable span. Now guards the parse and uses `Math.addExact`/`multiplyExact`, returning the `-1` "unparseable" sentinel so `describe()` falls back to the raw text.

## Verification

**1968 tests, 0 failures.** Each fix has a test proven to fail on the old code:

```
aPathologicalRegexIsAbandonedRatherThanHangingForever  took 8483ms ==> expected <true> but was <false>
anOversizedNumericRangeDoesNotThrow                    » NumberFormatException: "99999999999999999999"
aHugeNumberDoesNotThrow                                » NumberFormatException: "99999999999999999999"
```

(Careful note: my first cut of the ReDoS test passed `regex=false` and did a *literal* search, so it passed for the wrong reason — caught it by measuring `matches()` directly, which returned in 0 ms. The committed test genuinely exercises the regex path.)

## Traced and found robust (dropped)

`CsvParser`/`CsvAlign`, `TagRename`/`TagAutoClose` (the #308 fix holds), `CronExpression`/`CronField`, `MwDate`/`MarkwhenParser`, `SexpNav`/`Indenter`/`Filler`/`StringCase`, `MarkdownTable`, `GitignoreFilter`, `Workflow`, `Dockerfile`, `Fstab`, `SshConfig` — all terminate/guard on messy input.

🤖 Generated with [Claude Code](https://claude.com/claude-code)