### PR TITLE
Fix CI: the macro Alt-chord test asserted macOS-only behaviour

### DIFF
--- a/src/test/java/com/editora/ui/MacroCaptureFxTest.java
+++ b/src/test/java/com/editora/ui/MacroCaptureFxTest.java
@@ -34,6 +34,10 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class MacroCaptureFxTest {
 
+    /** Mirrors KeyDispatcher.IS_MAC — the Alt-consume that gates what this hook can see is per-OS. */
+    private static final boolean IS_MAC =
+            System.getProperty("os.name", "").toLowerCase(java.util.Locale.ROOT).contains("mac");
+
     @BeforeAll
     void setUp() throws Exception {
         FxTestSupport.bootToolkit();
@@ -104,9 +108,25 @@ class MacroCaptureFxTest {
         FxTestSupport.runOnFx(() -> {
             fire(r.buffer().getArea(), KeyCode.DOWN, true, false, false); // S-down: extend selection
             fire(r.buffer().getArea(), KeyCode.LEFT, false, true, false); // C-left: word left
-            fire(r.buffer().getArea(), KeyCode.DOWN, false, false, true); // M-down: unbound here
         });
-        assertEquals(List.of("key:S-DOWN", "key:C-LEFT", "key:M-DOWN"), r.captured());
+        assertEquals(List.of("key:S-DOWN", "key:C-LEFT"), r.captured());
+    }
+
+    /**
+     * An unbound plain-Alt chord is recorded only where the editor will actually act on it — i.e. macOS,
+     * where Option is Meta and the area handles Option-Down.
+     *
+     * <p>On Windows/Linux {@code KeyDispatcher} deliberately <em>consumes</em> an unbound key held with plain
+     * Alt, before this hook's fall-through: letting it through makes the OS treat it as a menu mnemonic and
+     * freezes the keyboard app-wide. The key therefore never reaches the area, so recording it would be
+     * wrong — replaying it would do nothing either. (This assertion was macOS-only and unguarded, which is
+     * what broke CI on the Linux runner.)
+     */
+    @Test
+    void anUnboundAltChordIsRecordedOnlyWhereTheEditorWillSeeIt() throws Exception {
+        Rig r = FxTestSupport.callOnFx(MacroCaptureFxTest::rig);
+        FxTestSupport.runOnFx(() -> fire(r.buffer().getArea(), KeyCode.DOWN, false, false, true)); // M-down
+        assertEquals(IS_MAC ? List.of("key:M-DOWN") : List.of(), r.captured());
     }
 
     private static void fire(javafx.scene.Node target, KeyCode code, boolean shift, boolean ctrl, boolean alt) {


### PR DESCRIPTION
**CI has been red on every commit since the Macros audit (#448)** — ten merged PRs, all on a broken build. The suite passes on macOS, which is the only place I ran it, and I never checked the runs. That's the part worth recording; the fix itself is small.

## The break

One assertion, out of 2150:

```
MacroCaptureFxTest.modifiersRideAlongInTheRecordedToken:109
  expected: <[key:S-DOWN, key:C-LEFT, key:M-DOWN]> but was: <[key:S-DOWN, key:C-LEFT]>
```

**The product is correct on both platforms; the test was wrong.** On Windows/Linux `KeyDispatcher` deliberately consumes an unbound key held with plain Alt, and returns *before* the macro hook's unbound-key fall-through:

```java
if (plainAltActive(IS_MAC, event.isAltDown(), event.isControlDown())) {
    event.consume();
    consumedPress = true;
    return;                      // <-- before the keyListener fall-through
}
// A lone, unbound key: ... hand it to the macro recorder
```

That's the documented menu-mode fix — letting an unbound Alt chord through makes the OS treat it as a menu mnemonic and freezes the keyboard app-wide. So on Linux the key never reaches the area, and **not** recording it is right: a replayed `M-DOWN` would do nothing there either. On macOS, Option is Meta, the area acts on Option-Down, and it must be recorded.

I asserted the macOS answer unconditionally.

## The fix

The Alt case moves into its own test asserting the real per-OS contract (mirroring `KeyDispatcher.IS_MAC`), and the modifier test keeps the two chords that behave identically everywhere:

```java
@Test
void anUnboundAltChordIsRecordedOnlyWhereTheEditorWillSeeIt() throws Exception {
    Rig r = FxTestSupport.callOnFx(MacroCaptureFxTest::rig);
    FxTestSupport.runOnFx(() -> fire(r.buffer().getArea(), KeyCode.DOWN, false, false, true));
    assertEquals(IS_MAC ? List.of("key:M-DOWN") : List.of(), r.captured());
}
```

This documents the cross-platform behaviour rather than hiding it behind a platform-dependent expectation.

## A note on verification

I could not reproduce the Linux branch locally, and the attempt was itself instructive: `-Dos.name=Linux` *is* overridable on the JVM, but surefire's `<argLine>@{argLine}</argLine>` late-binds to a property JaCoCo rewrites, so `-DargLine` never reached the forked JVM — the "simulation" passed while changing nothing, exactly like the `timeout`-doesn't-exist-on-macOS trap from the Debug audit.

So the evidence here is CI's own log (Linux observed `M-DOWN` missing; this test now asserts precisely that) plus the code path above. **CI is the oracle for this one** — which is the whole lesson.

🤖 Generated with [Claude Code](https://claude.com/claude-code)