### PR TITLE
Spell audit (2/2): personal-dictionary data loss, live apply, dropped callbacks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Your personal spell dictionary can no longer be silently lost.** `dictionary.txt` was rewritten by
+  truncating it first (a crash or full disk mid-write left it empty), and a single malformed byte anywhere in
+  it made Editora discard *every* word without a word — after which removing a word rewrote the file from that
+  empty set, making the loss permanent. It's now written atomically and read leniently (a stray byte or a
+  byte-order mark no longer costs you the file). (From a per-feature audit of Spell Check.)
+
+- **Adding or removing a word in Settings → Spell Check now takes effect immediately** instead of only after
+  toggling something else or restarting.
+
+- **"Add to Dictionary" now clears the squiggle in every open tab**, not just the one you right-clicked in.
+
+- **Restored tabs get their squiggles without needing a scroll or keystroke.** When several files asked for
+  the same dictionary at once (session restore, a language switch), only the first was told when it finished
+  loading — the rest silently showed no spell check at all.
+
+
 - **Spell check no longer squiggles inside Markdown fenced code blocks.** The "skip ``` code fences" rule was
   never actually switched on (it was decided before the file's language was known), so opening a README put red
   squiggles on `sudo`, `cd`, `xzf` and friends inside its code blocks. (From a per-feature audit of Spell

--- a/src/main/java/com/editora/config/SharedConfig.java
+++ b/src/main/java/com/editora/config/SharedConfig.java
@@ -366,7 +366,9 @@ public class SharedConfig {
         }
     }
 
-    /** Rewrites {@code dictionary.txt} from the in-memory set (one word per line); non-fatal on failure. */
+    /** Rewrites {@code dictionary.txt} from the in-memory set (one word per line); non-fatal on failure.
+     *  Written via temp + atomic move (the project convention): a plain {@code writeString} truncates first,
+     *  so a crash / disk-full between truncate and write left the whole personal dictionary empty. */
     private void rewriteUserDictionary() {
         try {
             Files.createDirectories(configDir);
@@ -374,7 +376,8 @@ public class SharedConfig {
             for (String w : userDictionary) {
                 sb.append(w).append(System.lineSeparator());
             }
-            Files.writeString(getUserDictionaryFile(), sb.toString());
+            com.editora.io.AtomicFileWrite.write(
+                    getUserDictionaryFile(), sb.toString().getBytes(java.nio.charset.StandardCharsets.UTF_8));
         } catch (IOException e) {
             // non-fatal: the in-memory set still applies for this session
         }
@@ -387,8 +390,12 @@ public class SharedConfig {
             return;
         }
         try {
-            for (String line : Files.readAllLines(file)) {
-                String w = line.strip().toLowerCase(java.util.Locale.ROOT);
+            // Lenient decode: Files.readAllLines REPORTs malformed bytes and throws, which silently discarded
+            // the ENTIRE personal dictionary over one bad byte — and a later remove would then rewrite the
+            // file from that empty set (permanent loss). new String(bytes, UTF_8) replaces instead of throwing.
+            String text = new String(Files.readAllBytes(file), java.nio.charset.StandardCharsets.UTF_8);
+            for (String line : text.split("\r?\n")) {
+                String w = stripBom(line).strip().toLowerCase(java.util.Locale.ROOT);
                 if (!w.isEmpty()) {
                     userDictionary.add(w);
                 }
@@ -396,6 +403,12 @@ public class SharedConfig {
         } catch (IOException ignored) {
             // missing/unreadable dictionary just means no user words
         }
+    }
+
+    /** Drops a leading UTF-8 BOM — {@link String#strip()} does not (U+FEFF is {@code Cf}, not whitespace), so
+     *  a BOM'd dictionary.txt left its first word permanently unmatchable. */
+    private static String stripBom(String s) {
+        return !s.isEmpty() && s.charAt(0) == '﻿' ? s.substring(1) : s;
     }
 
     // --- loading + saving the bucketed stores ---

--- a/src/main/java/com/editora/editor/EditorBuffer.java
+++ b/src/main/java/com/editora/editor/EditorBuffer.java
@@ -1980,6 +1980,13 @@ public class EditorBuffer implements TabContent {
         spellOverlay.refresh();
     }
 
+    /** Drops this buffer's memoized spell verdicts and repaints. Call after the shared user-word set changes:
+     *  the set is shared, but each buffer's overlay memoizes its own per-word results, so without this the
+     *  other tabs keep squiggling a word that was just added to the dictionary. */
+    public void refreshSpell() {
+        spellOverlay.refresh();
+    }
+
     /** The primary view. Tool windows, overlays, folding and highlighting all bind to this one. */
     public CodeArea getArea() {
         return area;

--- a/src/main/java/com/editora/editor/SpellDictionaries.java
+++ b/src/main/java/com/editora/editor/SpellDictionaries.java
@@ -3,6 +3,8 @@ package com.editora.editor;
 import java.io.IOException;
 import java.io.InputStream;
 import java.text.ParseException;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -33,6 +35,9 @@ public final class SpellDictionaries {
 
     private static final Map<String, Hunspell> CACHE = new ConcurrentHashMap<>();
     private static final Set<String> BUILDING = ConcurrentHashMap.newKeySet();
+    /** Callbacks waiting on an in-flight build, per language — several buffers commonly ask at once. */
+    private static final Map<String, List<Runnable>> PENDING = new ConcurrentHashMap<>();
+
     private static final ExecutorService BUILDER = Executors.newSingleThreadExecutor(r -> {
         Thread t = new Thread(r, "spell-dictionary-builder");
         t.setDaemon(true);
@@ -57,26 +62,45 @@ public final class SpellDictionaries {
 
     /**
      * Ensures {@code langId} is built (off-thread, once), then runs {@code onReady} on the FX thread.
-     * No-op if already built/building or unavailable. {@code onReady} may be {@code null}.
+     * {@code onReady} <b>always</b> fires (unless the language is unavailable): immediately when the language
+     * is already built, and after an in-flight build for every waiting caller. {@code onReady} may be null.
      */
     public static void ensureBuilt(String langId, Runnable onReady) {
-        if (langId == null || CACHE.containsKey(langId) || !AVAILABLE.contains(langId)) {
+        if (langId == null || !AVAILABLE.contains(langId)) {
             return;
         }
+        if (CACHE.containsKey(langId)) {
+            if (onReady != null) {
+                Platform.runLater(onReady); // already built — the caller still needs its callback
+            }
+            return;
+        }
+        // Queue BEFORE claiming the build: several buffers ask for the same language at once (session
+        // restore, a language switch), and dropping the losers' callbacks left those buffers with no
+        // squiggles at all until the user scrolled or typed.
+        if (onReady != null) {
+            PENDING.computeIfAbsent(langId, k -> Collections.synchronizedList(new ArrayList<>()))
+                    .add(onReady);
+        }
         if (!BUILDING.add(langId)) {
-            return; // a build is already in flight
+            return; // a build is in flight; it will run our queued callback
         }
         BUILDER.execute(() -> {
             try {
                 Hunspell h = build(langId);
                 CACHE.put(langId, h);
-                if (onReady != null) {
-                    Platform.runLater(onReady);
-                }
             } catch (Exception | LinkageError e) {
                 // Leave uncached; a later ensureBuilt() can retry. Never let a bad dictionary crash the app.
             } finally {
+                // Clear BUILDING first: a caller racing here then starts a fresh build that drains its own
+                // queued callback, rather than having it stranded in PENDING forever.
                 BUILDING.remove(langId);
+                List<Runnable> waiting = PENDING.remove(langId);
+                if (waiting != null) {
+                    for (Runnable r : waiting) {
+                        Platform.runLater(r);
+                    }
+                }
             }
         });
     }

--- a/src/main/java/com/editora/ui/MainController.java
+++ b/src/main/java/com/editora/ui/MainController.java
@@ -4999,7 +4999,7 @@ public class MainController implements com.editora.mcp.McpBridge {
         // Spell checking: share the user dictionary + persist "Add to Dictionary" (before applyViewSettings,
         // which sets the per-file language and enables checking).
         buffer.setSpellUserWords(config.getUserDictionary());
-        buffer.setOnAddToDictionary(config::addUserWord);
+        buffer.setOnAddToDictionary(this::addUserWordAndRefreshAll);
         applyViewSettings(buffer);
         buffer.getFoldManager().setOnFoldStateChanged(() -> persistFolds(buffer));
         buffer.setOnBookmarksChanged(() -> bookmarkCoordinator.persistBookmarks(buffer));
@@ -9960,6 +9960,19 @@ public class MainController implements com.editora.mcp.McpBridge {
             err.setHeaderText(tr("status.print.failed", ""));
             err.setContentText(msg);
             err.showAndWait();
+        }
+    }
+
+    /** Persists a word to the shared personal dictionary, then drops every open buffer's memoized spell
+     *  verdicts — the word set is shared, but each buffer's overlay caches its own results, so "Add to
+     *  Dictionary" in one tab used to leave the word squiggled in the others for the rest of the session. */
+    private void addUserWordAndRefreshAll(String word) {
+        config.addUserWord(word);
+        for (Tab tab : tabPane.getTabs()) {
+            EditorBuffer b = bufferOf(tab);
+            if (b != null) {
+                b.refreshSpell();
+            }
         }
     }
 

--- a/src/main/java/com/editora/ui/SettingsWindow.java
+++ b/src/main/java/com/editora/ui/SettingsWindow.java
@@ -2360,6 +2360,7 @@ public class SettingsWindow {
                 input.clear();
                 refreshDictionaryList();
                 dictionaryList.getSelectionModel().select(w);
+                apply(); // live-apply like every other control here: re-runs the spell overlays' caches
             }
             input.requestFocus();
         };
@@ -2374,6 +2375,7 @@ public class SettingsWindow {
             if (sel != null) {
                 config.removeUserWord(sel);
                 refreshDictionaryList();
+                apply(); // live-apply: the removed word must start being flagged again right away
             }
         });
 

--- a/src/test/java/com/editora/config/UserDictionaryTest.java
+++ b/src/test/java/com/editora/config/UserDictionaryTest.java
@@ -6,6 +6,7 @@ import java.nio.file.Path;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -33,5 +34,47 @@ class UserDictionaryTest {
         ConfigManager c = new ConfigManager(dir);
         c.removeUserWord("nothere"); // must not throw
         assertTrue(c.getUserDictionary().isEmpty());
+    }
+
+    // --- load robustness: dictionary.txt is a plain text file the user can also hand-edit -----------
+
+    /** Loads dictionary.txt fresh (as a new launch would). */
+    private static java.util.Set<String> reload(Path dir) {
+        ConfigManager fresh = new ConfigManager(dir);
+        fresh.load();
+        return java.util.Set.copyOf(fresh.getUserDictionary());
+    }
+
+    @Test
+    void aMalformedByteDoesNotDiscardTheWholeDictionary(@TempDir Path dir) throws Exception {
+        // A lone 0xE9 (latin-1 "é") is invalid UTF-8. A strict decode (readAllLines) threw on it and left the
+        // set EMPTY — losing every user word; a later remove would then rewrite the file from that empty set.
+        byte[] bad = {'a', 'l', 'p', 'h', 'a', '\n', (byte) 0xE9, '\n', 'g', 'a', 'm', 'm', 'a', '\n'};
+        Files.write(dir.resolve("dictionary.txt"), bad);
+
+        java.util.Set<String> words = reload(dir);
+        assertTrue(words.contains("alpha"), "a bad byte must not discard the surrounding words");
+        assertTrue(words.contains("gamma"));
+    }
+
+    @Test
+    void aByteOrderMarkDoesNotBreakTheFirstWord(@TempDir Path dir) throws Exception {
+        // String.strip() does NOT remove U+FEFF (it's Cf, not whitespace), so the first word stayed
+        // permanently unmatchable.
+        Files.write(
+                dir.resolve("dictionary.txt"),
+                "﻿editora\nhunspell\n".getBytes(java.nio.charset.StandardCharsets.UTF_8));
+
+        java.util.Set<String> words = reload(dir);
+        assertTrue(words.contains("editora"), "a BOM'd first word is still usable");
+        assertFalse(words.contains("﻿editora"));
+    }
+
+    @Test
+    void blankAndDuplicateLinesAreTolerated(@TempDir Path dir) throws Exception {
+        Files.write(
+                dir.resolve("dictionary.txt"),
+                "alpha\n\n  \nALPHA\r\nbeta\n".getBytes(java.nio.charset.StandardCharsets.UTF_8));
+        assertEquals(java.util.Set.of("alpha", "beta"), reload(dir));
     }
 }


### PR DESCRIPTION
The second half of the **Spell Check** audit (PR #431 covered the scanning fixes). Five confirmed findings — **two are data loss**.

## 1. 🔴 `dictionary.txt` was rewritten non-atomically
`rewriteUserDictionary` (used by remove) called `Files.writeString` = `CREATE + TRUNCATE_EXISTING + WRITE` — the file is **emptied before** the new bytes land, with no temp+move. A crash / disk-full in between left the user's whole personal dictionary empty, and the `IOException` was swallowed ("the in-memory set still applies for this session"), so they'd only discover it next launch. Now goes through `io/AtomicFileWrite` (temp + atomic move) — the convention `ConfigWriter`, `SnippetManager`, and `TemplateRegistry` all already follow. (`addUserWord` APPENDs, so it was never at risk.)

## 2. 🔴 One malformed byte discarded the *entire* dictionary
`Files.readAllLines` decodes with `CodingErrorAction.REPORT`, so **any** bad byte threw and the set stayed empty — **silently**. Then a later remove rewrote the file from that empty set: **permanent loss**. This is reachable through shipped features — the file is hand-editable via *"Open dictionary.txt…"*, and an EditorConfig `charset` rule under `~/.editora/` makes Editora itself write a file it can no longer read. Now decodes leniently. Also strips a **UTF-8 BOM**, which `String.strip()` does *not* (U+FEFF is `Cf`, not whitespace) — it left the first word permanently unmatchable.

## 3. Settings Add/Remove had no live effect
Both handlers skipped `apply()` — unlike every other control on the page — so a word added or removed in Settings → Spell Check didn't change the squiggles until an unrelated toggle or a restart.

## 4. Dictionary-ready callbacks were dropped
`ensureBuilt` returned early — discarding `onReady` — both when a build was **already in flight** and when the language was **already cached**. Restoring 3 Markdown tabs: buffer 1 wins the build; buffers 2 and 3 have their `refresh` thrown away and show **no squiggles at all** until the user scrolls or types. Callbacks are now queued per language and all fired (and fire immediately when already built).

## 5. "Add to Dictionary" left stale squiggles on other tabs
The user-word set is shared, but each buffer's overlay memoizes its own verdicts — so the word stayed squiggled in every *other* open tab for the rest of the session. `MainController` now fans the refresh out to all open buffers.

## Tests
`UserDictionaryTest` gains malformed-byte / BOM / blank+duplicate-line cases. The two data-loss cases **fail on the old strict read** (verified: `expected: <true> but was: <false>`). Full suite **2034 tests, 0 failures**; `spotless:check` clean.

## Known remaining gap
The Add-to-Dictionary fan-out is per-window; another window's tabs still need a settings apply to pick it up. Noted, not fixed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)