### PR TITLE
Don't retain the SFTP password on the session after auth (#437)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+- **An SFTP password no longer lingers in memory for the whole session.** After authenticating, Editora kept
+  the password on the SSH session's identity list until you disconnected — potentially hours — so a memory dump
+  of a long-running session could recover it. It is now dropped as soon as the handshake completes, since a
+  password is only needed to authenticate. (A password only needs one string copy at the SSH library's
+  boundary, which its API doesn't let us zero; this shrinks how long that copy is reachable from "until
+  disconnect" to "during the handshake".)
+
 - **Opening a terminal in an untrusted repo can no longer run its commands (Windows).** "Open Terminal Here"
   built a `cmd.exe` command line with the folder path spliced in (`cmd /k cd /d <dir>`), so a repository
   shipping a directory named with a shell metacharacter — `&`, `|`, `^`, all legal in Windows folder names —

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -234,7 +234,9 @@ icon (`Icons.findInFiles()`, `onFindInFiles → openSearchInFiles`) sits beside 
   `saveConnections`/`loadConnections`). **`RemoteFileSystems`** (UI-owned, the `GitService` idiom: a daemon
   executor + `Platform.runLater`) holds one `SftpFileSystem` per `user@host:port`, `connect(conn, secret,
   cb)` (auth precedence **default `~/.ssh` keys → key file → password**; the secret `char[]` is wiped after
-  use), `pathFor(SftpUri)`/`disconnect`/`shutdown`, and wires `Vfs.setRemoteResolver` so remote URIs in
+  use, and the password is removed from the SSH session the instant the handshake finishes —
+  `RemoteFileSystems.authenticate`'s `finally` — so MINA's String-only `addPasswordIdentity` copy isn't
+  retained on the session for the whole connection), `pathFor(SftpUri)`/`disconnect`/`shutdown`, and wires `Vfs.setRemoteResolver` so remote URIs in
   recent-files reconstruct to live Paths. **Local-only gating** (all inert for local files, so zero
   behavior change): `MainController.isLocalBuffer` + `Vfs.isLocal` guards on LSP (`syncBufferLsp`
   eligibility), DAP/breakpoints (`isDebuggableBuffer`), run/shell-run/HTTP (`addBuffer`), git

--- a/TODO.md
+++ b/TODO.md
@@ -3,6 +3,18 @@
 A backlog of planned features and improvements. Unordered within each section.
 
 ## Recently shipped
+- [x] **SFTP password lifetime (#437, security / defense-in-depth)** — the connect form wipes the `char[]`
+      secret, but `session.addPasswordIdentity(new String(secret))` kept a String copy on the **session's
+      identity list for the entire connected session** (hours), defeating the wipe at MINA's String-only
+      boundary. Since a password is only needed for the initial handshake (SSH re-keys against the host key,
+      not the password), `RemoteFileSystems.authenticate` now `removePasswordIdentity`s it in a `finally` right
+      after `session.auth()`, shrinking the copy's reachable lifetime from "until disconnect" to "the
+      handshake". The unavoidable String at the MINA boundary stays (no `char[]` client API; the issue notes
+      this) — this closes the *duration*, not the copy. Auth extracted into a testable `authenticate(session,
+      conn, secret, timeout)`; **proven against a real in-process SSH server** — after auth
+      `ClientSession.passwordIteratorOf(session)` is empty (success and rejected-password paths both), failing
+      on the old code (`expected: <false> but was: <true>`). Completes the SFTP hardening trio (host key #487,
+      this).
 - [x] **Windows cmd metacharacter injection in "Open Terminal Here"** (#413, security) —
       `DesktopActions.terminalArgv` built `cmd /c start cmd /k "cd /d " + dir`, splicing the folder path into a
       `cmd.exe` command line. A repo shipping a directory named `repo & calc.exe & rem ` (every char legal in a

--- a/src/main/java/com/editora/vfs/RemoteFileSystems.java
+++ b/src/main/java/com/editora/vfs/RemoteFileSystems.java
@@ -150,10 +150,37 @@ public final class RemoteFileSystems {
                 .verify(CONNECT_TIMEOUT)
                 .getSession();
         try {
+            authenticate(session, conn, secret, AUTH_TIMEOUT);
+            // On success the SftpFileSystem owns the session (closing the FS closes it).
+            return SftpClientFactory.instance().createSftpFileSystem(session);
+        } catch (IOException | RuntimeException e) {
+            session.close(true); // failed auth / FS creation: close the session so it isn't leaked
+            throw e;
+        }
+    }
+
+    /**
+     * Runs the auth handshake on {@code session} for {@code conn}, using {@code secret} as the password or key
+     * passphrase, returning once authenticated.
+     *
+     * <p>For password auth the password is <b>removed from the session as soon as the handshake finishes</b>.
+     * MINA's client API is String-only ({@code addPasswordIdentity(String)} / a String-returning
+     * {@code PasswordIdentityProvider}), so a String copy that the caller's {@code char[]} wipe cannot reach
+     * is unavoidable at this boundary — but {@code addPasswordIdentity} otherwise keeps that String on the
+     * session's identity list for the <em>entire connected session</em>, which can be hours. A password is
+     * only needed for the initial handshake (SSH re-keys against the host key, not the password), so removing
+     * it in a {@code finally} shrinks its lifetime from "until you disconnect" to "the handshake", after which
+     * it is unreachable and eligible for GC. Package-visible so it can be tested against a real SSH server.
+     */
+    static void authenticate(ClientSession session, RemoteConnection conn, char[] secret, Duration timeout)
+            throws IOException {
+        String passwordIdentity = null;
+        try {
             switch (conn.auth()) {
                 case PASSWORD -> {
                     if (secret != null) {
-                        session.addPasswordIdentity(new String(secret));
+                        passwordIdentity = new String(secret);
+                        session.addPasswordIdentity(passwordIdentity);
                     }
                 }
                 case KEY -> session.setKeyIdentityProvider(keyProvider(List.of(Path.of(conn.keyPath())), secret));
@@ -164,12 +191,11 @@ public final class RemoteFileSystems {
                     }
                 }
             }
-            session.auth().verify(AUTH_TIMEOUT);
-            // On success the SftpFileSystem owns the session (closing the FS closes it).
-            return SftpClientFactory.instance().createSftpFileSystem(session);
-        } catch (IOException | RuntimeException e) {
-            session.close(true); // failed auth / FS creation: close the session so it isn't leaked
-            throw e;
+            session.auth().verify(timeout);
+        } finally {
+            if (passwordIdentity != null) {
+                session.removePasswordIdentity(passwordIdentity); // don't retain it past the handshake
+            }
         }
     }
 

--- a/src/test/java/com/editora/vfs/PasswordIdentityLifetimeTest.java
+++ b/src/test/java/com/editora/vfs/PasswordIdentityLifetimeTest.java
@@ -1,0 +1,97 @@
+package com.editora.vfs;
+
+import java.nio.file.Path;
+import java.time.Duration;
+
+import org.apache.sshd.client.SshClient;
+import org.apache.sshd.client.keyverifier.AcceptAllServerKeyVerifier;
+import org.apache.sshd.client.session.ClientSession;
+import org.apache.sshd.server.SshServer;
+import org.apache.sshd.server.auth.password.AcceptAllPasswordAuthenticator;
+import org.apache.sshd.server.keyprovider.SimpleGeneratorHostKeyProvider;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * A password used for SFTP must not linger on the session after the handshake. MINA's client API is
+ * String-only, so a String copy of the password is unavoidable at the boundary — but {@code addPasswordIdentity}
+ * keeps it on the session's identity list for the whole connected session (potentially hours). Since a password
+ * is only needed for the initial handshake, {@link RemoteFileSystems#authenticate} removes it as soon as auth
+ * finishes, shrinking that String's lifetime to the handshake.
+ *
+ * <p>Driven against a real in-process SSH server, since the property is observable only on a real session
+ * (the password-identity list is read via {@code ClientSession.passwordIteratorOf}).
+ */
+class PasswordIdentityLifetimeTest {
+
+    private static SshServer startServer(Path hostKey) throws Exception {
+        SshServer sshd = SshServer.setUpDefaultServer();
+        sshd.setHost("127.0.0.1");
+        sshd.setPort(0);
+        sshd.setKeyPairProvider(new SimpleGeneratorHostKeyProvider(hostKey));
+        sshd.setPasswordAuthenticator(AcceptAllPasswordAuthenticator.INSTANCE);
+        sshd.start();
+        return sshd;
+    }
+
+    private static RemoteConnection passwordConnection(int port) {
+        return new RemoteConnection("127.0.0.1", port, "tester", RemoteConnection.AuthMethod.PASSWORD, "", "probe", "");
+    }
+
+    private static boolean sessionHoldsAPassword(ClientSession session) throws Exception {
+        return ClientSession.passwordIteratorOf(session).hasNext();
+    }
+
+    @Test
+    void thePasswordIsRemovedFromTheSessionAfterAuthentication(@TempDir Path dir) throws Exception {
+        SshServer server = startServer(dir.resolve("hostkey.ser"));
+        SshClient client = SshClient.setUpDefaultClient();
+        client.setServerKeyVerifier(AcceptAllServerKeyVerifier.INSTANCE); // host-key isn't what this test checks
+        client.start();
+        try (ClientSession session = client.connect("tester", "127.0.0.1", server.getPort())
+                .verify(Duration.ofSeconds(10))
+                .getSession()) {
+
+            RemoteFileSystems.authenticate(
+                    session, passwordConnection(server.getPort()), "hunter2".toCharArray(), Duration.ofSeconds(10));
+
+            assertTrue(session.isAuthenticated(), "precondition: auth succeeded, so removal didn't break it");
+            assertFalse(
+                    sessionHoldsAPassword(session),
+                    "the password must not linger on the session for its whole lifetime after the handshake");
+        } finally {
+            client.stop();
+            server.stop(true);
+        }
+    }
+
+    @Test
+    void aFailedPasswordAuthAlsoLeavesNoPasswordBehind(@TempDir Path dir) throws Exception {
+        SshServer server = startServer(dir.resolve("hostkey.ser"));
+        server.setPasswordAuthenticator((u, p, s) -> false); // reject every password
+        SshClient client = SshClient.setUpDefaultClient();
+        client.setServerKeyVerifier(AcceptAllServerKeyVerifier.INSTANCE);
+        client.start();
+        try (ClientSession session = client.connect("tester", "127.0.0.1", server.getPort())
+                .verify(Duration.ofSeconds(10))
+                .getSession()) {
+
+            try {
+                RemoteFileSystems.authenticate(
+                        session, passwordConnection(server.getPort()), "wrong".toCharArray(), Duration.ofSeconds(10));
+            } catch (Exception expected) {
+                // auth fails — that's the point of this case
+            }
+
+            assertFalse(
+                    sessionHoldsAPassword(session),
+                    "even a rejected password must be cleaned up (the finally runs on failure too)");
+        } finally {
+            client.stop();
+            server.stop(true);
+        }
+    }
+}


### PR DESCRIPTION
Closes #437.

## The gap

The connect form takes the secret as a `char[]` and wipes it — but `session.addPasswordIdentity(new String(secret))` kept a String copy on the SSH session's identity list for the **entire connected session** (potentially hours). The `char[]` wipe was defeated at that boundary, and a memory dump of a long-running session could recover the password.

## What's fixable, and what isn't

MINA's client API is **String-only** (`addPasswordIdentity(String)`, a String-returning `PasswordIdentityProvider`), so a String copy at that boundary is unavoidable — as the issue itself notes. There is no `char[]` overload to zero.

What *is* fixable is the copy's **lifetime**. A password is only needed for the initial handshake — SSH re-keys against the host key, not the password — so `RemoteFileSystems.authenticate` now `removePasswordIdentity`s it in a `finally` right after `session.auth()`:

```java
} finally {
    if (passwordIdentity != null) {
        session.removePasswordIdentity(passwordIdentity); // don't retain it past the handshake
    }
}
```

That shrinks how long the copy is reachable from **"until you disconnect"** to **"during the handshake"**. This closes the *duration*, not the copy — and I've been careful to say exactly that in the code, CHANGELOG and commit, rather than imply the password is now zeroed.

## Verification

The auth block is extracted into a testable `authenticate(session, conn, secret, timeout)`, and the property is checked **against a real in-process SSH server** — it's only observable on a real session, via `ClientSession.passwordIteratorOf`:

```
the password must not linger on the session ... ==> expected: <false> but was: <true>   (old code)
```

Both the successful-auth and rejected-password paths assert the identity list is empty afterward (the `finally` runs either way). Both fail on the old code and pass with the fix. The **host-key verification tests from #487 still pass**, confirming the `authenticate` extraction didn't disturb that path.

Full suite green: **2184**.

This completes the SFTP hardening pass: host-key verification (#487) and now the password lifetime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)