### PR TITLE
Spell audit (1/2): Markdown fences never skipped, typographic punctuation exempted words, dictionary built when disabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Spell check no longer squiggles inside Markdown fenced code blocks.** The "skip ``` code fences" rule was
+  never actually switched on (it was decided before the file's language was known), so opening a README put red
+  squiggles on `sudo`, `cd`, `xzf` and friends inside its code blocks. (From a per-feature audit of Spell
+  Check.)
+
+- **Spell check no longer skips whole phrases joined by typographic punctuation.** A sentence using an em dash
+  (`results—surprising—showed`), a smart apostrophe (`world’s`), or a non-breaking space had *every* word in
+  that run silently left unchecked — and since macOS/iOS auto-substitute `--`→`—` and `'`→`’`, that's ordinary
+  typed prose. Those characters are now understood as part of the word, and `don’t` is matched against the
+  dictionary's `don't` rather than being reported as a misspelling. Non-breaking spaces (pervasive in pasted
+  text, and required by French typography) now separate words properly.
+
+- **Editora no longer builds the spell-check dictionary at startup when spell check is turned off** — it cost
+  ~200 ms of CPU and ~1 MB of memory per language on every launch regardless of the setting.
+
+
 - **A running plugin-defined shell command no longer delays quitting Editora** — it ran on a non-daemon thread
   that could hold the JVM open until the command (or its 2-minute timeout) finished; it's now a daemon thread.
 

--- a/src/main/java/com/editora/editor/EditorBuffer.java
+++ b/src/main/java/com/editora/editor/EditorBuffer.java
@@ -5828,6 +5828,10 @@ public class EditorBuffer implements TabContent {
         this.grammar = g;
         folds.setLanguage(language);
         spellOverlay.setProseMode(isProse()); // prose checks all words; code only comments/strings
+        // Must be re-pushed here, not just from installOverlays(): that runs in the constructor, before the
+        // language is known, so it always saw plaintext ⇒ markdown stayed false forever and ``` fenced code
+        // blocks WERE spell-checked (sudo/cd/xzf squiggled inside a README's bash block).
+        spellOverlay.setMarkdown(isMarkdown());
         invalidateHighlighting(); // grammar changed with no text edit — re-tokenize the whole document
         applyHighlighting();
     }

--- a/src/main/java/com/editora/editor/SpellChecker.java
+++ b/src/main/java/com/editora/editor/SpellChecker.java
@@ -26,7 +26,9 @@ public final class SpellChecker {
     public SpellChecker(String langId, Set<String> userWords) {
         this.langId = langId;
         this.userWords = userWords == null ? new HashSet<>() : userWords;
-        SpellDictionaries.ensureBuilt(langId, null);
+        // Deliberately NOT ensureBuilt() here: every EditorBuffer constructs a SpellChecker, so building from
+        // the ctor spent ~200 ms of startup CPU + ~1 MB retained per language even with spell check OFF.
+        // setSpellCheckEnabled(true) and setLanguage() both already trigger the build when it's actually needed.
     }
 
     public void setLanguage(String langId, Runnable onReady) {
@@ -74,7 +76,10 @@ public final class SpellChecker {
         if (skip(word)) {
             return false;
         }
-        String lower = word.toLowerCase(Locale.ROOT);
+        // The dictionaries (and user words) spell "don't" with an ASCII apostrophe, but macOS/iOS
+        // auto-substitute U+2019 — normalize so "don’t" isn't reported as a misspelling.
+        String normalized = normalizeApostrophes(word);
+        String lower = normalized.toLowerCase(Locale.ROOT);
         if ((userWordsEnabled && userWords.contains(lower)) || ignored.contains(lower)) {
             return false;
         }
@@ -85,7 +90,43 @@ public final class SpellChecker {
         if (h == null) {
             return false;
         }
-        return !h.spell(word);
+        return !h.spell(normalized);
+    }
+
+    /** Replaces the typographic apostrophes editors auto-substitute with the ASCII {@code '} the dictionaries
+     *  actually contain, so {@code don’t} matches {@code don't}. Pure. */
+    static String normalizeApostrophes(String s) {
+        if (s == null || (s.indexOf('’') < 0 && s.indexOf('‘') < 0)) {
+            return s;
+        }
+        return s.replace('’', '\'').replace('‘', '\'');
+    }
+
+    /** An apostrophe that can sit inside a word — ASCII plus the typographic ones auto-substituted on
+     *  macOS/iOS ({@code don’t}). */
+    private static boolean isApostrophe(char c) {
+        return c == '\'' || c == '’' || c == '‘';
+    }
+
+    /** A hyphen/dash that joins words in prose. Includes the em/en dashes editors auto-substitute for
+     *  {@code --}/{@code -}, plus the soft hyphen — none of which make a token "structural". */
+    private static boolean isDash(char c) {
+        return c == '-'
+                || c == '‐' // hyphen
+                || c == '‑' // non-breaking hyphen
+                || c == '‒' // figure dash
+                || c == '–' // en dash
+                || c == '—' // em dash
+                || c == '−' // minus sign
+                || c == '­'; // soft hyphen
+    }
+
+    /** A character that ends a whitespace-bounded token. {@link Character#isWhitespace} is NOT enough: it
+     *  reports {@code false} for NBSP (U+00A0), which is pervasive in pasted text and required by French
+     *  typography — without this the words either side of an NBSP merge into one "structural" token and are
+     *  never checked. */
+    private static boolean isTokenBreak(char c) {
+        return Character.isWhitespace(c) || Character.isSpaceChar(c);
     }
 
     /** Up to a handful of suggestions for a misspelled word (empty if the dictionary isn't ready). */
@@ -130,7 +171,7 @@ public final class SpellChecker {
     /** Wrapping punctuation trimmed from a whitespace token's ends before judging it (quotes, brackets,
      *  sentence punctuation, Markdown emphasis). Notably excludes {@code / \\ @ _ = ~} and {@code -}: those
      *  are part of the token's structure (or intra-word), not edge decoration. */
-    private static final String EDGE = "\"'`()[]{}<>,;:.!?*#|…‘’“”";
+    private static final String EDGE = "\"'`()[]{}<>,;:.!?*#|…‘’“”«»";
 
     /**
      * Whether the letter run {@code [start, end)} is part of a URL, file path, e-mail, or
@@ -149,10 +190,10 @@ public final class SpellChecker {
         }
         int ts = start;
         int te = end;
-        while (ts > 0 && !Character.isWhitespace(line.charAt(ts - 1))) {
+        while (ts > 0 && !isTokenBreak(line.charAt(ts - 1))) {
             ts--;
         }
-        while (te < line.length() && !Character.isWhitespace(line.charAt(te))) {
+        while (te < line.length() && !isTokenBreak(line.charAt(te))) {
             te++;
         }
         while (ts < te && EDGE.indexOf(line.charAt(ts)) >= 0) {
@@ -163,7 +204,7 @@ public final class SpellChecker {
         }
         for (int k = ts; k < te; k++) {
             char c = line.charAt(k);
-            if (!Character.isLetter(c) && c != '-' && c != '\'') {
+            if (!Character.isLetter(c) && !isDash(c) && !isApostrophe(c)) {
                 return true;
             }
         }
@@ -194,14 +235,14 @@ public final class SpellChecker {
                 char ch = line.charAt(end);
                 if (Character.isLetter(ch)) {
                     end++;
-                } else if (ch == '\'' && end + 1 < n && Character.isLetter(line.charAt(end + 1))) {
-                    end++; // apostrophe between letters stays in the word
+                } else if (isApostrophe(ch) && end + 1 < n && Character.isLetter(line.charAt(end + 1))) {
+                    end++; // apostrophe between letters stays in the word (incl. the typographic "don’t")
                 } else {
                     break;
                 }
             }
             // Trim a trailing apostrophe that slipped in (shouldn't, given the look-ahead, but be safe).
-            while (end > start && line.charAt(end - 1) == '\'') {
+            while (end > start && isApostrophe(line.charAt(end - 1))) {
                 end--;
             }
             if (end > start) {

--- a/src/test/java/com/editora/editor/SpellCheckerTest.java
+++ b/src/test/java/com/editora/editor/SpellCheckerTest.java
@@ -88,6 +88,51 @@ class SpellCheckerTest {
     }
 
     @Test
+    void typographicPunctuationDoesNotExemptWordsFromChecking() {
+        // macOS/iOS auto-substitute "--"→"—" and "'"→"’". Those chars used to fail the letters-only token
+        // test, marking the WHOLE token structural — so every word joined by them was silently unchecked.
+        String em = "The results—surprising—showed up.";
+        for (int[] s : SpellChecker.wordSpans(em)) {
+            assertFalse(
+                    SpellChecker.partOfStructuredToken(em, s[0], s[1]),
+                    word(em, s) + " is prose joined by an em dash, not a structured token");
+        }
+        String smart = "The world’s problem";
+        for (int[] s : SpellChecker.wordSpans(smart)) {
+            assertFalse(
+                    SpellChecker.partOfStructuredToken(smart, s[0], s[1]),
+                    word(smart, s) + " is prose with a typographic apostrophe");
+        }
+        // …while real structured tokens are still skipped.
+        assertTrue(structural("https://x/y"));
+        assertTrue(structural("snake_case"));
+    }
+
+    @Test
+    void nonBreakingSpaceSeparatesTokens() {
+        // Character.isWhitespace(U+00A0) is false, so the token walk ran straight through an NBSP and merged
+        // the words either side into one "structural" token — pervasive in pasted text and French typography.
+        String line = "hello\u00A0world"; // a non-breaking space, not a regular one
+        for (int[] s : SpellChecker.wordSpans(line)) {
+            assertFalse(
+                    SpellChecker.partOfStructuredToken(line, s[0], s[1]),
+                    word(line, s) + " is a plain word (NBSP is a token break)");
+        }
+    }
+
+    @Test
+    void typographicApostropheStaysInsideTheWordAndNormalizes() {
+        String line = "isn’t";
+        List<int[]> spans = SpellChecker.wordSpans(line);
+        assertEquals(1, spans.size(), "isn’t is ONE word, not isn + t");
+        assertEquals("isn’t", word(line, spans.get(0)));
+        // …and the lookup normalizes it to the ASCII form the dictionaries actually contain.
+        assertEquals("isn't", SpellChecker.normalizeApostrophes("isn’t"));
+        assertEquals("don't", SpellChecker.normalizeApostrophes("don‘t"));
+        assertEquals("plain", SpellChecker.normalizeApostrophes("plain"));
+    }
+
+    @Test
     void skipsIdentifiersAcronymsNumbersAndShortWords() {
         assertTrue(SpellChecker.skip("a")); // too short
         assertTrue(SpellChecker.skip("getName")); // camelCase
@@ -116,6 +161,17 @@ class SpellCheckerTest {
         assertFalse(c.isMisspelled("zzx")); // ignored this session
 
         assertTrue(c.suggest("teh").contains("the"));
+    }
+
+    @Test
+    void typographicApostropheIsNotFlaggedAgainstTheRealDictionary() {
+        // The .dic spells contractions with an ASCII "'", but editors auto-substitute U+2019 — without
+        // normalization "don’t" would be reported misspelled.
+        assumeTrue(SpellDictionaries.buildBlocking("en_US").isPresent(), "en_US dictionary should build");
+        SpellChecker c = new SpellChecker("en_US", Set.of());
+        assertFalse(c.isMisspelled("don’t"), "don’t normalizes to don't");
+        assertFalse(c.isMisspelled("isn’t"));
+        assertTrue(c.isMisspelled("wrold’s"), "a genuine misspelling is still caught with a smart apostrophe");
     }
 
     @Test

--- a/src/test/java/com/editora/ui/SpellMarkdownFenceFxTest.java
+++ b/src/test/java/com/editora/ui/SpellMarkdownFenceFxTest.java
@@ -1,0 +1,55 @@
+package com.editora.ui;
+
+import java.nio.file.Path;
+
+import com.editora.editor.EditorBuffer;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Pins that a Markdown buffer's spell overlay actually knows it's Markdown, so ``` fenced code blocks are
+ * skipped. {@code setMarkdown} was only ever called from {@code installOverlays()} — which runs in the
+ * EditorBuffer constructor, before any path/language exists — so the flag was permanently false and the
+ * fenced-code skip (and its unit tests) were dead code in production: opening a README squiggled `sudo`,
+ * `cd`, `xzf` inside its ```bash block.
+ */
+@Tag("fx")
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class SpellMarkdownFenceFxTest {
+
+    @BeforeAll
+    void setUp() throws Exception {
+        FxTestSupport.bootToolkit();
+    }
+
+    private static boolean overlayThinksItsMarkdown(EditorBuffer b) {
+        Object overlay = FxTestSupport.field(b, "spellOverlay");
+        return FxTestSupport.<Boolean>field(overlay, "markdown");
+    }
+
+    @Test
+    void aMarkdownBufferTellsItsSpellOverlaySoFencesAreSkipped() throws Exception {
+        boolean markdown = FxTestSupport.callOnFx(() -> {
+            EditorBuffer b = new EditorBuffer();
+            b.setContent("text\n```bash\nsudo cd xzf\n```\n");
+            b.setPath(Path.of("README.md")); // → applyLanguage("markdown", …)
+            return overlayThinksItsMarkdown(b);
+        });
+        assertTrue(markdown, "a .md buffer's spell overlay must be in markdown mode (fenced code skipped)");
+    }
+
+    @Test
+    void aNonMarkdownBufferIsNotInMarkdownMode() throws Exception {
+        boolean markdown = FxTestSupport.callOnFx(() -> {
+            EditorBuffer b = new EditorBuffer();
+            b.setPath(Path.of("Main.java"));
+            return overlayThinksItsMarkdown(b);
+        });
+        assertFalse(markdown, "a code buffer is not in markdown mode");
+    }
+}


### PR DESCRIPTION
Per-feature audit indexed by Settings page — **Spell Check**. The audit found 9 confirmed issues; this PR is the **"what gets checked"** half. The personal-dictionary/refresh half (5 more, incl. two data-loss bugs) follows in a second PR.

## 1. Markdown fenced code blocks were spell-checked
`spellOverlay.setMarkdown(...)` was called **only** from `installOverlays()` — which runs in the `EditorBuffer` **constructor**, before any path/language exists, so `isMarkdown()` was always `false`. `applyLanguage()` pushed `setProseMode` but never `setMarkdown`. The flag was therefore permanently false for every buffer, making the fence-skip **and its 5 `SpellCheckOverlayTest` cases dead code in production**.

Measured on this repo with the real en_US dictionary: **`README.md` → 11 squiggles inside ``` fences** (`sudo`, `cd`, `xzf`, `dir`, `dev`, …); `docs/architecture.md` → 16. Fixed by pushing `setMarkdown` from `applyLanguage`. The new `SpellMarkdownFenceFxTest` **fails on the old code**.

## 2. Typographic punctuation silently exempted whole clauses
`partOfStructuredToken`'s allow-list was letters + ASCII `-` + ASCII `'`. Anything else made the entire whitespace-bounded token "structural" → **every word in it skipped**. Since macOS/iOS auto-substitute `--`→`—` and `'`→`’`, that's ordinary typed prose:

```
"The results—wrold surprising—showed up."  -> flagged: []       <<< 'wrold' MISSED
"The results--wrold surprising--showed up." -> flagged: [wrold]  (ASCII control: correct)
"The wrold’s problem"                       -> flagged: []       <<< MISSED
"hello<NBSP>wrold"                          -> flagged: []       <<< MISSED
```
`U+00A0` compounds it: `Character.isWhitespace(NBSP)` is **false**, so the token walk ran straight through it and merged the words either side — hits pasted-from-web text and **French**, a bundled language whose typography *requires* NBSP.

Fixed as one careful pass (the parts interact — a naive fix would newly false-positive `isn`/`didn`/`doesn`):
- `wordSpans` treats U+2018/U+2019 as intra-word apostrophes → `isn’t` is **one** span;
- `isMisspelled`/`suggest` **normalize** them to ASCII so the lookup matches the dictionary's `don't`;
- `partOfStructuredToken` allows the Unicode dash/apostrophe class, and its token walk breaks on `isSpaceChar` too;
- `«»` joined the trimmed edge set (French).

Real structured tokens (`https://x/y`, `snake_case`, `./mvnw`) are still skipped.

## 3. The dictionary was built even with spell check off
`SpellChecker`'s constructor called `ensureBuilt()` unconditionally, and **every** `EditorBuffer` constructs one — so a user with `spellCheck = false` still paid **~200 ms startup CPU + ~1 MB retained per language** (static cache, never evicted) on every launch. `setSpellCheckEnabled(true)`/`setLanguage` already trigger the build when it's actually needed; dropped it from the ctor. (Notable against the ~300 ms the AOT cache buys back.)

## Tests
`SpellCheckerTest`: em dash / smart apostrophe / NBSP are not structural; `isn’t` is one span; `normalizeApostrophes`; and an **end-to-end** check against the real en_US dictionary that `don’t`/`isn’t` are *not* flagged while `wrold’s` still is. Plus `SpellMarkdownFenceFxTest`, verified to fail on the old code (`expected: <true> but was: <false>`). Full suite **2031 tests, 0 failures**; `spotless:check` clean.

## Coming in PR 2/2
Settings Add/Remove personal word has no live effect; `ensureBuilt` drops `onReady` when a build is in flight (restored tabs show no squiggles); Add-to-Dictionary leaves stale squiggles on other tabs; `dictionary.txt` is rewritten non-atomically (crash ⇒ whole personal dictionary lost); one malformed byte in `dictionary.txt` silently discards it entirely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)