### PR TITLE
Perf: defer the Structure outline rebuild while its window is hidden (#549)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Performance
 
+- **The Structure outline no longer rebuilds while it's closed.** It re-split the whole document and rebuilt its
+  tree on every edit (debounced) even when the tool window was hidden. It now defers the rebuild while closed and
+  does it once when the window is reopened. (#549)
 - **The File Information panel no longer slows down typing.** It re-counted words (a whole-document scan) on
   every caret move and re-materialized the whole document on every keystroke — even when the panel was closed.
   It now rides the debounced change stream, counts words only on an actual edit, reads only the character under

--- a/src/main/java/com/editora/ui/StructurePanel.java
+++ b/src/main/java/com/editora/ui/StructurePanel.java
@@ -81,11 +81,28 @@ public class StructurePanel extends VBox implements ToolWindowContent {
     /** Guards against re-entrant kind-filter menu rebuilds firing the checkbox listeners. */
     private boolean rebuildingKindFilter;
 
+    // rebuild() (an O(n) document split + a full TreeView rebuild) fires on every debounced fold-region change,
+    // which happens on every edit whether or not this tool window is open. Skip it while hidden and coalesce to a
+    // single rebuild when the window is (re)opened. (#549)
+    private boolean pendingRebuild;
+
     public StructurePanel() {
         getStyleClass().add("structure-panel");
         // Opt out of the global key dispatcher so chords like C-n reach our local handler.
         getProperties().put("editora.ownsKeys", Boolean.TRUE);
         build();
+        // A closed tool window is removed from the scene (getScene() == null); rebuild once when it's (re)opened
+        // if the outline went stale while hidden.
+        sceneProperty().addListener((o, was, now) -> {
+            if (now != null && pendingRebuild) {
+                rebuild();
+            }
+        });
+    }
+
+    /** The tree is only worth rebuilding while the tool window is open (its node is in the scene). */
+    private boolean visible() {
+        return getScene() != null;
     }
 
     private void build() {
@@ -388,6 +405,11 @@ public class StructurePanel extends VBox implements ToolWindowContent {
     // --- Tree construction ---
 
     private void rebuild() {
+        if (!visible()) {
+            pendingRebuild = true; // defer the O(n) split + TreeView rebuild until the window is shown again
+            return;
+        }
+        pendingRebuild = false;
         if (buffer == null) {
             roots = new ArrayList<>(); // mutable: sortNodes sorts roots in place (a diff/Welcome tab has no buffer)
         } else if (lspSymbols != null) {

--- a/src/test/java/com/editora/ui/StructureHiddenFxTest.java
+++ b/src/test/java/com/editora/ui/StructureHiddenFxTest.java
@@ -1,0 +1,67 @@
+package com.editora.ui;
+
+import java.util.List;
+
+import javafx.scene.Scene;
+import javafx.scene.control.TreeView;
+import javafx.scene.layout.StackPane;
+
+import com.editora.editor.EditorBuffer;
+import com.editora.lsp.SymbolNode;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Regression for #549: the Structure outline rebuilt its tree (an O(n) document split + a full {@code TreeView}
+ * rebuild) on every debounced fold-region change — i.e. on every edit — whether or not the tool window was open.
+ * This verifies the rebuild is deferred while the panel is hidden (node not in a scene) and coalesced into a
+ * single rebuild when the window is (re)opened.
+ */
+@Tag("fx")
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class StructureHiddenFxTest {
+
+    @BeforeAll
+    void setUp() throws Exception {
+        FxTestSupport.bootToolkit();
+    }
+
+    @Test
+    void hiddenPanelDefersTheTreeRebuildUntilShown() throws Exception {
+        Object[] r = FxTestSupport.callOnFx(() -> {
+            StructurePanel panel = new StructurePanel(); // never added to a scene → hidden
+
+            EditorBuffer buffer = new EditorBuffer();
+            buffer.getArea().replaceText("class A {\n  void m() {}\n}\n");
+            panel.attach(buffer); // recompute → rebuild, but hidden → deferred
+
+            List<SymbolNode> syms = List.of(new SymbolNode(
+                    "A", "", "class", 0, 2, List.of(new SymbolNode("m", "()", "method", 1, 1, List.of()))));
+            panel.setLspSymbols(buffer, syms); // rebuild → deferred while hidden
+
+            TreeView<?> tree = FxTestSupport.field(panel, "tree");
+            boolean pendingWhileHidden = FxTestSupport.field(panel, "pendingRebuild");
+            int childrenWhileHidden =
+                    tree.getRoot() == null ? 0 : tree.getRoot().getChildren().size();
+
+            new Scene(new StackPane(panel), 300, 400); // sceneProperty → rebuild the deferred outline
+
+            boolean pendingAfterShow = FxTestSupport.field(panel, "pendingRebuild");
+            int childrenAfterShow =
+                    tree.getRoot() == null ? 0 : tree.getRoot().getChildren().size();
+
+            return new Object[] {pendingWhileHidden, childrenWhileHidden, pendingAfterShow, childrenAfterShow};
+        });
+
+        assertTrue((Boolean) r[0], "a rebuild requested while hidden is deferred (pending)");
+        assertEquals(0, (Integer) r[1], "the tree is not built while the panel is hidden");
+        assertFalse((Boolean) r[2], "showing the window clears the pending flag");
+        assertTrue((Integer) r[3] > 0, "the tree is built when the window is shown: " + r[3]);
+    }
+}

--- a/src/test/java/com/editora/ui/StructureNavFxTest.java
+++ b/src/test/java/com/editora/ui/StructureNavFxTest.java
@@ -2,8 +2,10 @@ package com.editora.ui;
 
 import java.util.List;
 
+import javafx.scene.Scene;
 import javafx.scene.control.TreeItem;
 import javafx.scene.control.TreeView;
+import javafx.scene.layout.StackPane;
 
 import com.editora.editor.EditorBuffer;
 import com.editora.lsp.SymbolNode;
@@ -37,6 +39,13 @@ class StructureNavFxTest {
         });
     }
 
+    /** A panel placed in a scene, as it is when its tool window is open (the outline only rebuilds while shown). */
+    private static StructurePanel shownPanel() {
+        StructurePanel p = new StructurePanel();
+        new Scene(new StackPane(p), 300, 400);
+        return p;
+    }
+
     private static List<SymbolNode> threeSymbols() {
         return List.of(
                 new SymbolNode("Alpha", null, "class", 0, 9, List.of()),
@@ -56,7 +65,7 @@ class StructureNavFxTest {
 
     @Test
     void unchangedSymbolsKeepSelectionAndDoNotRebuild() throws Exception {
-        StructurePanel panel = FxTestSupport.callOnFx(StructurePanel::new);
+        StructurePanel panel = FxTestSupport.callOnFx(StructureNavFxTest::shownPanel);
         EditorBuffer buffer = tenLineBuffer();
         FxTestSupport.runOnFx(() -> {
             panel.attach(buffer);
@@ -83,7 +92,7 @@ class StructureNavFxTest {
 
     @Test
     void changedSymbolsRebuildButPreserveTheSelectedSymbol() throws Exception {
-        StructurePanel panel = FxTestSupport.callOnFx(StructurePanel::new);
+        StructurePanel panel = FxTestSupport.callOnFx(StructureNavFxTest::shownPanel);
         EditorBuffer buffer = tenLineBuffer();
         FxTestSupport.runOnFx(() -> {
             panel.attach(buffer);

--- a/src/test/java/com/editora/ui/StructurePanelFxTest.java
+++ b/src/test/java/com/editora/ui/StructurePanelFxTest.java
@@ -2,8 +2,10 @@ package com.editora.ui;
 
 import java.util.List;
 
+import javafx.scene.Scene;
 import javafx.scene.control.TreeItem;
 import javafx.scene.control.TreeView;
+import javafx.scene.layout.StackPane;
 
 import com.editora.editor.EditorBuffer;
 import com.editora.lsp.SymbolNode;
@@ -32,13 +34,20 @@ class StructurePanelFxTest {
         return (TreeView<Object>) FxTestSupport.<TreeView<?>>field(p, "tree");
     }
 
+    /** A panel placed in a scene, as it is when its tool window is open (the outline only rebuilds while shown). */
+    private static StructurePanel shownPanel() {
+        StructurePanel p = new StructurePanel();
+        new Scene(new StackPane(p), 300, 400);
+        return p;
+    }
+
     private static SymbolNode method(String name, int line) {
         return new SymbolNode(name, "()", "method", line, line + 1, List.of());
     }
 
     @Test
     void lspSymbolsRenderTheClassMethodHierarchy() throws Exception {
-        StructurePanel p = FxTestSupport.callOnFx(StructurePanel::new);
+        StructurePanel p = FxTestSupport.callOnFx(StructurePanelFxTest::shownPanel);
         EditorBuffer buffer = FxTestSupport.callOnFx(() -> {
             EditorBuffer b = new EditorBuffer();
             b.setLanguageOverride("java");
@@ -62,7 +71,7 @@ class StructurePanelFxTest {
 
     @Test
     void symbolsForANonAttachedBufferAreIgnored() throws Exception {
-        StructurePanel p = FxTestSupport.callOnFx(StructurePanel::new);
+        StructurePanel p = FxTestSupport.callOnFx(StructurePanelFxTest::shownPanel);
         EditorBuffer attached = FxTestSupport.callOnFx(() -> {
             EditorBuffer b = new EditorBuffer();
             b.setLanguageOverride("java");


### PR DESCRIPTION
## Summary

Performance audit finding: the **Structure** outline rebuilt its whole tree on every edit, even when its tool window was closed.

`StructurePanel.attach(buffer)` (run on every tab switch) wires `setOnRegionsChanged(this::rebuild)`, and the fold-region recompute fires on every debounced (~250 ms) text change. `rebuild()` does an O(n) `getContent().split(...)` (in `attachDocs`) plus a full `TreeView` reconstruction — all wasted when the panel is hidden. So a user who never opens the Structure window still paid a whole-document split + tree rebuild every ~250 ms while typing.

(The fold-region *recompute* is still needed for the gutter fold chevrons; only the tree rebuild is skipped.)

## Fix

Gate `rebuild()` on visibility (`getScene() != null`): when the window is closed, mark the outline stale (`pendingRebuild`) and skip the O(n) split + tree build; rebuild once when the window is (re)opened via a `sceneProperty` listener.

## Test

`StructureHiddenFxTest` (FX): attaching a buffer + pushing LSP symbols while the panel is hidden leaves the tree empty and `pendingRebuild` set; adding the panel to a scene rebuilds it. Verified to fail without the gate.

The two existing `StructurePanel` FX tests (`StructurePanelFxTest`, `StructureNavFxTest`) now place the panel in a scene — reflecting real usage, where the outline only rebuilds while the tool window is shown.

## Cost

Strictly less FX-thread work: a closed Structure window no longer splits the document or rebuilds the tree on edits. No behavior change when the window is open.

Closes #549

🤖 Generated with [Claude Code](https://claude.com/claude-code)
