### PR TITLE
Stability: handle off-thread failures so callbacks aren't stranded (#556)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Local File History keeps garbage-collecting after a failed snapshot.** If writing a history snapshot to disk
+  failed, the internal completion callback was dropped, which left history GC disabled for the rest of the session
+  (old revision blobs then accumulated on disk). Failures are now handled and logged, and GC keeps running. A few
+  related background tasks (the log tail, the project file-watcher, a starting language server) were also hardened
+  so an unexpected error can't silently stop them. (#556)
 - **Text zoom now works inside Diff views.** `Ctrl`+`=`/`-`/`0`, the status-bar `−/+`, and `Ctrl`+mouse-wheel
   resize the font when comparing two files or a file against Git, the same as in a normal editor. (#533)
 - **Text zoom now scales the Welcome page too.** (#540)

--- a/src/main/java/com/editora/history/HistoryService.java
+++ b/src/main/java/com/editora/history/HistoryService.java
@@ -8,6 +8,8 @@ import java.util.Set;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.function.Consumer;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 import javafx.application.Platform;
 
@@ -25,6 +27,8 @@ import com.editora.history.HistoryRetention.RetentionPolicy;
  * (the auto-save precedent), so the executor never touches live editor state.
  */
 public final class HistoryService {
+
+    private static final Logger LOG = Logger.getLogger(HistoryService.class.getName());
 
     private final HistoryBlobStore blobs;
 
@@ -57,30 +61,45 @@ public final class HistoryService {
             Consumer<HistoryRevision> onRecorded) {
         List<HistoryRevision> snapshot = existing == null ? List.of() : new ArrayList<>(existing);
         exec.submit(() -> {
-            String sha = HistoryBlobStore.sha256(content);
-            if (!force && HistoryRetention.isDuplicate(snapshot, sha)) {
-                // Unchanged since the last revision — skip the blob write. Still report completion: the
-                // caller counts in-flight records to know when it is safe to GC.
+            try {
+                String sha = HistoryBlobStore.sha256(content);
+                if (!force && HistoryRetention.isDuplicate(snapshot, sha)) {
+                    // Unchanged since the last revision — skip the blob write. Still report completion: the
+                    // caller counts in-flight records to know when it is safe to GC.
+                    Platform.runLater(() -> onRecorded.accept(null));
+                    return;
+                }
+                blobs.put(content, sha);
+                long size = content.getBytes(StandardCharsets.UTF_8).length;
+                HistoryRevision rev =
+                        new HistoryRevision(file.toString(), now, size, sha, reason, label == null ? "" : label);
+                // Deliver just the revision: the caller folds it into the index on the FX thread, against the
+                // list as it is THEN. Building the new list here from the list as it was at submit time meant a
+                // second record for the same file (a label during a slow save; two dirty buffers on one autosave)
+                // overwrote the first one's revision with a list that never contained it.
+                Platform.runLater(() -> onRecorded.accept(rev));
+            } catch (Throwable t) {
+                // A failure here (e.g. the blob disk write) MUST still complete the callback: the caller
+                // decrements an in-flight counter in onRecorded and only GCs when it hits zero, so a stranded
+                // callback silently stops local-history GC for the rest of the session (blobs grow unbounded).
+                // The submit() Future is unobserved, so without this the throw is swallowed and never logged.
+                LOG.log(Level.WARNING, "Failed to record a history revision for " + file, t);
                 Platform.runLater(() -> onRecorded.accept(null));
-                return;
             }
-            blobs.put(content, sha);
-            long size = content.getBytes(StandardCharsets.UTF_8).length;
-            HistoryRevision rev =
-                    new HistoryRevision(file.toString(), now, size, sha, reason, label == null ? "" : label);
-            // Deliver just the revision: the caller folds it into the index on the FX thread, against the
-            // list as it is THEN. Building the new list here from the list as it was at submit time meant a
-            // second record for the same file (a label during a slow save; two dirty buffers on one autosave)
-            // overwrote the first one's revision with a list that never contained it.
-            Platform.runLater(() -> onRecorded.accept(rev));
         });
     }
 
     /** Fetches a revision's body off the FX thread and delivers it (or {@code null}) on the FX thread. */
     public void content(HistoryRevision rev, Consumer<String> onText) {
         exec.submit(() -> {
-            String text = rev == null ? null : blobs.get(rev.sha256());
-            Platform.runLater(() -> onText.accept(text));
+            try {
+                String text = rev == null ? null : blobs.get(rev.sha256());
+                Platform.runLater(() -> onText.accept(text));
+            } catch (Throwable t) {
+                // Always complete the callback so a diff/preview view doesn't hang "loading" on a read failure.
+                LOG.log(Level.WARNING, "Failed to read a history revision body", t);
+                Platform.runLater(() -> onText.accept(null));
+            }
         });
     }
 

--- a/src/main/java/com/editora/logviewer/LogTailService.java
+++ b/src/main/java/com/editora/logviewer/LogTailService.java
@@ -86,7 +86,9 @@ public final class LogTailService {
                             String text = a.text();
                             Platform.runLater(() -> listener.appended(text));
                         }
-                    } catch (Exception e) {
+                    } catch (Throwable e) {
+                        // Catch Throwable, not Exception: an Error escaping a scheduleWithFixedDelay body cancels
+                        // the recurring task, silently stopping the tail. Report it and mark done instead.
                         done.set(true);
                         String message = e.getMessage() == null ? e.toString() : e.getMessage();
                         Platform.runLater(() -> listener.error(message));

--- a/src/main/java/com/editora/lsp/LanguageServerSession.java
+++ b/src/main/java/com/editora/lsp/LanguageServerSession.java
@@ -102,7 +102,9 @@ final class LanguageServerSession implements LanguageClient {
     private final java.util.concurrent.atomic.AtomicBoolean deadReported =
             new java.util.concurrent.atomic.AtomicBoolean();
     private volatile boolean disposed;
-    private ServerCapabilities capabilities;
+    // Written on the LSP4J init thread (initialize().whenComplete), read on the FX thread (capabilities()).
+    // volatile gives the FX reader the happens-before edge so it can't transiently see null after init completed.
+    private volatile ServerCapabilities capabilities;
 
     LanguageServerSession(
             LspServerRegistry.ServerSpec spec,

--- a/src/main/java/com/editora/ui/ProjectPanel.java
+++ b/src/main/java/com/editora/ui/ProjectPanel.java
@@ -58,6 +58,9 @@ import static com.editora.i18n.Messages.tr;
  */
 public class ProjectPanel extends VBox implements ToolWindowContent {
 
+    private static final java.util.logging.Logger LOG =
+            java.util.logging.Logger.getLogger(ProjectPanel.class.getName());
+
     private static final int MAX_VISIT = 20_000;
     private static final int MAX_MATCHES = 300;
     private static final int MAX_DEPTH = 25;
@@ -522,29 +525,36 @@ public class ProjectPanel extends VBox implements ToolWindowContent {
             } catch (InterruptedException | java.nio.file.ClosedWatchServiceException e) {
                 return; // disposed
             }
-            // Inspect the events so a batch that is ONLY Editora's own throwaway temp files (the typst render
-            // input, created+deleted every render) doesn't spuriously rebuild the tree (#465). Otherwise we
-            // re-list from disk (individual events aren't applied) — an OVERFLOW or any real file forces it.
-            List<java.nio.file.WatchEvent<?>> events = key.pollEvents();
-            key.reset();
-            boolean overflow = false;
-            List<String> names = new java.util.ArrayList<>();
-            for (java.nio.file.WatchEvent<?> ev : events) {
-                if (ev.kind() == java.nio.file.StandardWatchEventKinds.OVERFLOW) {
-                    overflow = true;
-                    continue;
+            try {
+                // Inspect the events so a batch that is ONLY Editora's own throwaway temp files (the typst render
+                // input, created+deleted every render) doesn't spuriously rebuild the tree (#465). Otherwise we
+                // re-list from disk (individual events aren't applied) — an OVERFLOW or any real file forces it.
+                List<java.nio.file.WatchEvent<?>> events = key.pollEvents();
+                key.reset();
+                boolean overflow = false;
+                List<String> names = new java.util.ArrayList<>();
+                for (java.nio.file.WatchEvent<?> ev : events) {
+                    if (ev.kind() == java.nio.file.StandardWatchEventKinds.OVERFLOW) {
+                        overflow = true;
+                        continue;
+                    }
+                    Object ctx = ev.context();
+                    names.add(ctx instanceof Path p ? p.getFileName().toString() : "");
                 }
-                Object ctx = ev.context();
-                names.add(ctx instanceof Path p ? p.getFileName().toString() : "");
-            }
-            if (!watchEventsWarrantRefresh(names, overflow)) {
-                continue; // only Editora's own temp files changed — no tree rebuild
-            }
-            Platform.runLater(() -> {
-                if (!disposed) {
-                    watchDebounce.playFromStart();
+                if (!watchEventsWarrantRefresh(names, overflow)) {
+                    continue; // only Editora's own temp files changed — no tree rebuild
                 }
-            });
+                Platform.runLater(() -> {
+                    if (!disposed) {
+                        watchDebounce.playFromStart();
+                    }
+                });
+            } catch (Throwable t) {
+                // A transient failure processing one batch must NOT kill the watcher thread — that would
+                // silently stop live tree refresh for the rest of the session. Log and keep watching (the
+                // focus-regain refreshTree() still covers any gap).
+                LOG.log(java.util.logging.Level.WARNING, "project filesystem watch loop error", t);
+            }
         }
     }
 

--- a/src/test/java/com/editora/ui/HistoryServiceCallbackFxTest.java
+++ b/src/test/java/com/editora/ui/HistoryServiceCallbackFxTest.java
@@ -1,0 +1,63 @@
+package com.editora.ui;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import com.editora.config.HistoryRevision;
+import com.editora.history.HistoryBlobStore;
+import com.editora.history.HistoryRetention.RetentionPolicy;
+import com.editora.history.HistoryService;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.io.TempDir;
+
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Regression for #556: a failure in the off-thread history record (e.g. the blob disk write) must still fire the
+ * {@code onRecorded} callback. The caller ({@code HistoryCoordinator}) increments an in-flight counter before the
+ * call and decrements it in the callback, GC-ing local history only when the counter hits zero — so a stranded
+ * callback (the throw was swallowed into the unobserved {@code submit()} Future) silently stopped local-history GC
+ * for the whole session. The callback now fires with {@code null} on failure so the counter always balances.
+ */
+@Tag("fx")
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class HistoryServiceCallbackFxTest {
+
+    @BeforeAll
+    void setUp() throws Exception {
+        FxTestSupport.bootToolkit();
+    }
+
+    @Test
+    void aBlobWriteFailureStillFiresTheRecordCallback(@TempDir Path dir) throws Exception {
+        // A blob store whose "blobs dir" is actually a regular file → put() can't create its subdirs → it throws.
+        Path blobsDirIsAFile = dir.resolve("blobs-is-a-file");
+        Files.writeString(blobsDirIsAFile, "not a directory");
+        HistoryService svc = new HistoryService(new HistoryBlobStore(blobsDirIsAFile));
+
+        CountDownLatch latch = new CountDownLatch(1);
+        AtomicReference<HistoryRevision> got = new AtomicReference<>();
+        RetentionPolicy policy = new RetentionPolicy(20, Long.MAX_VALUE, Long.MAX_VALUE);
+
+        // force = true so the record isn't short-circuited as a duplicate; the blob write then throws.
+        FxTestSupport.runOnFx(() -> svc.snapshot(
+                Path.of("/x/Foo.java"), "some content", "save", null, true, List.of(), policy, 1000L, rev -> {
+                    got.set(rev);
+                    latch.countDown();
+                }));
+
+        assertTrue(
+                latch.await(5, TimeUnit.SECONDS),
+                "onRecorded must fire even when the blob write throws (else the caller's in-flight counter sticks)");
+        assertNull(got.get(), "a failed record reports no revision (null) so the in-flight counter still balances");
+        svc.shutdown();
+    }
+}


### PR DESCRIPTION
## Summary

From a stability/NPE audit (a fan-out sweep across every background service). **Bottom line: the async/callback layer is genuinely well-guarded — no reachable crash-severity NPE or race was found.** The classic vectors (stale FX callbacks after a tab/window closes, uncaught daemon-thread throws, undrained subprocess stderr) are all already handled with generation guards, null checks, and stderr drains. This PR fixes the one genuine correctness issue the sweep surfaced, plus a few cheap defensive guards.

## The real bug

`HistoryService.snapshot(...)` and `content(...)` run work inside `exec.submit(() -> { …; Platform.runLater(cb); })` with **no try/catch**. If the work throws (e.g. `HistoryBlobStore.put` → `UncheckedIOException` on a disk-write failure), the throwable is captured in the **unobserved `submit()` Future** — never logged — and `Platform.runLater(cb)` never runs, so the callback never fires.

For `snapshot`, that strands the caller's completion callback. `HistoryCoordinator` does `recordsInFlight++` before the call and `recordsInFlight--` **inside** the callback, running local-history GC only when the counter reaches zero. A stranded callback leaves the counter stuck above zero → **local-history GC silently stops for the rest of the session** → old revision blobs accumulate unbounded on disk. This matches the "intermittent, a feature quietly stops working" symptom.

**Fix:** wrap both submit bodies in `try/catch(Throwable)` — log the failure and still fire the callback with `null` (no-revision / no-content) on the FX thread, so the in-flight counter always balances and GC keeps working (and a diff/preview waiting on `content()` doesn't hang "loading").

## Defensive guards (same sweep)

- `LanguageServerSession.capabilities` → `volatile` (written on the LSP init thread, read on the FX thread — a benign "capability briefly unavailable" flicker otherwise).
- `LogTailService`'s `scheduleWithFixedDelay` body catches `Throwable`, not `Exception` (an `Error` would cancel the recurring task and silently stop the tail).
- `ProjectPanel`'s filesystem watch loop wraps the per-batch event processing in `try/catch(Throwable)` + continue, so a transient processing error can't kill the watcher thread (which would stop live tree refresh for the session).

## Test

`HistoryServiceCallbackFxTest` (FX): drives a `HistoryService` whose blob "dir" is actually a regular file (so `put()` throws) and asserts `onRecorded` still fires (with `null`). Verified to fail — times out — when the callback is stranded.

Closes #556

🤖 Generated with [Claude Code](https://claude.com/claude-code)
