### PR TITLE
Welcome: scale the Welcome page text with text zoom (#540)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Text zoom now works inside Diff views.** `Ctrl`+`=`/`-`/`0`, the status-bar `−/+`, and `Ctrl`+mouse-wheel
   resize the font when comparing two files or a file against Git, the same as in a normal editor. (#533)
+- **Text zoom now scales the Welcome page too.** (#540)
 - **The Commit panel now appears when a file changes outside Editora.** If another program (a terminal `git`
   command, another editor, a build) modified files under the repo while Editora was focused, the Commit stripe,
   Git status, and gutter change bars didn't update until you clicked away and back. They now refresh as soon as

--- a/src/main/java/com/editora/ui/MainController.java
+++ b/src/main/java/com/editora/ui/MainController.java
@@ -1081,6 +1081,7 @@ public class MainController implements com.editora.mcp.McpBridge {
      */
     private void addWelcomeTab() {
         welcomePane.refresh();
+        welcomePane.setFontScale(config.getSettings().getFontZoom()); // match the current text zoom (#540)
         if (welcomeTab != null && tabPane.getTabs().contains(welcomeTab)) {
             tabPane.getSelectionModel().select(welcomeTab);
             return;
@@ -10234,9 +10235,10 @@ public class MainController implements com.editora.mcp.McpBridge {
             }
         }
         // If the Welcome tab is open, rebuild it so its Open Folder / Clone actions track the
-        // Projects/Git toggles that may have just changed.
+        // Projects/Git toggles that may have just changed, and scale its text to the current zoom (#540).
         if (welcomeTab != null) {
             welcomePane.refresh();
+            welcomePane.setFontScale(settings.getFontZoom());
         }
     }
 

--- a/src/main/java/com/editora/ui/WelcomePane.java
+++ b/src/main/java/com/editora/ui/WelcomePane.java
@@ -113,6 +113,15 @@ public final class WelcomePane extends Region implements TabContent {
         return this;
     }
 
+    /**
+     * Scales the Welcome page's text to the editor text-zoom factor ({@code Settings.fontZoom}, 1.0 = 100%).
+     * The {@code .welcome-*} font sizes are all {@code em}-relative, so setting the root's font size scales the
+     * whole tree proportionally (#540). Survives {@link #refresh()} (which rebuilds only the inner content).
+     */
+    public void setFontScale(double zoom) {
+        setStyle("-fx-font-size: " + Math.max(0.5, zoom) + "em;");
+    }
+
     @Override
     public String title() {
         return tr("welcome.tab");

--- a/src/test/java/com/editora/ui/WelcomeZoomFxTest.java
+++ b/src/test/java/com/editora/ui/WelcomeZoomFxTest.java
@@ -1,0 +1,71 @@
+package com.editora.ui;
+
+import java.nio.file.Path;
+import java.util.List;
+
+import javafx.scene.Scene;
+import javafx.scene.control.Labeled;
+
+import com.editora.command.CommandRegistry;
+import com.editora.command.KeymapManager;
+import com.editora.config.RecentFiles;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.io.TempDir;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Regression for #540: text zoom must scale the Welcome page. Its {@code .welcome-*} font sizes are
+ * {@code em}-relative, so {@code setFontScale(zoom)} setting the root font size scales the whole tree — this
+ * verifies the title actually grows (≈2×) when the zoom doubles.
+ */
+@Tag("fx")
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class WelcomeZoomFxTest {
+
+    @BeforeAll
+    void setUp() throws Exception {
+        FxTestSupport.bootToolkit();
+    }
+
+    @Test
+    void doublingTheZoomRoughlyDoublesTheWelcomeTitle(@TempDir Path configDir) throws Exception {
+        double[] sizes = FxTestSupport.callOnFx(() -> {
+            WelcomePane pane = new WelcomePane(
+                    new CommandRegistry(),
+                    new KeymapManager(),
+                    new RecentFiles(configDir),
+                    p -> {},
+                    u -> {},
+                    () -> true,
+                    () -> true,
+                    List::of,
+                    r -> {},
+                    "");
+            Scene scene = new Scene(pane, 900, 700);
+            scene.getStylesheets()
+                    .add(WelcomePane.class
+                            .getResource("/com/editora/styles/app.css")
+                            .toExternalForm());
+
+            pane.setFontScale(1.0);
+            pane.applyCss();
+            pane.layout();
+            double s1 = ((Labeled) pane.lookup(".welcome-title")).getFont().getSize();
+
+            pane.setFontScale(2.0);
+            pane.applyCss();
+            pane.layout();
+            double s2 = ((Labeled) pane.lookup(".welcome-title")).getFont().getSize();
+            return new double[] {s1, s2};
+        });
+
+        assertTrue(sizes[0] > 0, "welcome title has a font size at 100% zoom");
+        assertTrue(
+                sizes[1] > sizes[0] * 1.8,
+                "welcome title roughly doubles at 200% zoom: " + sizes[0] + " -> " + sizes[1]);
+    }
+}


### PR DESCRIPTION
Fixes #540.

## The gap
Text zoom (`C-=`/`C--`/`C-0`, the status-bar `−/+`, `Ctrl`+wheel) resized editor buffers — and Diff views (#533) — but the **Welcome page** kept its fixed text size.

## The fix
The `.welcome-*` font sizes are all **`em`-relative**, so **`WelcomePane.setFontScale(zoom)`** sets the root's `-fx-font-size` in `em` and the whole tree scales proportionally. `MainController` pushes the current `Settings.fontZoom` when the Welcome tab is created (`addWelcomeTab`) and in `applyViewSettingsToAllBuffers`' welcome block, so a zoom change reflects live.

## Test
`WelcomeZoomFxTest` (headless-FX, real `app.css` applied): the rendered `.welcome-title` font is ~2× larger at 200% zoom than 100%. Neutering `setFontScale` leaves it unchanged (33.6 → 33.6) and fails.

Full suite green (2293). No new dependency / schema change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)