### PR TITLE
Web audit: preview-server symlink escape (security) + double-decode, unbounded pool, >> containment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security
+
+- **The HTML live-preview server no longer serves files outside the previewed file's folder via a symbolic
+  link.** Its path-traversal guard was purely lexical, so a symlink inside the folder that pointed elsewhere
+  (common in real project trees) could be fetched by the previewed page — an arbitrary-file read. The guard now
+  resolves symlinks and rejects anything whose real target leaves the folder. (From a per-feature audit of the
+  Web feature.)
+
 ### Fixed
+
+- **HTML preview assets whose filename contains `+`, `%`, or a space now load.** The server decoded the URL
+  path twice (and form-decoded `+` to a space), so `<img src="my+file.png">` 404'd; it now decodes once.
+
+- **The live-preview server uses a bounded thread pool**, so a flood of long-poll connections from another
+  local process can't grow threads without limit.
+
+- **A `.http` `>>` response-save operator can no longer write outside the request file's folder** (a `../`
+  path is now rejected).
 
 - **macOS Option-key text input works again.** Typing an accented or special character with Option (é, ç, ∞,
   dead keys) was being swallowed by the editor even when Option wasn't a bound shortcut; unbound Option

--- a/src/main/java/com/editora/http/HttpClientService.java
+++ b/src/main/java/com/editora/http/HttpClientService.java
@@ -252,9 +252,13 @@ public final class HttpClientService {
         if (baseDir == null || result.failed()) {
             return;
         }
+        Path baseReal = baseDir.toAbsolutePath().normalize();
         for (HttpFile.Redirect r : request.redirects()) {
             try {
-                Path target = baseDir.resolve(r.path());
+                Path target = baseReal.resolve(r.path()).normalize();
+                if (!target.startsWith(baseReal)) {
+                    continue; // a ">> ../../x" must not write outside the request file's folder
+                }
                 if (!r.force() && Files.exists(target)) {
                     continue;
                 }

--- a/src/main/java/com/editora/web/LivePreviewServer.java
+++ b/src/main/java/com/editora/web/LivePreviewServer.java
@@ -4,7 +4,6 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
-import java.net.URLDecoder;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
@@ -52,7 +51,10 @@ public final class LivePreviewServer {
             return server.getAddress().getPort();
         }
         server = HttpServer.create(new InetSocketAddress(InetAddress.getLoopbackAddress(), 0), 0);
-        pool = Executors.newCachedThreadPool(r -> {
+        // Bounded (not newCachedThreadPool): each /__editora_livereload request blocks a worker for up to
+        // POLL_TIMEOUT_MS, so an unbounded pool lets any localhost process exhaust threads/memory by holding
+        // many concurrent long-polls. A small fixed pool caps that; normal use holds one poll per open page.
+        pool = Executors.newFixedThreadPool(16, r -> {
             Thread t = new Thread(r, "html-preview-http");
             t.setDaemon(true);
             return t;
@@ -163,8 +165,10 @@ public final class LivePreviewServer {
             sendStatus(ex, 404);
             return;
         }
+        // urlPath is URI.getPath(), which is already %-decoded — do NOT URLDecoder.decode again (that is
+        // form decoding: it turns "+" into a space and double-decodes "%25", breaking asset filenames that
+        // contain "+", "%", or a space).
         String rel = urlPath.startsWith("/") ? urlPath.substring(1) : urlPath;
-        rel = URLDecoder.decode(rel, StandardCharsets.UTF_8);
         if (rel.isEmpty()) {
             rel = previewRelPath == null ? "" : previewRelPath; // "/" ⇒ the previewed file
         }
@@ -231,10 +235,23 @@ public final class LivePreviewServer {
     /**
      * Resolves {@code rel} against {@code root} and rejects anything that escapes the doc root (path
      * traversal), returning {@code null} when unsafe. {@code root} must be absolute + normalized.
+     *
+     * <p>Beyond the lexical {@code normalize()}+{@code startsWith} check, it canonicalizes an <em>existing</em>
+     * target with {@code toRealPath()} and re-checks containment — otherwise a symlink that lives inside the
+     * doc root but points outside it (common in real project trees) would pass the lexical check and let the
+     * preview server read an arbitrary file (same-origin with the previewed page). A target that doesn't exist
+     * yet (or can't be canonicalized) falls back to the lexical result — the subsequent read just 404s.
      */
     static Path safeResolve(Path root, String rel) {
         Path resolved = root.resolve(rel).normalize();
-        return resolved.startsWith(root) ? resolved : null;
+        if (!resolved.startsWith(root)) {
+            return null; // lexical escape (…/../…, absolute path)
+        }
+        try {
+            return resolved.toRealPath().startsWith(root.toRealPath()) ? resolved : null;
+        } catch (IOException notYetExisting) {
+            return resolved; // no such file — safe to return; the read will 404
+        }
     }
 
     /** Splices the live-reload {@code <script>} before {@code </body>} (appends when there is no body tag). */

--- a/src/test/java/com/editora/web/LivePreviewServerTest.java
+++ b/src/test/java/com/editora/web/LivePreviewServerTest.java
@@ -72,6 +72,27 @@ class LivePreviewServerTest {
         assertNull(LivePreviewServer.safeResolve(root, "a/../../outside.txt"));
     }
 
+    @Test
+    void safeResolveRejectsASymlinkPointingOutsideRoot(@TempDir Path tmp) throws Exception {
+        Path root = Files.createDirectories(tmp.resolve("site")).toRealPath();
+        Path outside = Files.writeString(tmp.resolve("secret.txt"), "top secret");
+        try {
+            Files.createSymbolicLink(root.resolve("escape.txt"), outside);
+        } catch (UnsupportedOperationException | java.io.IOException e) {
+            org.junit.jupiter.api.Assumptions.abort("symlinks not creatable on this platform");
+        }
+        // The lexical normalize()+startsWith check passes (escape.txt is under root), but the link's real
+        // target is outside → must be rejected.
+        assertNull(LivePreviewServer.safeResolve(root, "escape.txt"), "a symlink escaping the root is rejected");
+
+        // A normal file and an in-root symlink are still allowed.
+        Files.writeString(root.resolve("index.html"), "<html></html>");
+        assertNotNull(LivePreviewServer.safeResolve(root, "index.html"));
+        Path inner = Files.writeString(root.resolve("real.css"), "body{}");
+        Files.createSymbolicLink(root.resolve("alias.css"), inner);
+        assertNotNull(LivePreviewServer.safeResolve(root, "alias.css"), "an in-root symlink is fine");
+    }
+
     // --- end-to-end: a real loopback server (no browser involved) ---------------------------------
 
     @Test


### PR DESCRIPTION
Per-feature audit indexed by Settings page — the **Web** feature (HTML live preview + `.http` client). **One security fix** plus three correctness/hardening fixes; two low findings deferred.

## 🔴 Security: symlink escape in the live-preview server (arbitrary file read)
`LivePreviewServer.safeResolve` did a purely **lexical** containment check (`normalize()` + `startsWith`), never resolving symlinks. So a **symlink that lives inside the doc root but points outside it** (very common — `node_modules/.bin/*`, a `public/` symlinked to a shared dir, a link to `~`) passed the check, and `Files.readAllBytes` followed it. A page served by the preview server is **same-origin** with it, so JavaScript in the previewed (possibly untrusted) HTML could `GET /link` and read an arbitrary file off disk.

Now it canonicalizes an existing target with `toRealPath()` and re-checks containment against the real root; an in-root symlink is still allowed, and a not-yet-existing path falls back to the lexical result (404 on read). New symlink-escape test (`safeResolveRejectsASymlinkPointingOutsideRoot`).

## 1. Preview assets with `+`, `%`, or a space in the name 404'd
`serveFile` decoded the URL path **twice**: `urlPath` is `URI.getPath()` (already %-decoded), then `URLDecoder.decode` ran again — which is *form* decoding, turning `+` into a space and double-decoding `%25`. So `<img src="my+file.png">` / `a b.png` / a literal `%` couldn't be served. Dropped the extra decode.

## 2. Unbounded thread pool
The server used `newCachedThreadPool`, and each `/__editora_livereload` long-poll blocks a worker for up to 25 s — so a localhost process could exhaust threads/memory with concurrent polls. Switched to a bounded fixed pool (16); normal use holds one poll per open page.

## 3. `.http` `>>` write containment
The `>>` / `>>!` response-save operator did `baseDir.resolve(path)` with no guard, so `>> ../../x` wrote outside the request file's folder. Added a `startsWith(baseDir)` check.

## Deferred (low)
- A header value the JDK rejects (a stray CR in a `{{token}}`) is **silently dropped** → the request goes out unauthenticated with no diagnostic. Should be surfaced.
- `HttpFile.parseRequest` mis-parses a body with no blank line before it (malformed per the spec).

## Verified-clean (sampled)
`%`-encoded / dot-segment / absolute-path traversal (decode-before-check, component-wise `startsWith`), reload-script injection, content-type mapping, `Browsers.launchArgv` (every arg is a separate argv element, never a shell string), CRLF header injection (JDK-blocked), `file://`/redirect SSRF, and `HttpVars` `quoteReplacement`.

## Tests
`LivePreviewServerTest` (new symlink-escape case) + the existing http/web suites. Full suite **2025 tests, 0 failures**; `spotless:check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)