### PR TITLE
Plugins audit: declined-update consent bypass + plugin-command daemon thread

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   resolves symlinks and rejects anything whose real target leaves the folder. (From a per-feature audit of the
   Web feature.)
 
+- **Declining a plugin's capability prompt now disables it.** When updating an already-installed plugin, the
+  new code is written to disk before the "here's what it can do" prompt; declining used to leave the plugin
+  enabled, so the rejected update ran on the next launch. Declining now disables the plugin. (From a per-feature
+  audit of the Plugins feature.)
+
 ### Fixed
+
+- **A running plugin-defined shell command no longer delays quitting Editora** — it ran on a non-daemon thread
+  that could hold the JVM open until the command (or its 2-minute timeout) finished; it's now a daemon thread.
 
 - **HTML preview assets whose filename contains `+`, `%`, or a space now load.** The server decoded the URL
   path twice (and form-decoded `+` to a space), so `<img src="my+file.png">` 404'd; it now decodes once.

--- a/src/main/java/com/editora/ui/PluginCoordinator.java
+++ b/src/main/java/com/editora/ui/PluginCoordinator.java
@@ -253,26 +253,27 @@ final class PluginCoordinator {
                 ? d.dir()
                 : d.dir().resolve(c.dir).normalize();
         host.setStatus(tr("status.plugins.running", c.title == null || c.title.isBlank() ? c.id : c.title));
-        new Thread(
-                        () -> {
-                            ProcessRunner.Result r;
-                            try {
-                                r = ProcessRunner.run(cwd, Duration.ofSeconds(120), new ArrayList<>(c.run), Map.of());
-                            } catch (RuntimeException e) {
-                                Platform.runLater(() -> host.setStatus(tr("status.plugins.cmdFailed", e.getMessage())));
-                                return;
-                            }
-                            String out = (r.out() + "\n" + r.err()).strip();
-                            if (!out.isBlank()) {
-                                LOG.info("[plugin " + d.id() + "] " + out);
-                            }
-                            Platform.runLater(() -> host.setStatus(
-                                    r.ok()
-                                            ? tr("status.plugins.cmdDone", c.id)
-                                            : tr("status.plugins.cmdFailed", "exit " + r.exit())));
-                        },
-                        "plugin-cmd-" + d.id())
-                .start();
+        Thread t = new Thread(
+                () -> {
+                    ProcessRunner.Result r;
+                    try {
+                        r = ProcessRunner.run(cwd, Duration.ofSeconds(120), new ArrayList<>(c.run), Map.of());
+                    } catch (RuntimeException e) {
+                        Platform.runLater(() -> host.setStatus(tr("status.plugins.cmdFailed", e.getMessage())));
+                        return;
+                    }
+                    String out = (r.out() + "\n" + r.err()).strip();
+                    if (!out.isBlank()) {
+                        LOG.info("[plugin " + d.id() + "] " + out);
+                    }
+                    Platform.runLater(() -> host.setStatus(
+                            r.ok()
+                                    ? tr("status.plugins.cmdDone", c.id)
+                                    : tr("status.plugins.cmdFailed", "exit " + r.exit())));
+                },
+                "plugin-cmd-" + d.id());
+        t.setDaemon(true); // created off the non-daemon FX thread; don't let a running command block JVM exit
+        t.start();
     }
 
     // --- plugin registry (browse / install / uninstall) -----------------------------------------
@@ -413,6 +414,11 @@ final class PluginCoordinator {
             config.savePlugins();
             host.setStatus(tr("status.plugins.installed", r.name()));
         } else {
+            // Declining must DISABLE it: installBytes already moved the new code into place before this gate,
+            // so an *update* whose new capabilities the user rejected would otherwise stay enabled and run the
+            // rejected code on the next launch.
+            config.getPluginStore().setEnabled(r.id(), false);
+            config.savePlugins();
             host.setStatus(tr("status.plugins.notEnabled", r.name()));
         }
         settingsWindow.syncPluginsCheck(); // rebuilds the per-plugin list


### PR DESCRIPTION
Per-feature audit indexed by Settings page — the **Plugins** feature. The **critical security guards were all verified clean** (see below); two fixes, one resource finding deferred.

## Consent bypass: declining a plugin update left it enabled
`installFromUrl`/`installFromZip` → `installBytes` **replaces the on-disk plugin folder and re-discovers it before** the "here's what this plugin can do" prompt. For an **already-enabled** plugin whose update adds a jar / declared external commands / keymap remaps, clicking **Cancel** at that prompt only set a status — `plugins.json` still said `enabled=true`, and the rejected new code ran on the next launch. Declining now sets `enabled=false` + `savePlugins`, so a refused install/update can't run.

## A running plugin command delayed quitting
`runDeclaredCommand` spawned a bare `Thread` from the (non-daemon) FX thread, which inherits **non-daemon** status and runs `ProcessRunner` with a 120 s timeout — so quitting Editora while a plugin's declarative command was running hung JVM exit until it finished. Now a daemon thread.

## ⚠️ Deferred
The per-plugin `URLClassLoader` is **never closed** on re-`discover()` (Settings Reload / install / uninstall) or window dispose — it leaks jar handles and, on **Windows**, locks the jar so uninstall/update can't overwrite it. The correct fix is entangled with the classloader-unload / hot-reload work `CLAUDE.md` explicitly defers (the loader is shared app-wide; closing one still in use would break a running plugin), so it belongs with that.

## ✅ Verified-clean (the security-critical guards)
- **Unzip zip-slip**: `safeEntryName` rejects blank/absolute/drive-or-colon/backslash/`..`-segment names; `isUnderDir` re-checks with component-wise `Path.startsWith` (sibling-prefix `/dest-evil` fails). No symlink entries are ever created. Double-guarded.
- **Zip-bomb caps**: entry-count checked before processing; per-entry (64 MB) + total (256 MB) checked inside the read loop before each write.
- **`installFromUrl` integrity**: sha-256 is **mandatory** (blank/absent → abort), over the exact downloaded zip bytes (128 MB cap), HTTPS-only, no HTTPS→HTTP downgrade; a cross-host redirect still can't bypass the signed hash. `isSafeId` blocks a traversal id.
- **Registry authenticity**: Ed25519 verified over the exact fetched `index.json` bytes (no re-serialization), **fails closed**; `pluginRequireSignature` defaults true and `browse()` refuses an unsigned/unverified index before the picker shows.
- **Consent coverage**: the capability disclosure fires at all three arming points (install-from-URL, install-from-disk, the Settings per-plugin checkbox); lenient manifest parsing isolates a bad plugin.

## Tests
The critical guards keep their existing `UnzipTest`/`PluginInstallerTest`/`RegistryIndexTest` coverage. The two fixes here are UI-flow (the consent prompt is a modal dialog), verified by inspection. Full suite **2025 tests, 0 failures**; `spotless:check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)