### PR TITLE
Snippets/Templates audit: parser crashes on dollar amounts; multi-line choice dropdown lost

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **A snippet or template containing a plain dollar amount no longer fails silently.** A body with text like
+  `$12345678901` (a `$` followed by a very long number) threw internally, so the snippet didn't expand / the
+  template didn't create — the number is now treated as ordinary text. A body ending in a stray `${` is
+  likewise handled instead of erroring. (From a per-feature audit of Snippets & Templates.)
+
+- **Multi-line snippets with a choice field now show their dropdown when expanded on an indented line.** The
+  `${1|a,b,c|}` choice list was being dropped during re-indentation, so the field became a plain placeholder;
+  the dropdown is preserved now.
+
 - **Running an External Tool on a remote (SFTP) file no longer hangs the app.** The tool tried to launch a
   local process in the remote file's directory, which can't work; the "Running…" status hung forever with no
   output. External Tools are now disabled for remote buffers with a clear message. (From a per-feature audit of

--- a/src/main/java/com/editora/snippet/SnippetParser.java
+++ b/src/main/java/com/editora/snippet/SnippetParser.java
@@ -103,7 +103,10 @@ public final class SnippetParser {
             while (j < s.length() && Character.isDigit(s.charAt(j))) {
                 j++;
             }
-            int num = Integer.parseInt(s.substring(n, j));
+            Integer num = parseStopNumber(s, n, j);
+            if (num == null) {
+                return false; // an over-long number (e.g. a literal "$12345678901") → treat "$…" as text
+            }
             emitStop(num, null, out, ranges, firstText);
             pos[0] = j;
             return true;
@@ -124,6 +127,16 @@ public final class SnippetParser {
         return false;
     }
 
+    /** A tab-stop number {@code s[from,to)}, or {@code null} when the digit run overflows an int (so the
+     *  caller can treat the {@code $…} as literal text rather than throwing). */
+    private static Integer parseStopNumber(String s, int from, int to) {
+        try {
+            return Integer.parseInt(s.substring(from, to));
+        } catch (NumberFormatException overflow) {
+            return null;
+        }
+    }
+
     /** Parses a {@code ${…}} construct beginning at {@code pos[0]} (the '$'). */
     private static boolean parseBrace(
             String s,
@@ -134,12 +147,19 @@ public final class SnippetParser {
             Map<Integer, List<String>> choices,
             Variables vars) {
         int i = pos[0] + 2; // past "${"
+        if (i >= s.length()) {
+            return false; // a bare "${" at end of the body → treat it as literal text (don't crash)
+        }
         if (Character.isDigit(s.charAt(i))) {
             int j = i;
             while (j < s.length() && Character.isDigit(s.charAt(j))) {
                 j++;
             }
-            int num = Integer.parseInt(s.substring(i, j));
+            Integer boxed = parseStopNumber(s, i, j);
+            if (boxed == null) {
+                return false; // over-long number → treat the "${…" as literal text
+            }
+            int num = boxed;
             char sep = j < s.length() ? s.charAt(j) : '}';
             if (sep == '}') { // ${1}
                 emitStop(num, null, out, ranges, firstText);

--- a/src/main/java/com/editora/snippet/SnippetSession.java
+++ b/src/main/java/com/editora/snippet/SnippetSession.java
@@ -367,7 +367,8 @@ public final class SnippetSession {
             for (int[] r : s.ranges()) {
                 rs.add(new int[] {r[0] + add[r[0]], r[1] + add[r[1]]});
             }
-            stops.add(new TabStop(s.number(), rs, s.placeholder()));
+            stops.add(new TabStop(s.number(), rs, s.placeholder(), s.choices())); // keep choices (the 3-arg
+            // ctor drops them → a multi-line ${1|a,b|} choice field would lose its dropdown after re-indent)
         }
         return new ParsedSnippet(sb.toString(), stops);
     }

--- a/src/test/java/com/editora/snippet/SnippetParserTest.java
+++ b/src/test/java/com/editora/snippet/SnippetParserTest.java
@@ -61,6 +61,24 @@ class SnippetParserTest {
     }
 
     @Test
+    void unterminatedDollarBraceAtEndIsLiteralNotACrash() {
+        // "${" with nothing after it must not StringIndexOutOfBounds — treat it as literal text.
+        assertEquals("foo${", SnippetParser.parse("foo${", NONE).text());
+        assertEquals("${", SnippetParser.parse("${", NONE).text());
+    }
+
+    @Test
+    void overlongTabStopNumberIsTreatedAsLiteral() {
+        // A literal dollar amount: "$" + 11 digits overflows an int — must not throw NumberFormatException.
+        ParsedSnippet p = SnippetParser.parse("Price: $12345678901", NONE);
+        assertEquals("Price: $12345678901", p.text());
+        assertEquals(0, p.stops().size());
+        assertEquals(
+                "${999999999999:x}",
+                SnippetParser.parse("${999999999999:x}", NONE).text());
+    }
+
+    @Test
     void choiceUsesFirstOptionAndCapturesAll() {
         ParsedSnippet p = SnippetParser.parse("${1|alpha,beta,gamma|}", NONE);
         assertEquals("alpha", p.text());

--- a/src/test/java/com/editora/snippet/SnippetSessionTest.java
+++ b/src/test/java/com/editora/snippet/SnippetSessionTest.java
@@ -62,4 +62,16 @@ class SnippetSessionTest {
         ParsedSnippet p = new ParsedSnippet("abc", List.of(new TabStop(0, List.of(new int[] {3, 3}), "")));
         assertEquals(p, SnippetSession.reindent(p, "    "));
     }
+
+    @Test
+    void reindentPreservesChoicesSoTheDropdownSurvives() {
+        // A multi-line choice snippet expanded at an indent runs through reindent, which used to rebuild the
+        // TabStop with the 3-arg ctor and drop the choices → no dropdown.
+        TabStop choice = new TabStop(1, List.of(new int[] {2, 3}), "a", List.of("a", "b", "c"));
+        ParsedSnippet p = new ParsedSnippet("{\na\n}", List.of(choice));
+        ParsedSnippet out = SnippetSession.reindent(p, "  ");
+        TabStop s = out.stops().get(0);
+        assertEquals(List.of("a", "b", "c"), s.choices());
+        assertEquals(true, s.hasChoices());
+    }
 }


### PR DESCRIPTION
Per-feature audit indexed by Settings page — **Snippets** and **File Templates**. Three confirmed bugs fixed; the template path-traversal guard and persistence were checked and found solid.

## 1. Parser crashed on a plain dollar amount or a stray `${`
`SnippetParser.parse` threw on two legitimate-ish inputs, and both propagate **uncaught** out of `EditorBuffer.startSnippet` and the New-From-Template path (`TemplateEngine.substitute`/`expand`):
- A body ending in `${` — `parseBrace` did `s.charAt(pos+2)` with no bound → `StringIndexOutOfBoundsException`.
- A body with a `$` followed by a very long number, e.g. a **literal dollar amount** `$12345678901` — `Integer.parseInt` over the digit run overflowed → `NumberFormatException`.

So a snippet whose body mentions a price silently failed to expand, and a template with such text failed to create. Both are now treated as **literal text** (a bare `${` at end, and an overflowing `$<digits>`).

## 2. Multi-line choice snippet lost its dropdown
A `${1|a,b,c|}` choice field in a **multi-line** snippet, expanded at an **indented** caret, lost its dropdown — `SnippetSession.reindent` rebuilt each `TabStop` with the 3-arg constructor, which drops `choices`, so the field became a plain placeholder. `reindent` now preserves choices.

## Verified-clean (sampled)
- **`TemplateEngine.resolveTargetPath` traversal guard** — uses **component-wise** `Path.startsWith` (not string-prefix), so `../`, absolute-path, and `dir=/a/b` + `../bc` escapes are correctly rejected.
- `collapseDuplicateExtension` leaves `types.d.ts` / `foo.tar.gz` / `foo.min.js` alone.
- Overwrite is refused; multi-file writes guard each file.
- `saveUserSnippets` / `saveUserTemplate` are atomic (temp + `ATOMIC_MOVE`) with the cache cleared.
- Malformed-user-JSON leniency, override-by-prefix/id, escapes, unterminated `${1:default` / `${1|a,b`, and `SnippetSession.shift` offset math all hold.

## Tests
`SnippetParserTest` (`${`-at-end, overflow number) + `SnippetSessionTest` (reindent preserves choices). Full suite **2018 tests, 0 failures**; `spotless:check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)