### PR TITLE
Give the login-shell PATH precedence in augmentedPath()

### DIFF
--- a/src/main/java/com/editora/process/ProcessRunner.java
+++ b/src/main/java/com/editora/process/ProcessRunner.java
@@ -174,11 +174,18 @@ public final class ProcessRunner {
     private static volatile String cachedPath;
 
     /**
-     * The inherited PATH, the user's <em>login-shell</em> PATH (so a GUI-launched {@code .app} picks up
-     * version-manager dirs like nvm/fnm/asdf/volta and Homebrew that the profile sets — see
-     * {@link #loginShellPath()}), and any {@link #EXTRA_PATH_DIRS} that exist — de-duplicated, in that
+     * The user's <em>login-shell</em> PATH (so a GUI-launched {@code .app} picks up version-manager dirs
+     * like sdkman/nvm/fnm/asdf/volta and Homebrew that the profile sets — see {@link #loginShellPath()}),
+     * then the inherited PATH, then any {@link #EXTRA_PATH_DIRS} that exist — de-duplicated, in that
      * priority order. Cached after the first call. Best warmed off the FX thread (see the warm-up in
      * {@code LspManager}) since the login-shell probe spawns a short-lived process.
+     *
+     * <p>The login-shell PATH is added <em>first</em>, on purpose: when a tool exists in both a
+     * version-manager dir and a stock system dir (e.g. sdkman's {@code java/current/bin/java} is JDK 25
+     * while {@code /usr/bin/java} is JDK 21), the user's shell resolves it to the version-manager copy, and
+     * the app must match — otherwise the stripped inherited PATH a menu/desktop launcher hands the app
+     * (which has {@code /usr/bin} but not the version-manager dir) would shadow it with the older system
+     * copy, and a compact-source run would report the wrong Java version.
      */
     public static String augmentedPath() {
         String cached = cachedPath;
@@ -186,8 +193,8 @@ public final class ProcessRunner {
             return cached;
         }
         LinkedHashSet<String> dirs = new LinkedHashSet<>();
-        addPathEntries(dirs, System.getenv("PATH"));
         addPathEntries(dirs, loginShellPath());
+        addPathEntries(dirs, System.getenv("PATH"));
         for (String d : EXTRA_PATH_DIRS) {
             if (!dirs.contains(d) && Files.isDirectory(Path.of(d))) {
                 dirs.add(d);


### PR DESCRIPTION
## Problem

A user's shell resolved `java` to JDK 25 (sdkman), but Editora reported "Compact source files need JDK 25 or newer — found Java 21" when running a compact source file.

Root cause: the running app was the installed `.deb` (`/opt/editora/bin/Editora`), launched from a menu/desktop entry, so its inherited PATH was stripped — it had `/usr/bin` (JDK 21) but **not** sdkman's `.../java/current/bin` (JDK 25).

`ProcessRunner.augmentedPath()` merged the **inherited PATH first**, then the login-shell PATH, de-duping in insertion order. So `/usr/bin` was inserted ahead of sdkman's dir, and `resolveExecutable("java")` found `/usr/bin/java` (21) before ever reaching the sdkman copy (25).

## Fix

Add the **login-shell PATH first** so a version-manager tool (sdkman/nvm/asdf/volta/Homebrew) wins over a stock system copy — matching what the user's shell resolves (the VS Code `resolveShellEnv` approach). This is the whole reason `loginShellPath()` exists.

Windows is unaffected (`loginShellPath()` returns null there, so the inherited PATH is used as before).

## Notes
- No behavioral change for a tool present in only one PATH source; only a tool in **both** at different dirs now prefers the login-shell copy.
- No test added: `augmentedPath()` reads live `System.getenv` + spawns the login-shell probe, so it isn't unit-testable as-is. The pure helpers it relies on (`addPathEntries`/`extractMarked`) remain covered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)