### PR TITLE
Typst: show the buffer name in a compile error, not the temp UUID (#462)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,6 +91,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **A Typst compile error now shows your file name, not an internal temp filename.** Previously every typo in
+  the Typst preview reported an error against `.editora-typst-<uuid>.typ` (the throwaway file Editora renders
+  through). The buffer's name is now shown instead; line and column were already correct. (#462)
 - **A failed settings/session save is now surfaced instead of vanishing silently.** If Editora couldn't write
   `settings.toml` or the session state (full disk, read-only config directory, permissions), a setting change
   or the session on quit was lost with no indication. Editora now shows a status message on the failure. (#418)

--- a/src/main/java/com/editora/editor/EditorBuffer.java
+++ b/src/main/java/com/editora/editor/EditorBuffer.java
@@ -4331,7 +4331,7 @@ public class EditorBuffer implements TabContent {
             java.nio.file.Path root = local && typstRootResolver != null ? typstRootResolver.apply(path) : fileDir;
             String retainKey = path != null ? path.toString() : ("untitled@" + System.identityHashCode(this));
             javafx.scene.layout.VBox box = new javafx.scene.layout.VBox(
-                    TypstImages.node(area.getText(), lw -> lw * scale, retainKey, fileDir, root));
+                    TypstImages.node(area.getText(), lw -> lw * scale, retainKey, fileDir, root, getDisplayName()));
             box.getStyleClass().add("markdown-preview");
             StackPane wrap = new StackPane(box);
             wrap.getStyleClass().add("markdown-preview-wrap");

--- a/src/main/java/com/editora/editor/TypstImages.java
+++ b/src/main/java/com/editora/editor/TypstImages.java
@@ -130,15 +130,22 @@ public final class TypstImages {
      * {@code fileDir} is the saved file's own folder (where relative refs resolve) and {@code root} the
      * {@code --root} sandbox (possibly a higher project root) — both {@code null} for an untitled/remote buffer.
      */
-    public static Node node(String source, DoubleUnaryOperator sizer, String retainKey, Path fileDir, Path root) {
+    public static Node node(
+            String source, DoubleUnaryOperator sizer, String retainKey, Path fileDir, Path root, String displayName) {
         StackPane host = new StackPane();
         host.getStyleClass().add("md-diagram");
-        fill(host, source, sizer, retainKey, fileDir, root);
+        fill(host, source, sizer, retainKey, fileDir, root, displayName);
         return host;
     }
 
     private static void fill(
-            StackPane host, String source, DoubleUnaryOperator sizer, String retainKey, Path fileDir, Path root) {
+            StackPane host,
+            String source,
+            DoubleUnaryOperator sizer,
+            String retainKey,
+            Path fileDir,
+            Path root,
+            String displayName) {
         String key = key(source, fileDir, root);
         Cached hit = CACHE.get(key);
         if (hit != null && hit.expired()) {
@@ -157,7 +164,7 @@ public final class TypstImages {
         }
         List<String> cmd = command;
         EXEC.submit(() -> {
-            TypstRenderer.Pages r = TypstRenderer.renderPages(cmd, source, fileDir, root);
+            TypstRenderer.Pages r = TypstRenderer.renderPages(cmd, source, fileDir, root, displayName);
             Cached result;
             if (r.ok()) {
                 int total = r.pages().size();

--- a/src/main/java/com/editora/typst/TypstRenderer.java
+++ b/src/main/java/com/editora/typst/TypstRenderer.java
@@ -116,6 +116,15 @@ public final class TypstRenderer {
      * untitled/remote buffer (→ isolated temp).
      */
     public static Pages renderPages(List<String> cmd, String source, Path fileDir, Path root) {
+        return renderPages(cmd, source, fileDir, root, null);
+    }
+
+    /**
+     * As {@link #renderPages(List, String, Path, Path)}, but a non-null {@code displayName} rewrites the
+     * throwaway {@code .editora-typst-<uuid>.typ} basename in a compile-error message to the buffer's real
+     * name — otherwise every Typst typo shows the internal UUID temp filename, not the user's file (#462).
+     */
+    public static Pages renderPages(List<String> cmd, String source, Path fileDir, Path root, String displayName) {
         Prep p = null;
         Path input = null;
         Path outDir = null;
@@ -129,11 +138,11 @@ public final class TypstRenderer {
                     p.root(), RENDER_TIMEOUT, renderArgs(cmd, p.root(), input, outTemplate, renderPpi()));
             List<byte[]> pages = readPages(outDir);
             if (pages.isEmpty()) {
-                return Pages.fail(r.ok() ? "no pages rendered" : r.message());
+                return Pages.fail(r.ok() ? "no pages rendered" : friendlyMessage(r.message(), displayName));
             }
             return Pages.ok(pages);
         } catch (IOException e) {
-            return Pages.fail(e.getMessage());
+            return Pages.fail(friendlyMessage(e.getMessage(), displayName));
         } finally {
             deleteIfExists(input);
             deleteRecursively(outDir);
@@ -141,6 +150,22 @@ public final class TypstRenderer {
                 deleteRecursively(p.inputDir());
             }
         }
+    }
+
+    /** Matches the throwaway input filename (with any leading path typst may print) in a diagnostic. */
+    private static final Pattern TEMP_INPUT = Pattern.compile("\\S*\\.editora-typst-[0-9a-fA-F-]+\\.typ");
+
+    /**
+     * Rewrites the throwaway {@code .editora-typst-<uuid>.typ} filename in a typst diagnostic to
+     * {@code displayName} (or a neutral {@code document.typ} when none is given), so the user sees their own
+     * file name in an error, not an internal UUID. Line/column are untouched. Pure; unit-tested.
+     */
+    static String friendlyMessage(String message, String displayName) {
+        if (message == null || message.isBlank()) {
+            return message;
+        }
+        String name = displayName == null || displayName.isBlank() ? "document.typ" : displayName;
+        return TEMP_INPUT.matcher(message).replaceAll(Matcher.quoteReplacement(name));
     }
 
     /**

--- a/src/test/java/com/editora/typst/TypstRendererTest.java
+++ b/src/test/java/com/editora/typst/TypstRendererTest.java
@@ -126,4 +126,26 @@ class TypstRendererTest {
         assertFalse(TypstRenderer.detect(java.util.List.of("npx", "typst-definitely-not-a-package")));
         assertTrue(TypstRenderer.detect(java.util.List.of("sh", "-c", "exit 0")), "a wrapper that succeeds counts");
     }
+
+    @Test
+    void friendlyMessageRewritesTheTempFilenameToTheBufferName() {
+        // The typo path a user hits most: typst names the throwaway UUID temp file. Rewrite it to the buffer.
+        String raw =
+                "error: unknown variable: foo\n" + "  ┌─ .editora-typst-cf099c21-4e48-4307-9a38-3695b0b53f6e.typ:1:1";
+        String out = TypstRenderer.friendlyMessage(raw, "report.typ");
+        assertTrue(out.contains("report.typ:1:1"), "line/column preserved, filename rewritten");
+        assertFalse(out.contains(".editora-typst-"), "no internal temp filename leaks through");
+
+        // A leading path typst may print is rewritten along with the basename.
+        assertEquals(
+                "  ┌─ doc.typ:2:5 error",
+                TypstRenderer.friendlyMessage("  ┌─ /tmp/x/.editora-typst-abc-123.typ:2:5 error", "doc.typ"));
+
+        // No display name → a neutral placeholder, never the UUID.
+        assertEquals("at document.typ:1:1", TypstRenderer.friendlyMessage("at .editora-typst-9f.typ:1:1", null));
+
+        // Null / a message with no temp filename passes through unchanged.
+        assertEquals(null, TypstRenderer.friendlyMessage(null, "x"));
+        assertEquals("network down", TypstRenderer.friendlyMessage("network down", "x"));
+    }
 }


### PR DESCRIPTION
Fixes #462.

## The bug
`TypstRenderer` writes the buffer to a throwaway `.editora-typst-<uuid>.typ` before compiling, and typst's diagnostics name that file. So the preview's error banner showed the internal UUID temp filename for **every typo** — the most common Typst error path:
```
error: unknown variable: undefined_function
  ┌─ .editora-typst-cf099c21-4e48-4307-9a38-3695b0b53f6e.typ:1:1
```

## The fix
A pure `TypstRenderer.friendlyMessage(message, displayName)` rewrites the temp basename (with any leading path typst prints) to the buffer's display name (or a neutral `document.typ` when none is given). Line/column are untouched. The display name is threaded `renderPages` → `TypstImages.node`/`fill` → `EditorBuffer` (`getDisplayName()`). The print path (`TypstService.renderPages`) discards the error text, so it's unaffected.

## Test
`TypstRendererTest.friendlyMessageRewritesTheTempFilenameToTheBufferName` (pure): the temp filename is rewritten, line/column preserved, a leading path stripped, null-name → `document.typ`, and a non-typst message passes through. Reverting the rewrite fails it.

Full suite green (2269). No new dependency / schema change.

## Perf
None — one regex replace only on the error path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)