### PR TITLE
Build tools: default the task windows to the right stripe (#531)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **The Maven / Gradle / npm / Cargo / Go task panels now open on the right by default** instead of the bottom
+  (a better fit for a vertical task list). A panel you've already moved keeps its side. (#531)
 - **The gutter fold arrow is 35% larger** — easier to see and click. (#530)
 
 ## [0.9.6] - 2026-07-17

--- a/src/main/java/com/editora/ui/MainController.java
+++ b/src/main/java/com/editora/ui/MainController.java
@@ -2254,12 +2254,15 @@ public class MainController implements com.editora.mcp.McpBridge {
         for (BuildCoordinator c : buildCoordinators) {
             BuildTool tool = c.tool();
             // The primary window: the IntelliJ-style tasks tree (its stripe appears when the marker is found).
+            // Defaults to the RIGHT stripe (a better fit for a vertical task list); a window with a persisted
+            // side keeps it (currentSide reads WorkspaceState first). The shared Build Output console stays
+            // BOTTOM. (#531)
             buildToolWindows.put(
                     tool,
                     new ToolWindow(
                             tool.id(),
                             tr("toolwindow." + tool.id()),
-                            ToolWindow.Side.BOTTOM,
+                            ToolWindow.Side.RIGHT,
                             c.iconSupplier(),
                             c.tasksPanel(),
                             "tool." + tool.id()));


### PR DESCRIPTION
Fixes #531.

The Maven/Gradle/npm/Cargo/Go **tasks-tree** tool windows registered with `ToolWindow.Side.BOTTOM`; the default is now `Side.RIGHT` (a better fit for a vertical task list). `ToolWindowManager.currentSide` reads `WorkspaceState.toolWindowSides` first, so a window with a persisted side keeps it — this only changes the default for windows without a saved side. The shared **Build Output** console stays on the bottom.

Full suite green (2289). No new dependency / schema change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)