### PR TITLE
Palette: show unavailable commands grayed out, not hidden (#532)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **The command palette now shows commands that can't run in the current context, grayed out**, instead of
+  hiding them. A command for a disabled feature (e.g. Git commands while Git is off) is listed with its
+  keybinding but dimmed and non-actionable, so you can see it exists. (#532)
+
 ### Fixed
 
 - **Text zoom now works inside Diff views.** `Ctrl`+`=`/`-`/`0`, the status-bar `−/+`, and `Ctrl`+mouse-wheel

--- a/src/main/java/com/editora/ui/CommandPalette.java
+++ b/src/main/java/com/editora/ui/CommandPalette.java
@@ -57,8 +57,10 @@ public class CommandPalette {
     private java.util.function.Consumer<String> docsOpener = url -> {};
 
     private Map<String, String> commandToKey;
-    /** Only commands matching this predicate are listed (e.g. project commands hidden when disabled). */
-    private final java.util.function.Predicate<Command> visible;
+    /** A command matching this predicate is <em>enabled</em> (actionable); one that fails it is still listed
+     *  but rendered grayed out and skipped by the selection cursor (e.g. a Git command while Git is off) —
+     *  so the user sees the command exists and its keybinding rather than it silently missing (#532). */
+    private final java.util.function.Predicate<Command> enabled;
 
     private final TextField input = new TextField();
     private final ListView<Command> list = new ListView<>();
@@ -78,12 +80,16 @@ public class CommandPalette {
     }
 
     public CommandPalette(
-            CommandRegistry registry, KeymapManager keymap, java.util.function.Predicate<Command> visible) {
+            CommandRegistry registry, KeymapManager keymap, java.util.function.Predicate<Command> enabled) {
         this.registry = registry;
         this.keymap = keymap;
         this.commandToKey = invert(keymap.bindings());
-        this.visible = visible;
+        this.enabled = enabled;
         build();
+    }
+
+    private boolean isEnabled(Command c) {
+        return enabled.test(c);
     }
 
     /** Rebuilds the chord hints from the current keymap (after a live keymap switch). */
@@ -215,14 +221,25 @@ public class CommandPalette {
         if (size == 0) {
             return;
         }
-        int idx = Math.floorMod(list.getSelectionModel().getSelectedIndex() + delta, size);
-        list.getSelectionModel().select(idx);
-        list.scrollTo(idx);
+        int cur = list.getSelectionModel().getSelectedIndex();
+        if (cur < 0) {
+            cur = 0;
+        }
+        // Step in `delta`'s direction (wrapping) to the next ENABLED command, skipping grayed-out ones.
+        for (int step = 1; step <= size; step++) {
+            int idx = Math.floorMod(cur + delta * step, size);
+            if (isEnabled(items.get(idx))) {
+                list.getSelectionModel().select(idx);
+                list.scrollTo(idx);
+                return;
+            }
+        }
+        // No enabled command anywhere — leave the selection as-is.
     }
 
     private void runSelected() {
         Command command = list.getSelectionModel().getSelectedItem();
-        if (command != null) {
+        if (command != null && isEnabled(command)) { // a grayed-out (disabled) command is not actionable (#532)
             hide();
             registry.run(command.id());
         }
@@ -232,9 +249,8 @@ public class CommandPalette {
         String q = query.toLowerCase(Locale.ROOT).trim();
         List<Command> matches = new ArrayList<>();
         for (Command command : registry.all()) {
-            if (!visible.test(command)) {
-                continue; // e.g. project commands when project support is disabled
-            }
+            // A command that fails the enabled predicate (a disabled feature) is still listed — grayed and
+            // non-actionable — rather than hidden (#532).
             if (q.isEmpty() || isSubsequence(q, command.title().toLowerCase(Locale.ROOT))) {
                 matches.add(command);
             }
@@ -245,9 +261,19 @@ public class CommandPalette {
             matches.sort(Comparator.comparing(Command::title, byRelevance(q)));
         }
         items.setAll(matches);
-        if (!items.isEmpty()) {
-            list.getSelectionModel().select(0);
+        selectFirstEnabled();
+    }
+
+    /** Selects the first <em>enabled</em> result (the cursor never rests on a grayed-out command). */
+    private void selectFirstEnabled() {
+        for (int i = 0; i < items.size(); i++) {
+            if (isEnabled(items.get(i))) {
+                list.getSelectionModel().select(i);
+                list.scrollTo(i);
+                return;
+            }
         }
+        list.getSelectionModel().clearSelection(); // all matches are disabled
     }
 
     /** True if every char of {@code needle} appears in {@code haystack} in order (fuzzy match). */
@@ -327,9 +353,10 @@ public class CommandPalette {
         CommandCell() {
             box.setAlignment(Pos.CENTER_LEFT);
             key.getStyleClass().add("keybinding");
-            // Click a command to run it (the keyboard runs the selected item on Enter).
+            // Click an ENABLED command to run it (the keyboard runs the selected item on Enter). A grayed-out
+            // (disabled-feature) command is inert — clicking it does nothing (#532).
             setOnMouseClicked(e -> {
-                if (e.getButton() == MouseButton.PRIMARY && !isEmpty() && getItem() != null) {
+                if (e.getButton() == MouseButton.PRIMARY && !isEmpty() && getItem() != null && isEnabled(getItem())) {
                     getListView().getSelectionModel().select(getItem());
                     runSelected();
                 }
@@ -351,6 +378,10 @@ public class CommandPalette {
             }
             title.setText(item.title());
             key.setText(commandToKey.getOrDefault(item.id(), ""));
+            box.getStyleClass().remove("palette-disabled");
+            if (!isEnabled(item)) {
+                box.getStyleClass().add("palette-disabled"); // grayed + non-actionable (#532)
+            }
             setGraphic(box);
         }
     }

--- a/src/main/resources/com/editora/styles/app.css
+++ b/src/main/resources/com/editora/styles/app.css
@@ -1524,6 +1524,11 @@
     -fx-text-fill: -color-fg-muted;
 }
 
+/* A command that can't run in the current context (a disabled feature): shown, but grayed and inert (#532). */
+.command-palette .list-cell .palette-disabled {
+    -fx-opacity: 0.4;
+}
+
 /* Small "ⓘ" info badge (e.g. next to the Enable-projects setting); hover shows a tooltip. */
 .info-badge {
     -fx-text-fill: -color-accent-fg;

--- a/src/test/java/com/editora/ui/CommandPaletteDisabledFxTest.java
+++ b/src/test/java/com/editora/ui/CommandPaletteDisabledFxTest.java
@@ -1,0 +1,55 @@
+package com.editora.ui;
+
+import java.util.List;
+
+import javafx.scene.control.ListView;
+
+import com.editora.command.Command;
+import com.editora.command.CommandRegistry;
+import com.editora.command.KeymapManager;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Regression for #532: the command palette must <b>show</b> commands that can't run in the current context
+ * (a disabled feature) rather than hiding them — grayed out and skipped by the selection cursor, not filtered
+ * away entirely.
+ */
+@Tag("fx")
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class CommandPaletteDisabledFxTest {
+
+    @BeforeAll
+    void setUp() throws Exception {
+        FxTestSupport.bootToolkit();
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void disabledCommandsAreShownButTheCursorSkipsThem() throws Exception {
+        CommandRegistry reg = new CommandRegistry();
+        reg.register(Command.of("git.disabled", "Git Thing", () -> {})); // disabled feature
+        reg.register(Command.of("edit.enabled", "Edit Thing", () -> {})); // enabled
+
+        CommandPalette palette = FxTestSupport.callOnFx(
+                () -> new CommandPalette(reg, new KeymapManager(), c -> !c.id().startsWith("git."))); // git.* disabled
+
+        // Populate the results with an empty query.
+        FxTestSupport.runOnFx(() -> FxTestSupport.call(palette, "filter", new Class<?>[] {String.class}, ""));
+
+        // Both commands are listed — the disabled one is shown, not hidden.
+        List<Command> items = FxTestSupport.field(palette, "items");
+        assertEquals(2, items.size(), "the disabled command is still listed");
+        assertTrue(items.stream().anyMatch(c -> c.id().equals("git.disabled")), "grayed, but present");
+
+        // The cursor lands on the enabled command, skipping the leading disabled one.
+        ListView<Command> list = FxTestSupport.field(palette, "list");
+        Command selected = FxTestSupport.callOnFx(() -> list.getSelectionModel().getSelectedItem());
+        assertEquals("edit.enabled", selected.id(), "the cursor never rests on a grayed-out command");
+    }
+}


### PR DESCRIPTION
Fixes #532.

## The change
The command palette **hid** commands that can't run in the current context — feature-gated ones (Git off, LSP off, a disabled build tool, Simple UI mode) were filtered out via `Chrome.paletteVisible`. Now it **shows** every matching command and **grays out** the ones that can't run (VS Code style):

- The palette's predicate is reinterpreted from `visible` → **`enabled`**. A command that fails it stays in the results.
- Disabled rows get a `.palette-disabled` style (`-fx-opacity: 0.4`) and are **skipped by the selection cursor** — the initial selection and up/down (`move`) land on the next *enabled* command.
- Enter (`runSelected`) and click on a disabled row are **no-ops**.

So the user sees a command exists and learns its keybinding, instead of it silently missing.

## Scope
This covers the **feature-gated** commands `paletteVisible` already knows about (the issue's "disabled feature" case). Per-buffer applicability ("can't run on the current buffer") isn't tracked as a palette-level predicate today — those commands already no-op with a status when run — so they aren't grayed here; that would need per-command enablement state (a follow-up).

## Test
`CommandPaletteDisabledFxTest` (headless-FX): a disabled command **is present** in the results, and the cursor lands on the enabled command, skipping the leading disabled one. Reverting to the hide behavior fails it.

Full suite green (2292). No new dependency / schema change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)