### PR TITLE
Remote/SFTP audit: external-tool hang, wrong-restore, connection leaks, IPv6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Running an External Tool on a remote (SFTP) file no longer hangs the app.** The tool tried to launch a
+  local process in the remote file's directory, which can't work; the "Running…" status hung forever with no
+  output. External Tools are now disabled for remote buffers with a clear message. (From a per-feature audit of
+  the Remote/SFTP feature.)
+
+- **A remote file that was open when you quit no longer reopens the wrong local file on restart.** The session
+  stored the bare path (dropping the `sftp://` host), so on the next launch a same-named local file could be
+  opened in its place; remote entries are now stored as their full URI and skipped on restart until you
+  reconnect (matching Recent Files).
+
+- **Failed SSH logins and reconnects no longer leak connections.** A wrong password left the SSH session open,
+  and reconnecting the same host stranded the previous filesystem; both are now closed.
+
+- **Remote hosts given as bracketed IPv6 literals** (`sftp://[::1]:2222/…`) now parse and round-trip correctly.
+
 - **Replace All in Find-in-Files now changes exactly what the search preview showed.** The results list matches
   line by line, but Replace All applied a regex over the *whole file* — so `;$` previewed a hit on every line
   but only replaced the last one, and a cross-line pattern like `foo\nbar` previewed nothing yet rewrote across

--- a/src/main/java/com/editora/ui/ExternalToolCoordinator.java
+++ b/src/main/java/com/editora/ui/ExternalToolCoordinator.java
@@ -160,6 +160,14 @@ final class ExternalToolCoordinator {
         if (!isEnabled() || tool == null) {
             return;
         }
+        // A remote (SFTP) buffer's path/dir can't feed a local subprocess: ProcessRunner does
+        // workingDir.toFile(), and SftpPath.toFile() throws UnsupportedOperationException on the service
+        // thread — the "Running…" status would hang forever with no output. Gate on the active buffer.
+        EditorBuffer active = host.activeBuffer();
+        if (active != null && active.getPath() != null && !host.isLocalBuffer(active)) {
+            host.setStatus(tr("status.externalTool.remoteUnsupported"));
+            return;
+        }
         ToolInvocation inv = ToolInvocation.of(tool, buildContext(), defaultDir());
         if (inv.isEmpty()) {
             host.setStatus(tr("status.externalTool.noCommand", tool.getName()));

--- a/src/main/java/com/editora/ui/MainController.java
+++ b/src/main/java/com/editora/ui/MainController.java
@@ -4661,7 +4661,13 @@ public class MainController implements com.editora.mcp.McpBridge {
         WorkspaceState state = config.getWorkspaceState();
         List<WorkspaceState.OpenFile> files = new ArrayList<>();
         for (WorkspaceState.OpenFile f : state.getOpenFiles()) {
-            if (f.getPath() != null && !f.getPath().isBlank() && Files.isReadable(Path.of(f.getPath()))) {
+            // parseStorable reconstructs a local path directly, or a remote (sftp://) one via the resolver —
+            // which is null until its connection is open, so a remote entry is skipped at startup rather than
+            // reopened as a same-named *local* file.
+            Path rp = f.getPath() == null || f.getPath().isBlank()
+                    ? null
+                    : com.editora.vfs.Vfs.parseStorable(f.getPath());
+            if (rp != null && Files.isReadable(rp)) {
                 files.add(f);
             }
         }
@@ -4677,7 +4683,7 @@ public class MainController implements com.editora.mcp.McpBridge {
         int activeIndex = 0;
         for (int i = 0; i < files.size(); i++) {
             WorkspaceState.OpenFile f = files.get(i);
-            Path p = Path.of(f.getPath());
+            Path p = com.editora.vfs.Vfs.parseStorable(f.getPath()); // non-null: the filter above kept only readable
             boolean active = f.getPath().equals(activePath);
             if (active) {
                 activeIndex = i;
@@ -6848,13 +6854,16 @@ public class MainController implements com.editora.mcp.McpBridge {
             Path p = tabPath(tab); // buffer or image-viewer path (image tabs restore too)
             if (p != null) {
                 int caret = buffer != null ? buffer.getArea().getCaretPosition() : 0;
-                files.add(new WorkspaceState.OpenFile(p.toAbsolutePath().toString(), caret, pinned.contains(tab)));
+                // Vfs.toStorableString keeps a remote file's sftp:// URI — a bare path would be reopened as a
+                // *local* file on restart (a same-named local file could silently open in its place).
+                files.add(new WorkspaceState.OpenFile(
+                        com.editora.vfs.Vfs.toStorableString(p), caret, pinned.contains(tab)));
             }
         }
         WorkspaceState state = config.getWorkspaceState();
         state.setOpenFiles(files);
         Path activePath = tabPath(tabPane.getSelectionModel().getSelectedItem());
-        state.setActiveFile(activePath != null ? activePath.toAbsolutePath().toString() : "");
+        state.setActiveFile(activePath != null ? com.editora.vfs.Vfs.toStorableString(activePath) : "");
         persistWindowBounds(state);
         toolWindows.persistDividers(); // capture a divider dragged but left open (close() only saves on hide)
         restoreCliFocusToolWindows(state);

--- a/src/main/java/com/editora/vfs/RemoteFileSystems.java
+++ b/src/main/java/com/editora/vfs/RemoteFileSystems.java
@@ -74,7 +74,10 @@ public final class RemoteFileSystems {
             Result result;
             try {
                 SftpFileSystem fs = open(conn, secret);
-                byAuthority.put(conn.id(), fs);
+                SftpFileSystem prev = byAuthority.put(conn.id(), fs);
+                if (prev != null && prev != fs) {
+                    closeQuietly(prev); // reconnecting the same site: don't leak the previous filesystem
+                }
                 String start = conn.lastPath() != null && !conn.lastPath().isBlank() ? conn.lastPath() : ".";
                 result = new Result(true, fs.getPath(start), null); // "." resolves to the SFTP home dir
             } catch (Exception e) {
@@ -93,22 +96,36 @@ public final class RemoteFileSystems {
         ClientSession session = client.connect(conn.user(), conn.host(), conn.port())
                 .verify(CONNECT_TIMEOUT)
                 .getSession();
-        switch (conn.auth()) {
-            case PASSWORD -> {
-                if (secret != null) {
-                    session.addPasswordIdentity(new String(secret));
+        try {
+            switch (conn.auth()) {
+                case PASSWORD -> {
+                    if (secret != null) {
+                        session.addPasswordIdentity(new String(secret));
+                    }
+                }
+                case KEY -> session.setKeyIdentityProvider(keyProvider(List.of(Path.of(conn.keyPath())), secret));
+                case DEFAULT_KEYS -> {
+                    List<Path> keys = defaultKeyFiles();
+                    if (!keys.isEmpty()) {
+                        session.setKeyIdentityProvider(keyProvider(keys, secret));
+                    }
                 }
             }
-            case KEY -> session.setKeyIdentityProvider(keyProvider(List.of(Path.of(conn.keyPath())), secret));
-            case DEFAULT_KEYS -> {
-                List<Path> keys = defaultKeyFiles();
-                if (!keys.isEmpty()) {
-                    session.setKeyIdentityProvider(keyProvider(keys, secret));
-                }
-            }
+            session.auth().verify(AUTH_TIMEOUT);
+            // On success the SftpFileSystem owns the session (closing the FS closes it).
+            return SftpClientFactory.instance().createSftpFileSystem(session);
+        } catch (IOException | RuntimeException e) {
+            session.close(true); // failed auth / FS creation: close the session so it isn't leaked
+            throw e;
         }
-        session.auth().verify(AUTH_TIMEOUT);
-        return SftpClientFactory.instance().createSftpFileSystem(session);
+    }
+
+    private static void closeQuietly(java.io.Closeable c) {
+        try {
+            c.close();
+        } catch (Exception ignored) {
+            // best-effort
+        }
     }
 
     private static KeyIdentityProvider keyProvider(List<Path> files, char[] passphrase) {

--- a/src/main/java/com/editora/vfs/SftpUri.java
+++ b/src/main/java/com/editora/vfs/SftpUri.java
@@ -29,14 +29,35 @@ public record SftpUri(String user, String host, int port, String path) {
             authority = authority.substring(at + 1);
         }
         int port = DEFAULT_PORT;
-        int colon = authority.indexOf(':');
-        String host = authority;
-        if (colon >= 0) {
-            host = authority.substring(0, colon);
-            try {
-                port = Integer.parseInt(authority.substring(colon + 1).strip());
-            } catch (NumberFormatException e) {
+        String host;
+        if (authority.startsWith("[")) {
+            // Bracketed IPv6 literal: sftp://[::1]:2222/path — split the port only after the closing ']'
+            // (an IPv6 address is full of colons, so a plain indexOf(':') would mangle it).
+            int close = authority.indexOf(']');
+            if (close < 0) {
                 return null;
+            }
+            host = authority.substring(1, close);
+            String after = authority.substring(close + 1);
+            if (after.startsWith(":")) {
+                try {
+                    port = Integer.parseInt(after.substring(1).strip());
+                } catch (NumberFormatException e) {
+                    return null;
+                }
+            } else if (!after.isEmpty()) {
+                return null; // junk between ']' and the path
+            }
+        } else {
+            int colon = authority.indexOf(':');
+            host = authority;
+            if (colon >= 0) {
+                host = authority.substring(0, colon);
+                try {
+                    port = Integer.parseInt(authority.substring(colon + 1).strip());
+                } catch (NumberFormatException e) {
+                    return null;
+                }
             }
         }
         if (host.isBlank() || port <= 0 || port > 65535) {
@@ -51,7 +72,7 @@ public record SftpUri(String user, String host, int port, String path) {
         if (user != null && !user.isEmpty()) {
             sb.append(user).append('@');
         }
-        sb.append(host);
+        sb.append(bracketedHost());
         if (port != DEFAULT_PORT) {
             sb.append(':').append(port);
         }
@@ -60,7 +81,12 @@ public record SftpUri(String user, String host, int port, String path) {
 
     /** The connection key ({@code user@host:port}) — all paths on one host+user+port share a filesystem. */
     public String authority() {
-        return (user == null || user.isEmpty() ? "" : user + "@") + host + ":" + port;
+        return (user == null || user.isEmpty() ? "" : user + "@") + bracketedHost() + ":" + port;
+    }
+
+    /** The host as it appears in a URI: an IPv6 literal (contains {@code :}) is wrapped in {@code [...]}. */
+    private String bracketedHost() {
+        return host.indexOf(':') >= 0 && !host.startsWith("[") ? "[" + host + "]" : host;
     }
 
     /** A short {@code host:/path} label for the UI. */

--- a/src/main/resources/com/editora/i18n/messages.properties
+++ b/src/main/resources/com/editora/i18n/messages.properties
@@ -2239,6 +2239,7 @@ externalTool.idle=No tool run yet
 externalTool.done={0} — done
 externalTool.exited={0} — exit code {1}
 status.externalTool.running=Running {0}…
+status.externalTool.remoteUnsupported=External tools can't run on a remote (SFTP) file.
 status.externalTool.done={0} finished
 status.externalTool.failed={0} failed: {1}
 status.externalTool.noCommand={0} has no command

--- a/src/main/resources/com/editora/i18n/messages_de.properties
+++ b/src/main/resources/com/editora/i18n/messages_de.properties
@@ -2231,6 +2231,7 @@ externalTool.idle=Noch kein Werkzeug ausgeführt
 externalTool.done={0} — fertig
 externalTool.exited={0} — Exit-Code {1}
 status.externalTool.running={0} wird ausgeführt…
+status.externalTool.remoteUnsupported=Externe Werkzeuge können nicht auf einer entfernten (SFTP-)Datei ausgeführt werden.
 status.externalTool.done={0} abgeschlossen
 status.externalTool.failed={0} fehlgeschlagen: {1}
 status.externalTool.noCommand={0} hat keinen Befehl

--- a/src/main/resources/com/editora/i18n/messages_es.properties
+++ b/src/main/resources/com/editora/i18n/messages_es.properties
@@ -2231,6 +2231,7 @@ externalTool.idle=Aún no se ha ejecutado ninguna herramienta
 externalTool.done={0} — listo
 externalTool.exited={0} — código de salida {1}
 status.externalTool.running=Ejecutando {0}…
+status.externalTool.remoteUnsupported=Las herramientas externas no pueden ejecutarse en un archivo remoto (SFTP).
 status.externalTool.done={0} finalizó
 status.externalTool.failed={0} falló: {1}
 status.externalTool.noCommand={0} no tiene comando

--- a/src/main/resources/com/editora/i18n/messages_fr.properties
+++ b/src/main/resources/com/editora/i18n/messages_fr.properties
@@ -2231,6 +2231,7 @@ externalTool.idle=Aucun outil exécuté pour l'instant
 externalTool.done={0} — terminé
 externalTool.exited={0} — code de sortie {1}
 status.externalTool.running=Exécution de {0}…
+status.externalTool.remoteUnsupported=Les outils externes ne peuvent pas s'exécuter sur un fichier distant (SFTP).
 status.externalTool.done={0} terminé
 status.externalTool.failed={0} a échoué : {1}
 status.externalTool.noCommand={0} n''a pas de commande

--- a/src/main/resources/com/editora/i18n/messages_it.properties
+++ b/src/main/resources/com/editora/i18n/messages_it.properties
@@ -2231,6 +2231,7 @@ externalTool.idle=Nessuno strumento ancora eseguito
 externalTool.done={0} — completato
 externalTool.exited={0} — codice di uscita {1}
 status.externalTool.running=Esecuzione di {0}…
+status.externalTool.remoteUnsupported=Gli strumenti esterni non possono essere eseguiti su un file remoto (SFTP).
 status.externalTool.done={0} completato
 status.externalTool.failed={0} non riuscito: {1}
 status.externalTool.noCommand={0} non ha un comando

--- a/src/main/resources/com/editora/i18n/messages_pt.properties
+++ b/src/main/resources/com/editora/i18n/messages_pt.properties
@@ -2231,6 +2231,7 @@ externalTool.idle=Ainda não foi executada nenhuma ferramenta
 externalTool.done={0} — concluído
 externalTool.exited={0} — código de saída {1}
 status.externalTool.running=A executar {0}…
+status.externalTool.remoteUnsupported=As ferramentas externas não podem ser executadas em um arquivo remoto (SFTP).
 status.externalTool.done={0} concluído
 status.externalTool.failed={0} falhou: {1}
 status.externalTool.noCommand={0} não tem comando

--- a/src/test/java/com/editora/vfs/SftpUriTest.java
+++ b/src/test/java/com/editora/vfs/SftpUriTest.java
@@ -56,4 +56,31 @@ class SftpUriTest {
         assertNull(SftpUri.parse("sftp://")); // no host
         assertNull(SftpUri.parse("sftp://h:notaport/x")); // bad port
     }
+
+    @Test
+    void bracketedIpv6HostWithPort() {
+        SftpUri u = SftpUri.parse("sftp://ada@[::1]:2222/srv/app.js");
+        assertEquals("::1", u.host());
+        assertEquals(2222, u.port());
+        assertEquals("ada", u.user());
+        assertEquals("/srv/app.js", u.path());
+        assertEquals("ada@[::1]:2222", u.authority());
+        assertEquals("sftp://ada@[::1]:2222/srv/app.js", u.format(), "round-trips with brackets");
+    }
+
+    @Test
+    void bracketedIpv6HostDefaultPort() {
+        SftpUri u = SftpUri.parse("sftp://[fe80::1]/etc/hosts");
+        assertEquals("fe80::1", u.host());
+        assertEquals(22, u.port());
+        assertEquals("sftp://[fe80::1]/etc/hosts", u.format());
+        assertEquals("[fe80::1]:22", u.authority());
+    }
+
+    @Test
+    void rejectsMalformedIpv6() {
+        assertNull(SftpUri.parse("sftp://[::1")); // unclosed bracket
+        assertNull(SftpUri.parse("sftp://[::1]x/y")); // junk after ]
+        assertNull(SftpUri.parse("sftp://[::1]:bad/y")); // bad port
+    }
 }


### PR DESCRIPTION
Per-feature audit indexed by Settings page — the **Remote (SFTP)** feature. Four confirmed bugs fixed; **three findings deferred to their own PRs** (a half-fix would be worse), including a host-key verification hole flagged below.

## 1. External Tools on a remote buffer hung the app forever
External Tools was gated only on `!simpleMode`, never on `isLocalBuffer`. With a remote (SFTP) buffer active, `ProcessRunner` did `workingDir.toFile()` on the remote `SftpPath` → `UnsupportedOperationException` on the service thread (before the `try { pb.start() }`), so the callback never fired and the **"Running…" status hung permanently**. Now gated on the active buffer being local, with a clear message.

## 2. Session restore reopened the *wrong local file* for a remote file
The open-files session store wrote the **bare path** (dropping the `sftp://` host) and restored via `Path.of(...)` + `Files.isReadable` — so a same-named local file (`/etc/hosts`, `/srv/app/main.js`) could silently open in place of the remote one. Now uses `Vfs.toStorableString` / `parseStorable` like Recent Files: remote entries keep their full URI and are **skipped at startup** (until you reconnect), never reopened as a local path.

## 3. Connection/filesystem leaks
A **failed auth** (wrong password) left the `ClientSession` open (socket + I/O threads leaked per attempt), and **reconnecting** the same host replaced the `byAuthority` entry without closing the old `SftpFileSystem`. Both are now closed.

## 4. IPv6 hosts
`SftpUri` split the authority on the first `:`, mangling a bracketed IPv6 literal (`sftp://[::1]:2222/…`). `parse`/`format`/`authority` are now bracket-aware and round-trip.

## ⚠️ Deferred to their own PRs
- **Host-key verification is disabled** — `RemoteFileSystems` uses `AcceptAllServerKeyVerifier`, accepting **any** server key with no `known_hosts`/TOFU, so a network attacker can MITM the connection (capturing the password and all file contents). The proper fix is `known_hosts` + a first-connect accept-and-record **dialog** (a cross-thread prompt from the off-thread connect) — its own security PR. **This is the top-priority follow-up.**
- **Multi-window clobbers the single static `Vfs` remote hooks** — `RemoteFileSystems` is per-window but `Vfs`'s resolver/storable hooks are one static slot, so a second SFTP window strands the first's remote paths (and closing the newer window nulls the hooks while the older is still connected). Architectural fix (dispatch by owning `FileSystem`).
- The password `char[]` wipe is defeated by a `String` copy at MINA's `addPasswordIdentity(String)` boundary — API-limited defense-in-depth.

## Verified-clean (sampled)
Local-only gating is correct for **every other feature** (Run/HTTP/Git/LSP/DAP/build/HTML-preview/log-tail/local-history/agent/ripgrep/external-change) — External Tools was the sole gap. `ConnectionStore` never serializes a secret; no secret logging; atomic-write-over-SFTP works (MINA ignores `ATOMIC_MOVE`, no crash); auth precedence fails closed.

## Tests
`SftpUriTest` (IPv6 parse/format/authority + malformed cases). Full suite **2015 tests, 0 failures**; `spotless:check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)