### PR TITLE
Typst: bound the preview cache by pages, not entry count (#461)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,6 +91,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **The Typst preview no longer retains gigabytes of page images.** Its render cache was bounded by document
+  count, but each entry is a whole multi-page document — so a 40-page document could retain ~570 MB, and
+  editing it (each keystroke a new render) accumulated several times that. The cache is now bounded by total
+  pages, keeping memory in check. (#461)
 - **A Typst compile error now shows your file name, not an internal temp filename.** Previously every typo in
   the Typst preview reported an error against `.editora-typst-<uuid>.typ` (the throwaway file Editora renders
   through). The buffer's name is now shown instead; line and column were already correct. (#462)

--- a/src/main/java/com/editora/editor/TypstImages.java
+++ b/src/main/java/com/editora/editor/TypstImages.java
@@ -68,29 +68,27 @@ public final class TypstImages {
     /** How long a failed render is reused before being retried — mirrors {@link PreviewImageLoader}. */
     private static final long FAILURE_TTL_MS = 60_000;
 
-    /** Cap on cached rendered documents (each page pins a GPU texture — bounded LRU). */
-    private static final int MAX_CACHED = 8;
-
     /** Cap on pages stacked in the preview — a many-page document would otherwise pin one texture per page.
      *  Beyond this the preview shows the first N pages + a "… more pages" note; export/print use all pages. */
     private static final int MAX_PREVIEW_PAGES = 40;
 
+    /**
+     * Cache bound expressed in <b>pages</b>, not entries — the cost is one decoded {@link Image} (a pinned GPU
+     * texture) per page, and one Typst entry is a whole {@code MAX_PREVIEW_PAGES}-page document, so a plain
+     * entry-count LRU (copied from {@code DiagramImages}, where an entry is one image) let a single 40-page
+     * doc retain ~570 MB and eight distinct renders ~4.5 GB — against the {@code -Xmx2g} packaged heap (#461).
+     * At A4/192-PPI a page is ~14 MB decoded, so ~60 pages ≈ 850 MB worst case. Both {@link #CACHE} and
+     * {@link #LAST_GOOD} are bounded by this after every insert (never evicting the just-inserted entry).
+     */
+    private static final int MAX_CACHED_PAGES = 60;
+
+    /** Access-ordered so a re-render of the visible doc keeps it; eviction is by {@link #evictToPageBudget}. */
     private static final Map<String, Cached> CACHE =
-            Collections.synchronizedMap(new LinkedHashMap<String, Cached>(16, 0.75f, true) {
-                @Override
-                protected boolean removeEldestEntry(Map.Entry<String, Cached> eldest) {
-                    return size() > MAX_CACHED;
-                }
-            });
+            Collections.synchronizedMap(new LinkedHashMap<String, Cached>(16, 0.75f, true));
 
     /** The last good render per preview surface, so a re-render shows it instead of a placeholder. */
     private static final Map<String, List<Loaded>> LAST_GOOD =
-            Collections.synchronizedMap(new LinkedHashMap<String, List<Loaded>>(16, 0.75f, true) {
-                @Override
-                protected boolean removeEldestEntry(Map.Entry<String, List<Loaded>> eldest) {
-                    return size() > MAX_CACHED * 2;
-                }
-            });
+            Collections.synchronizedMap(new LinkedHashMap<String, List<Loaded>>(16, 0.75f, true));
 
     private static final ExecutorService EXEC = Executors.newFixedThreadPool(2, r -> {
         Thread t = new Thread(r, "typst-render");
@@ -121,6 +119,43 @@ public final class TypstImages {
 
     public static boolean isEnabled() {
         return enabled;
+    }
+
+    /**
+     * Evicts the least-recently-used entries of an access-ordered {@code cache} until the total page count
+     * (via {@code pages}) is within {@code maxPages}, never removing the most-recent (just-inserted) entry.
+     */
+    private static <V> void evictToPageBudget(
+            Map<String, V> cache, java.util.function.ToIntFunction<V> pages, int maxPages) {
+        synchronized (cache) {
+            List<Map.Entry<String, Integer>> oldestFirst = new ArrayList<>();
+            for (Map.Entry<String, V> e : cache.entrySet()) {
+                oldestFirst.add(Map.entry(e.getKey(), Math.max(0, pages.applyAsInt(e.getValue()))));
+            }
+            for (String k : keysToEvict(oldestFirst, maxPages)) {
+                cache.remove(k);
+            }
+        }
+    }
+
+    /**
+     * Given cache entries oldest→newest with their page counts, returns the oldest keys to drop so the total
+     * retained pages fits {@code maxPages}, always keeping the newest entry (so the just-rendered document is
+     * never evicted, even when it alone exceeds the budget). Pure; unit-tested.
+     */
+    static List<String> keysToEvict(List<Map.Entry<String, Integer>> oldestFirst, int maxPages) {
+        int total = 0;
+        for (Map.Entry<String, Integer> e : oldestFirst) {
+            total += e.getValue();
+        }
+        List<String> evict = new ArrayList<>();
+        int i = 0;
+        while (total > maxPages && (oldestFirst.size() - evict.size()) > 1) {
+            Map.Entry<String, Integer> e = oldestFirst.get(i++);
+            evict.add(e.getKey());
+            total -= e.getValue();
+        }
+        return evict;
     }
 
     /**
@@ -185,8 +220,10 @@ public final class TypstImages {
                 result = new Cached(null, r.error(), 0);
             }
             CACHE.put(key, result);
+            evictToPageBudget(CACHE, c -> c.pages() == null ? 0 : c.pages().size(), MAX_CACHED_PAGES);
             if (result.ok()) {
                 LAST_GOOD.put(retainKey, result.pages());
+                evictToPageBudget(LAST_GOOD, List::size, MAX_CACHED_PAGES);
             }
             Platform.runLater(() -> applyCached(host, result, sizer, retainKey));
         });

--- a/src/test/java/com/editora/editor/TypstImagesTest.java
+++ b/src/test/java/com/editora/editor/TypstImagesTest.java
@@ -1,0 +1,40 @@
+package com.editora.editor;
+
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Regression for #461: the Typst preview cache must be bounded by total <em>pages</em> (each page pins a
+ * decoded {@link javafx.scene.image.Image}), not by entry count — one entry is a whole multi-page document,
+ * so an 8-entry LRU let a 40-page doc retain ~570 MB. {@link TypstImages#keysToEvict} is the pure eviction
+ * decision.
+ */
+class TypstImagesTest {
+
+    private static Map.Entry<String, Integer> e(String k, int pages) {
+        return Map.entry(k, pages);
+    }
+
+    @Test
+    void nothingEvictedWhenUnderBudget() {
+        assertEquals(List.of(), TypstImages.keysToEvict(List.of(e("a", 10), e("b", 10)), 60));
+    }
+
+    @Test
+    void evictsOldestUntilWithinThePageBudget() {
+        // Three 40-page docs = 120 pages, budget 60. Drop the two oldest, keep the newest "c" (40 ≤ 60).
+        List<String> out = TypstImages.keysToEvict(List.of(e("a", 40), e("b", 40), e("c", 40)), 60);
+        assertEquals(List.of("a", "b"), out);
+    }
+
+    @Test
+    void neverEvictsTheNewestEvenWhenItAloneExceedsTheBudget() {
+        // The just-rendered (visible) document must always stay cached.
+        assertEquals(List.of("a"), TypstImages.keysToEvict(List.of(e("a", 10), e("big", 100)), 60));
+        assertEquals(List.of(), TypstImages.keysToEvict(List.of(e("big", 100)), 60), "the only entry is kept");
+    }
+}


### PR DESCRIPTION
Fixes #461.

## The gap
`TypstImages`' `MAX_CACHED = 8` was copied from `DiagramImages`, where one entry is **one** image. In Typst one entry is a whole document — up to `MAX_PREVIEW_PAGES = 40` decoded `Image`s, each pinning a GPU texture. At A4/192-PPI a page is ~14 MB decoded, so:
- one 40-page document = **~570 MB** retained
- editing it churns the source hash, so 8 distinct renders accumulate → **~4.5 GB**

against the packaged `-Xmx2g` heap — contradicting the CLAUDE.md bound-retained-textures rule. `LAST_GOOD` (up to 16 keys) compounded it.

## The fix
Both `CACHE` and `LAST_GOOD` are now bounded by a **`MAX_CACHED_PAGES` (60)** total-page budget instead of an entry count (~850 MB worst case). After every insert, the pure **`keysToEvict(oldestFirst, maxPages)`** drops least-recently-used entries until the total page count fits — but **never the newest (just-rendered, visible) entry**, even when it alone exceeds the budget. The maps stay access-ordered so a re-render of the visible doc keeps it.

## Test
`TypstImagesTest.keysToEvict` (pure, no FX): nothing evicted under budget; oldest dropped until within budget; the newest is never evicted even when it alone exceeds the budget (and a lone over-budget entry is kept). Reverting the eviction loop fails it.

Full suite green (2272). No new dependency / schema change.

## Perf
This *reduces* retained memory (the point). Eviction is an O(entries) scan after each async render — negligible, off the FX thread.

🤖 Generated with [Claude Code](https://claude.com/claude-code)