### PR TITLE
Git: refresh the Commit stripe on an external file change (#529)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **The Commit panel now appears when a file changes outside Editora.** If another program (a terminal `git`
+  command, another editor, a build) modified files under the repo while Editora was focused, the Commit stripe,
+  Git status, and gutter change bars didn't update until you clicked away and back. They now refresh as soon as
+  the project tree sees the change. (#529)
+
 ### Changed
 
 - **The Maven / Gradle / npm / Cargo / Go task panels now open on the right by default** instead of the bottom

--- a/src/main/java/com/editora/ui/MainController.java
+++ b/src/main/java/com/editora/ui/MainController.java
@@ -1930,6 +1930,14 @@ public class MainController implements com.editora.mcp.McpBridge {
                 file -> historyCoordinator.captureBeforeDelete(file)); // snapshot to Local History before delete
         projectPanel.setOnNewFromTemplate(this::newFromTemplate); // folder "New From Template…"
         projectPanel.setOnStatus(this::setStatus); // drag-move / multi-delete feedback in the status bar
+        // An external program (a terminal `git`, another editor, a build) changed files under the repo while
+        // Editora already had focus: re-evaluate the working-tree-anchored surfaces the focus-regain handler
+        // also refreshes — Git status + the Commit stripe, build-tool markers, and open diffs (#529).
+        projectPanel.setOnExternalChange(() -> {
+            git.refresh();
+            refreshBuildTools();
+            diffCoordinator.refreshOpenDiffs();
+        });
         projectPanel.setOnReveal((p, dir) -> revealInFileManager(p, dir, com.editora.vfs.Vfs.isLocal(p)));
         projectPanel.setOnOpenTerminal((p, dir) -> openTerminalAt(p, dir, com.editora.vfs.Vfs.isLocal(p)));
         // Breadcrumb crumbs offer the same Reveal / Open Terminal as the Project tree (local files only).

--- a/src/main/java/com/editora/ui/ProjectPanel.java
+++ b/src/main/java/com/editora/ui/ProjectPanel.java
@@ -75,6 +75,10 @@ public class ProjectPanel extends VBox implements ToolWindowContent {
     private Consumer<Path> onBeforeDelete = p -> {};
     /** Injected by MainController: show a transient status-bar message (drag-move / multi-delete feedback). */
     private Consumer<String> onStatus = m -> {};
+    /** Notified after the filesystem watcher picks up an <em>external</em> change (not the app's own edit), so
+     *  the window can refresh things anchored to the working tree — Git status / the Commit stripe, build-tool
+     *  markers, open diffs — which otherwise only re-evaluate on focus-regain / tab switch (#529). */
+    private Runnable onExternalChange = () -> {};
     /** Injected by MainController: "New From Template…" on a folder, given the target directory. */
     private Consumer<Path> onNewFromTemplate;
     /** Injected by MainController: reveal a path in the OS file manager. Args: (path, isDirectory). */
@@ -210,6 +214,7 @@ public class ProjectPanel extends VBox implements ToolWindowContent {
             }
             refreshTree();
             syncWatches(); // a newly-created folder that's expanded would need watching
+            onExternalChange.run(); // an external change → refresh Git/Commit stripe, build markers, diffs (#529)
         });
 
         Label placeholder = new Label(tr("project.placeholder"));
@@ -761,6 +766,11 @@ public class ProjectPanel extends VBox implements ToolWindowContent {
     /** Injects the status-message sink used for drag-move / multi-delete feedback. */
     public void setOnStatus(Consumer<String> onStatus) {
         this.onStatus = onStatus == null ? m -> {} : onStatus;
+    }
+
+    /** Injects the external-change hook (see {@link #onExternalChange}); {@code null} restores the no-op. */
+    public void setOnExternalChange(Runnable onExternalChange) {
+        this.onExternalChange = onExternalChange == null ? () -> {} : onExternalChange;
     }
 
     /** Injects the "Reveal in File Manager" handler ({@code (path, isDirectory)}) for the cell menu. */

--- a/src/test/java/com/editora/ui/ProjectExternalChangeFxTest.java
+++ b/src/test/java/com/editora/ui/ProjectExternalChangeFxTest.java
@@ -1,0 +1,61 @@
+package com.editora.ui;
+
+import java.nio.file.Path;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import javafx.animation.PauseTransition;
+import javafx.event.ActionEvent;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.io.TempDir;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Regression for #529: when an external program changes files under the repo while Editora already has focus,
+ * the filesystem watcher's coalesced refresh must also fire the {@code onExternalChange} hook (which the window
+ * wires to a Git / Commit-stripe / build-marker / diff refresh) — but a change the app made itself (guarded by
+ * the self-change window) must not.
+ */
+@Tag("fx")
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class ProjectExternalChangeFxTest {
+
+    @BeforeAll
+    void setUp() throws Exception {
+        FxTestSupport.bootToolkit();
+    }
+
+    /** Fire the watcher's coalesced-refresh handler (the {@code watchDebounce} {@code onFinished}) directly. */
+    private static void fireWatchDebounce(ProjectPanel panel) {
+        PauseTransition pt = FxTestSupport.field(panel, "watchDebounce");
+        pt.getOnFinished().handle(new ActionEvent());
+    }
+
+    @Test
+    void anExternalChangeFiresTheHookButASelfChangeDoesNot(@TempDir Path root) throws Exception {
+        AtomicInteger fired = new AtomicInteger();
+        ProjectPanel panel = FxTestSupport.callOnFx(() -> {
+            ProjectPanel p = new ProjectPanel(x -> {}, (a, b) -> {}, x -> {}, x -> false);
+            p.setOnExternalChange(fired::incrementAndGet);
+            p.setRoot(root);
+            return p;
+        });
+
+        // An external filesystem change → the hook fires (Git/Commit/build/diffs re-evaluate).
+        FxTestSupport.runOnFx(() -> fireWatchDebounce(panel));
+        assertEquals(1, fired.get(), "an external change fires the hook");
+
+        // A change the app just made itself (within the self-change window) must NOT fire the hook.
+        FxTestSupport.runOnFx(() -> {
+            FxTestSupport.invoke(panel, "markLocalChange");
+            fireWatchDebounce(panel);
+        });
+        assertEquals(1, fired.get(), "a self-change does not fire the hook");
+
+        FxTestSupport.runOnFx(panel::dispose);
+    }
+}


### PR DESCRIPTION
Fixes #529.

## The gap
The Commit tool-window stripe (+ the status-bar Git segment + gutter change bars) refreshes on tab switch, focus-regain, save, and Git mutations — but **not** when an external process (a terminal `git`, another editor, a build) changes files under the repo while Editora already has focus. So a clean→dirty transition made purely from outside didn't show the Commit window until the user clicked away and back.

## The fix
`ProjectPanel` gains an **`onExternalChange`** hook, fired from the filesystem watcher's coalesced-refresh path — and only for a genuine external change (the self-change window already suppresses the app's own edits). `MainController` wires it to `git.refresh()` + `refreshBuildTools()` + `diffCoordinator.refreshOpenDiffs()`, i.e. the same working-tree-anchored surfaces the focus-regain handler refreshes, so an external change is handled the same whether or not the window has focus.

## Test
`ProjectExternalChangeFxTest` (headless-FX): invoking the watcher's coalesced-refresh handler fires the hook once for an external change, and **not** for a self-change (after `markLocalChange`). Removing the `onExternalChange.run()` call fails it.

Full suite green (2290). No new dependency / schema change.

## Perf
Rides the existing debounced (250 ms) watcher pulse — no new per-event work; the git refresh is already generation-guarded/coalesced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)