### PR TITLE
Editor audit: Backspace over-delete on empty pairs + Markdown list-number overflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Backspace on an empty auto-inserted bracket pair no longer eats the line's indentation.** With the caret
+  between a just-typed `()`/`[]`/`{}` sitting in a line's leading whitespace, a single Backspace removed the
+  pair *and* the indentation (and the newline above), jumping up to the previous line — because two Backspace
+  handlers on the editor both ran even though the first had already handled the key (a JavaFX quirk: `consume()`
+  stops the event reaching other nodes, not other handlers on the same node). Now the second handler yields, so
+  Backspace removes only the pair. (First finding from a per-feature audit pass over the editor's core editing
+  mechanics.)
+
+- **Pressing Enter on a Markdown ordered-list item with an absurdly long number no longer throws.** A list
+  marker whose number overflowed a 64-bit integer (20+ digits) raised an uncaught error on Enter; it now falls
+  back to a plain newline.
+
 ### Added
 
 - **Editora now tells you when a new version is available.** On startup (at most once a day) it checks GitHub

--- a/src/main/java/com/editora/editor/EditorBuffer.java
+++ b/src/main/java/com/editora/editor/EditorBuffer.java
@@ -6447,8 +6447,14 @@ public class EditorBuffer implements TabContent {
         // whole indent — and on an otherwise-blank (auto-indented) line it also removes the newline, so
         // a single press jumps back to the end of the previous line ("back to where you hit Enter").
         // Only consumes when it removes more than one char, so a normal single-char Backspace still runs
-        // everywhere else (and the auto-close empty-pair handler, registered earlier, gets first dibs).
+        // everywhere else. The auto-close empty-pair handler is registered earlier and gets first dibs: it
+        // consumes when it deletes a pair, but JavaFX runs *every* filter on a node regardless of consume()
+        // (consume only stops propagation to other nodes), so we must re-check isConsumed() here ourselves —
+        // otherwise Backspace on an empty pair inside leading whitespace deletes the pair AND the indent.
         a.addEventFilter(KeyEvent.KEY_PRESSED, e -> {
+            if (e.isConsumed()) { // the empty-pair handler already consumed this Backspace
+                return;
+            }
             if (multiCaretActiveOn(a)) { // suspend single-caret assists while multiple carets exist
                 return;
             }
@@ -6488,6 +6494,9 @@ public class EditorBuffer implements TabContent {
             }
         });
         a.addEventFilter(KeyEvent.KEY_TYPED, e -> {
+            if (e.isConsumed()) { // the auto-close KEY_TYPED handler (registered earlier) already acted
+                return;
+            }
             if (multiCaretActiveOn(a)) { // suspend single-caret assists while multiple carets exist
                 return;
             }

--- a/src/main/java/com/editora/markdown/MarkdownLines.java
+++ b/src/main/java/com/editora/markdown/MarkdownLines.java
@@ -175,7 +175,15 @@ public final class MarkdownLines {
         }
         Matcher o = ORDERED.matcher(line);
         if (o.matches()) {
-            long n = Long.parseLong(o.group(2));
+            // The regex accepts an unbounded digit run; a number that overflows a long can't be
+            // auto-incremented, so don't continue the list (Enter falls back to a plain newline) rather
+            // than throwing NumberFormatException out of the Enter key filter.
+            long n;
+            try {
+                n = Long.parseLong(o.group(2));
+            } catch (NumberFormatException overflow) {
+                return null;
+            }
             return o.group(1) + (n + 1) + o.group(3) + o.group(4);
         }
         Matcher q = QUOTE.matcher(line);

--- a/src/test/java/com/editora/markdown/MarkdownLinesTest.java
+++ b/src/test/java/com/editora/markdown/MarkdownLinesTest.java
@@ -24,6 +24,12 @@ class MarkdownLinesTest {
     }
 
     @Test
+    void anOrderedNumberTooLargeToIncrementDoesNotThrow() {
+        // 20 nines overflows a long; must not throw NumberFormatException out of the Enter key filter.
+        assertNull(MarkdownLines.continuation("99999999999999999999. item"), "overflowing number → no continuation");
+    }
+
+    @Test
     void continuesTasksResetToUnchecked() {
         assertEquals("- [ ] ", MarkdownLines.continuation("- [ ] todo"));
         assertEquals("- [ ] ", MarkdownLines.continuation("- [x] done"));

--- a/src/test/java/com/editora/ui/SmartBackspacePairFxTest.java
+++ b/src/test/java/com/editora/ui/SmartBackspacePairFxTest.java
@@ -1,0 +1,61 @@
+package com.editora.ui;
+
+import javafx.scene.input.KeyCode;
+import javafx.scene.input.KeyEvent;
+
+import com.editora.editor.EditorBuffer;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Regression for the stacked-{@code BACK_SPACE}-filter over-delete: the auto-close empty-pair handler and the
+ * smart-backspace handler are both {@code KEY_PRESSED} filters on the same {@code area}, and JavaFX runs every
+ * filter on a node regardless of {@code consume()} — so after the empty-pair handler deletes {@code ()} and
+ * consumes, the smart-backspace handler used to run anyway on the now-blank indent and delete the indentation
+ * (and the preceding newline). One Backspace deleted three things. Fires a real {@code BACK_SPACE} event
+ * through the buffer's filters so both handlers participate.
+ */
+@Tag("fx")
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class SmartBackspacePairFxTest {
+
+    @BeforeAll
+    void setUp() throws Exception {
+        FxTestSupport.bootToolkit();
+    }
+
+    private static void backspace(EditorBuffer b) {
+        b.getArea()
+                .fireEvent(new KeyEvent(KeyEvent.KEY_PRESSED, "", "", KeyCode.BACK_SPACE, false, false, false, false));
+    }
+
+    @Test
+    void backspaceOnAnEmptyPairInLeadingWhitespaceRemovesOnlyThePair() throws Exception {
+        String result = FxTestSupport.callOnFx(() -> {
+            EditorBuffer b = new EditorBuffer();
+            b.setContent("x\n    ()"); // an indented blank line where "(" was just typed → "()"
+            b.getArea().moveTo(7); // caret between "(" (index 6) and ")" (index 7)
+            backspace(b);
+            return b.getArea().getText();
+        });
+        // The pair is gone; the line's indentation and the newline survive.
+        assertEquals("x\n    ", result, "one Backspace must remove only the empty pair, not the indent + newline");
+    }
+
+    @Test
+    void smartBackspaceStillCollapsesABlankIndentedLine() throws Exception {
+        // Guard the fix didn't disable the normal smart-backspace (empty-pair handler doesn't fire here).
+        String result = FxTestSupport.callOnFx(() -> {
+            EditorBuffer b = new EditorBuffer();
+            b.setContent("x\n    "); // a blank auto-indented line, caret at end
+            b.getArea().moveTo(6);
+            backspace(b);
+            return b.getArea().getText();
+        });
+        assertEquals("x", result, "Backspace on a blank indented line still jumps back to the previous line's end");
+    }
+}


### PR DESCRIPTION
First pass of a **per-feature audit indexed by Settings page** — this one covers the **Editor** page's core editing mechanics (indent / EditorConfig / EOL / charset / auto-close / smart backspace-Enter). Each finding was verified against the code before fixing (the #401–#411 method).

## 1. Backspace on an empty auto-close pair ate the line's indentation

With the caret between a just-typed `()` / `[]` / `{}` that sits in a line's **leading whitespace**, one Backspace removed the pair **and** the indentation **and** the newline above — jumping the caret up to the previous line.

**Root cause:** the auto-close *empty-pair* Backspace handler and the *smart-backspace* handler are both `KEY_PRESSED` filters on the **same** `area` node. In JavaFX, `Event.consume()` stops the event reaching **other nodes** in the dispatch chain — it does **not** stop sibling filters on the same node (`CompositeEventHandler` iterates them all). So after the empty-pair handler deleted `()` and consumed, the smart-backspace handler still ran on the now-blank indent and deleted it (plus the newline). The "gets first dibs" comment assumed a guarantee that doesn't exist.

**Repro** (`SmartBackspacePairFxTest`, fails on old code): `"x\n    ()"` with the caret between the parens, one Backspace → **`"x"`** instead of the expected **`"x\n    "`**.

**Fix:** the smart-backspace filter (and the analogous KEY_TYPED closer-dedent filter) now `return` when `e.isConsumed()`, so a consuming earlier handler truly gets exclusive handling. The common `foo(`→`foo()`→Backspace case was already safe (non-blank text before the caret), which is why it survived manual testing.

## 2. Enter on a Markdown ordered-list item with a 20+ digit number threw

`MarkdownLines.continuation` did `Long.parseLong` on the list marker's unbounded `\d+`, so a number that overflowed a `long` raised an uncaught `NumberFormatException` out of the Enter key filter. Now it falls back to no continuation (a plain newline). Contrived, but a real uncaught throw on a normal keystroke.

## Verified-not-a-bug
`EditorConfigTransform` with `insert_final_newline = false` strips **all** trailing newlines — checked and left as-is: that's the spec-correct meaning ("the file does not end with a newline"); removing only one would still leave it ending in `\n`.

## Tests
- New `SmartBackspacePairFxTest` (fires a real `BACK_SPACE` through the buffer's filters; fails on the old code) + a `MarkdownLinesTest` case for the overflow.
- Full suite **2003 tests, 0 failures**; `spotless:check` clean.

Next audit targets (highest-risk first): Git, LSP, Remote, Plugins, Web, plus the Editor page's preview sub-features under their own pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)