### PR TITLE
Make ConfigDurabilityTest's cancel test deterministic (flaky on CI)

### DIFF
--- a/src/main/java/com/editora/config/ConfigWriter.java
+++ b/src/main/java/com/editora/config/ConfigWriter.java
@@ -33,11 +33,25 @@ public final class ConfigWriter {
     /** Config files can hold credentials + private content, so they are owner-only (0600). */
     private static final java.util.Set<PosixFilePermission> OWNER_ONLY = PosixFilePermissions.fromString("rw-------");
 
-    private final ExecutorService io = Executors.newSingleThreadExecutor(r -> {
-        Thread t = new Thread(r, "config-writer");
-        t.setDaemon(true);
-        return t;
-    });
+    private final ExecutorService io;
+
+    public ConfigWriter() {
+        this(Executors.newSingleThreadExecutor(r -> {
+            Thread t = new Thread(r, "config-writer");
+            t.setDaemon(true);
+            return t;
+        }));
+    }
+
+    /**
+     * Test seam: supply the executor that runs the drains. Production uses the no-arg constructor's single
+     * daemon thread. A test can inject a controllable executor to make the {@code enqueue}→{@code cancel}
+     * ordering deterministic — otherwise the real writer thread may drain a queued write <em>before</em> a
+     * following {@code cancel} runs (a race that flaked {@code ConfigDurabilityTest} on loaded CI runners).
+     */
+    ConfigWriter(ExecutorService io) {
+        this.io = io;
+    }
 
     private final Object lock = new Object();
     private final Map<Path, byte[]> pending = new LinkedHashMap<>();

--- a/src/test/java/com/editora/config/ConfigDurabilityTest.java
+++ b/src/test/java/com/editora/config/ConfigDurabilityTest.java
@@ -99,11 +99,17 @@ class ConfigDurabilityTest {
         // Deleting a project deletes its session file — but a coalesced write may still be in the queue, and
         // it would land afterwards and re-create it. Project ids are derived from the folder path, so a
         // resurrected file gets picked straight back up if the folder is ever re-added.
+        //
+        // The drain runs on the writer's executor, so with the real thread this test races: the write can land
+        // before `cancel` is called, flaking on a loaded CI runner (which it did). A paused executor holds the
+        // drain until after `cancel`, making the ordering the test actually means to check deterministic.
         Path file = dir.resolve("projects").resolve("ghost.json");
-        ConfigWriter writer = new ConfigWriter();
+        PausableExecutor exec = new PausableExecutor();
+        ConfigWriter writer = new ConfigWriter(exec);
+
         writer.enqueue(file, "{\"resurrected\":true}".getBytes(java.nio.charset.StandardCharsets.UTF_8));
-        writer.cancel(file);
-        writer.flush();
+        writer.cancel(file); // reaches the queue before the (still-paused) drain
+        exec.resume(); // now the drain runs — it must find nothing to write
         assertFalse(Files.exists(file), "a cancelled write must not land");
 
         // Sanity: without the cancel it does land (so the test proves the cancel, not a broken writer).
@@ -111,6 +117,58 @@ class ConfigDurabilityTest {
         writer.flush();
         assertTrue(Files.exists(file));
         writer.shutdown();
+    }
+
+    /**
+     * An executor that queues submitted tasks while paused, then runs them (and everything after) inline once
+     * {@link #resume} is called. Lets a test fix the {@code enqueue}→{@code cancel}→drain ordering that the
+     * real writer thread would otherwise race.
+     */
+    private static final class PausableExecutor extends java.util.concurrent.AbstractExecutorService {
+        private final java.util.Queue<Runnable> queued = new java.util.ArrayDeque<>();
+        private boolean paused = true;
+
+        @Override
+        public synchronized void execute(Runnable command) {
+            if (paused) {
+                queued.add(command);
+            } else {
+                command.run();
+            }
+        }
+
+        void resume() {
+            java.util.List<Runnable> toRun;
+            synchronized (this) {
+                paused = false;
+                toRun = new java.util.ArrayList<>(queued);
+                queued.clear();
+            }
+            toRun.forEach(Runnable::run);
+        }
+
+        @Override
+        public void shutdown() {}
+
+        @Override
+        public java.util.List<Runnable> shutdownNow() {
+            return List.of();
+        }
+
+        @Override
+        public boolean isShutdown() {
+            return false;
+        }
+
+        @Override
+        public boolean isTerminated() {
+            return false;
+        }
+
+        @Override
+        public boolean awaitTermination(long timeout, java.util.concurrent.TimeUnit unit) {
+            return true;
+        }
     }
 
     @Test


### PR DESCRIPTION
A pre-existing flaky test that just failed an **unrelated** PR's CI (#489, the SFTP password fix — which touches no config code). Fixing it here so CI is a trustworthy signal again, then the SFTP PR rebases onto green.

## The race

`ConfigDurabilityTest.aQueuedWriteForADeletedFileIsDropped` does:

```java
writer.enqueue(file, bytes);
writer.cancel(file);
writer.flush();
assertFalse(Files.exists(file));
```

`enqueue` submits a drain to the writer's async executor. So on a loaded runner the writer thread can drain the batch — and write the file — **before** `cancel()` runs. `cancel` only removes from the pending map; once the drain has claimed the batch, it's too late.

```
ConfigDurabilityTest.aQueuedWriteForADeletedFileIsDropped:107
  a cancelled write must not land ==> expected: <false> but was: <true>
```

Reproduced deterministically by inserting a 50 ms gap between `enqueue` and `cancel` — the drain runs first and the write lands, exactly the CI failure.

## Why the fix is test-side

No change to the writer's behaviour makes "enqueue then cancel" deterministic against a running executor: the writer might write in the gap, and that write genuinely happened. The test has to control **when** the drain runs.

So `ConfigWriter` gains a package-visible constructor taking the `ExecutorService` (production is unchanged — the no-arg constructor still uses its single daemon thread), and the test injects a **paused executor** that holds the drain until after `cancel()`. The ordering the test actually means to check — a cancel reaching the queue ahead of the drain — is now deterministic.

## Verification

- **30/30 runs green** (was intermittently failing).
- Still catches a broken `cancel`: stubbing out `pending.remove` → `expected: <false> but was: <true>`. So it proves the cancel, not just the paused executor.
- Full suite green: **2182**.

## Note

There's arguably a *real* production race adjacent to this — `cancel` can't revoke a write the drain has already claimed but not yet written, so a deleted project's session file could in principle be resurrected. That's a separate, more involved concurrency change (and can't hold the lock during I/O — that's the FX-thread hot path), so it's out of scope here; this PR only makes the existing best-effort contract deterministically testable. Worth a follow-up issue if the production race matters.

🤖 Generated with [Claude Code](https://claude.com/claude-code)