### PR TITLE
Search audit: Replace-All vs preview mismatch, unicode-case regex, whole-word boundaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Replace All in Find-in-Files now changes exactly what the search preview showed.** The results list matches
+  line by line, but Replace All applied a regex over the *whole file* — so `;$` previewed a hit on every line
+  but only replaced the last one, and a cross-line pattern like `foo\nbar` previewed nothing yet rewrote across
+  the newline. Replace is now line-oriented like the preview (line endings preserved). (From a per-feature
+  audit of Search.)
+
+- **Case-insensitive regex search now matches accented and other non-ASCII letters.** A regex search for
+  `café` (case-insensitive) missed `CAFÉ` — the regex engine was folding only ASCII, unlike the plain-text
+  search and ripgrep. All three now agree.
+
+- **Whole-word search for a term that starts or ends with punctuation now behaves like a word-boundary
+  match.** e.g. `+foo` now matches inside `a+foo`, matching the regex/ripgrep whole-word rule; ordinary words
+  are unaffected.
+
 - **Files with accented or non-ASCII names now work with Git.** A file like `café.txt` was left with Git's
   raw quoted-and-escaped name (`"caf\303\251.txt"`) throughout the integration, so it got no color in the
   Project tree and staging / unstaging / discarding / diffing it failed with "pathspec did not match". Editora

--- a/src/main/java/com/editora/editor/SearchMatcher.java
+++ b/src/main/java/com/editora/editor/SearchMatcher.java
@@ -100,7 +100,11 @@ public final class SearchMatcher {
     public static Pattern compileRegex(String query, boolean caseSensitive, boolean wholeWord) {
         String pattern = wholeWord ? "\\b(?:" + (query == null ? "" : query) + ")\\b" : (query == null ? "" : query);
         try {
-            return Pattern.compile(pattern, caseSensitive ? 0 : Pattern.CASE_INSENSITIVE);
+            // UNICODE_CASE so case-insensitive folds non-ASCII too (é↔É) — matching the literal path's
+            // String.regionMatches folding and ripgrep's -i; without it the regex path silently misses
+            // accented/Cyrillic/Greek case variants that the other two backends find.
+            int flags = caseSensitive ? 0 : (Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CASE);
+            return Pattern.compile(pattern, flags);
         } catch (PatternSyntaxException e) {
             return null;
         }
@@ -192,10 +196,20 @@ public final class SearchMatcher {
         }
     }
 
+    /**
+     * True word-boundary ({@code \b}) test for a literal match — a boundary exists where the char inside the
+     * match and the char just outside it differ in word-ness. Using {@code \b} semantics (rather than
+     * "the outside char must be a non-word char") keeps literal whole-word in agreement with the regex path's
+     * {@code \b(?:…)\b} and with ripgrep {@code -w} when the query's own edge char is a non-word char (e.g.
+     * {@code +foo} does match in {@code a+foo} — there is a boundary between {@code a} and {@code +}). For a
+     * query with word-char edges (the common case) this is identical to the old test.
+     */
     private static boolean isWordBounded(String text, int start, int end) {
-        boolean leftOk = start == 0 || !isWordChar(text.charAt(start - 1));
-        boolean rightOk = end == text.length() || !isWordChar(text.charAt(end));
-        return leftOk && rightOk;
+        boolean beforeWord = start > 0 && isWordChar(text.charAt(start - 1));
+        boolean firstWord = isWordChar(text.charAt(start));
+        boolean lastWord = isWordChar(text.charAt(end - 1));
+        boolean afterWord = end < text.length() && isWordChar(text.charAt(end));
+        return (beforeWord != firstWord) && (lastWord != afterWord);
     }
 
     private static boolean isWordChar(char c) {

--- a/src/main/java/com/editora/search/MultiFileSearch.java
+++ b/src/main/java/com/editora/search/MultiFileSearch.java
@@ -47,33 +47,60 @@ public final class MultiFileSearch {
      * Replaces every match of {@code q} in {@code text}. In regex mode the replacement supports
      * capture-group references ({@code $1}/{@code ${name}}, with {@code \} escapes); in literal mode
      * {@code $}/{@code \} are inserted verbatim. A bad group reference is a graceful no-op (text unchanged).
+     *
+     * <p><b>Line-oriented</b>, exactly like {@link #matchesInText} — the matcher runs per line (a trailing
+     * {@code \r} excluded, EOLs preserved), so what Replace All changes is precisely what the search preview
+     * showed. (A whole-text regex replace instead diverged from the per-line preview: {@code ;$} matched every
+     * line in the panel but only once at end-of-file, and a cross-line regex like {@code foo\nbar} matched
+     * nothing in the panel yet rewrote across the newline.)
      */
     public static ReplaceResult replaceAll(String text, SearchQuery q, String replacement) {
         if (text == null) {
             return new ReplaceResult("", 0);
         }
-        List<int[]> matches = SearchMatcher.matches(text, q.text(), q.caseSensitive(), q.regex(), q.wholeWord());
-        if (matches.isEmpty()) {
+        if (q == null || q.text() == null || q.text().isEmpty()) {
             return new ReplaceResult(text, 0);
         }
         String repl = replacement == null ? "" : replacement;
-        if (q.regex()) {
-            java.util.regex.Pattern p = SearchMatcher.compileRegex(q.text(), q.caseSensitive(), q.wholeWord());
-            if (p != null) {
-                try {
-                    return new ReplaceResult(p.matcher(text).replaceAll(repl), matches.size());
-                } catch (RuntimeException badReplacementRef) {
-                    return new ReplaceResult(text, 0); // invalid $-group reference → leave the text untouched
-                }
-            }
+        java.util.regex.Pattern regex =
+                q.regex() ? SearchMatcher.compileRegex(q.text(), q.caseSensitive(), q.wholeWord()) : null;
+        if (q.regex() && regex == null) {
+            return new ReplaceResult(text, 0); // bad pattern → leave the text untouched
         }
-        StringBuilder sb = new StringBuilder(text.length());
+        StringBuilder out = new StringBuilder(text.length());
+        int count = 0;
+        int n = text.length();
         int i = 0;
-        for (int[] m : matches) {
-            sb.append(text, i, m[0]).append(repl);
-            i = m[1];
+        try {
+            while (i <= n) {
+                int nl = text.indexOf('\n', i);
+                int lineEnd = nl < 0 ? n : nl;
+                int contentEnd = lineEnd > i && text.charAt(lineEnd - 1) == '\r' ? lineEnd - 1 : lineEnd;
+                String content = text.substring(i, contentEnd);
+                List<int[]> ms = SearchMatcher.matches(content, q.text(), q.caseSensitive(), q.regex(), q.wholeWord());
+                if (ms.isEmpty()) {
+                    out.append(content);
+                } else if (regex != null) {
+                    out.append(regex.matcher(content).replaceAll(repl)); // honors $1/${name} on this line
+                    count += ms.size();
+                } else {
+                    int last = 0;
+                    for (int[] m : ms) {
+                        out.append(content, last, m[0]).append(repl);
+                        last = m[1];
+                    }
+                    out.append(content, last, content.length());
+                    count += ms.size();
+                }
+                out.append(text, contentEnd, nl < 0 ? n : nl + 1); // preserve this line's \r?\n terminator
+                if (nl < 0) {
+                    break;
+                }
+                i = nl + 1;
+            }
+        } catch (RuntimeException badReplacementRef) {
+            return new ReplaceResult(text, 0); // invalid $-group reference → leave the text untouched
         }
-        sb.append(text, i, text.length());
-        return new ReplaceResult(sb.toString(), matches.size());
+        return new ReplaceResult(out.toString(), count);
     }
 }

--- a/src/test/java/com/editora/editor/SearchMatcherTest.java
+++ b/src/test/java/com/editora/editor/SearchMatcherTest.java
@@ -48,6 +48,25 @@ class SearchMatcherTest {
     }
 
     @Test
+    void caseInsensitiveRegexFoldsNonAscii() {
+        // Without UNICODE_CASE, CASE_INSENSITIVE only folds ASCII, so "café" wouldn't match "CAFÉ" in regex
+        // mode — while the literal path does. Both must agree.
+        assertRanges(SearchMatcher.matches("CAFÉ", "café", false, true, false), m(0, 4));
+        assertRanges(SearchMatcher.matches("CAFÉ", "café", false, false, false), m(0, 4)); // literal, for parity
+    }
+
+    @Test
+    void wholeWordLiteralUsesRealWordBoundaries() {
+        // A query with a non-word edge char: there IS a \b between "a" and "+", so "+foo" matches "a+foo" —
+        // matching the regex path's \b(?:…)\b and ripgrep -w (the old test required a non-word char outside).
+        assertRanges(SearchMatcher.matches("a+foo", "+foo", true, false, true), m(1, 5));
+        // Both edges non-word ⇒ no boundary after ")", so it correctly does NOT match (like regex \b(?:…)\b).
+        assertRanges(SearchMatcher.matches("call(foo)", "(foo)", true, false, true));
+        // A word-edge query is unchanged: "cat" is still not a whole word inside "xcat".
+        assertRanges(SearchMatcher.matches("xcat cat", "cat", true, false, true), m(5, 8));
+    }
+
+    @Test
     void regexWholeWordWraps() {
         // \b(?:in)\b must not match "inside"
         assertRanges(SearchMatcher.matches("in inside in", "in", true, true, true), m(0, 2), m(10, 12));

--- a/src/test/java/com/editora/search/MultiFileSearchTest.java
+++ b/src/test/java/com/editora/search/MultiFileSearchTest.java
@@ -62,6 +62,36 @@ class MultiFileSearchTest {
     }
 
     @Test
+    void regexReplaceIsPerLineLikeThePreview() {
+        // ";$" matches every line's trailing ; in the preview (per-line); replace must do the same, not just
+        // the single end-of-file match a whole-text regex replace would do.
+        SearchQuery q = new SearchQuery(";$", false, true, false);
+        assertEquals(3, MultiFileSearch.matchesInText("a;\nb;\nc;", q).size(), "preview matches every line");
+        MultiFileSearch.ReplaceResult r = MultiFileSearch.replaceAll("a;\nb;\nc;", q, "X");
+        assertEquals("aX\nbX\ncX", r.text());
+        assertEquals(3, r.count());
+    }
+
+    @Test
+    void regexReplaceNeverSpansALineBreak() {
+        // A cross-line regex matches nothing in the per-line preview; replace must not rewrite across "\n".
+        SearchQuery q = new SearchQuery("foo\nbar", false, true, false);
+        String text = "x foo\nbar y";
+        assertEquals(0, MultiFileSearch.matchesInText(text, q).size());
+        MultiFileSearch.ReplaceResult r = MultiFileSearch.replaceAll(text, q, "Z");
+        assertEquals(text, r.text(), "no cross-line rewrite");
+        assertEquals(0, r.count());
+    }
+
+    @Test
+    void regexReplacePreservesCrlf() {
+        MultiFileSearch.ReplaceResult r =
+                MultiFileSearch.replaceAll("a;\r\nb;\r\n", new SearchQuery(";$", false, true, false), "X");
+        assertEquals("aX\r\nbX\r\n", r.text());
+        assertEquals(2, r.count());
+    }
+
+    @Test
     void regexAndWholeWordHonored() {
         List<LineMatch> ms =
                 MultiFileSearch.matchesInText("cat cats category cat", new SearchQuery("cat", true, false, true));


### PR DESCRIPTION
Per-feature audit indexed by Settings page — the **Search** feature. Three confirmed bugs fixed, each traced to a concrete input; one inherent limitation noted.

## 1. Replace All diverged from the search preview (data bug)
The Find-in-Files results panel matches **per line** (`matchesInText`), but `MultiFileSearch.replaceAll` ran the regex over the **whole file** (no `MULTILINE`). So:
- `;$` (regex) previewed a hit on **every line** but Replace All changed only the **end-of-file** one ("replaced 1" while you saw 3).
- A cross-line regex like `foo\nbar` previewed **0** hits yet Replace All **rewrote across the newline** — content that was never shown as a match.

`replaceAll` is now **line-oriented**, identical to the preview (a trailing `\r` excluded, EOLs preserved, `$1`/`${name}` still honored per line). Literal replace is unchanged.

## 2. Case-insensitive regex only folded ASCII
`SearchMatcher.compileRegex` used `Pattern.CASE_INSENSITIVE` without `UNICODE_CASE`, so a case-insensitive regex `café` **missed** `CAFÉ` — while the plain-text path (`String.regionMatches`) and ripgrep `-i` matched it. The three backends disagreed. Added `UNICODE_CASE` (shared by the find bar, the walker, and `replaceAll`).

## 3. Literal whole-word disagreed with the regex path at punctuation edges
`isWordBounded` required the char just outside the match to be a non-word char, unconditionally — so a query with a non-word edge char, e.g. `+foo`, did **not** match `a+foo`, even though the regex path's `\b(?:…)\b` (and ripgrep `-w`) do. Rewrote it to true `\b` semantics (a boundary is where word-ness differs across the edge). Identical to the old behavior for ordinary word-edge queries.

## Deferred / inherent
Literal case-insensitive can't do length-changing case folds (`ß`↔`SS`) through `regionMatches` — rare, noted.

## Verified-clean (sampled)
ripgrep **byte→char offset mapping** (multibyte lines agree with the walker's char columns), zero-width regex matches (no infinite loop; the deadline guard is sound), literal-vs-regex replacement `$`/`\` handling, CRLF preservation, non-UTF-8 closed-file replace (throws→caught, no corruption), open-buffer-vs-disk precedence, GitignoreFilter/Globs, and the generation guard.

## Tests
`MultiFileSearchTest` (per-line regex replace matches the preview, no cross-line rewrite, CRLF preserved) + `SearchMatcherTest` (unicode-case regex, whole-word `\b`). Full suite **2012 tests, 0 failures**; `spotless:check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)