### PR TITLE
Perf: take the status-bar file size off the per-caret/keystroke path (#542)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Performance
+
+- **Moving the caret or typing in a large file is much lighter.** The status bar recomputed the file size — which
+  scans and copies the whole document — on every caret move and keystroke (and re-materialized the whole
+  document per keystroke besides). The size now updates only when the file actually changes, debounced, so
+  arrow-keying and typing no longer allocate the entire document on the UI thread. (#542)
+
 ### Changed
 
 - **The command palette now shows commands that can't run in the current context, grayed out**, instead of

--- a/src/main/java/com/editora/ui/StatusBar.java
+++ b/src/main/java/com/editora/ui/StatusBar.java
@@ -98,8 +98,11 @@ public final class StatusBar extends HBox {
     private boolean lspLoadingState;
     /** Whether the app-wide MCP server is running, so Simple-mode toggling can re-apply its visibility. */
     private boolean mcpRunning;
-    /** A single listener refreshes every segment on caret / text / selection changes. */
-    private final InvalidationListener changeListener = obs -> refresh();
+    /** Caret / selection changes update only the cheap caret-dependent segments (Ln/Col + the CSV field) —
+     *  NOT the file-size segment, which is O(document) and doesn't change when the caret moves. */
+    private final InvalidationListener caretListener = obs -> refreshCaretSegments();
+    /** The debounced edit subscription that recomputes the (O(n)) file-size segment once per typing burst. */
+    private org.reactfx.Subscription sizeSub;
 
     public StatusBar(Supplier<EditorBuffer> activeBuffer, CommandRegistry registry, Supplier<Settings> settings) {
         this.activeBuffer = activeBuffer;
@@ -400,15 +403,31 @@ public final class StatusBar extends HBox {
     /** Re-binds live listeners to {@code buffer} (or none) and refreshes the segments. */
     public void attach(EditorBuffer buffer) {
         if (attached != null) {
-            attached.getArea().caretPositionProperty().removeListener(changeListener);
-            attached.getArea().textProperty().removeListener(changeListener);
-            attached.getArea().selectionProperty().removeListener(changeListener);
+            attached.getArea().caretPositionProperty().removeListener(caretListener);
+            attached.getArea().selectionProperty().removeListener(caretListener);
+        }
+        if (sizeSub != null) {
+            sizeSub.unsubscribe();
+            sizeSub = null;
         }
         attached = buffer;
         if (buffer != null) {
-            buffer.getArea().caretPositionProperty().addListener(changeListener);
-            buffer.getArea().textProperty().addListener(changeListener);
-            buffer.getArea().selectionProperty().addListener(changeListener);
+            // Ln/Col + the CSV field track the caret cheaply (no full-document scan).
+            buffer.getArea().caretPositionProperty().addListener(caretListener);
+            buffer.getArea().selectionProperty().addListener(caretListener);
+            // The file size only changes on an EDIT — and computing it materializes the whole document (an
+            // O(n) String + byte[]), so it must not run per keystroke. It was previously bound to textProperty
+            // (which itself re-materializes the whole document per keystroke) AND recomputed on every caret
+            // move; now it's a debounced plainTextChanges pulse — once per typing burst, delta-based.
+            sizeSub = buffer.getArea()
+                    .plainTextChanges()
+                    .successionEnds(java.time.Duration.ofMillis(200))
+                    .subscribe(ignore -> {
+                        EditorBuffer b = activeBuffer.get();
+                        if (b != null) {
+                            refreshSize(b);
+                        }
+                    });
         }
         refresh();
     }
@@ -479,7 +498,24 @@ public final class StatusBar extends HBox {
             csvField.setManaged(false);
             return;
         }
-        var area = buffer.getArea();
+        refreshPositionAndCsv(buffer, buffer.getArea());
+        language.setText(displayLanguage(buffer.getLanguage()));
+        endings.setText(buffer.getLineEnding());
+        refreshSize(buffer);
+    }
+
+    /** Updates only the caret-dependent segments for the active buffer (the {@link #caretListener} target). */
+    private void refreshCaretSegments() {
+        EditorBuffer b = activeBuffer.get();
+        if (b != null) {
+            refreshPositionAndCsv(b, b.getArea());
+        }
+    }
+
+    /** The caret-dependent segments — Ln/Col (+ selection) and the CSV "Field N of M" readout. Cheap: only
+     *  single-line scans, no full-document materialization, so it's safe on the per-caret-move path (updated
+     *  by {@link #caretListener} without recomputing the O(n) file size). */
+    private void refreshPositionAndCsv(EditorBuffer buffer, org.fxmisc.richtext.CodeArea area) {
         int line = area.getCurrentParagraph() + 1;
         int col = area.getCaretColumn() + 1;
         int selected = area.getSelection().getLength();
@@ -491,10 +527,9 @@ public final class StatusBar extends HBox {
         position.setText(text);
         position.getTooltip().setText(tr("statusbar.tip.offset", area.getCaretPosition()));
 
-        // CSV/TSV column readout — "Field N of M". Cost is two single-line scans (the header row for the
-        // column count, the caret's line up to the caret for the field index), so it's cheap next to the
-        // O(n) file-size formatting already done here. Approximation: a field whose quotes span multiple
-        // physical lines is counted per line (RFC-4180 multi-line fields are rare in practice).
+        // CSV/TSV column readout — "Field N of M". Two single-line scans (the header row for the column count,
+        // the caret's line up to the caret for the field index). Approximation: a field whose quotes span
+        // multiple physical lines is counted per line (RFC-4180 multi-line fields are rare in practice).
         boolean csv = buffer.isCsv() && !simpleMode;
         csvField.setVisible(csv);
         csvField.setManaged(csv);
@@ -506,9 +541,12 @@ public final class StatusBar extends HBox {
             int idx = com.editora.csv.CsvParser.fieldIndexAt(cur, delim, area.getCaretColumn());
             csvField.setText(tr("statusbar.csvField", idx, total));
         }
+    }
 
-        language.setText(displayLanguage(buffer.getLanguage()));
-        endings.setText(buffer.getLineEnding());
+    /** The file-size segment. Materializes the whole document (an O(n) String + byte[]) to count UTF-8 bytes,
+     *  so it is kept OFF the per-caret / per-keystroke path — computed only on a full {@link #refresh()} (tab
+     *  switch / state change) and a debounced edit pulse, never per caret move (it doesn't change on one). */
+    private void refreshSize(EditorBuffer buffer) {
         size.setText(formatSize(buffer.getContent().getBytes(StandardCharsets.UTF_8).length));
     }
 

--- a/src/test/java/com/editora/ui/StatusBarSizeHotpathFxTest.java
+++ b/src/test/java/com/editora/ui/StatusBarSizeHotpathFxTest.java
@@ -1,0 +1,57 @@
+package com.editora.ui;
+
+import javafx.scene.control.Label;
+
+import com.editora.command.CommandRegistry;
+import com.editora.config.Settings;
+import com.editora.editor.EditorBuffer;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Performance regression: the status bar's file-size segment materializes the whole document (an O(n) String
+ * + byte[]) to count UTF-8 bytes. It must NOT run on a caret move — the size doesn't change when the caret
+ * moves, and doing it per arrow-key/keystroke allocated the entire document twice on the FX thread. This
+ * asserts a caret move updates Ln/Col but leaves the size segment untouched.
+ */
+@Tag("fx")
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class StatusBarSizeHotpathFxTest {
+
+    @BeforeAll
+    void setUp() throws Exception {
+        FxTestSupport.bootToolkit();
+    }
+
+    @Test
+    void aCaretMoveDoesNotRecomputeTheFileSize() throws Exception {
+        boolean[] ok = FxTestSupport.callOnFx(() -> {
+            Settings settings = new Settings();
+            EditorBuffer buffer = new EditorBuffer();
+            buffer.setContent("hello world\nsecond line\nthird\n");
+            StatusBar sb = new StatusBar(() -> buffer, new CommandRegistry(), () -> settings);
+            sb.attach(buffer); // full refresh computes the real size
+
+            Label size = FxTestSupport.field(sb, "size");
+            Label position = FxTestSupport.field(sb, "position");
+            boolean sizeComputed = !size.getText().isBlank();
+
+            // Poison the size label; a caret move must leave it untouched (no O(n) recompute).
+            size.setText("SENTINEL");
+            buffer.getArea().moveTo(4); // fires caretPositionProperty → caretListener
+
+            boolean sizeUntouched = "SENTINEL".equals(size.getText());
+            boolean lnColUpdated = position.getText().contains("Col");
+            return new boolean[] {sizeComputed, sizeUntouched, lnColUpdated};
+        });
+
+        assertTrue(ok[0], "the size segment is computed on attach (full refresh)");
+        assertEquals(true, ok[1], "a caret move must NOT recompute the file size (stayed SENTINEL)");
+        assertTrue(ok[2], "Ln/Col still updates on a caret move");
+    }
+}


### PR DESCRIPTION
Fixes #542. First finding of the performance audit.

## The problem
`StatusBar.attach()` bound one listener → `refresh()` on `caretPositionProperty`, `textProperty`, **and** `selectionProperty`, and `refresh()` ends with:

```java
size.setText(formatSize(buffer.getContent().getBytes(StandardCharsets.UTF_8).length));
```

So **every caret move / selection change / keystroke** materialized the whole document as a `String` (O(n)) *and* allocated the full UTF-8 `byte[]` (O(n)) — for a size label a caret move never changes. Binding to `textProperty` additionally forced RichTextFX to re-materialize the whole document per keystroke (the exact O(n)-per-char trap the editor's own dirty-check avoids). On a large file this allocated megabytes per arrow-key on the FX thread.

## The fix
- The **caret/selection listener** now calls `refreshCaretSegments()` → `refreshPositionAndCsv()`, which updates only Ln/Col + the CSV "Field N of M" (single-line scans, no full-document materialization).
- The **file size** (`refreshSize()`) is recomputed only on a full `refresh()` (tab switch / state change) and on a **debounced** `plainTextChanges` pulse (200 ms — once per typing burst, delta-based; no `textProperty`).

## Test
`StatusBarSizeHotpathFxTest` (headless-FX): after attach the size is computed; poisoning the size label and moving the caret leaves it untouched (no O(n) recompute) while Ln/Col updates. Reverting the caret listener to the full `refresh()` recomputes size on the move and fails it.

Full suite green (2294). No new dependency / schema change.

## Perf
This is the fix — a caret move drops from O(document) (two full allocations) to O(1)-ish (a couple of single-line scans), and typing recomputes size once per burst instead of ~3× O(n) per keystroke.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
