### PR TITLE
Git audit: non-ASCII filenames, rename diffs, detached-HEAD push, Windows pathspecs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Files with accented or non-ASCII names now work with Git.** A file like `café.txt` was left with Git's
+  raw quoted-and-escaped name (`"caf\303\251.txt"`) throughout the integration, so it got no color in the
+  Project tree and staging / unstaging / discarding / diffing it failed with "pathspec did not match". Editora
+  now decodes Git's quoting, so non-ASCII filenames behave like any other. (From a per-feature audit of the Git
+  integration.)
+
+- **Diffing a renamed file from the Git Log no longer shows the whole file as newly added.** For a commit that
+  renamed a file, the "before" side was fetched under the new name (which didn't exist yet at the parent), so
+  the diff looked like a 100%-added file; it now uses the original name and shows the real change.
+
+- **Pushing while on a detached HEAD no longer builds an invalid command.** It used to try
+  `push --set-upstream origin (detached)`, which Git rejects with a confusing refname error; it now falls back
+  to a plain `push` (Git then gives its own clear "detached HEAD" message).
+
+- **Staging/unstaging/discarding the current file works for files in subfolders on Windows.** Those three
+  actions built the path with backslashes, which Git treats as escapes; they now use forward slashes like the
+  Project-tree actions already did.
+
 - **Backspace on an empty auto-inserted bracket pair no longer eats the line's indentation.** With the caret
   between a just-typed `()`/`[]`/`{}` sitting in a line's leading whitespace, a single Backspace removed the
   pair *and* the indentation (and the newline above), jumping up to the previous line — because two Backspace

--- a/src/main/java/com/editora/git/GitService.java
+++ b/src/main/java/com/editora/git/GitService.java
@@ -358,7 +358,10 @@ public final class GitService {
      */
     public static String[] pushArgs(String branch, String upstream) {
         boolean noUpstream = upstream == null || upstream.isBlank();
-        boolean haveBranch = branch != null && !branch.isBlank();
+        // A detached HEAD is reported as "(detached)" (non-blank), and no real branch name can start with
+        // "(" — so guard against it, else we'd emit `push --set-upstream origin (detached)`, which git
+        // rejects as a bad refname. A plain `push` lets git give its own clearer "detached HEAD" message.
+        boolean haveBranch = branch != null && !branch.isBlank() && !branch.startsWith("(");
         if (noUpstream && haveBranch) {
             return new String[] {"push", "--set-upstream", "origin", branch};
         }

--- a/src/main/java/com/editora/git/StatusParser.java
+++ b/src/main/java/com/editora/git/StatusParser.java
@@ -1,5 +1,7 @@
 package com.editora.git;
 
+import java.io.ByteArrayOutputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -53,7 +55,7 @@ public final class StatusParser {
                     // 1 <XY> <sub> <mH> <mI> <mW> <hH> <hI> <path>
                     String[] f = line.split(" ", 9);
                     if (f.length == 9 && f[1].length() == 2) {
-                        files.add(new FileEntry(f[8], f[1].charAt(0), f[1].charAt(1), null));
+                        files.add(new FileEntry(unquotePath(f[8]), f[1].charAt(0), f[1].charAt(1), null));
                     }
                 }
                 case '2' -> {
@@ -61,15 +63,17 @@ public final class StatusParser {
                     String[] f = line.split(" ", 10);
                     if (f.length == 10 && f[1].length() == 2) {
                         String rest = f[9];
+                        // The path/orig separator is a literal tab; a tab *inside* a name is C-quoted as
+                        // "\t" (two chars), so this split never lands inside a quoted name.
                         int tab = rest.indexOf('\t');
                         String path = tab >= 0 ? rest.substring(0, tab) : rest;
                         String orig = tab >= 0 ? rest.substring(tab + 1) : null;
-                        files.add(new FileEntry(path, f[1].charAt(0), f[1].charAt(1), orig));
+                        files.add(new FileEntry(unquotePath(path), f[1].charAt(0), f[1].charAt(1), unquotePath(orig)));
                     }
                 }
                 case '?' -> {
                     if (line.length() > 2) {
-                        files.add(new FileEntry(line.substring(2), '?', '?', null));
+                        files.add(new FileEntry(unquotePath(line.substring(2)), '?', '?', null));
                     }
                 }
                 default -> {
@@ -78,6 +82,49 @@ public final class StatusParser {
             }
         }
         return new GitStatus(true, branch, upstream, ahead, behind, files);
+    }
+
+    /**
+     * Decodes git's C-style quoted path back to the real name. With {@code core.quotePath=true} (the default),
+     * {@code git status --porcelain} (no {@code -z}) wraps a path containing non-ASCII/control/quote/backslash
+     * bytes in double-quotes and escapes those bytes — {@code café.txt} → {@code "caf\303\251.txt"}. An
+     * unquoted field (no surrounding quotes) is returned unchanged. The octal escapes are the raw UTF-8 bytes,
+     * so they are collected and decoded as UTF-8. Returns {@code null} unchanged (rename orig may be absent).
+     */
+    static String unquotePath(String field) {
+        if (field == null || field.length() < 2 || field.charAt(0) != '"' || field.charAt(field.length() - 1) != '"') {
+            return field; // not quoted
+        }
+        String s = field.substring(1, field.length() - 1);
+        ByteArrayOutputStream bytes = new ByteArrayOutputStream(s.length());
+        for (int i = 0; i < s.length(); i++) {
+            char c = s.charAt(i);
+            if (c != '\\' || i + 1 >= s.length()) {
+                bytes.write(c); // a literal (printable ASCII) byte
+                continue;
+            }
+            char e = s.charAt(++i);
+            if (e >= '0' && e <= '7') { // \NNN octal byte (1-3 digits)
+                int val = e - '0';
+                for (int k = 0; k < 2 && i + 1 < s.length() && s.charAt(i + 1) >= '0' && s.charAt(i + 1) <= '7'; k++) {
+                    val = (val << 3) | (s.charAt(++i) - '0');
+                }
+                bytes.write(val & 0xFF);
+            } else {
+                bytes.write(
+                        switch (e) {
+                            case 'a' -> 7;
+                            case 'b' -> 8;
+                            case 't' -> 9;
+                            case 'n' -> 10;
+                            case 'v' -> 11;
+                            case 'f' -> 12;
+                            case 'r' -> 13;
+                            default -> e; // \" \\ and any other escaped char → the char itself
+                        });
+            }
+        }
+        return bytes.toString(StandardCharsets.UTF_8);
     }
 
     private static int parseInt(String s) {

--- a/src/main/java/com/editora/ui/DiffCoordinator.java
+++ b/src/main/java/com/editora/ui/DiffCoordinator.java
@@ -479,18 +479,29 @@ final class DiffCoordinator {
 
     /** Diff a commit's version of a file against its parent (commit~1 ↔ commit), read-only. */
     void diffCommitFile(String hash, String repoRel) {
+        diffCommitFile(hash, repoRel, null);
+    }
+
+    /**
+     * Diff a commit's version of a file against its parent. For a rename ({@code origRepoRel} non-null), the
+     * parent side is fetched at the file's <em>original</em> path — otherwise {@code <hash>~1:<newPath>} misses
+     * (the file didn't exist under the new name at the parent) and the whole file shows as added instead of the
+     * rename.
+     */
+    void diffCommitFile(String hash, String repoRel, String origRepoRel) {
         Path root = git.repoRoot(); // capture at open time; see diffPathVsHead
         if (root == null) {
             return;
         }
         String name = repoRel.substring(repoRel.lastIndexOf('/') + 1);
+        String parentRel = origRepoRel != null && !origRepoRel.isBlank() ? origRepoRel : repoRel;
         openDiff(
                 tr("diff.title.commitFile", name, GitFormat.shortHash(hash)),
                 tr("diff.side.parent"),
                 tr("diff.title.vsCommitShort", GitFormat.shortHash(hash)),
                 name,
                 name,
-                cb -> git.service().show(root, hash + "~1:" + repoRel, cb),
+                cb -> git.service().show(root, hash + "~1:" + parentRel, cb),
                 cb -> git.service().show(root, hash + ":" + repoRel, cb),
                 DiffViewerPane.EditableSide.NONE,
                 null);

--- a/src/main/java/com/editora/ui/GitCoordinator.java
+++ b/src/main/java/com/editora/ui/GitCoordinator.java
@@ -644,11 +644,8 @@ final class GitCoordinator {
             host.setStatus(tr("status.noGitFile"));
             return;
         }
-        gitOp(
-                "Staged " + file.getFileName(),
-                "add",
-                "--",
-                repoRoot.relativize(file.toAbsolutePath()).toString());
+        // rel() forward-slash-normalizes the pathspec (git treats "\" as an escape on Windows).
+        gitOp("Staged " + file.getFileName(), "add", "--", rel(file));
     }
 
     /** Unstages the active file (palette {@code git.unstageFile}; mirrors {@link #gitStageActiveFile}). */
@@ -659,13 +656,7 @@ final class GitCoordinator {
             host.setStatus(tr("status.noGitFile"));
             return;
         }
-        gitOp(
-                "Unstaged " + file.getFileName(),
-                "reset",
-                "-q",
-                "HEAD",
-                "--",
-                repoRoot.relativize(file.toAbsolutePath()).toString());
+        gitOp("Unstaged " + file.getFileName(), "reset", "-q", "HEAD", "--", rel(file));
     }
 
     /** Discards the active file's changes (palette {@code git.discardFile}; confirms first). */
@@ -676,7 +667,7 @@ final class GitCoordinator {
             host.setStatus(tr("status.noGitFile"));
             return;
         }
-        discardChanges(repoRoot.relativize(file.toAbsolutePath()).toString(), false);
+        discardChanges(rel(file), false);
     }
 
     // --- Project-tree file/folder actions (act on a given path, not the active buffer) ------------

--- a/src/main/java/com/editora/ui/GitLogPanel.java
+++ b/src/main/java/com/editora/ui/GitLogPanel.java
@@ -40,7 +40,8 @@ public final class GitLogPanel extends VBox implements ToolWindowContent {
 
         void selected(String hash);
 
-        void openFileDiff(String hash, String repoRelativePath);
+        /** Diff a commit's file against its parent; {@code origRepoRelativePath} is the pre-rename path (or null). */
+        void openFileDiff(String hash, String repoRelativePath, String origRepoRelativePath);
 
         void copyHash(String hash);
 
@@ -147,7 +148,7 @@ public final class GitLogPanel extends VBox implements ToolWindowContent {
         Commit c = commits.getSelectionModel().getSelectedItem();
         CommitFile f = files.getSelectionModel().getSelectedItem();
         if (c != null && f != null) {
-            actions.openFileDiff(c.hash(), f.path());
+            actions.openFileDiff(c.hash(), f.path(), f.origPath());
         }
     }
 

--- a/src/main/java/com/editora/ui/MainController.java
+++ b/src/main/java/com/editora/ui/MainController.java
@@ -4063,8 +4063,8 @@ public class MainController implements com.editora.mcp.McpBridge {
             }
 
             @Override
-            public void openFileDiff(String hash, String repoRel) {
-                diffCoordinator.diffCommitFile(hash, repoRel);
+            public void openFileDiff(String hash, String repoRel, String origRepoRel) {
+                diffCoordinator.diffCommitFile(hash, repoRel, origRepoRel);
             }
 
             @Override

--- a/src/test/java/com/editora/git/GitPushArgsTest.java
+++ b/src/test/java/com/editora/git/GitPushArgsTest.java
@@ -34,4 +34,12 @@ class GitPushArgsTest {
         // upstream present but branch blank still falls back to a plain push
         assertArrayEquals(new String[] {"push"}, GitService.pushArgs("", "origin/main"));
     }
+
+    @Test
+    void detachedHeadDoesNotSetUpstreamToTheLiteralMarker() {
+        // git status --branch reports a detached HEAD as the non-blank "(detached)"; it must not become
+        // `push --set-upstream origin (detached)` (git rejects that refname). A plain push instead.
+        assertArrayEquals(new String[] {"push"}, GitService.pushArgs("(detached)", ""));
+        assertArrayEquals(new String[] {"push"}, GitService.pushArgs("(no branch)", ""));
+    }
 }

--- a/src/test/java/com/editora/git/StatusParserTest.java
+++ b/src/test/java/com/editora/git/StatusParserTest.java
@@ -95,4 +95,30 @@ class StatusParserTest {
         GitStatus s = StatusParser.parse(out);
         assertEquals("my file with spaces.txt", s.files().get(0).path());
     }
+
+    @Test
+    void cQuotedNonAsciiPathIsDecoded() {
+        // With core.quotePath=true (git's default), "café.txt" is emitted as "caf\303\251.txt".
+        String out = "# branch.head main\n" + "1 .M N... 100644 100644 100644 ccc ddd \"caf\\303\\251.txt\"\n";
+        GitStatus s = StatusParser.parse(out);
+        assertEquals("café.txt", s.files().get(0).path(), "the quoted octal-escaped UTF-8 path is decoded");
+    }
+
+    @Test
+    void cQuotedRenameDecodesBothPaths() {
+        String out = "# branch.head main\n"
+                + "2 R. N... 100644 100644 100644 aaa bbb R100 \"nu\\303\\251vo.txt\"\t\"vi\\303\\251jo.txt\"\n";
+        GitStatus s = StatusParser.parse(out);
+        FileEntry e = s.files().get(0);
+        assertEquals("nuévo.txt", e.path());
+        assertEquals("viéjo.txt", e.origPath());
+    }
+
+    @Test
+    void cQuotedEscapesForTabAndQuoteAreDecoded() {
+        // A name with a literal tab and a quote: git quotes it as "a\tb\"c.txt".
+        String out = "# branch.head main\n" + "? \"a\\tb\\\"c.txt\"\n";
+        GitStatus s = StatusParser.parse(out);
+        assertEquals("a\tb\"c.txt", s.files().get(0).path());
+    }
 }


### PR DESCRIPTION
Per-feature audit indexed by Settings page — this one is the **Git** integration. Four confirmed bugs fixed; each traced to a concrete failing input before fixing. Two lower-risk findings deferred (below).

## 1. Files with non-ASCII names broke Git
With `core.quotePath=true` (Git's default), `git status --porcelain` (no `-z`) **C-quotes** a path containing non-ASCII/control/quote bytes: `café.txt` → `"caf\303\251.txt"`. `StatusParser` stored that literal string, so:
- `GitFileStatus.byPath` did `root.resolve("\"caf\\303\\251.txt\"")` → never matched the real file → **no Project-tree color**.
- Stage / unstage / discard / diff passed the quoted-escaped string as a pathspec → **"pathspec did not match any files"** (and a blank side in the diff viewer).

`StatusParser` now decodes Git's C-quoting (octal escapes are the raw UTF-8 bytes → collected and decoded) for the `1`/`2`/`?` entry paths and the rename `origPath`.

## 2. Renamed-file commit diffs showed the whole file as added
`diffCommitFile` fetched the parent side as `git show <hash>~1:<newPath>` — but at the parent the file had its **old** name, so the blob was empty and the diff rendered as a 100%-added file. Threaded `CommitFile.origPath` through `openFileDiff` → `diffCommitFile` so the parent side uses the pre-rename path.

## 3. Push on a detached HEAD built an invalid command
`git status --branch` reports a detached HEAD as the non-blank literal `(detached)`, and `pushArgs` only guarded `isBlank()` — so it emitted `push --set-upstream origin (detached)`, which Git rejects as a bad refname. Now a branch starting with `(` is treated as no branch → plain `push` (Git gives its own clear message).

## 4. Windows pathspecs for the active-file actions
`gitStage/Unstage/DiscardActiveFile` built the pathspec without the `\`→`/` normalization the sibling `rel()` helper already applies, so a file in a subfolder used backslash pathspecs on Windows (Git treats `\` as an escape). Routed all three through `rel()`.

## Deferred (noted, not fixed here)
- A **symlinked repo root** makes `repoRelative` return null (`rev-parse --show-toplevel` resolves symlinks, the file path doesn't) → ops report "not in repo". Fix needs `toRealPath()` on both sides — riskier, its own change.
- `git show` blobs are **force-decoded UTF-8** in the diff viewer → mojibake for Latin-1/UTF-16 tracked files.

## Verified-clean (sampled)
DiffParser (all the `@@` edge cases + `\ No newline`), BlameParser (uncommitted/boundary), StashParser, parseLog/parseTrack, the `NO_ROOT` identity sentinel, the generation guard, `reloadAllFromDiskSilently` skipping dirty buffers, and GitLogPanel/BranchPopup acting on the selected object (not a stale index).

## Tests
`StatusParserTest` (C-quoted non-ASCII, quoted rename both sides, tab+quote escapes) + `GitPushArgsTest` (detached HEAD). Full suite **2007 tests, 0 failures**; `spotless:check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)