### PR TITLE
Close the Windows terminal command-injection in Open-Terminal-Here (#413)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+- **Opening a terminal in an untrusted repo can no longer run its commands (Windows).** "Open Terminal Here"
+  built a `cmd.exe` command line with the folder path spliced in (`cmd /k cd /d <dir>`), so a repository
+  shipping a directory named with a shell metacharacter — `&`, `|`, `^`, all legal in Windows folder names —
+  executed arbitrary commands the moment you opened a terminal there. The folder is now handed to the child
+  process as its working directory, where no shell parses it, instead of being placed in any command line.
+  (macOS and Linux were never affected — they exec the terminal launcher directly, with no shell. "Reveal in
+  Explorer" was never affected either: `explorer.exe` is launched directly and runs no subcommand.)
+
 - **SFTP connections now verify the server's host key.** Editora accepted *any* key, so anyone positioned
   between you and your server — hostile Wi-Fi, a compromised router, DNS spoofing — could impersonate it
   silently, and with password auth Editora simply handed them the password, along with the contents of every

--- a/TODO.md
+++ b/TODO.md
@@ -3,6 +3,18 @@
 A backlog of planned features and improvements. Unordered within each section.
 
 ## Recently shipped
+- [x] **Windows cmd metacharacter injection in "Open Terminal Here"** (#413, security) —
+      `DesktopActions.terminalArgv` built `cmd /c start cmd /k "cd /d " + dir`, splicing the folder path into a
+      `cmd.exe` command line. A repo shipping a directory named `repo & calc.exe & rem ` (every char legal in a
+      Windows folder name) ran `calc.exe` when the user picked Open-Terminal-Here on it. Fixed by construction:
+      the path is delivered as the child's **working directory** (`ProcessBuilder.directory`, i.e. CreateProcess
+      `lpCurrentDirectory`, parsed by no shell) and the argv is fixed literals (`cmd /c start "" cmd /k`); a new
+      `DesktopActions.Command{argv, workingDir}` record carries the split. mac/linux exec their launcher directly
+      (no shell) so their path-as-argv was always safe; **Reveal-in-Explorer was never a command-injection vector
+      either** — `explorer.exe` is launched directly and runs no subcommand (documented, not "fixed"). The
+      injection-closure is proven by a pure test (the malicious path appears in no cmd argument, fails on the old
+      code); **the launch behaviour — that `start ""` opens a console inheriting the working directory — is the
+      one part unverifiable on macOS and wants a Windows device-test** (per the issue's own caveat).
 - [x] **SFTP host-key verification (GHSA-p4qf-p7q6-2mrw)** — the initiative's top open security item, and the
       first of the deferred backlog. `RemoteFileSystems` passed **`AcceptAllServerKeyVerifier`**, so SSH's
       entire security model was off: a MITM on the path presented their own key, Editora connected without a

--- a/src/main/java/com/editora/process/DesktopActions.java
+++ b/src/main/java/com/editora/process/DesktopActions.java
@@ -24,6 +24,20 @@ public final class DesktopActions {
         WINDOWS
     }
 
+    /**
+     * A desktop command to launch: its {@code argv}, plus an optional {@code workingDir} that is set on the
+     * child process (via {@link ProcessBuilder#directory}) instead of being interpolated into any argument.
+     *
+     * <p>The distinction is a security boundary. On Windows the terminal is opened through {@code cmd.exe},
+     * which parses its command line — so a folder path placed <em>in</em> that command line (the old
+     * {@code cmd /k "cd /d " + dir}) lets a directory named with a shell metacharacter — {@code &}, {@code |},
+     * {@code ^}, all legal in Windows folder names — run arbitrary commands when the user picks "Open Terminal
+     * Here" on an untrusted repo. Routing the path through {@code directory()} hands it to CreateProcess's
+     * working-directory parameter, which no shell parses, so there is nothing to inject into. {@code null}
+     * means the child inherits the app's working directory.
+     */
+    public record Command(List<String> argv, Path workingDir) {}
+
     private static final ExecutorService EXEC = Executors.newSingleThreadExecutor(r -> {
         Thread t = new Thread(r, "desktop-actions");
         t.setDaemon(true);
@@ -61,13 +75,23 @@ public final class DesktopActions {
         };
     }
 
-    /** The command that opens a terminal with its working directory set to {@code dir}. Pure. */
-    public static List<String> terminalArgv(Os os, Path dir) {
+    /**
+     * The command that opens a terminal at {@code dir}. Pure.
+     *
+     * <p>macOS and Linux exec their launcher directly (no shell), so passing {@code dir} as an argv element is
+     * safe — a metacharacter in it is just a literal character. Windows must open the terminal through
+     * {@code cmd.exe}, so {@code dir} is <em>not</em> put in the command line: the argv is fixed literals and
+     * the folder is delivered as the child's {@link Command#workingDir}. A new console still needs
+     * {@code start} (a launched-from-a-windowless-process {@code cmd} would get no visible window); the new
+     * window inherits its parent's working directory, which is why {@code directory(dir)} is enough and no
+     * {@code cd} / {@code start /D <path>} appears anywhere a shell could parse it. See {@link Command}.
+     */
+    public static Command terminalCommand(Os os, Path dir) {
         String d = dir.toString();
         return switch (os) {
-            case MAC -> List.of("open", "-a", "Terminal", d);
-            case WINDOWS -> List.of("cmd", "/c", "start", "cmd", "/k", "cd /d " + d);
-            case LINUX -> List.of("x-terminal-emulator", "--working-directory=" + d);
+            case MAC -> new Command(List.of("open", "-a", "Terminal", d), null);
+            case WINDOWS -> new Command(List.of("cmd", "/c", "start", "", "cmd", "/k"), dir);
+            case LINUX -> new Command(List.of("x-terminal-emulator", "--working-directory=" + d), null);
         };
     }
 
@@ -80,21 +104,33 @@ public final class DesktopActions {
         return parent != null ? parent : path;
     }
 
-    /** Reveals {@code path} in the file manager; on failure calls {@code onError} (off the FX thread). */
+    /**
+     * Reveals {@code path} in the file manager; on failure calls {@code onError} (off the FX thread).
+     *
+     * <p>Every {@code revealArgv} launcher ({@code open}/{@code explorer}/{@code xdg-open}) is exec'd
+     * directly via {@link ProcessBuilder} — <em>not</em> through a shell — so the path is a single argv
+     * element and a metacharacter in it is inert. In particular the Windows {@code explorer /select,<path>}
+     * is not a command-injection vector: {@code explorer.exe} parses its own arguments and runs no subcommand.
+     */
     public static void reveal(Path path, boolean isDir, Consumer<String> onError) {
-        launch(revealArgv(currentOs(), path, isDir, containingDir(path, isDir)), onError);
+        launch(revealArgv(currentOs(), path, isDir, containingDir(path, isDir)), null, onError);
     }
 
     /** Opens a terminal at {@code path}'s containing folder; calls {@code onError} (off the FX thread). */
     public static void openTerminal(Path path, boolean isDir, Consumer<String> onError) {
-        launch(terminalArgv(currentOs(), containingDir(path, isDir)), onError);
+        Command cmd = terminalCommand(currentOs(), containingDir(path, isDir));
+        launch(cmd.argv(), cmd.workingDir(), onError);
     }
 
-    private static void launch(List<String> argv, Consumer<String> onError) {
+    private static void launch(List<String> argv, Path workingDir, Consumer<String> onError) {
         EXEC.submit(() -> {
             try {
                 ProcessBuilder pb = new ProcessBuilder(ProcessRunner.resolveExecutable(argv));
                 ProcessRunner.applyStandardEnv(pb);
+                if (workingDir != null) {
+                    // The child's working directory (CreateProcess lpCurrentDirectory), never a shell argument.
+                    pb.directory(workingDir.toFile());
+                }
                 pb.redirectOutput(ProcessBuilder.Redirect.DISCARD);
                 pb.redirectError(ProcessBuilder.Redirect.DISCARD);
                 pb.start();

--- a/src/test/java/com/editora/process/DesktopActionsTest.java
+++ b/src/test/java/com/editora/process/DesktopActionsTest.java
@@ -7,6 +7,8 @@ import com.editora.process.DesktopActions.Os;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 class DesktopActionsTest {
 
@@ -32,13 +34,40 @@ class DesktopActionsTest {
 
     @Test
     void terminalOpensAtDirectory() {
-        assertEquals(List.of("open", "-a", "Terminal", DIR.toString()), DesktopActions.terminalArgv(Os.MAC, DIR));
+        // mac/linux exec their launcher directly (no shell), so the path is safe as an argv element.
         assertEquals(
-                List.of("cmd", "/c", "start", "cmd", "/k", "cd /d " + DIR),
-                DesktopActions.terminalArgv(Os.WINDOWS, DIR));
+                new DesktopActions.Command(List.of("open", "-a", "Terminal", DIR.toString()), null),
+                DesktopActions.terminalCommand(Os.MAC, DIR));
         assertEquals(
-                List.of("x-terminal-emulator", "--working-directory=" + DIR),
-                DesktopActions.terminalArgv(Os.LINUX, DIR));
+                new DesktopActions.Command(List.of("x-terminal-emulator", "--working-directory=" + DIR), null),
+                DesktopActions.terminalCommand(Os.LINUX, DIR));
+        // Windows opens through cmd.exe, so the path is delivered as the working directory, not in the argv.
+        assertEquals(
+                new DesktopActions.Command(List.of("cmd", "/c", "start", "", "cmd", "/k"), DIR),
+                DesktopActions.terminalCommand(Os.WINDOWS, DIR));
+    }
+
+    @Test
+    void windowsTerminalNeverPutsTheFolderPathInAnyCmdArgument() {
+        // A folder named with cmd metacharacters — all legal in a Windows folder name — must not be able to
+        // run a command when the user picks "Open Terminal Here". The old `cmd /k "cd /d " + dir` interpolated
+        // it into the cmd command line; the fix routes it through the working directory, which no shell parses.
+        Path malicious = Path.of("C:\\repo & calc.exe & rem ");
+        DesktopActions.Command cmd = DesktopActions.terminalCommand(Os.WINDOWS, malicious);
+
+        assertEquals(malicious, cmd.workingDir(), "the folder is the child's working directory, verbatim");
+        for (String arg : cmd.argv()) {
+            assertFalse(
+                    arg.contains("calc.exe") || arg.contains("&") || arg.contains(malicious.toString()),
+                    "no cmd argument may carry any part of the folder path: " + arg);
+        }
+    }
+
+    @Test
+    void nonWindowsTerminalSetsNoWorkingDirectory() {
+        // The path rides in the argv there (exec'd directly), so nothing needs the directory() treatment.
+        assertNull(DesktopActions.terminalCommand(Os.MAC, DIR).workingDir());
+        assertNull(DesktopActions.terminalCommand(Os.LINUX, DIR).workingDir());
     }
 
     @Test


### PR DESCRIPTION
Closes #413.

## The bug

On Windows, `DesktopActions.terminalArgv` built:

```
cmd /c start cmd /k "cd /d " + dir
```

The folder path is spliced into a `cmd.exe` command line. `cmd /k` parses that last argument, and `&` separates commands — so a repository shipping a directory named with a shell metacharacter (`&`, `|`, `^`, all legal in Windows folder names) runs arbitrary commands the moment the user picks **Open Terminal Here** on it:

```
OLD Windows terminal argv for a folder named 'repo & calc.exe & rem ':
  [cmd] [/c] [start] [cmd] [/k] [cd /d C:\repo & calc.exe & rem ]
                                  └─ cmd parses: cd C:\repo ; run calc.exe ; rem (eat the rest)
```

## The fix, by construction

The path never appears in any string a shell parses. It's handed to the child process as its **working directory** (`ProcessBuilder.directory()` → CreateProcess `lpCurrentDirectory`), and the argv is fixed literals whose new console window inherits that directory:

```
["cmd", "/c", "start", "", "cmd", "/k"]   +   directory(dir)
```

A new `DesktopActions.Command{argv, workingDir}` record carries the split. There is nothing left for `cmd` to interpolate.

## Scope — stated honestly

- **macOS and Linux exec their terminal launcher directly** (no shell), so passing the path as an argv element was always safe. Unchanged.
- **Reveal-in-Explorer was never a command-injection vector.** `explorer.exe` is launched directly via CreateProcess and runs no subcommand — a metacharacter in the path is inert. I documented it as safe rather than "fixing" a non-bug.

## Verification — and its limit

The **injection closure is proven** by a pure test: for a folder named `C:\repo & calc.exe & rem `, the path appears in *no* cmd argument and rides only in `workingDir`. It fails on the old code:

```
expected: <C:\repo & calc.exe & rem > but was: <null>          (the path wasn't the working dir)
expected: <Command[argv=[cmd, /c, start, , cmd, /k], …]>
     but: <Command[argv=[cmd, /c, start, cmd, /k, cd /d …]]>   (…it was in the command line)
```

The **launch behaviour** — that `start ""` opens a console inheriting the working directory — **cannot be exercised on macOS and wants a Windows device-test**, exactly as the issue itself flagged. What I can guarantee is the security property; what a Windows user should confirm is that the window still opens at the right folder.

Full suite green: **2182**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)