### PR TITLE
Editor: make the gutter fold chevron 35% bigger (#530)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **The gutter fold arrow is 35% larger** — easier to see and click. (#530)
+
 ## [0.9.6] - 2026-07-17
 
 ### Security

--- a/src/main/resources/com/editora/styles/app.css
+++ b/src/main/resources/com/editora/styles/app.css
@@ -65,8 +65,8 @@
 .editor-area .fold-chevron {
     -fx-text-fill: #8c959f;
     -fx-font-family: "sans-serif";
-    -fx-font-size: 13px;
-    -fx-min-width: 14;
+    -fx-font-size: 17.5px; /* 35% larger than the former 13px — easier to see/hit (#530) */
+    -fx-min-width: 19;
     -fx-alignment: center;
 }
 


### PR DESCRIPTION
Fixes #530.

The fold collapse/expand arrow (`.fold-chevron`) was 13px and hard to hit. Bumped to **17.5px** (35% larger) with `min-width` 14→19 to match. CSS-only visual change (no logic to unit-test); full suite green (2289).

🤖 Generated with [Claude Code](https://claude.com/claude-code)