### PR TITLE
LSP: split each file once in Find References previews (#471)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,6 +91,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Find References is faster on symbols with many references.** Building the results list re-scanned the
+  whole file once per reference; on a heavily-used symbol in a large open file that caused a visible stall.
+  Each file is now scanned once. (#471)
 - **Closing the window that started the MCP server no longer stops MCP for the other windows.** Ownership now
   moves to a surviving window (keeping the same port and token, so a connected agent stays connected); the
   server is stopped only when the last window closes. (#463)

--- a/src/main/java/com/editora/ui/LspCoordinator.java
+++ b/src/main/java/com/editora/ui/LspCoordinator.java
@@ -837,24 +837,42 @@ final class LspCoordinator {
                 ops.openAndGoto(t.file(), t.line(), t.character());
                 return;
             }
+            List<String> previews = previewLines(targets, f -> {
+                EditorBuffer buffer = ops.bufferForPath(f);
+                return buffer == null ? null : buffer.getContent();
+            });
             List<ReferencesPanel.Reference> refs = new java.util.ArrayList<>(targets.size());
-            for (LspManager.Target t : targets) {
-                refs.add(new ReferencesPanel.Reference(t.file(), t.line(), t.character(), previewLine(t)));
+            for (int i = 0; i < targets.size(); i++) {
+                LspManager.Target t = targets.get(i);
+                refs.add(new ReferencesPanel.Reference(t.file(), t.line(), t.character(), previews.get(i)));
             }
             referencesPanel.setReferences(refs);
             ops.openReferencesWindow();
         });
     }
 
-    /** A one-line preview of a reference — from the file's open buffer when one holds it (cheap, FX-safe,
-     *  reflects unsaved edits), else empty (closed files show just the line number; no disk I/O on the FX thread). */
-    private String previewLine(LspManager.Target t) {
-        EditorBuffer buffer = ops.bufferForPath(t.file());
-        if (buffer == null) {
-            return "";
+    private static final String[] NO_LINES = new String[0];
+
+    /**
+     * One-line previews for each reference target, splitting <b>each file's content at most once</b> —
+     * previously the per-target {@code previewLine} re-split the whole document for <em>every</em> target, so
+     * 500 references into one open file did 500 full {@code getText()} walks + splits in a single FX pulse
+     * (#471). {@code contentOf} maps a file to its open-buffer content (cheap, FX-safe, reflects unsaved
+     * edits), or {@code null} for a file with no open tab (closed files show just the line number — no disk I/O
+     * on the FX thread). Pure; unit-tested.
+     */
+    static List<String> previewLines(
+            List<LspManager.Target> targets, java.util.function.Function<Path, String> contentOf) {
+        java.util.Map<Path, String[]> byFile = new java.util.HashMap<>();
+        List<String> out = new java.util.ArrayList<>(targets.size());
+        for (LspManager.Target t : targets) {
+            String[] lines = byFile.computeIfAbsent(t.file(), f -> {
+                String content = contentOf.apply(f);
+                return content == null ? NO_LINES : content.split("\n", -1);
+            });
+            out.add(t.line() >= 0 && t.line() < lines.length ? lines[t.line()].strip() : "");
         }
-        String[] lines = buffer.getContent().split("\n", -1);
-        return t.line() >= 0 && t.line() < lines.length ? lines[t.line()].strip() : "";
+        return out;
     }
 
     /**

--- a/src/test/java/com/editora/ui/LspCoordinatorPreviewTest.java
+++ b/src/test/java/com/editora/ui/LspCoordinatorPreviewTest.java
@@ -1,0 +1,45 @@
+package com.editora.ui;
+
+import java.nio.file.Path;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import com.editora.lsp.LspManager;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Regression for #471: Find References must split each file's content <em>once</em>, not once per reference —
+ * 500 references into one open file did 500 whole-document splits in a single FX pulse.
+ */
+class LspCoordinatorPreviewTest {
+
+    @Test
+    void previewLinesSplitsEachFileAtMostOnce() {
+        Path a = Path.of("/proj/A.java");
+        Path b = Path.of("/proj/B.java");
+        Path closed = Path.of("/proj/Closed.java");
+        List<LspManager.Target> targets = List.of(
+                new LspManager.Target(a, 0, 0),
+                new LspManager.Target(a, 2, 4),
+                new LspManager.Target(b, 1, 0),
+                new LspManager.Target(a, 0, 9), // a again — must NOT re-split A
+                new LspManager.Target(closed, 3, 0)); // no open buffer
+
+        AtomicInteger calls = new AtomicInteger();
+        List<String> previews = LspCoordinator.previewLines(targets, f -> {
+            calls.incrementAndGet();
+            if (f.equals(a)) {
+                return "  alpha\nbeta\ngamma  ";
+            }
+            if (f.equals(b)) {
+                return "one\n  two\n";
+            }
+            return null; // closed file → no content
+        });
+
+        assertEquals(3, calls.get(), "content fetched once per distinct file (A, B, Closed), not once per target");
+        assertEquals(List.of("alpha", "gamma", "two", "alpha", ""), previews);
+    }
+}


### PR DESCRIPTION
Fixes #471.

## The gap
`LspCoordinator.previewLine` called `buffer.getContent().split("\n", -1)` for **every** reference target, inside the `findReferences` callback — O(references × document). `M-?` on a widely-used symbol in a 10k-line / 400 KB open file returning 500 references did 500 full `getText()` rope walks + splits in a single FX pulse: a visible stall on the thread CLAUDE.md calls sacred.

## The fix
The per-target `previewLine` becomes the pure **`previewLines(targets, contentOf)`**, which splits each file's content **at most once** (a `Map<Path, String[]>` via `computeIfAbsent`) and indexes per target. `contentOf` maps a file to its open-buffer content (cheap, FX-safe, reflects unsaved edits) or `null` for a file with no open tab (closed files still contribute no disk I/O on the FX thread).

## Test
`LspCoordinatorPreviewTest.previewLinesSplitsEachFileAtMostOnce` (pure): five targets across two open files + one closed file fetch content exactly 3 times (once per distinct file), with correct per-target previews. Reverting to the per-target split makes it 5 and fails.

Full suite green (2278). No new dependency / schema change.

## Perf
This is the perf fix — O(distinct files) splits instead of O(references).

🤖 Generated with [Claude Code](https://claude.com/claude-code)