### PR TITLE
MCP: reap a stale mcp-endpoint.json at launch (#464)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,6 +91,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **A stale MCP endpoint file left by a crash is now cleaned up at launch.** If Editora exited hard while the
+  MCP server was running, `mcp-endpoint.json` lingered — pointing an MCP client at a dead port with a
+  live-looking token. Editora now stamps the file with its process identity and removes a stale one on the
+  next launch. (#464)
 - **Editing a Mermaid diagram no longer piles up background renders.** Each pause while typing in a `.mmd`
   file queued another headless-Chromium render (~4 s each) even though only the latest result is shown, so a
   burst of edits could back up many seconds of wasted work. Superseded renders are now skipped, so only the

--- a/src/main/java/com/editora/App.java
+++ b/src/main/java/com/editora/App.java
@@ -74,6 +74,9 @@ public class App extends Application {
         // before any window builds (which can start servers) so we don't race a fresh server's startup.
         com.editora.process.ProcessRegistry.setLedgerFile(shared.getConfigDir().resolve("spawned-servers.txt"));
         com.editora.process.ProcessRegistry.reapOrphans();
+        // Delete a mcp-endpoint.json left by a crashed run — it advertises a dead port with a live-looking
+        // token. Reaped by the stamped pid + start instant, before any MCP server starts this session (#464).
+        com.editora.mcp.McpServer.reapStaleEndpoint(shared.getConfigDir());
 
         // Localize the UI: pick the language (explicit setting, else system, else English) and load the
         // message catalog before any UI text is created. A change takes effect on the next launch.

--- a/src/main/java/com/editora/mcp/McpServer.java
+++ b/src/main/java/com/editora/mcp/McpServer.java
@@ -207,6 +207,11 @@ public final class McpServer {
         ObjectNode node = mapper.createObjectNode();
         node.put("url", url());
         node.put("token", token);
+        // Stamp this process so a stale file left by a crash can be reaped at the next launch (#464): the
+        // recorded pid + start instant let reapStaleEndpoint tell a live server from a dead one, safely
+        // against a reused PID (mirrors ProcessRegistry.reapOrphans).
+        node.put("pid", ProcessHandle.current().pid());
+        currentProcessStartMillis().ifPresent(ms -> node.put("startMillis", ms));
         try {
             Path file = configDir.resolve(ENDPOINT_FILE);
             Files.createDirectories(configDir);
@@ -216,6 +221,74 @@ public final class McpServer {
         } catch (IOException e) {
             LOG.log(Level.WARNING, "Could not write " + ENDPOINT_FILE, e);
         }
+    }
+
+    /** This JVM process's start instant as epoch millis, if the OS exposes it. */
+    private static java.util.Optional<Long> currentProcessStartMillis() {
+        return ProcessHandle.current().info().startInstant().map(java.time.Instant::toEpochMilli);
+    }
+
+    /**
+     * Reaps a {@code mcp-endpoint.json} left behind by a crash/SIGKILL — the file is deleted only in
+     * {@link #stop()}, so a hard exit leaves it advertising a dead port with a live-looking token (a client
+     * then fails, or worse hands the token to whatever later binds that port). Run once at launch, before any
+     * server starts. The stamped pid + start instant let {@link #isStaleEndpoint} distinguish a genuinely
+     * live server (a concurrent instance) from a stale file, safely against a reused PID (#464).
+     */
+    public static void reapStaleEndpoint(Path configDir) {
+        Path file = configDir.resolve(ENDPOINT_FILE);
+        if (!Files.isRegularFile(file)) {
+            return;
+        }
+        Long pid = null;
+        Long startMillis = null;
+        try {
+            JsonNode node = new ObjectMapper().readTree(file.toFile());
+            if (node != null && node.hasNonNull("pid")) {
+                pid = node.get("pid").asLong();
+            }
+            if (node != null && node.hasNonNull("startMillis")) {
+                startMillis = node.get("startMillis").asLong();
+            }
+        } catch (IOException e) {
+            // Unreadable/corrupt endpoint file — it can't identify a live server, so treat it as stale.
+        }
+        if (isStaleEndpoint(pid, startMillis, McpServer::processStartMillis)) {
+            try {
+                Files.deleteIfExists(file);
+                LOG.info("Reaped stale " + ENDPOINT_FILE);
+            } catch (IOException e) {
+                LOG.log(Level.WARNING, "Could not delete stale " + ENDPOINT_FILE, e);
+            }
+        }
+    }
+
+    /** The start instant (epoch millis) of the live process {@code pid}, or empty when it isn't running. */
+    private static java.util.Optional<Long> processStartMillis(long pid) {
+        return ProcessHandle.of(pid).flatMap(h -> h.info().startInstant()).map(java.time.Instant::toEpochMilli);
+    }
+
+    /**
+     * Whether an endpoint file's recorded {@code pid}/{@code startMillis} identify a dead (or non-matching)
+     * server, so the file should be reaped. {@code liveStart} returns the live start-millis of a pid (empty if
+     * not running). Pure; unit-tested. Reap when: no pid (an old/unstamped file at launch is from a previous
+     * run), the pid isn't a live process, or it is live but its start time differs (the PID was reused). When
+     * the pid is live but we have no recorded start time to compare, keep it (conservative — never delete a
+     * possibly-live endpoint).
+     */
+    static boolean isStaleEndpoint(
+            Long pid, Long startMillis, java.util.function.LongFunction<java.util.Optional<Long>> liveStart) {
+        if (pid == null) {
+            return true;
+        }
+        java.util.Optional<Long> live = liveStart.apply(pid);
+        if (live.isEmpty()) {
+            return true;
+        }
+        if (startMillis == null) {
+            return false;
+        }
+        return !live.get().equals(startMillis);
     }
 
     /** Best-effort owner-only permissions; a no-op where POSIX views aren't supported (Windows). */

--- a/src/test/java/com/editora/mcp/McpServerTest.java
+++ b/src/test/java/com/editora/mcp/McpServerTest.java
@@ -211,4 +211,44 @@ class McpServerTest {
             s.stop();
         }
     }
+
+    @Test
+    void isStaleEndpointReapsDeadOrReusedPidsButKeepsALiveMatch() {
+        // A live process whose recorded start matches → not stale (a concurrent Editora instance).
+        java.util.function.LongFunction<java.util.Optional<Long>> live =
+                pid -> pid == 100 ? java.util.Optional.of(5000L) : java.util.Optional.empty();
+        assertFalse(McpServer.isStaleEndpoint(100L, 5000L, live), "live pid + matching start → keep");
+        // The pid is alive but its start time differs → the PID was reused → stale.
+        assertTrue(McpServer.isStaleEndpoint(100L, 4000L, live), "reused pid → reap");
+        // No live process with that pid → stale.
+        assertTrue(McpServer.isStaleEndpoint(200L, 5000L, live), "dead pid → reap");
+        // No pid at all (an old/unstamped file at launch is from a previous run) → stale.
+        assertTrue(McpServer.isStaleEndpoint(null, null, live), "no pid → reap");
+        // Live pid but no recorded start to compare → conservative: keep (never delete a possibly-live one).
+        assertFalse(McpServer.isStaleEndpoint(100L, null, live), "live pid, unknown start → keep");
+    }
+
+    @Test
+    void reapStaleEndpointDeletesAFileFromADeadProcessButKeepsALiveOne(@TempDir Path dir) throws Exception {
+        Path file = dir.resolve("mcp-endpoint.json");
+
+        // A file from a dead process (a pid that isn't running) is reaped.
+        Files.writeString(file, "{\"url\":\"http://127.0.0.1:63681/mcp\",\"token\":\"t\",\"pid\":999999999}");
+        McpServer.reapStaleEndpoint(dir);
+        assertFalse(Files.exists(file), "stale endpoint file (dead pid) should be reaped");
+
+        // A file stamped with THIS live process is kept.
+        long pid = ProcessHandle.current().pid();
+        Long start = ProcessHandle.current()
+                .info()
+                .startInstant()
+                .map(java.time.Instant::toEpochMilli)
+                .orElse(null);
+        String json = start == null
+                ? "{\"token\":\"t\",\"pid\":" + pid + "}"
+                : "{\"token\":\"t\",\"pid\":" + pid + ",\"startMillis\":" + start + "}";
+        Files.writeString(file, json);
+        McpServer.reapStaleEndpoint(dir);
+        assertTrue(Files.exists(file), "a live process's endpoint file must not be reaped");
+    }
 }


### PR DESCRIPTION
Fixes #464.

## The gap
`McpServer` deletes `mcp-endpoint.json` only in `stop()`, so a crash (or SIGKILL) leaves it behind — observed live on the audit machine: a file dated 10 Jul pointing at port 63681 with nothing listening. Two consequences: a client configured from that file just fails; and if an unrelated process later binds that port, a client following the stale file would hand **it** the bearer token. (The file is already owner-only from #461, so this is about staleness, not readability.)

## The fix
- `writeEndpointFile` now stamps the process **pid + start instant** into the file.
- A new static **`McpServer.reapStaleEndpoint(configDir)`**, called once from `App.start` before any server starts (beside `ProcessRegistry.reapOrphans`), deletes the file when the pure **`isStaleEndpoint(pid, startMillis, liveStart)`** judges it dead: no pid (an old/unstamped file at launch), the pid isn't a live process, or it is live but its start time differs (the PID was reused). A live process whose start matches (a concurrent Editora instance) is kept; a live pid with no recorded start is conservatively kept (never delete a possibly-live endpoint) — the exact safe-against-reused-PID shape `ProcessRegistry.reapOrphans` already uses.

## Tests
- `isStaleEndpointReapsDeadOrReusedPidsButKeepsALiveMatch` (pure): live+match keep, reused-pid reap, dead-pid reap, no-pid reap, live+unknown-start keep.
- `reapStaleEndpointDeletesAFileFromADeadProcessButKeepsALiveOne` (temp filesystem): a dead-pid file is deleted; a file stamped with this live process is kept. Reverting the reap decision fails both.

Full suite green (2276). No new dependency / schema change.

## Perf
None — one file read at launch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)