### PR TITLE
LSP: clear diagnostics on edit so they don't paint on shifted lines (#417)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,6 +91,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Error squiggles no longer briefly underline the wrong line while you type.** After an edit, the diagnostic
+  underlines, scrollbar ticks, and minimap marks stayed on their old line numbers until the language server
+  re-reported (a fraction of a second later), so inserting a line above an error moved the squiggle onto
+  unrelated text. They now clear on the edit and reappear, correctly placed, on the next update. (#417)
 - **A PlantUML file with several `@startuml` diagrams no longer hides the extras silently.** Only the first
   diagram was shown, with no sign the others existed; the preview now shows the first plus a "N more
   diagram(s) not shown" note. (#459)

--- a/src/main/java/com/editora/editor/EditorBuffer.java
+++ b/src/main/java/com/editora/editor/EditorBuffer.java
@@ -707,6 +707,14 @@ public class EditorBuffer implements TabContent {
                 semanticGen++;
                 semanticStale = true;
             }
+            // LSP diagnostics are anchored to absolute line/col and only replaced when the server re-pushes
+            // (a debounced didChange + round-trip, ~300 ms+). Until then every keystroke would repaint the OLD
+            // squiggles/stripe/minimap ticks at their OLD lines — underlining whatever text now sits there.
+            // Clear them on the edit so nothing paints on shifted lines; setLspDiagnostics re-anchors on the
+            // next push (which always follows an edit — jdtls republishes, pull servers re-pull) (#417).
+            if (lspActive) {
+                suppressStaleDiagnostics();
+            }
         });
         area.multiPlainChanges().successionEnds(Duration.ofMillis(150)).subscribe(ignore -> {
             applyHighlighting();
@@ -3035,6 +3043,16 @@ public class EditorBuffer implements TabContent {
         }
         minimap.setDiagnostics(diagnostics);
         diagnosticStripe.setDiagnostics(diagnostics);
+    }
+
+    /** Clears the diagnostic overlay/stripe/minimap on an edit so their line/col-anchored marks don't paint on
+     *  shifted lines until the server re-pushes (#417). A no-op cost beyond the repaint the edit already does. */
+    private void suppressStaleDiagnostics() {
+        if (lspOverlay != null) {
+            lspOverlay.setDiagnostics(java.util.List.of());
+        }
+        minimap.setDiagnostics(java.util.List.of());
+        diagnosticStripe.setDiagnostics(java.util.List.of());
     }
 
     /** The debounced semantic-tokens request (fired on the 300 ms didChange pulse while active); null = none. */

--- a/src/test/java/com/editora/ui/DiagnosticStaleOnEditFxTest.java
+++ b/src/test/java/com/editora/ui/DiagnosticStaleOnEditFxTest.java
@@ -1,0 +1,61 @@
+package com.editora.ui;
+
+import java.util.List;
+
+import com.editora.editor.EditorBuffer;
+import com.editora.editor.LspDiagnostic;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Regression for #417: LSP diagnostics are anchored to absolute line/col and only replaced when the server
+ * re-pushes. Between an edit and that push, the overlay/stripe/minimap must NOT keep painting the old marks
+ * on the now-shifted lines — an edit clears them until {@code setLspDiagnostics} re-anchors.
+ */
+@Tag("fx")
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class DiagnosticStaleOnEditFxTest {
+
+    @BeforeAll
+    void setUp() throws Exception {
+        FxTestSupport.bootToolkit();
+    }
+
+    private static final List<LspDiagnostic> ONE =
+            List.of(new LspDiagnostic(2, 0, 2, 4, LspDiagnostic.Severity.ERROR, "oops", "E1", "javac"));
+
+    @SuppressWarnings("unchecked")
+    private static int overlayCount(EditorBuffer b) {
+        Object overlay = FxTestSupport.field(b, "lspOverlay");
+        return overlay == null ? 0 : ((List<?>) FxTestSupport.field(overlay, "diagnostics")).size();
+    }
+
+    @Test
+    void anEditClearsTheDiagnosticOverlayUntilTheNextPush() throws Exception {
+        EditorBuffer buffer = FxTestSupport.callOnFx(() -> {
+            EditorBuffer b = new EditorBuffer();
+            b.setLanguageOverride("java");
+            b.setContent("class A {\n  int x;\n  bad code\n}\n");
+            b.getNode(); // realize the scene graph so the overlay can attach
+            b.setLspActive(true);
+            b.setLspDiagnostics(ONE);
+            return b;
+        });
+        assertEquals(1, FxTestSupport.callOnFx(() -> overlayCount(buffer)), "diagnostic painted");
+
+        // The user inserts a line above the error — its stored line/col now point at shifted text.
+        FxTestSupport.runOnFx(() -> buffer.getArea().insertText(0, "// header\n"));
+        assertEquals(
+                0,
+                FxTestSupport.callOnFx(() -> overlayCount(buffer)),
+                "the overlay is cleared on edit so nothing paints on the shifted line");
+
+        // The server re-pushes → the overlay re-anchors.
+        FxTestSupport.runOnFx(() -> buffer.setLspDiagnostics(ONE));
+        assertEquals(1, FxTestSupport.callOnFx(() -> overlayCount(buffer)), "re-anchored on the next push");
+    }
+}


### PR DESCRIPTION
Fixes #417 (the primary LSP-diagnostics case).

## The pattern
`LspDiagnostic` marks are stored as absolute 0-based line/char and are only replaced when the server pushes new diagnostics (a debounced `didChange` + round-trip, ~300 ms+). In that window every keystroke fires `multiPlainChanges` and the overlay / scrollbar stripe / minimap redraw the **old** diagnostics at their **old** line numbers — insert a line above an error and its squiggle underlines whatever text now sits on the old line. This is the same staleness the semantic-token fix (#409) closed, but the diagnostic overlays had no on-edit invalidation.

## The fix
`EditorBuffer` clears the diagnostic overlay + `DiagnosticStripe` + minimap ticks on the immediate edit pulse (`suppressStaleDiagnostics`, right beside the existing `semanticStale` write). The next `setLspDiagnostics` re-anchors them — a push always follows an edit (jdtls republishes on `didChange`; pull-model servers re-pull on the 300 ms pulse). Suppression (clear) is the simpler of the two shapes the issue suggests and matches the established `#409` precedent.

**No new hot-path cost:** the overlays already repaint on every edit pulse; they now repaint *empty* instead of *stale*.

## Test
`DiagnosticStaleOnEditFxTest` (headless-FX): set a diagnostic, insert a line above it → the overlay's mark list is cleared; the next `setLspDiagnostics` restores it. Removing the suppression call keeps the stale mark and fails the test.

Full suite green (2283). No new dependency / schema change.

## Scope
This closes the **primary** case (LSP diagnostics, the longest/network window). The milder siblings the issue lists (TODO highlight, Search highlight, Git change bars — shorter, local recompute windows) are left as follow-ups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
