### PR TITLE
Diff: apply text zoom to the diff view areas (#533)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Text zoom now works inside Diff views.** `Ctrl`+`=`/`-`/`0`, the status-bar `−/+`, and `Ctrl`+mouse-wheel
+  resize the font when comparing two files or a file against Git, the same as in a normal editor. (#533)
 - **The Commit panel now appears when a file changes outside Editora.** If another program (a terminal `git`
   command, another editor, a build) modified files under the repo while Editora was focused, the Commit stripe,
   Git status, and gutter change bars didn't update until you clicked away and back. They now refresh as soon as

--- a/src/main/java/com/editora/ui/DiffViewerPane.java
+++ b/src/main/java/com/editora/ui/DiffViewerPane.java
@@ -58,7 +58,7 @@ public final class DiffViewerPane implements TabContent {
     private String rightText;
     private DiffModel model;
     private final IGrammar grammar;
-    private final String fontStyle;
+    private String fontStyle; // mutable so text zoom can resize the diff areas live (#533)
     private final boolean showLineNumbers;
     private java.util.function.Consumer<String> onExportPatch = p -> {};
     /** Re-fetches both sides + re-renders if changed (set by the controller); the file-on-disk refresh. */
@@ -131,6 +131,21 @@ public final class DiffViewerPane implements TabContent {
 
     public void setOnExportPatch(java.util.function.Consumer<String> onExportPatch) {
         this.onExportPatch = onExportPatch == null ? p -> {} : onExportPatch;
+    }
+
+    /** Resizes the diff areas' font (text zoom): rebuilds the inline font style and re-applies it to whichever
+     *  areas are currently built (side-by-side or unified). Newly built areas pick up the latest style (#533). */
+    public void setFont(String family, int size) {
+        this.fontStyle = "-fx-font-family: \"" + family + "\"; -fx-font-size: " + size + "px;";
+        if (leftArea != null) {
+            leftArea.setStyle(fontStyle);
+        }
+        if (rightArea != null) {
+            rightArea.setStyle(fontStyle);
+        }
+        if (unifiedArea != null) {
+            unifiedArea.setStyle(fontStyle);
+        }
     }
 
     /** Installs the controller's re-fetch-and-rerender hook (run on focus-regain / after git mutation). */

--- a/src/main/java/com/editora/ui/MainController.java
+++ b/src/main/java/com/editora/ui/MainController.java
@@ -10229,6 +10229,8 @@ public class MainController implements com.editora.mcp.McpBridge {
             EditorBuffer buffer = bufferOf(tab);
             if (buffer != null) {
                 applyViewSettings(buffer);
+            } else if (tab.getUserData() instanceof DiffViewerPane diff) {
+                diff.setFont(settings.getFontFamily(), consoleFont); // text zoom applies inside a Diff tab too (#533)
             }
         }
         // If the Welcome tab is open, rebuild it so its Open Folder / Clone actions track the

--- a/src/test/java/com/editora/ui/DiffViewerFontFxTest.java
+++ b/src/test/java/com/editora/ui/DiffViewerFontFxTest.java
@@ -1,0 +1,43 @@
+package com.editora.ui;
+
+import java.util.List;
+
+import com.editora.diff.DiffEngine;
+import com.editora.diff.DiffModels.DiffModel;
+import org.fxmisc.richtext.CodeArea;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Regression for #533: text zoom must resize the Diff view's areas. {@code DiffViewerPane.setFont} rebuilds
+ * the inline font style and re-applies it to the currently-built areas, so the zoom the controller pushes on
+ * a settings/zoom change takes effect inside a diff tab (it previously kept its fixed construction font).
+ */
+@Tag("fx")
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class DiffViewerFontFxTest {
+
+    @BeforeAll
+    void setUp() throws Exception {
+        FxTestSupport.bootToolkit();
+    }
+
+    @Test
+    void setFontResizesTheSideBySideDiffAreas() throws Exception {
+        DiffModel model = DiffEngine.compute(List.of("a", "b"), List.of("a", "c"));
+        DiffViewerPane pane = FxTestSupport.callOnFx(() -> new DiffViewerPane(
+                "t", null, null, "L.txt", "R.txt", "a\nb\n", "a\nc\n", model, "Monospaced", 13, true, null));
+
+        // Constructed at 13px; a zoom pushes 22px.
+        FxTestSupport.runOnFx(() -> pane.setFont("Monospaced", 22));
+
+        CodeArea left = FxTestSupport.field(pane, "leftArea");
+        CodeArea right = FxTestSupport.field(pane, "rightArea");
+        assertTrue(FxTestSupport.callOnFx(left::getStyle).contains("-fx-font-size: 22px"), "left area resized");
+        assertTrue(FxTestSupport.callOnFx(right::getStyle).contains("-fx-font-size: 22px"), "right area resized");
+    }
+}


### PR DESCRIPTION
Fixes #533.

## The gap
Text zoom (`C-=`/`C--`/`C-0`, the status-bar `−/+`, `Ctrl`+wheel) resized editor buffers but had **no effect** inside a Diff view — the side-by-side / unified `CodeArea`s in `DiffViewerPane` kept their fixed construction font.

## The fix
- `DiffViewerPane.setFont(family, size)` rebuilds the inline font style (`fontStyle` is now mutable) and re-applies it to whichever areas are currently built.
- `zoomFromWheel` already routes a diff tab (no active buffer) to `textZoom` → `applyViewSettingsToAllBuffers`; that loop now also pushes the effective font (`round(fontSize × fontZoom)`) to any `DiffViewerPane` tab. So the keyboard, status-bar, and `Ctrl`+wheel zoom all reach the diff.

## Test
`DiffViewerFontFxTest` (headless-FX): `setFont("Monospaced", 22)` restyles the left and right areas to 22px. Reverting the re-apply fails it.

Full suite green (2291). No new dependency / schema change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)