### PR TITLE
LSP: drop stale format + semantic-token responses instead of applying them to a changed buffer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Format Document no longer corrupts the file if you edit while it's working.** A language server computes
+  formatting against the file as it was when asked; if you typed during the round-trip, those edits landed at
+  the wrong offsets, silently mangling lines. Editora now detects that the file changed and skips the stale
+  result, telling you to run it again.
+- **Semantic highlighting no longer briefly mis-colors code while you type.** A slow server's colors,
+  computed against an older version of the file, could paint onto shifted text (a variable colored as a
+  function, the whole overlay off by a line) until the next response caught up. Stale responses are now
+  dropped.
+
 - **A pathological regex in Find no longer freezes the editor.** Typing a valid-but-catastrophic pattern
   (the classic ReDoS case) with regex search on could send the find bar backtracking for many seconds — on the
   UI thread, so the whole editor locked up with no way out. Regex search is now time-bounded and abandons a

--- a/src/main/java/com/editora/editor/EditorBuffer.java
+++ b/src/main/java/com/editora/editor/EditorBuffer.java
@@ -485,6 +485,10 @@ public class EditorBuffer implements TabContent {
     /** True once the document changed after {@link #semanticTokens} were captured — suppresses the overlay
      *  (so we never mis-color shifted text) until a fresh response lands via {@link #setSemanticTokens}. */
     private boolean semanticStale;
+    /** Bumped on every edit and read when a semantic-tokens request is issued, so a response computed against
+     *  an older document is dropped instead of re-anchoring stale tokens onto the current text (see
+     *  {@link #semanticGen()} / {@link #setSemanticTokens(java.util.List, long)}). */
+    private long semanticGen;
     /** Debounces a viewport semantic-tokens re-request after scrolling settles (so a new region gets
      *  tokens without firing a server request per scroll frame). */
     private final javafx.animation.PauseTransition semanticScrollDebounce =
@@ -681,8 +685,10 @@ public class EditorBuffer implements TabContent {
                 dirtyFromLine = Math.min(dirtyFromLine, line);
             }
             // The cached semantic tokens now point at shifted offsets; suppress the overlay until the
-            // next response re-anchors them (one boolean write — off the per-char path's cost budget).
-            if (semanticActive && !semanticStale) {
+            // next response re-anchors them (one boolean write — off the per-char path's cost budget). The
+            // generation bump invalidates any in-flight request so its (now-stale) response is dropped.
+            if (semanticActive) {
+                semanticGen++;
                 semanticStale = true;
             }
         });
@@ -3035,14 +3041,31 @@ public class EditorBuffer implements TabContent {
         return semanticActive;
     }
 
+    /** The generation to capture when issuing a semantic-tokens request; pass it back to
+     *  {@link #setSemanticTokens(java.util.List, long)} so a response for an older document is dropped. */
+    public long semanticGen() {
+        return semanticGen;
+    }
+
     /** Pushes fresh server semantic tokens (absolute positions) and re-applies so they overlay the
      *  TextMate highlight immediately. No-op when semantic highlighting is off for this buffer. */
     public void setSemanticTokens(java.util.List<SemanticToken> tokens) {
-        if (!semanticActive) {
+        setSemanticTokens(tokens, semanticGen);
+    }
+
+    /**
+     * Applies a semantic-tokens response only if the document hasn't changed since the request was issued
+     * ({@code requestGen == } the current {@link #semanticGen()}). A stale response — the server computed it
+     * against an older version, or an older request's reply arrives after a newer one — is <b>dropped</b>,
+     * leaving {@link #semanticStale} set so the overlay stays suppressed rather than re-anchoring the old
+     * tokens onto the shifted text (which mis-colored characters/lines until the next response).
+     */
+    public void setSemanticTokens(java.util.List<SemanticToken> tokens, long requestGen) {
+        if (!semanticActive || requestGen != semanticGen) {
             return;
         }
         semanticTokens = tokens == null ? java.util.List.of() : tokens;
-        semanticStale = false; // these are anchored to the current text → safe to overlay again
+        semanticStale = false; // anchored to the current (unchanged since request) text → safe to overlay
         invalidateHighlighting();
         applyHighlighting();
     }

--- a/src/main/java/com/editora/ui/LspCoordinator.java
+++ b/src/main/java/com/editora/ui/LspCoordinator.java
@@ -443,10 +443,11 @@ final class LspCoordinator {
             return;
         }
         int[] window = buffer.visibleLineWindow();
+        long gen = buffer.semanticGen(); // capture now; the reply is dropped if the doc changes before it lands
         lspManager.requestSemanticTokens(
                 path, window[0] - SEMANTIC_WINDOW_PAD, window[1] + SEMANTIC_WINDOW_PAD, tokens -> {
                     if (buffer == host.activeBuffer()) {
-                        buffer.setSemanticTokens(tokens);
+                        buffer.setSemanticTokens(tokens, gen);
                     }
                 });
     }
@@ -877,9 +878,18 @@ final class LspCoordinator {
         }
         int tabSize = host.settings().getTabSize();
         host.setStatus(tr("status.lsp.formatting"));
+        // The server computes whole-document edits (line/col based) against the text as it is NOW. If the
+        // user edits during the async round-trip, those offsets no longer line up — and applyLspEdits only
+        // clamps + swallows, so a stale format silently corrupts the file (every line mis-formatted/shifted).
+        // Snapshot the text and drop the reply if it changed, mirroring tryLspReindentLine's line guard.
+        String snapshot = buffer.getContent();
         lspManager.formatDocument(path, tabSize, buffer.detectInsertSpaces(tabSize), edits -> {
             if (buffer != host.activeBuffer()) {
                 return; // user switched tabs before the server replied
+            }
+            if (!buffer.getContent().equals(snapshot)) {
+                host.setStatus(tr("status.lsp.formatStale")); // edited mid-format — a re-run formats cleanly
+                return;
             }
             if (edits.isEmpty()) {
                 host.setStatus(tr("status.lsp.formatNoChange"));

--- a/src/main/resources/com/editora/i18n/messages.properties
+++ b/src/main/resources/com/editora/i18n/messages.properties
@@ -1282,6 +1282,7 @@ status.lsp.restarted=Language servers restarted
 status.lsp.formatting=Formatting…
 status.lsp.formatted=Document formatted
 status.lsp.formatNoChange=Already formatted
+status.lsp.formatStale = Not formatted: the file changed while formatting. Run it again.
 status.lsp.formatUnavailable=No formatter available for this file
 status.lsp.unavailable=No language server for this file
 status.lsp.noDefinition=No definition found

--- a/src/main/resources/com/editora/i18n/messages_de.properties
+++ b/src/main/resources/com/editora/i18n/messages_de.properties
@@ -1274,6 +1274,7 @@ status.lsp.restarted=Sprachserver neu gestartet
 status.lsp.formatting=Formatieren…
 status.lsp.formatted=Dokument formatiert
 status.lsp.formatNoChange=Bereits formatiert
+status.lsp.formatStale = Nicht formatiert: Die Datei wurde während der Formatierung geändert. Erneut versuchen.
 status.lsp.formatUnavailable=Kein Formatierer für diese Datei verfügbar
 status.lsp.unavailable=Kein Sprachserver für diese Datei
 status.lsp.noDefinition=Keine Definition gefunden

--- a/src/main/resources/com/editora/i18n/messages_es.properties
+++ b/src/main/resources/com/editora/i18n/messages_es.properties
@@ -1274,6 +1274,7 @@ status.lsp.restarted=Servidores de lenguaje reiniciados
 status.lsp.formatting=Formateando…
 status.lsp.formatted=Documento formateado
 status.lsp.formatNoChange=Ya está formateado
+status.lsp.formatStale = No formateado: el archivo cambió durante el formateo. Vuelve a intentarlo.
 status.lsp.formatUnavailable=No hay formateador disponible para este archivo
 status.lsp.unavailable=No hay servidor de lenguaje para este archivo
 status.lsp.noDefinition=No se encontró la definición

--- a/src/main/resources/com/editora/i18n/messages_fr.properties
+++ b/src/main/resources/com/editora/i18n/messages_fr.properties
@@ -1274,6 +1274,7 @@ status.lsp.restarted=Serveurs de langage redémarrés
 status.lsp.formatting=Formatage…
 status.lsp.formatted=Document formaté
 status.lsp.formatNoChange=Déjà formaté
+status.lsp.formatStale = Non formaté : le fichier a changé pendant le formatage. Réessayez.
 status.lsp.formatUnavailable=Aucun formateur disponible pour ce fichier
 status.lsp.unavailable=Aucun serveur de langage pour ce fichier
 status.lsp.noDefinition=Aucune définition trouvée

--- a/src/main/resources/com/editora/i18n/messages_it.properties
+++ b/src/main/resources/com/editora/i18n/messages_it.properties
@@ -1274,6 +1274,7 @@ status.lsp.restarted=Language server riavviati
 status.lsp.formatting=Formattazione…
 status.lsp.formatted=Documento formattato
 status.lsp.formatNoChange=Già formattato
+status.lsp.formatStale = Non formattato: il file è cambiato durante la formattazione. Riprova.
 status.lsp.formatUnavailable=Nessun formattatore disponibile per questo file
 status.lsp.unavailable=Nessun language server per questo file
 status.lsp.noDefinition=Nessuna definizione trovata

--- a/src/main/resources/com/editora/i18n/messages_pt.properties
+++ b/src/main/resources/com/editora/i18n/messages_pt.properties
@@ -1274,6 +1274,7 @@ status.lsp.restarted=Servidores de linguagem reiniciados
 status.lsp.formatting=Formatando…
 status.lsp.formatted=Documento formatado
 status.lsp.formatNoChange=Já está formatado
+status.lsp.formatStale = Não formatado: o arquivo mudou durante a formatação. Tente novamente.
 status.lsp.formatUnavailable=Nenhum formatador disponível para este arquivo
 status.lsp.unavailable=Nenhum servidor de linguagem para este arquivo
 status.lsp.noDefinition=Nenhuma definição encontrada

--- a/src/test/java/com/editora/ui/SemanticTokenStalenessFxTest.java
+++ b/src/test/java/com/editora/ui/SemanticTokenStalenessFxTest.java
@@ -1,0 +1,75 @@
+package com.editora.ui;
+
+import java.util.List;
+
+import com.editora.editor.EditorBuffer;
+import com.editora.editor.SemanticToken;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * A semantic-tokens response computed against an older document must be dropped, not re-anchored onto the
+ * current (shifted) text. Every other async-highlight path in the codebase uses a generation guard; this one
+ * used only a {@code semanticStale} boolean that {@code setSemanticTokens} <b>unconditionally cleared</b> — so
+ * a reply that landed after a keystroke (or an older reply arriving after a newer one) painted stale colors
+ * onto moved characters until the next response re-anchored them. Now the request's generation is checked.
+ */
+@Tag("fx")
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class SemanticTokenStalenessFxTest {
+
+    @BeforeAll
+    void setUp() throws Exception {
+        FxTestSupport.bootToolkit();
+    }
+
+    private static final List<SemanticToken> TOKENS = List.of(new SemanticToken(0, 0, 3, "keyword"));
+
+    @SuppressWarnings("unchecked")
+    private static int tokenCount(EditorBuffer b) {
+        return ((List<SemanticToken>) FxTestSupport.<List<?>>field(b, "semanticTokens")).size();
+    }
+
+    private static boolean stale(EditorBuffer b) {
+        return FxTestSupport.<Boolean>field(b, "semanticStale");
+    }
+
+    @Test
+    void aResponseForAnOlderDocumentIsDropped() throws Exception {
+        EditorBuffer buffer = FxTestSupport.callOnFx(() -> {
+            EditorBuffer b = new EditorBuffer();
+            b.setContent("let x = 1\n");
+            b.setSemanticActive(true);
+            return b;
+        });
+
+        // A response for the current document applies and clears the stale flag.
+        long gen0 = FxTestSupport.callOnFx(buffer::semanticGen);
+        FxTestSupport.runOnFx(() -> buffer.setSemanticTokens(TOKENS, gen0));
+        assertEquals(1, FxTestSupport.callOnFx(() -> tokenCount(buffer)), "current-gen tokens applied");
+        assertFalse(FxTestSupport.callOnFx(() -> stale(buffer)), "and the overlay is un-suppressed");
+
+        // Now the user types. The edit listener bumps the generation and marks the tokens stale.
+        FxTestSupport.runOnFx(() -> buffer.getArea().insertText(0, "\n")); // shift everything down a line
+        long gen1 = FxTestSupport.callOnFx(buffer::semanticGen);
+        assertNotEquals(gen0, gen1, "an edit advances the semantic generation");
+        assertTrue(FxTestSupport.callOnFx(() -> stale(buffer)), "and suppresses the overlay");
+
+        // The in-flight request's reply (captured gen0) lands late — it must be DROPPED, staying suppressed,
+        // NOT re-anchored onto the now-shifted text.
+        FxTestSupport.runOnFx(() -> buffer.setSemanticTokens(List.of(new SemanticToken(0, 0, 9, "string")), gen0));
+        assertTrue(FxTestSupport.callOnFx(() -> stale(buffer)), "a stale response leaves the overlay suppressed");
+
+        // A fresh response for the current document re-anchors and un-suppresses.
+        FxTestSupport.runOnFx(() -> buffer.setSemanticTokens(TOKENS, gen1));
+        assertFalse(FxTestSupport.callOnFx(() -> stale(buffer)), "the current-gen response applies");
+        assertEquals(1, FxTestSupport.callOnFx(() -> tokenCount(buffer)));
+    }
+}


### PR DESCRIPTION
From the offset-math and threading audits. Two async LSP results were applied to a buffer that could have changed since the request, with **no version/content guard** — the guard every other async-highlight path in this codebase has, and which the sibling `tryLspReindentLine` already implements per-line.

## 1. Format Document corrupted the file if you edited mid-format

The server computes whole-document formatting (line/col edits) against the text as it is **now**. The callback only checked `buffer == activeBuffer()`, never that the text was unchanged. And `applyLspEdits` just **clamps offsets and swallows exceptions** — so a stale format doesn't throw, it silently writes edits to the wrong places.

**Repro:** invoke Format Document; before the server replies, press Enter at the top of the file. Every reply edit was computed for the pre-insert line numbering, so applied to the shifted buffer they land one line off — the whole file comes back mis-formatted/duplicated, dirty, with no error.

Now snapshots `buffer.getContent()` and drops the reply if it changed (`status.lsp.formatStale` — "run it again"), mirroring `tryLspReindentLine`.

## 2. Semantic highlighting mis-colored code while typing

`setSemanticTokens` **unconditionally cleared** the `semanticStale` flag on *any* response — even one computed against an older document. The `semanticStale` boolean's entire job (per its own comment) is to suppress the overlay while the cached tokens point at shifted offsets. Clearing it on a stale response defeats that.

**Interleaving:** the 300 ms pulse sends `didChange(V1)` + requests tokens for V1. You type one more char → V2, `semanticStale = true`. The V1 response lands, `setSemanticTokens` stores V1 tokens and clears `semanticStale`, and the highlight apply then maps V1 token positions through the live V2 text — colors land on the wrong characters/lines. With overlapping requests (scroll + type), an older reply arriving after a newer one makes it *stick*.

Added a `semanticGen` counter bumped on every edit and captured when the request is issued; `setSemanticTokens(tokens, requestGen)` drops a response whose gen no longer matches, leaving the overlay suppressed rather than mis-painting.

## Verification

**1969 tests, 0 failures.** New FX test for the semantic guard, proven to fail on the old code:

```
aResponseForAnOlderDocumentIsDropped
  ==> a stale response leaves the overlay suppressed: expected <true> but was <false>
```

The format guard is a content-equality check identical in shape to the already-tested `tryLspReindentLine` guard; a dedicated test would need a live LSP round-trip, so I leaned on the shared pattern rather than a fragile mock.

## Deferred → filed separately

The completion **auto-import** `additionalTextEdits` (the third finding) have the same missing guard, but the correct fix threads the completion-*request* document snapshot through the accept flow — the accept itself mutates the document, so a plain "content unchanged" check can't work. That's a real refactor with regression risk on a feature that's hard to test headlessly, so I'm filing it rather than bundling a rushed partial fix here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)