### PR TITLE
Fix breakpoint/bookmark lost when joining a line upward

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Joining two lines no longer silently loses a breakpoint or bookmark on the lower line.** Pressing
+  Backspace at the start of a line (or Delete at the end of the line above) merges the two lines — the code
+  survives, but a breakpoint or bookmark on the merged-up line was being dropped, so you'd set a breakpoint,
+  tidy up the line above, and then debug without it. The marker now follows its code to the joined line.
+
 - **French and Italian error/status messages no longer show a literal `{0}` instead of the filename or
   error.** In those languages an apostrophe (`l'`, `d'`, `dell'`) sits right before the value placeholder, and
   an unescaped apostrophe is a MessageFormat escape that swallowed it — so "save failed: /path" came out as

--- a/src/main/java/com/editora/editor/BookmarkManager.java
+++ b/src/main/java/com/editora/editor/BookmarkManager.java
@@ -283,12 +283,21 @@ public final class BookmarkManager {
         int delta = insertedNL - removedNL;
         int pivot = atLineStart ? startLine - 1 : startLine;
         int removedEndLine = pivot + removedNL;
+        // A mid-line deletion (not at column 0) joins its last touched line onto the edit — that line's
+        // trailing content survives (a line-join: Backspace at column 0, or Delete at a line's end). A
+        // bookmark on that join line must follow its content to pivot+insertedNL rather than be dropped.
+        // (An at-line-start deletion genuinely removes that line's content; its successor is the survivor and
+        // is handled by the shift branch, so this only applies when !atLineStart.) Mirrors BreakpointManager.
+        boolean joinSurvives = !atLineStart && removedNL > 0;
         int maxLine = Math.max(0, paragraphCount - 1);
         NavigableMap<Integer, Bookmark> out = new TreeMap<>();
         for (Bookmark bm : current.values()) {
             int line = bm.line();
             if (line <= pivot) {
                 out.put(line, bm);
+            } else if (line == removedEndLine && joinSurvives) {
+                int moved = Math.min(Math.max(pivot + insertedNL, 0), maxLine);
+                out.put(moved, bm.withLine(moved));
             } else if (line <= removedEndLine) {
                 continue; // inside the deleted span: drop the bookmark
             } else {

--- a/src/main/java/com/editora/editor/BreakpointManager.java
+++ b/src/main/java/com/editora/editor/BreakpointManager.java
@@ -265,12 +265,22 @@ public final class BreakpointManager {
         int delta = insertedNL - removedNL;
         int pivot = atLineStart ? startLine - 1 : startLine;
         int removedEndLine = pivot + removedNL;
+        // When the deletion starts MID-line (not at column 0), the last line it touches isn't fully deleted —
+        // its trailing content merges onto the edit, i.e. a line-join (Backspace at column 0, or Delete at a
+        // line's end). A breakpoint on that join line must follow its surviving content to pivot+insertedNL,
+        // not vanish — otherwise you'd set a breakpoint, join the line above, and silently debug without it.
+        // (For an at-line-start deletion the last removed line's content really is gone; its successor is the
+        // survivor and the shift branch below already handles that, so this only applies when !atLineStart.)
+        boolean joinSurvives = !atLineStart && removedNL > 0;
         int maxLine = Math.max(0, paragraphCount - 1);
         NavigableMap<Integer, Breakpoint> out = new TreeMap<>();
         for (Breakpoint bp : current.values()) {
             int line = bp.line();
             if (line <= pivot) {
                 out.put(line, bp);
+            } else if (line == removedEndLine && joinSurvives) {
+                int moved = Math.min(Math.max(pivot + insertedNL, 0), maxLine);
+                out.put(moved, bp.withLine(moved));
             } else if (line <= removedEndLine) {
                 continue; // inside the deleted span
             } else {

--- a/src/test/java/com/editora/editor/BookmarkManagerTest.java
+++ b/src/test/java/com/editora/editor/BookmarkManagerTest.java
@@ -177,4 +177,13 @@ class BookmarkManagerTest {
         var out = BookmarkManager.reanchor(saved(new Bookmark(1, "", "beta")), 3, lines, 2000);
         assertTrue(out.containsKey(1));
     }
+
+    @Test
+    void joiningALineUpwardKeepsTheBookmarkOnTheJoinLine() {
+        // A bookmark on line 5; Backspace at column 0 of line 5 (mid-line delete of the newline: startLine=4,
+        // atLineStart=false, removedNL=1) joins it onto line 4. Its content survives, so it must follow to 4.
+        NavigableMap<Integer, Bookmark> out = BookmarkManager.shift(map(5), 4, false, 1, 0, 100);
+        assertTrue(out.containsKey(4), "the bookmark follows its joined content to line 4 (not dropped)");
+        assertFalse(out.containsKey(5), "line 5 no longer exists");
+    }
 }

--- a/src/test/java/com/editora/editor/BreakpointManagerTest.java
+++ b/src/test/java/com/editora/editor/BreakpointManagerTest.java
@@ -77,4 +77,23 @@ class BreakpointManagerTest {
         assertEquals(2, merged.get(1).line());
         assertEquals(9, merged.get(2).line()); // new one appended
     }
+
+    @Test
+    void joiningALineUpwardKeepsTheBreakpointOnTheJoinLine() {
+        // foo() on line 18, bar() on line 19 with a breakpoint. Backspace at column 0 of line 19 removes only
+        // the newline (mid-line delete: startLine=18, atLineStart=false, removedNL=1), joining bar() onto
+        // line 18. bar()'s code survives, so its breakpoint must follow to line 18 — not silently vanish.
+        NavigableMap<Integer, Breakpoint> out = BreakpointManager.shift(map(19), 18, false, 1, 0, 30);
+        assertTrue(out.containsKey(18), "the breakpoint on the join line follows its code to line 18");
+        assertFalse(out.containsKey(19), "line 19 no longer exists — the breakpoint wasn't just dropped");
+    }
+
+    @Test
+    void aMidLineDeleteSpanningLinesKeepsTheTrailingSurvivorButDropsTheMiddle() {
+        // Delete from mid-line 18 through the start of line 20 (removedNL=2, atLineStart=false): line 19 is
+        // consumed, line 20's content merges onto 18. A bp on 19 is dropped; a bp on 20 follows to 18.
+        NavigableMap<Integer, Breakpoint> out = BreakpointManager.shift(map(19, 20), 18, false, 2, 0, 30);
+        assertFalse(out.containsKey(19), "the fully-deleted middle line's breakpoint is dropped");
+        assertTrue(out.containsKey(18), "the trailing survivor line's breakpoint follows to the join line");
+    }
 }


### PR DESCRIPTION
From the line-tracking side-table audit. `BreakpointManager.shift` / `BookmarkManager.shift` track a marker's line through document edits. A **mid-line deletion that removes newlines — a line-join** (Backspace at column 0, or Delete at the end of the line above) — merges the last touched line's trailing content onto the edit line. The code survives, but the marker on that join line was being **dropped**.

## Repro

`foo()` on line 18, `bar()` on line 19 with a **breakpoint**. Backspace at column 0 of line 19 removes only the `\n`:

```
startLine=18, atLineStart=false, removedNL=1  ⇒  pivot=18, removedEndLine=19
bp on line 19:  line (19) <= removedEndLine (19)  →  DROPPED
```

…even though `bar()`'s text now lives on line 18. You set a breakpoint, tidy the line above, and then **debug without it** — the worst kind of silent failure because you don't notice until you're staring at a run that didn't stop.

The tell that it's a bug, not intended "drop inside a deleted span": if line 18 were *blank*, the position lands at column 0 (`atLineStart=true`), and the same breakpoint instead **survives** and moves to 18. Whether a marker lives shouldn't depend on the line above happening to be empty.

## Fix

When the deletion is mid-line (`!atLineStart`) and removes newlines, the marker on the join line (`== removedEndLine`) follows its surviving content to `pivot + insertedNL`, instead of being dropped. For an *at-line-start* deletion the last removed line's content really is gone, and its successor (the actual survivor) is already handled correctly by the shift branch — so this only applies when `!atLineStart`, and **every existing case is unchanged**: insert, insert-at-line-start (forward gravity), whole-line delete, net-delta replace, intra-line edit. Two lines joining into one naturally dedupe to a single marker (you can't have two breakpoints on one physical line).

I derived the rule against all seven existing `shift` tests before writing a line — the identical one-line change lands in both managers (`NoteManager` is offset-based and was never affected).

## Verification

**1978 tests, 0 failures.** Three join tests added (2 breakpoint, 1 bookmark), each proven to fail on the old code:

```
joiningALineUpwardKeepsTheBreakpointOnTheJoinLine   expected: <true> but was: <false>
aMidLineDeleteSpanningLinesKeepsTheTrailingSurvivor expected: <true> but was: <false>
joiningALineUpwardKeepsTheBookmarkOnTheJoinLine     expected: <true> but was: <false>
```

Both the breakpoint and bookmark join tests initially passed for the *wrong reason* (I'd seeded a marker on the pivot line too, so `containsKey(pivot)` was satisfied by the wrong marker) — caught by re-running against the reverted logic and isolating the marker to the join line alone.

## Related findings (filed, not in this PR)

The same audit flagged that **LSP diagnostic squiggles / stripe / minimap marks paint on shifted lines** between an edit and the next server push — the same staleness pattern the semantic-token fix (#409) addressed, but for diagnostics. Milder (visual, self-corrects) and a different subsystem; filing separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)