### PR TITLE
Perf: debounce the per-edit marker persist off the FX hot path (#551)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Performance
 
+- **Editing above a bookmark, note, or breakpoint no longer stutters.** When an edit shifted a marker's line
+  (e.g. holding Enter above a bookmark), the editor did a blocking `bookmarks.json`/`notes.json` write plus a
+  full tool-window tree rebuild on the UI thread — once per newline. That persist is now coalesced to a single
+  write after editing settles; explicit actions (toggle/add/reorder) still save immediately. (#551)
 - **The Structure outline no longer rebuilds while it's closed.** It re-split the whole document and rebuilt its
   tree on every edit (debounced) even when the tool window was hidden. It now defers the rebuild while closed and
   does it once when the window is reopened. (#549)

--- a/src/main/java/com/editora/ui/BookmarkCoordinator.java
+++ b/src/main/java/com/editora/ui/BookmarkCoordinator.java
@@ -54,9 +54,17 @@ final class BookmarkCoordinator {
     private final BookmarksPanel panel;
     private final QuickOpen<BookmarkEntry> jumpPalette;
 
+    // The per-edit (line-shift) persist is coalesced: a synchronous atomic bookmarks.json write + a full
+    // Bookmarks-tree rebuild per newline (holding Enter above a bookmark) would block the FX thread. Explicit
+    // user actions (toggle/add/reorder) still persist immediately via persistBookmarks. (#551)
+    private final javafx.animation.PauseTransition persistDebounce =
+            new javafx.animation.PauseTransition(javafx.util.Duration.millis(300));
+    private EditorBuffer pendingPersist;
+
     BookmarkCoordinator(CoordinatorHost host, Ops ops) {
         this.host = host;
         this.ops = ops;
+        persistDebounce.setOnFinished(e -> flushPendingPersist());
         this.panel = new BookmarksPanel(ops::bookmarks, new BookmarksPanel.Actions() {
             @Override
             public void openAndJump(Path file, int line) {
@@ -108,6 +116,25 @@ final class BookmarkCoordinator {
     }
 
     // --- per-buffer persistence (called from addBuffer / session restore / save) ---------------------
+
+    /**
+     * Coalesces the per-edit persist (fired from {@code BookmarkManager.onChanged} when a line shift moves a
+     * bookmark) so holding Enter above a bookmark doesn't do a synchronous atomic file write + tree rebuild per
+     * newline on the FX thread. The write lands once, ~300 ms after editing settles; a crash before then loses
+     * only line-shift indices, which reanchor-on-open recovers. (#551)
+     */
+    void schedulePersistBookmarks(EditorBuffer buffer) {
+        pendingPersist = buffer;
+        persistDebounce.playFromStart();
+    }
+
+    private void flushPendingPersist() {
+        EditorBuffer b = pendingPersist;
+        pendingPersist = null;
+        if (b != null) {
+            persistBookmarks(b);
+        }
+    }
 
     void persistBookmarks(EditorBuffer buffer) {
         Path file = buffer.getPath();

--- a/src/main/java/com/editora/ui/DebugCoordinator.java
+++ b/src/main/java/com/editora/ui/DebugCoordinator.java
@@ -135,12 +135,19 @@ final class DebugCoordinator {
      */
     private volatile List<DapModels.FileBreakpoints> closedBreakpoints = List.of();
 
+    // Coalesce the per-edit (line-shift) breakpoint persist off the FX hot path — see schedulePersistBreakpoints.
+    // Only the synchronous breakpoints.json write is debounced; the adapter update stays immediate. (#551)
+    private final javafx.animation.PauseTransition persistDebounce =
+            new javafx.animation.PauseTransition(javafx.util.Duration.millis(300));
+    private EditorBuffer pendingPersist;
+
     DebugCoordinator(CoordinatorHost host, DapManager dapManager, LspManager lspManager, LspCoordinator lsp, Ops ops) {
         this.host = host;
         this.dapManager = dapManager;
         this.lspManager = lspManager;
         this.lsp = lsp;
         this.ops = ops;
+        persistDebounce.setOnFinished(e -> flushPendingPersist());
         this.debugPanel = new DebugPanel(debugActions());
         debugPanel.setPrompt(host::promptText);
         debugPanel.setOnLink(ops::openLink); // double-clicked stack-trace line → jump
@@ -269,9 +276,27 @@ final class DebugCoordinator {
 
     /** Persists a buffer's breakpoints + (if a session is live) re-sends that file's set to the adapter. */
     void onBreakpointsChanged(EditorBuffer buffer) {
-        persistBreakpoints(buffer);
+        schedulePersistBreakpoints(buffer); // debounced FS write (off the per-newline hot path)
         if (buffer.getPath() != null && dapManager.isActive()) {
-            dapManager.updateBreakpoints(fileBreakpoints(buffer));
+            dapManager.updateBreakpoints(fileBreakpoints(buffer)); // adapter stays current immediately
+        }
+    }
+
+    /**
+     * Coalesces the synchronous breakpoints.json write fired per line-shifting edit (holding Enter above a
+     * breakpoint) so it lands once, ~300 ms after editing settles, instead of blocking the FX thread per newline.
+     * reanchor-on-open recovers indices lost to a crash before the write. (#551)
+     */
+    private void schedulePersistBreakpoints(EditorBuffer buffer) {
+        pendingPersist = buffer;
+        persistDebounce.playFromStart();
+    }
+
+    private void flushPendingPersist() {
+        EditorBuffer b = pendingPersist;
+        pendingPersist = null;
+        if (b != null) {
+            persistBreakpoints(b);
         }
     }
 

--- a/src/main/java/com/editora/ui/MainController.java
+++ b/src/main/java/com/editora/ui/MainController.java
@@ -5050,9 +5050,9 @@ public class MainController implements com.editora.mcp.McpBridge {
         buffer.setOnAddToDictionary(this::addUserWordAndRefreshAll);
         applyViewSettings(buffer);
         buffer.getFoldManager().setOnFoldStateChanged(() -> persistFolds(buffer));
-        buffer.setOnBookmarksChanged(() -> bookmarkCoordinator.persistBookmarks(buffer));
+        buffer.setOnBookmarksChanged(() -> bookmarkCoordinator.schedulePersistBookmarks(buffer));
         buffer.setGutterBookmarkClick(bookmarkCoordinator::onGutterBookmarkClick);
-        buffer.setOnNotesChanged(() -> notesCoordinator.persistNotes(buffer));
+        buffer.setOnNotesChanged(() -> notesCoordinator.schedulePersistNotes(buffer));
         buffer.setNoteMarkerClick(notesCoordinator::onNoteMarkerClick);
         buffer.setGutterBlameClick(git::onGutterBlameClick);
         todoCoordinator.applyToBuffer(buffer); // push the compiled TODO/highlight matcher (on by default)

--- a/src/main/java/com/editora/ui/NotesCoordinator.java
+++ b/src/main/java/com/editora/ui/NotesCoordinator.java
@@ -75,9 +75,15 @@ final class NotesCoordinator {
 
     private boolean supportApplied;
 
+    // Coalesce the per-edit (line-shift) persist off the FX hot path — see schedulePersistNotes. (#551)
+    private final javafx.animation.PauseTransition persistDebounce =
+            new javafx.animation.PauseTransition(javafx.util.Duration.millis(300));
+    private EditorBuffer pendingPersist;
+
     NotesCoordinator(CoordinatorHost host, Ops ops) {
         this.host = host;
         this.ops = ops;
+        persistDebounce.setOnFinished(e -> flushPendingPersist());
         this.panel = new NotesPanel(ops::notes, new NotesPanel.Actions() {
             @Override
             public void openAndJump(String fileKey, PersonalNote note) {
@@ -168,6 +174,25 @@ final class NotesCoordinator {
     }
 
     // --- per-buffer persistence (called from addBuffer / session restore / save) ---------------------
+
+    /**
+     * Coalesces the per-edit persist (fired from {@code NoteManager.onChanged} when a line shift moves a note) so
+     * holding Enter above a note doesn't do a synchronous atomic notes.json write + tree rebuild per newline on
+     * the FX thread. The write lands once, ~300 ms after editing settles; relocate-on-open recovers any indices
+     * lost to a crash before then. (#551)
+     */
+    void schedulePersistNotes(EditorBuffer buffer) {
+        pendingPersist = buffer;
+        persistDebounce.playFromStart();
+    }
+
+    private void flushPendingPersist() {
+        EditorBuffer b = pendingPersist;
+        pendingPersist = null;
+        if (b != null) {
+            persistNotes(b);
+        }
+    }
 
     /** Persists the active buffer's notes (keyed by canonical path), preserving the panel's order. */
     void persistNotes(EditorBuffer buffer) {

--- a/src/test/java/com/editora/ui/MarkerPersistDebounceFxTest.java
+++ b/src/test/java/com/editora/ui/MarkerPersistDebounceFxTest.java
@@ -1,0 +1,88 @@
+package com.editora.ui;
+
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Consumer;
+
+import javafx.animation.PauseTransition;
+import javafx.event.ActionEvent;
+
+import com.editora.config.Bookmark;
+import com.editora.editor.EditorBuffer;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Regression for #551: a line-shifting edit above a bookmark (holding Enter, pasting/cutting lines) used to do a
+ * synchronous atomic {@code bookmarks.json} write + a full Bookmarks-tree rebuild on the FX thread, once per
+ * newline. The per-edit persist is now coalesced: {@code schedulePersistBookmarks} does not write synchronously —
+ * the write lands once when the debounce fires. (Bookmarks is the exemplar; notes and breakpoints share the
+ * identical mechanism.)
+ */
+@Tag("fx")
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class MarkerPersistDebounceFxTest {
+
+    @BeforeAll
+    void setUp() throws Exception {
+        FxTestSupport.bootToolkit();
+    }
+
+    @Test
+    void schedulingABookmarkPersistIsDebouncedNotSynchronous() throws Exception {
+        int[] saves = {0};
+        int[] counts = FxTestSupport.callOnFx(() -> {
+            BookmarkCoordinator.Ops ops = new BookmarkCoordinator.Ops() {
+                final Map<String, List<Bookmark>> map = new HashMap<>();
+
+                @Override
+                public void openPath(Path file) {}
+
+                @Override
+                public void navigateToLine(int line) {}
+
+                @Override
+                public EditorBuffer bufferForPath(Path file) {
+                    return null;
+                }
+
+                @Override
+                public void promptText(String title, String label, String initial, Consumer<String> onAccept) {}
+
+                @Override
+                public Map<String, List<Bookmark>> bookmarks() {
+                    return map;
+                }
+
+                @Override
+                public void saveBookmarks() {
+                    saves[0]++;
+                }
+            };
+            BookmarkCoordinator coord = new BookmarkCoordinator(new CoordinatorHostStub(), ops);
+
+            EditorBuffer buffer = new EditorBuffer();
+            buffer.setPath(Path.of("/tmp/marker-persist-test.txt"));
+            buffer.getBookmarkManager().add(0, "");
+
+            coord.schedulePersistBookmarks(buffer);
+            int immediate = saves[0]; // must still be 0 — the write is deferred, not run on the edit event
+
+            // Fire the coalescing debounce (as the ~300 ms PauseTransition would).
+            PauseTransition pt = FxTestSupport.field(coord, "persistDebounce");
+            pt.getOnFinished().handle(new ActionEvent());
+            int afterFlush = saves[0]; // the write lands exactly once
+
+            return new int[] {immediate, afterFlush};
+        });
+
+        assertEquals(0, counts[0], "scheduling a persist must not write synchronously on the FX hot path");
+        assertEquals(1, counts[1], "the coalesced persist writes once when the debounce fires");
+    }
+}


### PR DESCRIPTION
## Summary

Performance audit finding (surfaced by a fan-out explorer over the marker-manager `onChanged` chains): a **line-shifting edit above a bookmark/note/breakpoint did a synchronous, FX-thread-blocking disk write per newline**.

The per-buffer `BookmarkManager` / `NoteManager` / `BreakpointManager` subscribe to the raw edit stream and fire `onChanged` whenever a line shift moves a marker. The wired callbacks ran **synchronously on the FX thread**:

- `BookmarkCoordinator.persistBookmarks` → `ConfigWriter.writeAtomic` (temp + fsync + rename) **+ `BookmarksPanel.refresh()`** (full tree rebuild)
- `NotesCoordinator.persistNotes` → atomic write **+ `NotesPanel.refresh()`**
- `DebugCoordinator.onBreakpointsChanged` → atomic write

So **holding Enter above a bookmark** = one `bookmarks.json` write + a full Bookmarks-tree rebuild, **per newline, inline in the keystroke** — violating "never block the FX thread" and "debounce/coalesce."

## Fix

Coalesce the **`onChanged`-driven** persist behind a ~300 ms `PauseTransition` in each coordinator (`schedulePersist*`), so the write (+ refresh) lands **once after editing settles** instead of per newline. Explicit user actions (toggle/add/reorder, save, session restore) still persist **immediately** — only the line-shift hot path is debounced. For breakpoints only the FS write is debounced; the DAP adapter update stays immediate.

Safe because a crash before the debounce fires loses only line-shift *indices*, which the existing reanchor/relocate-on-open logic recovers (markers self-heal against their saved `lineText`).

## Test

`MarkerPersistDebounceFxTest` (FX) builds a `BookmarkCoordinator` with a save-counting fake `Ops`, calls `schedulePersistBookmarks`, and asserts **no write happened synchronously**, then fires the debounce and asserts **exactly one write**. Verified to fail when the schedule is made synchronous. (Bookmarks is the exemplar; notes and breakpoints share the identical mechanism.)

## Cost

Removes a synchronous `fsync` + (bookmarks/notes) a full tree rebuild from the per-newline edit path; N writes-per-burst → one. Net positive, no behavior change.

Closes #551

🤖 Generated with [Claude Code](https://claude.com/claude-code)
