### PR TITLE
Mermaid: coalesce live-editing renders so superseded ones skip mmdc (#458)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,6 +91,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Editing a Mermaid diagram no longer piles up background renders.** Each pause while typing in a `.mmd`
+  file queued another headless-Chromium render (~4 s each) even though only the latest result is shown, so a
+  burst of edits could back up many seconds of wasted work. Superseded renders are now skipped, so only the
+  diagram you're actually editing is rendered. (#458)
 - **The Typst preview no longer retains gigabytes of page images.** Its render cache was bounded by document
   count, but each entry is a whole multi-page document — so a 40-page document could retain ~570 MB, and
   editing it (each keystroke a new render) accumulated several times that. The cache is now bounded by total

--- a/src/main/java/com/editora/editor/EditorBuffer.java
+++ b/src/main/java/com/editora/editor/EditorBuffer.java
@@ -4275,8 +4275,11 @@ public class EditorBuffer implements TabContent {
             // applyPreviewScale() here — it re-enters this branch for diagrams (would recurse).
             double v = previewPane().getVvalue();
             double scale = previewFontScale;
+            // A stable per-buffer surface key so live-editing pulses coalesce (only the latest render spawns
+            // mmdc) instead of piling up ~4 s Chromium renders on every 250 ms pause (#458).
+            String surfaceKey = path != null ? path.toString() : ("mmd@" + System.identityHashCode(this));
             javafx.scene.layout.VBox box =
-                    new javafx.scene.layout.VBox(MermaidImages.node(area.getText(), lw -> lw * scale));
+                    new javafx.scene.layout.VBox(MermaidImages.node(area.getText(), lw -> lw * scale, surfaceKey));
             box.getStyleClass().add("markdown-preview");
             StackPane wrap = new StackPane(box);
             wrap.getStyleClass().add("markdown-preview-wrap");

--- a/src/main/java/com/editora/editor/MermaidImages.java
+++ b/src/main/java/com/editora/editor/MermaidImages.java
@@ -66,6 +66,18 @@ public final class MermaidImages {
         return t;
     });
 
+    /**
+     * The most-recent render generation submitted per preview <em>surface</em> (a stable key the caller passes
+     * for a live-editing preview). A queued render only spawns mmdc (headless Chromium, ~4 s) if it is still
+     * the latest for its surface — a superseded one skips the spawn instead of running to completion and
+     * landing on a detached node. Without this, each 250 ms edit pulse in a {@code .mmd} enqueued another ~4 s
+     * Chromium spawn on the 2-thread pool, nine of ten thrown away (#458). Markdown diagram blocks pass a
+     * {@code null} surface (they render distinct concurrent diagrams, so there is nothing to coalesce).
+     */
+    private static final Map<String, Long> LATEST = new java.util.concurrent.ConcurrentHashMap<>();
+
+    private static final java.util.concurrent.atomic.AtomicLong SEQ = new java.util.concurrent.atomic.AtomicLong();
+
     private static volatile boolean enabled;
     private static volatile List<String> mmdc = List.of("mmdc");
     private static volatile List<String> maid = List.of("maid");
@@ -107,6 +119,18 @@ public final class MermaidImages {
         return enabled;
     }
 
+    /** Whether generation {@code gen} for {@code surfaceKey} has been superseded by a newer submission — then
+     *  the queued render should skip its expensive spawn. A null surface (Markdown blocks) is never
+     *  superseded. Pure; unit-tested via {@link #superseded(String, long, Long)}. */
+    private static boolean superseded(String surfaceKey, long gen) {
+        return surfaceKey != null && superseded(surfaceKey, gen, LATEST.get(surfaceKey));
+    }
+
+    /** Pure core: a render is superseded when a newer generation was recorded for its surface. */
+    static boolean superseded(String surfaceKey, long gen, Long latest) {
+        return surfaceKey != null && latest != null && latest.longValue() != gen;
+    }
+
     /**
      * Returns a node for the diagram {@code source}, filled asynchronously: a centered {@link ImageView}
      * on success, or a {@code .mermaid-error} label with mmdc's message on failure. Cache hits apply
@@ -115,13 +139,23 @@ public final class MermaidImages {
      * the zoom factor (so zoom actually resizes the image).
      */
     public static Node node(String source, java.util.function.DoubleUnaryOperator sizer) {
+        return node(source, sizer, null);
+    }
+
+    /**
+     * As {@link #node(String, java.util.function.DoubleUnaryOperator)}, but a non-null {@code surfaceKey}
+     * coalesces live-editing re-renders: only the latest render per surface actually spawns mmdc, so typing
+     * in a {@code .mmd} can't pile up ~4 s Chromium renders (#458).
+     */
+    public static Node node(String source, java.util.function.DoubleUnaryOperator sizer, String surfaceKey) {
         StackPane host = new StackPane();
         host.getStyleClass().add("md-mermaid");
-        fill(host, source, sizer);
+        fill(host, source, sizer, surfaceKey);
         return host;
     }
 
-    private static void fill(StackPane host, String source, java.util.function.DoubleUnaryOperator sizer) {
+    private static void fill(
+            StackPane host, String source, java.util.function.DoubleUnaryOperator sizer, String surfaceKey) {
         String key = key(source, dark);
         Cached hit = CACHE.get(key);
         if (hit != null && hit.expired()) {
@@ -137,7 +171,14 @@ public final class MermaidImages {
         List<String> maidExe = maid;
         boolean useMaid = maidAvailable;
         boolean useDark = dark;
+        long gen = surfaceKey == null ? -1 : SEQ.incrementAndGet();
+        if (surfaceKey != null) {
+            LATEST.put(surfaceKey, gen);
+        }
         EXEC.submit(() -> {
+            if (superseded(surfaceKey, gen)) {
+                return; // a newer pulse for this surface has arrived — skip the ~4 s Chromium spawn (#458)
+            }
             Mermaid.Render r = Mermaid.renderPng(exe, source, useDark);
             Cached result;
             if (r.ok()) {

--- a/src/test/java/com/editora/editor/MermaidImagesTest.java
+++ b/src/test/java/com/editora/editor/MermaidImagesTest.java
@@ -20,4 +20,20 @@ class MermaidImagesTest {
         assertFalse(MermaidImages.looksLikeChromeMissing(""));
         assertFalse(MermaidImages.looksLikeChromeMissing(null));
     }
+
+    @Test
+    void aRenderIsSupersededWhenANewerGenerationExistsForItsSurface() {
+        // #458: gen 1 was queued, then gen 2 arrived for the same surface → gen 1 must skip its ~4 s spawn.
+        assertTrue(MermaidImages.superseded("file.mmd", 1L, 2L));
+        // The latest generation still renders.
+        assertFalse(MermaidImages.superseded("file.mmd", 2L, 2L));
+        // No recorded generation (nothing newer) → render.
+        assertFalse(MermaidImages.superseded("file.mmd", 1L, null));
+    }
+
+    @Test
+    void aNullSurfaceIsNeverSuperseded() {
+        // Markdown diagram blocks pass no surface — distinct concurrent diagrams, never coalesced.
+        assertFalse(MermaidImages.superseded(null, 1L, 5L));
+    }
 }


### PR DESCRIPTION
Fixes #458.

## The gap
`MermaidImages.fill` submitted every render to a 2-thread pool with an **unbounded queue**, driven by the editor's 250 ms debounce. Nothing deduped in-flight work or cancelled a superseded render. The stale-result guard is node identity (each pulse builds a fresh `StackPane`, so an old result lands on a detached node), but **the process still ran to completion** — a real `mmdc` render is ~4 s (it spawns headless Chromium). Editing a `.mmd` in SPLIT mode: every 250 ms pause enqueued another ~4 s spawn; ten pauses ⇒ ~10 queued renders, nine thrown away, and the diagram you want appears only once the backlog drains.

## The fix
`node()` gains an optional stable **`surfaceKey`**; the standalone `.mmd` preview passes one (buffer path / identity). Each submission takes a monotonic generation and records it as the surface's latest (`LATEST`); the queued task checks the pure **`superseded(surfaceKey, gen, latest)`** *before* spawning mmdc and returns early when a newer pulse has arrived — so only the latest render per surface actually runs. Markdown diagram blocks pass `null` (they render distinct concurrent diagrams, so there's nothing to coalesce — unchanged behavior).

(A currently-executing render still finishes — killing the Chromium process would need deeper plumbing — but the queue no longer backs up: every superseded render skips the spawn.)

## Test
`MermaidImagesTest.superseded` (pure): a queued gen is superseded by a newer one for the same surface; the latest still renders; no recorded gen renders; a null surface is never superseded. Reverting the check fails it.

Full suite green (2274). No new dependency / schema change.

## Perf
This *removes* wasted work (the point). The added check is a `ConcurrentHashMap.get` per queued render, off the FX thread.

Note: `DiagramImages` (DOT/PlantUML) has the same shape but `dot` is ~83 ms, so it's far less visible; a follow-up could apply the same coalescing there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)