### PR TITLE
Release 0.9.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.6] - 2026-07-17
+
 ### Security
 
 - **Your AI API key is no longer sent in cleartext to a remote server.** If you pointed an AI provider at a

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.editora</groupId>
     <artifactId>editora</artifactId>
-    <version>0.9.5</version>
+    <version>0.9.6</version>
     <packaging>jar</packaging>
 
     <name>Editora</name>


### PR DESCRIPTION
Version bump 0.9.5 → 0.9.6 + CHANGELOG roll (`[Unreleased]` → `[0.9.6] - 2026-07-17`). Full suite green (2289). Tagging `v0.9.6` on master after merge fires the release pipeline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)