### PR TITLE
MCP: re-own the server to a surviving window on close (#463)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,6 +91,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Closing the window that started the MCP server no longer stops MCP for the other windows.** Ownership now
+  moves to a surviving window (keeping the same port and token, so a connected agent stays connected); the
+  server is stopped only when the last window closes. (#463)
 - **A stale MCP endpoint file left by a crash is now cleaned up at launch.** If Editora exited hard while the
   MCP server was running, `mcp-endpoint.json` lingered — pointing an MCP client at a dead port with a
   live-looking token. Editora now stamps the file with its process identity and removes a stale one on the

--- a/src/main/java/com/editora/mcp/McpServer.java
+++ b/src/main/java/com/editora/mcp/McpServer.java
@@ -38,20 +38,30 @@ public final class McpServer {
     private static final Logger LOG = Logger.getLogger(McpServer.class.getName());
     private static final String ENDPOINT_FILE = "mcp-endpoint.json";
 
-    private final McpBridge bridge;
     private final Path configDir;
     private final ObjectMapper mapper = new ObjectMapper();
-    private final McpTools tools;
+    /** Volatile + reassignable so ownership can move to a surviving window on close ({@link #rebind}) without
+     *  restarting the server (keeping the same port/token/endpoint file, so a connected agent stays connected). */
+    private volatile McpTools tools;
+
     private final String token;
 
     private HttpServer server;
     private ExecutorService pool;
 
     public McpServer(McpBridge bridge, Path configDir) {
-        this.bridge = bridge;
         this.configDir = configDir;
         this.tools = new McpTools(bridge, mapper);
         this.token = randomToken();
+    }
+
+    /**
+     * Re-points the server at a new bridge (a different window's {@code MainController}). Used when the window
+     * that started MCP is closed while others remain: ownership moves to a survivor instead of stopping the
+     * server, so a connected agent isn't dropped (#463). Keeps the same port/token/endpoint file.
+     */
+    public void rebind(McpBridge bridge) {
+        this.tools = new McpTools(bridge, mapper);
     }
 
     /** Starts the server on an ephemeral loopback port (idempotent); returns the bound port. */

--- a/src/main/java/com/editora/ui/MainController.java
+++ b/src/main/java/com/editora/ui/MainController.java
@@ -3425,10 +3425,23 @@ public class MainController implements com.editora.mcp.McpBridge {
         return confirm.showAndWait().orElse(ButtonType.CANCEL) == ButtonType.OK;
     }
 
-    /** Stops the MCP server if this window owns it (called from {@link #disposeWindow}). */
+    /**
+     * Handles the MCP server when this window (its owner) closes (called from {@link #disposeWindow}). If
+     * another window is still open, ownership <b>moves</b> to it — the server is re-bound to that window's
+     * bridge (same port/token/endpoint), so a connected agent isn't dropped and the survivor's indicator is
+     * refreshed. Only when this is the last window is the server actually stopped (#463).
+     */
     private void stopMcpIfOwner() {
-        if (mcpServer != null && mcpOwner == this) {
-            mcpServer.stop();
+        if (mcpServer == null || mcpOwner != this) {
+            return;
+        }
+        MainController survivor = windowManager != null ? windowManager.otherLiveController(this) : null;
+        if (survivor != null) {
+            mcpServer.rebind(survivor); // move ownership; keep the server running for the surviving window
+            mcpOwner = survivor;
+            survivor.statusBar.setMcpRunning(mcpServer.isRunning());
+        } else {
+            mcpServer.stop(); // last window — really stop + remove the endpoint file
             mcpServer = null;
             mcpOwner = null;
         }

--- a/src/main/java/com/editora/ui/WindowManager.java
+++ b/src/main/java/com/editora/ui/WindowManager.java
@@ -300,6 +300,21 @@ public class WindowManager {
         return windows.isEmpty() ? null : windows.get(windows.size() - 1);
     }
 
+    /**
+     * Any live window's controller other than {@code exclude}, or {@code null} if none — used to move MCP
+     * server ownership to a surviving window when its owner closes (#463). Called from {@code disposeWindow},
+     * which runs <em>before</em> {@link #onWindowClosed} removes the closing window, so {@code exclude} is
+     * still in the list and must be skipped.
+     */
+    MainController otherLiveController(MainController exclude) {
+        for (Holder h : windows) {
+            if (h.controller() != null && h.controller() != exclude) {
+                return h.controller();
+            }
+        }
+        return null;
+    }
+
     /** Directory holding per-window session files for untitled no-project windows ({@code windows/<uuid>.json}). */
     private Path windowsDir() {
         return shared.getConfigDir().resolve("windows");

--- a/src/test/java/com/editora/mcp/McpServerTest.java
+++ b/src/test/java/com/editora/mcp/McpServerTest.java
@@ -154,6 +154,32 @@ class McpServerTest {
         assertFalse(Files.exists(ep));
     }
 
+    @Test
+    void rebindMovesToolCallsToTheNewBridgeKeepingThePortAndToken(@TempDir Path dir) throws Exception {
+        // #463: when the MCP-owning window closes but others remain, the server is re-bound to a survivor
+        // instead of stopped — same port/token, tool calls now route to the survivor's bridge.
+        FakeBridge first = new FakeBridge();
+        FakeBridge second = new FakeBridge();
+        McpServer s = new McpServer(first, dir);
+        int port = s.start();
+        String token = s.token();
+        String call = "{\"jsonrpc\":\"2.0\",\"id\":3,\"method\":\"tools/call\","
+                + "\"params\":{\"name\":\"execute_command\",\"arguments\":{\"id\":\"file.save\"}}}";
+        try {
+            assertEquals(200, post(port, token, call).statusCode());
+            assertEquals("file.save", first.lastExecuted, "first bridge got the call");
+
+            s.rebind(second); // window that started MCP closed → ownership moves to a survivor
+            assertEquals(port, s.port(), "same port after rebind (server not restarted)");
+            assertEquals(token, s.token(), "same token after rebind");
+
+            assertEquals(200, post(port, token, call).statusCode());
+            assertEquals("file.save", second.lastExecuted, "the call now routes to the survivor's bridge");
+        } finally {
+            s.stop();
+        }
+    }
+
     private static HttpResponse<String> post(int port, String token, String body) throws Exception {
         HttpRequest.Builder b = HttpRequest.newBuilder(URI.create("http://127.0.0.1:" + port + "/mcp"))
                 .timeout(Duration.ofSeconds(5))


### PR DESCRIPTION
Fixes #463.

## The bug
`MainController` holds the MCP server in a **static** field with an `mcpOwner`, and `disposeWindow` called `stopMcpIfOwner` unconditionally. So with two windows open and MCP enabled, closing the one that started it stopped the server and deleted `mcp-endpoint.json` — a connected agent got connection-refused, and no surviving window restarted it (`applyMcpSupport` only runs at init / on a settings apply). The survivor's status indicator was left stale too.

## The fix
- **`McpServer.rebind(bridge)`** re-points the server at a new bridge (rebuilds `McpTools`; `tools` is now `volatile`) **without restarting** — same port, token, and endpoint file, so a connected agent isn't dropped.
- On owner close, `stopMcpIfOwner` asks **`WindowManager.otherLiveController(this)`** for a survivor: if one exists, ownership **moves** to it (`rebind` + refresh its indicator); only when this is the last window is the server actually stopped. (`disposeWindow` runs before `onWindowClosed` removes the closing window, so the closing controller is excluded explicitly.)

## Test
`rebindMovesToolCallsToTheNewBridgeKeepingThePortAndToken` (real loopback HTTP): a tool call routes to bridge A; after `rebind(B)` the port and token are unchanged and the same call now routes to B. Reverting `rebind` to a no-op fails it.

Full suite green (2277). No new dependency / schema change.

## Perf
None — rebind is a window-close event, not a hot path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)