### PR TITLE
Project: ignore Editora's typst temp file in the tree watcher (#465)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,6 +91,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Previewing a Typst document no longer churns the project tree.** Each render writes and deletes a
+  throwaway `.typ` file beside your document; on some systems the project tree's file watcher reacted to that
+  by rebuilding itself on every render. It now ignores Editora's own temporary render files. (#465)
 - **Error squiggles no longer briefly underline the wrong line while you type.** After an edit, the diagnostic
   underlines, scrollbar ticks, and minimap marks stayed on their old line numbers until the language server
   re-reported (a fraction of a second later), so inserting a line above an error moved the squiggle onto

--- a/src/main/java/com/editora/ui/ProjectPanel.java
+++ b/src/main/java/com/editora/ui/ProjectPanel.java
@@ -517,14 +517,46 @@ public class ProjectPanel extends VBox implements ToolWindowContent {
             } catch (InterruptedException | java.nio.file.ClosedWatchServiceException e) {
                 return; // disposed
             }
-            key.pollEvents(); // we re-list rather than apply individual events; just drain them
+            // Inspect the events so a batch that is ONLY Editora's own throwaway temp files (the typst render
+            // input, created+deleted every render) doesn't spuriously rebuild the tree (#465). Otherwise we
+            // re-list from disk (individual events aren't applied) — an OVERFLOW or any real file forces it.
+            List<java.nio.file.WatchEvent<?>> events = key.pollEvents();
             key.reset();
+            boolean overflow = false;
+            List<String> names = new java.util.ArrayList<>();
+            for (java.nio.file.WatchEvent<?> ev : events) {
+                if (ev.kind() == java.nio.file.StandardWatchEventKinds.OVERFLOW) {
+                    overflow = true;
+                    continue;
+                }
+                Object ctx = ev.context();
+                names.add(ctx instanceof Path p ? p.getFileName().toString() : "");
+            }
+            if (!watchEventsWarrantRefresh(names, overflow)) {
+                continue; // only Editora's own temp files changed — no tree rebuild
+            }
             Platform.runLater(() -> {
                 if (!disposed) {
                     watchDebounce.playFromStart();
                 }
             });
         }
+    }
+
+    /** Whether a batch of filesystem watch events warrants a tree refresh — {@code false} only when every
+     *  changed name is one of Editora's own throwaway temp files (so a typst render, which creates+deletes a
+     *  {@code .editora-typst-*.typ} input beside the file, doesn't rebuild the tree). An OVERFLOW or an empty
+     *  batch forces a refresh (we can't tell what changed). Pure; unit-tested (#465). */
+    static boolean watchEventsWarrantRefresh(List<String> names, boolean overflow) {
+        if (overflow || names.isEmpty()) {
+            return true;
+        }
+        return names.stream().anyMatch(n -> !isEditoraTempName(n));
+    }
+
+    /** Whether {@code name} is an Editora-internal throwaway file the tree watcher should ignore. */
+    static boolean isEditoraTempName(String name) {
+        return name != null && name.startsWith(".editora-typst-");
     }
 
     /** Stops the watcher + its thread; call on window close so the daemon thread + native handles are freed. */

--- a/src/test/java/com/editora/ui/ProjectWatchFilterTest.java
+++ b/src/test/java/com/editora/ui/ProjectWatchFilterTest.java
@@ -1,0 +1,44 @@
+package com.editora.ui;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Regression for #465: the project-tree filesystem watcher must ignore Editora's own throwaway typst render
+ * input (created + deleted every render), so a render doesn't spuriously rebuild the tree — while any real
+ * file change still triggers a refresh.
+ */
+class ProjectWatchFilterTest {
+
+    @Test
+    void aBatchOfOnlyEditoraTempFilesDoesNotWarrantARefresh() {
+        // The typst render writes then deletes `.editora-typst-<uuid>.typ` beside the file.
+        assertFalse(ProjectPanel.watchEventsWarrantRefresh(
+                List.of(".editora-typst-cf099c21.typ", ".editora-typst-cf099c21.typ"), false));
+    }
+
+    @Test
+    void anyRealFileChangeStillWarrantsARefresh() {
+        assertTrue(ProjectPanel.watchEventsWarrantRefresh(List.of("Main.java"), false));
+        // A mixed batch (temp + a real file) refreshes.
+        assertTrue(ProjectPanel.watchEventsWarrantRefresh(List.of(".editora-typst-x.typ", "notes.md"), false));
+    }
+
+    @Test
+    void overflowOrAnEmptyBatchForcesARefresh() {
+        assertTrue(ProjectPanel.watchEventsWarrantRefresh(List.of(".editora-typst-x.typ"), true), "OVERFLOW");
+        assertTrue(ProjectPanel.watchEventsWarrantRefresh(List.of(), false), "empty batch — can't tell");
+    }
+
+    @Test
+    void isEditoraTempNameRecognizesTheTypstInput() {
+        assertTrue(ProjectPanel.isEditoraTempName(".editora-typst-abc-123.typ"));
+        assertFalse(ProjectPanel.isEditoraTempName("report.typ"));
+        assertFalse(ProjectPanel.isEditoraTempName(".gitignore"));
+        assertFalse(ProjectPanel.isEditoraTempName(null));
+    }
+}


### PR DESCRIPTION
Fixes #465.

## The bug
`TypstRenderer` writes the live text to a throwaway `.editora-typst-<uuid>.typ` **inside** the document's own folder (so relative `#import`/`#image` resolve) and deletes it after each render. Meanwhile `ProjectPanel`'s filesystem watcher drained events with **no filtering** and always scheduled a `refreshTree()`. On an inotify-backed OS (Linux) that means every render — i.e. every typing pause in a `.typ` preview — rebuilds the project tree. (On macOS the JDK's polling watcher usually misses the fast create+delete, so it's intermittent there.)

## The fix
`watchLoop` now inspects the drained events: a batch whose changed names are **all** Editora temp files is skipped (no rebuild); any real file, an `OVERFLOW`, or an empty batch still refreshes. The decision is the pure, unit-tested **`watchEventsWarrantRefresh(names, overflow)`** + **`isEditoraTempName`** (matches the `.editora-typst-` prefix).

## Test
`ProjectWatchFilterTest` (pure): a batch of only temp files → no refresh; a real file / mixed batch / OVERFLOW / empty batch → refresh; `isEditoraTempName` recognizes the typst input and rejects real files. Reverting the filter (always refresh) fails the temp-only case.

Full suite green (2287). No new dependency / schema change.

## Perf
The watcher already ran per event batch; it now does a cheap name check before scheduling — and *avoids* a full tree rebuild for Editora's own temp files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
