### PR TITLE
Release 0.9.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.5] - 2026-07-15
+
 ### Fixed
 
 - **Joining two lines no longer silently loses a breakpoint or bookmark on the lower line.** Pressing

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.editora</groupId>
     <artifactId>editora</artifactId>
-    <version>0.9.4</version>
+    <version>0.9.5</version>
     <packaging>jar</packaging>
 
     <name>Editora</name>


### PR DESCRIPTION
Cuts **0.9.5** — bumps `pom.xml` (the single version source; `AppInfo.VERSION` derives from it) and rolls `[Unreleased]` into `[0.9.5] - 2026-07-15`.

This release is a large **correctness + data-safety** sweep from three audit passes (11 fix PRs). Highlights:

**Data loss / corruption**
- Ctrl+S on a huge (partially-loaded) file no longer truncates it (#403)
- Quitting no longer discards other windows' unsaved work + session (#403)
- Crash-safe atomic config writes; a torn file is kept, not silently emptied (#404)
- Save path: autosave/manual-save race, silent charset `?` corruption, mostly-LF→CRLF ratchet, non-atomic doc writes (#405)
- Format Document no longer corrupts the file if you edit mid-format (#409)
- Breakpoint/bookmark no longer lost when joining a line (#416)

**Freezes / leaks / security**
- Pathological Find regex no longer freezes the UI (#408)
- Preview-image SSRF guard — an untrusted `.md` can't probe your network or leak creds (#411)
- Image/hex/PDF tabs, per-window services, and run/build subprocesses no longer leak (#406)

**Locale / polish**
- 60 French/Italian messages that showed a literal `{0}` instead of the filename/error (#414)
- `--zen`/`--expert` are now genuinely session-only (#402)
- Six bugs in the new Project tree + build-tool tree (#401)

After merge I'll tag `v0.9.5` on master to trigger the release pipeline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)