### PR TITLE
Perf: skip the redundant LSP change-send at an unchanged version (#553)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Performance
 
+- **Language-server updates aren't sent twice per keystroke.** After a trigger character (e.g. `.`), the editor
+  materialized and pushed the whole document to the server both on the completion trigger and again on the
+  debounced edit pulse — the same version twice. It now skips a resend when the document hasn't changed since the
+  last one. (#553)
 - **Editing above a bookmark, note, or breakpoint no longer stutters.** When an edit shifted a marker's line
   (e.g. holding Enter above a bookmark), the editor did a blocking `bookmarks.json`/`notes.json` write plus a
   full tool-window tree rebuild on the UI thread — once per newline. That persist is now coalesced to a single

--- a/src/main/java/com/editora/editor/EditorBuffer.java
+++ b/src/main/java/com/editora/editor/EditorBuffer.java
@@ -485,6 +485,10 @@ public class EditorBuffer implements TabContent {
     private boolean lspActive;
 
     private java.util.function.Consumer<String> lspChangeListener;
+    /** {@link #docVersion} of the document text last sent to the server, so a send whose content hasn't changed
+     *  since (the completion flush and the debounced pulse both fire for one edit) skips the whole-document
+     *  {@code getText()} + {@code didChange}. Reset to -1 on LSP (de)activation so a re-attach always re-sends. */
+    private long lastLspSentVersion = -1;
     /** Debounced pull-diagnostics request (servers that answer textDocument/diagnostic); null = none. */
     private Runnable lspDiagnosticsRequester;
     /** Debounced semantic-tokens request (servers advertising range semantic tokens); null = none. */
@@ -734,8 +738,8 @@ public class EditorBuffer implements TabContent {
         // here, not in lspChangeListener, so it fires once per debounce — not on every completion keystroke
         // (requestLspCompletion flushes lspChangeListener directly to send fresh text before completing).
         area.multiPlainChanges().successionEnds(Duration.ofMillis(300)).subscribe(ignore -> {
-            if (lspActive && lspChangeListener != null) {
-                lspChangeListener.accept(area.getText());
+            if (lspActive) {
+                sendLspChange();
             }
             if (lspActive && lspDiagnosticsRequester != null) {
                 lspDiagnosticsRequester.run();
@@ -2815,6 +2819,20 @@ public class EditorBuffer implements TabContent {
         this.lspChangeListener = listener;
     }
 
+    /**
+     * Sends the current document text to the language server — unless it already has this version (the same
+     * {@link #docVersion} as the last send). Both the completion flush and the debounced edit pulse call this for
+     * one edit; the guard drops the second, avoiding a redundant whole-document {@code getText()} + {@code
+     * didChange}. Split views share the document, so {@code area.getText()} is the canonical full text.
+     */
+    private void sendLspChange() {
+        if (lspChangeListener == null || docVersion == lastLspSentVersion) {
+            return;
+        }
+        lastLspSentVersion = docVersion;
+        lspChangeListener.accept(area.getText());
+    }
+
     /** Injects the debounced pull-diagnostics request (fired on the same pulse as didChange); null disables. */
     public void setLspDiagnosticsRequester(Runnable requester) {
         this.lspDiagnosticsRequester = requester;
@@ -3017,6 +3035,7 @@ public class EditorBuffer implements TabContent {
         // to map + render (the Problems tree, minimap + scrollbar stripes), freezing the editor. largeFile
         // is implied by hugeFile (see setReadOnly), so this single guard covers both.
         this.lspActive = on && isLspLanguage() && !largeFile && !heavyFile;
+        lastLspSentVersion = -1; // an (de)activation re-syncs via didOpen; force the next change-send to fire
         if (this.lspActive || lspOverlay != null) {
             lspOverlay().setActive(this.lspActive);
         }
@@ -7612,10 +7631,9 @@ public class EditorBuffer implements TabContent {
         // Flush the current text to the server FIRST: the completion auto-trigger (≈120ms) fires before
         // the debounced didChange (≈300ms), so without this the server still has stale text and member
         // completion after '.' resolves against the old document. JSON-RPC preserves order, so this
-        // didChange is applied before the completion request below.
-        if (lspChangeListener != null) {
-            lspChangeListener.accept(a.getText());
-        }
+        // didChange is applied before the completion request below. (Skipped when the server already has this
+        // version — e.g. the debounced pulse just sent it — so it doesn't re-materialize the whole document.)
+        sendLspChange();
         lspCompletionProvider.accept(new int[] {a.getCurrentParagraph(), a.getCaretColumn()}, lspItems -> {
             // Drop a response the document has moved past. The caret check alone isn't enough: an edit can
             // put the caret back on the same offset (select the word, retype it), which would show items

--- a/src/test/java/com/editora/ui/LspSendDedupeFxTest.java
+++ b/src/test/java/com/editora/ui/LspSendDedupeFxTest.java
@@ -1,0 +1,57 @@
+package com.editora.ui;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import com.editora.editor.EditorBuffer;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Regression for #553: dedupe of the LSP change-send. Both the completion flush (~120 ms) and the debounced edit
+ * pulse (~300 ms) send the document to the server for one edit; the second used to re-materialize the whole
+ * document ({@code getText()}) and re-send it at the same version. {@code EditorBuffer.sendLspChange} now skips a
+ * send whose {@code docVersion} hasn't advanced since the last, dropping the redundant send — but a real edit
+ * still sends.
+ */
+@Tag("fx")
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class LspSendDedupeFxTest {
+
+    @BeforeAll
+    void setUp() throws Exception {
+        FxTestSupport.bootToolkit();
+    }
+
+    @Test
+    void aSecondSendAtTheSameVersionIsSkippedButAnEditReSends() throws Exception {
+        List<String> sent = new ArrayList<>();
+        int[] counts = FxTestSupport.callOnFx(() -> {
+            EditorBuffer b = new EditorBuffer();
+            b.setLspChangeListener(sent::add);
+
+            b.getArea().replaceText("obj."); // an edit → docVersion advances
+            FxTestSupport.invoke(b, "sendLspChange"); // completion flush: sends
+            int afterFlush = sent.size();
+
+            FxTestSupport.invoke(b, "sendLspChange"); // debounced pulse, same version → skipped
+            int afterPulse = sent.size();
+
+            b.getArea().appendText("field"); // a real edit → new version
+            FxTestSupport.invoke(b, "sendLspChange"); // sends again
+            int afterEdit = sent.size();
+
+            return new int[] {afterFlush, afterPulse, afterEdit};
+        });
+
+        assertEquals(1, counts[0], "the first send goes out");
+        assertEquals(1, counts[1], "a second send at the same version is skipped (no redundant getText/didChange)");
+        assertEquals(2, counts[2], "a real edit re-sends");
+        assertEquals("obj.", sent.get(0), "the first send carries the current document");
+        assertEquals("obj.field", sent.get(1), "the re-send carries the edited document");
+    }
+}


### PR DESCRIPTION
## Summary

The safe slice of the LSP-incremental-sync discussion — a high-confidence win with no protocol change and no desync risk.

`EditorBuffer` sends the document to the language server from **two** places for a single edit:
- the **completion flush** in `requestLspCompletion` (fires on the ~120 ms completion auto-trigger, before the debounce), and
- the **debounced edit pulse** (~300 ms).

Each calls `area.getText()` (a whole-document materialize on the FX thread) + `didChange`. Typing a trigger char (`obj.`) and pausing fires **both** for the same edit, so the **same document version is materialized and sent twice** — a redundant `getText()` on the FX thread plus a redundant `didChange` (serialize + pipe + server reparse, off-thread).

## Fix

New `sendLspChange()` helper tracks the `docVersion` of the last text sent (`lastLspSentVersion`) and **skips a send whose version hasn't advanced**. Both sites route through it. Reset on LSP (de)activation so a re-attach always re-sends (the coordinator's `didOpen` covers the initial text).

No range math, no protocol change — the server still gets full text, just never the same version twice. This deliberately does **not** attempt full incremental sync (range-based `TextDocumentContentChangeEvent`), which is correctness-risky (a range off-by-one silently desyncs the server) and would need per-server device testing across all 21 servers.

## Test

`LspSendDedupeFxTest` (FX): a second `sendLspChange` at the same version is skipped while a real edit re-sends (with the correct document text each time). Verified to fail when the version guard is removed.

## Cost

Removes one whole-document `getText()` (FX thread) + one `didChange` (off-thread) per completion-triggered edit burst. Net positive; the server's mirror is identical either way.

Closes #553

🤖 Generated with [Claude Code](https://claude.com/claude-code)
