### PR TITLE
Perf: text zoom skips the full settings cascade (#545)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Performance
 
+- **Zooming text is much smoother.** A text zoom (`Ctrl`+wheel, `Ctrl`+`=`/`-`/`0`, the status-bar `−/+`) reran
+  the entire settings-apply cascade per notch — re-swapping the editor-theme stylesheet (a full-scene CSS
+  reapply) and re-running ~20 feature `applySupport()` calls (Git, LSP, previews, …), none of which change on a
+  font zoom. Zoom now re-applies only the fonts and per-buffer view, so a Ctrl+wheel gesture no longer churns
+  the scene stylesheet or re-detects every language server. (#545)
 - **Moving the caret or typing in a large file is much lighter.** The status bar recomputed the file size — which
   scans and copies the whole document — on every caret move and keystroke (and re-materialized the whole
   document per keystroke besides). The size now updates only when the file actually changes, debounced, so

--- a/src/main/java/com/editora/ui/MainController.java
+++ b/src/main/java/com/editora/ui/MainController.java
@@ -9148,7 +9148,9 @@ public class MainController implements com.editora.mcp.McpBridge {
         }
         s.setFontZoom(z);
         requestSave();
-        applyViewSettingsToAllBuffers(s);
+        // A font zoom changes no feature gate or theme — apply only the fonts/per-buffer view, not the full
+        // settings cascade (editor-theme stylesheet swap + ~20 applySupport() calls). #545
+        applyFontsAndPerBufferView(s);
         statusBar.refresh();
         setStatus(tr("status.textZoom", Math.round(z * 100)));
     }
@@ -10220,7 +10222,24 @@ public class MainController implements com.editora.mcp.McpBridge {
         lspCoordinator.applySupport(); // (re)configure LSP: command/enabled change re-detects + re-gates buffers
         debugCoordinator.applySupport(); // (re)configure DAP after LSP (it layers on jdtls)
         applyMarkdownPreviewTheme(); // re-resolve "follow app" previews + the toggle glyph after a theme change
-        // Match the console fonts (External Tools / Run / Debug / build tools) to the editor's code-area font.
+        // Match the console fonts + per-buffer view to the editor font/zoom (shared with the text-zoom path).
+        applyFontsAndPerBufferView(settings);
+        // If the Welcome tab is open, rebuild it so its Open Folder / Clone actions track the
+        // Projects/Git toggles that may have just changed (a font-only zoom skips this rebuild).
+        if (welcomeTab != null) {
+            welcomePane.refresh();
+        }
+    }
+
+    /**
+     * Re-applies fonts (editor buffers, Diff panes, and the console tool windows) and per-buffer view settings to
+     * every open tab, plus the Welcome tab's font scale. Shared by the full {@link #applyViewSettingsToAllBuffers}
+     * and the lighter {@link #textZoom} path — a font zoom changes none of the feature gates or the editor theme,
+     * so {@code textZoom} calls only this and skips the editor-theme stylesheet swap + the ~20 {@code applySupport()}
+     * service calls the full apply runs (a Ctrl+wheel gesture fires many notches, each of which used to re-swap the
+     * scene stylesheet and re-run the whole cascade — #545).
+     */
+    private void applyFontsAndPerBufferView(Settings settings) {
         int consoleFont = Math.max(1, (int) Math.round(settings.getFontSize() * settings.getFontZoom()));
         externalToolCoordinator.panel().setOutputFont(settings.getFontFamily(), consoleFont);
         runCoordinator.panel().setOutputFont(settings.getFontFamily(), consoleFont);
@@ -10234,11 +10253,8 @@ public class MainController implements com.editora.mcp.McpBridge {
                 diff.setFont(settings.getFontFamily(), consoleFont); // text zoom applies inside a Diff tab too (#533)
             }
         }
-        // If the Welcome tab is open, rebuild it so its Open Folder / Clone actions track the
-        // Projects/Git toggles that may have just changed, and scale its text to the current zoom (#540).
         if (welcomeTab != null) {
-            welcomePane.refresh();
-            welcomePane.setFontScale(settings.getFontZoom());
+            welcomePane.setFontScale(settings.getFontZoom()); // scale Welcome text to the current zoom (#540)
         }
     }
 

--- a/src/test/java/com/editora/ui/TextZoomLightweightFxTest.java
+++ b/src/test/java/com/editora/ui/TextZoomLightweightFxTest.java
@@ -1,0 +1,72 @@
+package com.editora.ui;
+
+import javafx.beans.InvalidationListener;
+import javafx.stage.Stage;
+
+import com.editora.config.ConfigManager;
+import com.editora.config.Settings;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Regression for #545: a text zoom (Ctrl+wheel / {@code C-=}) must NOT re-run the full settings cascade. The old
+ * {@code textZoom} called {@code applyViewSettingsToAllBuffers}, which re-swaps the editor-theme stylesheet on the
+ * scene (a full-scene CSS reapply) and runs ~20 {@code applySupport()} service calls — none of which change on a
+ * font zoom. This asserts that a zoom advances the zoom level but leaves the scene stylesheet list untouched
+ * (the old path fired remove+add on it, i.e. ≥1 mutation).
+ */
+@Tag("fx")
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class TextZoomLightweightFxTest {
+
+    private FxWindowFixture fx;
+
+    @BeforeAll
+    void setUp() throws Exception {
+        FxTestSupport.bootToolkit();
+        fx = FxWindowFixture.create();
+    }
+
+    @AfterAll
+    void tearDown() throws Exception {
+        if (fx != null) {
+            fx.dispose();
+        }
+    }
+
+    @Test
+    void zoomAdvancesTheLevelWithoutReswappingTheEditorThemeStylesheet() throws Exception {
+        int[] stylesheetMutations = {0};
+        double newZoom = FxTestSupport.callOnFx(() -> {
+            ConfigManager config = FxTestSupport.field(fx.controller, "config");
+            Settings settings = config.getSettings();
+
+            // Force a non-default editor theme (its override stylesheet is non-null), then apply it so
+            // currentEditorThemeCss is established and the sheet is present on the scene.
+            settings.setEditorTheme("Dracula");
+            FxTestSupport.call(fx.controller, "applyEditorTheme", new Class[] {String.class}, "Dracula");
+
+            Stage stage = FxTestSupport.field(fx.controller, "stage");
+            InvalidationListener counter = obs -> stylesheetMutations[0]++;
+            stage.getScene().getStylesheets().addListener(counter);
+
+            double before = settings.getFontZoom();
+            fx.controller.textZoom(1); // one wheel notch in
+            double after = settings.getFontZoom();
+
+            stage.getScene().getStylesheets().removeListener(counter);
+            // Sanity: the zoom actually advanced (so the method didn't early-return).
+            assertEquals(Math.round((before + 0.1) * 10.0) / 10.0, after, 1e-9, "zoom advanced by one notch");
+            return after;
+        });
+
+        // Editor buffers may exist or not, but the SCENE STYLESHEET must be untouched by a font zoom.
+        assertEquals(0, stylesheetMutations[0], "a text zoom must not re-swap the editor-theme stylesheet");
+        assertEquals(1.1, newZoom, 1e-9, "zoom is now 110%");
+    }
+}


### PR DESCRIPTION
## Summary

Performance audit finding: a text zoom (`Ctrl`+wheel, `Ctrl`+`=`/`-`/`0`, the status-bar `−/+`) ran the **entire** settings-apply cascade per notch. `textZoom(int)` called `applyViewSettingsToAllBuffers`, which:

1. **re-swaps the editor-theme stylesheet** on the scene via `applyEditorTheme` (a full-scene CSS reapply), and
2. runs **~20 feature `applySupport()` calls** (Git, LSP, Mermaid, diagram, Typst, HTTP, HTML preview, log, MCP, agent, AI, TODO, CSV, debug, …), each re-detecting/re-gating.

None of that changes on a font zoom, and a Ctrl+wheel gesture fires many notches, so each notch churned the scene stylesheet and re-detected every language server → visible jank while zooming.

## Fix

Extracted the fonts + per-buffer-view tail of `applyViewSettingsToAllBuffers` into a shared `applyFontsAndPerBufferView(Settings)`:

- editor buffers → `applyViewSettings(buffer)` (resizes fonts)
- Diff panes → `diff.setFont(...)`
- console tool windows (External Tools / Run / Debug / Build Output) → `setOutputFont`
- Welcome tab → `setFontScale`

`textZoom` now calls **only** that method, skipping the editor-theme stylesheet swap and the `applySupport()` cascade. The full apply is unchanged — it delegates the same tail, then does its own Welcome `refresh()` (which a font-only zoom doesn't need).

## Test

`TextZoomLightweightFxTest` (FX) forces a non-default editor theme (so the theme stylesheet is present), attaches an invalidation listener to the scene's stylesheet list, calls `textZoom(1)`, and asserts **zero** stylesheet mutations (plus that the zoom level advanced). Verified to fail when `textZoom` is pointed back at `applyViewSettingsToAllBuffers` (old path → remove+add → ≥1 mutation).

## Cost

Strictly less FX-thread work per zoom notch — no scene-stylesheet remove/add, no service re-detection. Per-buffer `applyViewSettings` still runs (needed to resize fonts). Net positive.

Closes #545

🤖 Generated with [Claude Code](https://claude.com/claude-code)
