### PR TITLE
Perf: take the File Information panel off the edit hot path (#547)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Performance
 
+- **The File Information panel no longer slows down typing.** It re-counted words (a whole-document scan) on
+  every caret move and re-materialized the whole document on every keystroke — even when the panel was closed.
+  It now rides the debounced change stream, counts words only on an actual edit, reads only the character under
+  the caret (not the whole file), and does nothing at all while its tool window is hidden. (#547)
 - **Zooming text is much smoother.** A text zoom (`Ctrl`+wheel, `Ctrl`+`=`/`-`/`0`, the status-bar `−/+`) reran
   the entire settings-apply cascade per notch — re-swapping the editor-theme stylesheet (a full-scene CSS
   reapply) and re-running ~20 feature `applySupport()` calls (Git, LSP, previews, …), none of which change on a

--- a/src/main/java/com/editora/ui/FileInformationPanel.java
+++ b/src/main/java/com/editora/ui/FileInformationPanel.java
@@ -7,6 +7,7 @@ import java.nio.file.attribute.BasicFileAttributes;
 import java.nio.file.attribute.PosixFileAttributes;
 import java.nio.file.attribute.PosixFilePermission;
 import java.nio.file.attribute.PosixFilePermissions;
+import java.time.Duration;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.util.Locale;
@@ -67,13 +68,27 @@ public class FileInformationPanel extends VBox implements ToolWindowContent {
 
     private EditorBuffer attached;
     private final ChangeListener<Number> caretListener = (o, w, n) -> refreshCaret();
-    private final ChangeListener<String> textListener = (o, w, n) -> refreshText();
+    // Edits fire the whole-document word count, so ride the debounced delta stream (not textProperty, which
+    // materializes the whole document on every keystroke just to notify) — and only while the panel is visible.
+    private org.reactfx.Subscription textSub;
 
     public FileInformationPanel() {
         getStyleClass().add("file-info-panel");
         setSpacing(6);
         buildUI();
+        // A closed tool window is removed from the scene (getScene() == null), so the caret/edit refreshes below
+        // no-op while hidden; refresh once when it's (re)opened so a freshly-shown panel is current.
+        sceneProperty().addListener((o, was, now) -> {
+            if (now != null) {
+                refresh();
+            }
+        });
         refresh();
+    }
+
+    /** The panel does real work only while its tool window is open (its node is in the scene). */
+    private boolean visible() {
+        return getScene() != null;
     }
 
     @Override
@@ -86,12 +101,18 @@ public class FileInformationPanel extends VBox implements ToolWindowContent {
     public void attach(EditorBuffer buffer) {
         if (attached != null) {
             attached.getArea().caretPositionProperty().removeListener(caretListener);
-            attached.getArea().textProperty().removeListener(textListener);
+        }
+        if (textSub != null) {
+            textSub.unsubscribe();
+            textSub = null;
         }
         attached = buffer;
         if (buffer != null) {
             buffer.getArea().caretPositionProperty().addListener(caretListener);
-            buffer.getArea().textProperty().addListener(textListener);
+            textSub = buffer.getArea()
+                    .plainTextChanges()
+                    .successionEnds(Duration.ofMillis(200))
+                    .subscribe(ignore -> refreshText());
         }
         refresh();
     }
@@ -206,31 +227,37 @@ public class FileInformationPanel extends VBox implements ToolWindowContent {
     // --- Live refresh ---
 
     private void refresh() {
+        if (!visible()) {
+            return; // hidden tool window: nothing on screen to update; refreshed on open via the scene listener
+        }
         if (attached == null) {
             clearAll();
             return;
         }
-        refreshFile(attached.getPath()); // reads disk attributes — only on attach (tab switch), not edits
+        refreshFile(attached.getPath()); // reads disk attributes — only on attach (tab switch) while shown, not edits
         refreshTextSettings(attached);
         refreshCounts(attached);
         refreshCharacter(attached);
     }
 
-    /** Caret moved: only the position + character-under-caret change — never re-read the file (a network
-     *  round-trip for remote files). */
+    /** Caret moved: only the position, selection, and character-under-caret change — never the word total (which
+     *  changes only on an edit) and never a whole-document materialize or a file read. No-op while hidden. */
     private void refreshCaret() {
-        if (attached == null) {
+        if (attached == null || !visible()) {
             return;
         }
-        refreshCounts(attached); // includes line / column / caret location
+        refreshPositionAndTotals(attached); // cheap: getLength()/paragraphs count, no word count, no getText()
         refreshCharacter(attached);
     }
 
-    /** Text edited: re-derive the in-memory counts + char info; disk metadata only changes on save (which
-     *  re-attaches), so still no file read here. */
+    /** Text edited (debounced): re-derive the in-memory counts (incl. the O(n) word count) + char info; disk
+     *  metadata only changes on save (which re-attaches), so still no file read here. No-op while hidden. */
     private void refreshText() {
         if (attached == null) {
             clearAll();
+            return;
+        }
+        if (!visible()) {
             return;
         }
         refreshTextSettings(attached);
@@ -319,16 +346,22 @@ public class FileInformationPanel extends VBox implements ToolWindowContent {
         return lang.substring(0, 1).toUpperCase(Locale.ROOT) + lang.substring(1);
     }
 
+    /** Full counts: the O(n) word count (materializes the whole document) plus the cheap position/totals. Only on
+     *  an edit (debounced) or on attach/open — never per caret move. */
     private void refreshCounts(EditorBuffer buffer) {
-        var area = buffer.getArea();
-        String text = area.getText();
-        int lineCount = area.getParagraphs().size();
-        int charCount = text.length();
-        int wordCount = countWords(text);
+        wordsValue.setText(formatNum(countWords(buffer.getArea().getText())));
+        refreshPositionAndTotals(buffer);
+    }
 
-        int selStartPara = area.getParagraphs().size() == 0 ? 0 : 0;
-        int selectedLines;
+    /** Line/char totals, selection, and caret location — all cheap (no whole-document {@code getText()}: char count
+     *  comes from {@code getLength()} and line count from the paragraph list). Safe to run on every caret move. */
+    private void refreshPositionAndTotals(EditorBuffer buffer) {
+        var area = buffer.getArea();
+        int lineCount = area.getParagraphs().size();
+        int charCount = area.getLength();
+
         int selectedChars = area.getSelection().getLength();
+        int selectedLines;
         if (selectedChars > 0) {
             String selText = area.getSelectedText();
             selectedLines = (int) selText.lines().count();
@@ -343,29 +376,26 @@ public class FileInformationPanel extends VBox implements ToolWindowContent {
                 selectedLines > 0 ? formatNum(lineCount) + " (" + selectedLines + ")" : formatNum(lineCount));
         charsValue.setText(
                 selectedChars > 0 ? formatNum(charCount) + " (" + selectedChars + ")" : formatNum(charCount));
-        wordsValue.setText(formatNum(wordCount));
 
         locationValue.setText(formatNum(area.getCaretPosition()));
         lineValue.setText(formatNum(area.getCurrentParagraph() + 1));
         columnValue.setText(formatNum(area.getCaretColumn() + 1));
-        // selStartPara unused — placeholder for future enhancement.
-        if (selStartPara < 0) {
-            // no-op
-        }
     }
 
     private void refreshCharacter(EditorBuffer buffer) {
         var area = buffer.getArea();
-        String text = area.getText();
         int caret = area.getCaretPosition();
-        if (caret < 0 || caret >= text.length()) {
+        int len = area.getLength();
+        if (caret < 0 || caret >= len) {
             codePointValue.setText("–");
             charNameValue.setText("–");
             charBlockValue.setText("–");
             charCategoryValue.setText("–");
             return;
         }
-        int codePoint = text.codePointAt(caret);
+        // Read just the char(s) at the caret (up to a surrogate pair) — not the whole document.
+        String at = area.getText(caret, Math.min(caret + 2, len));
+        int codePoint = at.codePointAt(0);
         codePointValue.setText(String.format("U+%04X", codePoint));
         String name = Character.getName(codePoint);
         charNameValue.setText(name == null ? "–" : name);

--- a/src/test/java/com/editora/ui/FileInfoHotpathFxTest.java
+++ b/src/test/java/com/editora/ui/FileInfoHotpathFxTest.java
@@ -1,0 +1,78 @@
+package com.editora.ui;
+
+import javafx.scene.Scene;
+import javafx.scene.control.TextField;
+import javafx.scene.layout.StackPane;
+
+import com.editora.editor.EditorBuffer;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+/**
+ * Regression for #547: the File Information panel used to re-count words (an O(n) whole-document scan) on every
+ * caret move, and refresh on every keystroke via the code area's {@code textProperty} (which materializes the
+ * whole document just to fire) — all with no gate for whether the tool window is even open. This verifies:
+ * (1) a pure caret move updates the caret position but NOT the word total, and (2) a hidden panel (its node not in
+ * a scene) does no work on a caret move.
+ */
+@Tag("fx")
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class FileInfoHotpathFxTest {
+
+    @BeforeAll
+    void setUp() throws Exception {
+        FxTestSupport.bootToolkit();
+    }
+
+    @Test
+    void caretMoveUpdatesPositionButNotTheWordCount() throws Exception {
+        String[] result = FxTestSupport.callOnFx(() -> {
+            FileInformationPanel panel = new FileInformationPanel();
+            new Scene(new StackPane(panel), 300, 400); // panel now has a scene → visible() == true
+
+            EditorBuffer buffer = new EditorBuffer();
+            buffer.getArea().replaceText("one two three four\nfive six\n");
+            panel.attach(buffer);
+
+            TextField words = FxTestSupport.field(panel, "wordsValue");
+            TextField line = FxTestSupport.field(panel, "lineValue");
+
+            // A word count is present after attach.
+            String wordsAfterAttach = words.getText();
+
+            // Poison the word field, then move the caret only (no edit). The caret path must not touch it.
+            words.setText("SENTINEL");
+            buffer.getArea().moveTo(0); // fires caretPositionProperty → refreshCaret
+            String wordsAfterCaret = words.getText();
+            String lineAfterCaret = line.getText();
+            return new String[] {wordsAfterAttach, wordsAfterCaret, lineAfterCaret};
+        });
+
+        assertNotEquals("–", result[0], "attach computed a word count");
+        assertEquals("SENTINEL", result[1], "a pure caret move must not recompute the word total");
+        assertEquals("1", result[2], "the caret line still updates on a caret move");
+    }
+
+    @Test
+    void hiddenPanelDoesNoWorkOnCaretMove() throws Exception {
+        String sentinel = FxTestSupport.callOnFx(() -> {
+            FileInformationPanel panel = new FileInformationPanel(); // never added to a scene → visible() == false
+
+            EditorBuffer buffer = new EditorBuffer();
+            buffer.getArea().replaceText("alpha beta gamma\n");
+            panel.attach(buffer);
+
+            TextField line = FxTestSupport.field(panel, "lineValue");
+            line.setText("SENTINEL");
+            buffer.getArea().moveTo(3); // caret move on a hidden panel must be a no-op
+            return line.getText();
+        });
+
+        assertEquals("SENTINEL", sentinel, "a hidden File Information panel does no work on a caret move");
+    }
+}


### PR DESCRIPTION
## Summary

Performance audit finding: the **File Information** tool window did heavy per-edit / per-caret work on the editor hot path, whether or not the window was even open.

- It listened to the code area's **`textProperty()`**, which materializes the whole document on every keystroke just to fire.
- **`refreshCaret`** (every caret move) re-counted **words** — an O(n) whole-document scan — even though the word total can't change on a caret move.
- **`refreshCharacter`** read `area.getText()` (whole document) just to get the single code point under the caret.
- None of it was gated on the tool window being open. `attach(buffer)` runs on every tab switch, so a user who never opens File Information still paid the cost on every edit.

## Fix

- Ride the debounced **`plainTextChanges()`** delta stream instead of `textProperty()` (no whole-document materialize to detect a change).
- **Split the counts:** the O(n) word count runs only on an edit (debounced); a caret move updates only position/selection/char-under-caret. Char/line totals now come from `getLength()` / the paragraph list (cheap, no `getText()`), and the char-under-caret is read with `getText(caret, caret+2)`.
- **Gate on visibility** (`getScene() != null`): a closed tool window does zero work; the panel refreshes once when (re)opened via a `sceneProperty` listener.

## Test

`FileInfoHotpathFxTest` (FX):
1. A pure caret move updates the caret line but leaves a sentinel in the word field untouched (old path overwrote it with a fresh recount).
2. A hidden panel (node not in a scene) does nothing on a caret move (sentinel untouched).

Both verified to fail when `refreshCaret` is pointed back at the old per-caret word recount without the visibility gate.

## Cost

Strictly less FX-thread work — a closed panel is inert; an open one no longer word-counts per caret move or materializes the whole document per keystroke. Net positive.

Closes #547

🤖 Generated with [Claude Code](https://claude.com/claude-code)
