### PR TITLE
Run console: color stderr so error output stands out (#558)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **The Run console now colors error output.** A program's stderr (e.g. a Python traceback) is tinted so it
+  stands out from normal output, instead of appearing in the same plain color. (#558)
 - **The command palette now shows commands that can't run in the current context, grayed out**, instead of
   hiding them. A command for a disabled feature (e.g. Git commands while Git is off) is listed with its
   keybinding but dimmed and non-actionable, so you can see it exists. (#532)

--- a/src/main/java/com/editora/ui/RunPanel.java
+++ b/src/main/java/com/editora/ui/RunPanel.java
@@ -1,5 +1,7 @@
 package com.editora.ui;
 
+import java.util.Collection;
+import java.util.List;
 import java.util.function.Consumer;
 
 import javafx.geometry.Insets;
@@ -14,7 +16,10 @@ import javafx.scene.layout.Region;
 import javafx.scene.layout.VBox;
 
 import com.editora.run.StackTraceLinks;
+import org.fxmisc.flowless.VirtualizedScrollPane;
 import org.fxmisc.richtext.CodeArea;
+import org.fxmisc.richtext.model.StyleSpans;
+import org.fxmisc.richtext.model.StyleSpansBuilder;
 
 import static com.editora.i18n.Messages.tr;
 
@@ -24,9 +29,10 @@ import static com.editora.i18n.Messages.tr;
  * A {@link ToolWindowContent} modeled on {@link ProblemsPanel}; the controller drives it via
  * {@code started/appendOutput/finished/failed} on the FX thread.
  *
- * <p>Output goes into a read-only monospace {@link TextArea} (cheap and robust for large/streaming text)
- * whose contents are capped so a runaway program can't grow memory without bound. stdout and stderr are
- * interleaved in arrival order; per-stream coloring is a future enhancement.
+ * <p>Output goes into a read-only monospace RichTextFX {@link CodeArea} (like the build console) whose
+ * contents are capped so a runaway program can't grow memory without bound. stdout and stderr are
+ * interleaved in arrival order; stderr lines are colored ({@code .text.run-stderr}) so error output — e.g. a
+ * Python traceback — stands out from normal output.
  */
 public final class RunPanel extends VBox implements ToolWindowContent {
 
@@ -34,7 +40,7 @@ public final class RunPanel extends VBox implements ToolWindowContent {
     private static final int MAX_CHARS = 200_000;
 
     private final Label status = new Label();
-    private final TextArea output = new TextArea();
+    private final CodeArea output = new CodeArea();
     private final TextField input = new TextField();
     private final Button stopButton = new Button();
     private final Button clearButton = new Button();
@@ -66,7 +72,7 @@ public final class RunPanel extends VBox implements ToolWindowContent {
 
         output.setEditable(false);
         output.setWrapText(false);
-        output.getStyleClass().add("run-output");
+        output.getStyleClass().addAll("editor-area", "run-output");
         installLinkClicks(output, () -> onLink);
 
         // stdin: one line per Enter, echoed into the console (the program won't echo it back).
@@ -83,8 +89,9 @@ public final class RunPanel extends VBox implements ToolWindowContent {
             input.clear();
         });
 
-        VBox.setVgrow(output, Priority.ALWAYS);
-        getChildren().addAll(header, output, input);
+        VirtualizedScrollPane<CodeArea> scroll = new VirtualizedScrollPane<>(output);
+        VBox.setVgrow(scroll, Priority.ALWAYS);
+        getChildren().addAll(header, scroll, input);
         idle();
     }
 
@@ -96,11 +103,9 @@ public final class RunPanel extends VBox implements ToolWindowContent {
         this.onLink = onLink;
     }
 
-    /** Matches the console font to the editor's code-area font (family + effective size). Sets the
-     *  control's {@code font} property directly (user-set, so the {@code .run-output} stylesheet rule
-     *  can't override it) rather than {@code -fx-font-size} via setStyle, which a TextArea ignores. */
+    /** Matches the console font to the editor's code-area font (family + effective size). */
     public void setOutputFont(String family, int size) {
-        output.setFont(javafx.scene.text.Font.font(family, size));
+        output.setStyle("-fx-font-family: \"" + family + "\"; -fx-font-size: " + size + "px;");
     }
 
     /** Double-clicking a console line that holds a stack-trace location jumps to it. Shared with the
@@ -170,17 +175,23 @@ public final class RunPanel extends VBox implements ToolWindowContent {
         input.setDisable(false);
     }
 
-    /** Appends one line of program output (stdout or stderr), trims if over the cap, and auto-scrolls. */
+    /** Appends one line of program output (stdout or stderr), colors stderr, trims if over the cap, and
+     *  auto-scrolls. stderr lines get {@code .text.run-stderr} so error output stands out. */
     public void appendOutput(String line, boolean stderr) {
+        int start = output.getLength();
         output.appendText(line + "\n");
+        if (stderr && !line.isEmpty()) {
+            StyleSpans<Collection<String>> spans = new StyleSpansBuilder<Collection<String>>()
+                    .add(List.of("run-stderr"), line.length())
+                    .create();
+            output.setStyleSpans(start, spans);
+        }
         int len = output.getLength();
         if (len > MAX_CHARS) {
-            String kept = output.getText(len - MAX_CHARS, len);
-            int nl = kept.indexOf('\n');
-            output.replaceText(0, len, nl >= 0 ? kept.substring(nl + 1) : kept);
+            output.deleteText(0, len - MAX_CHARS);
         }
-        output.positionCaret(output.getLength());
-        output.setScrollTop(Double.MAX_VALUE);
+        output.moveTo(output.getLength());
+        output.requestFollowCaret();
     }
 
     /** The process exited; shows the exit code (or a "stopped" note for a killed run) and disables Stop. */

--- a/src/main/resources/com/editora/styles/syntax.css
+++ b/src/main/resources/com/editora/styles/syntax.css
@@ -57,6 +57,10 @@
 .text.maven-build-success { -fx-fill: -color-success-fg; -fx-font-weight: bold; }
 .text.maven-build-failure { -fx-fill: -color-danger-fg; -fx-font-weight: bold; }
 
+/* Run console (com.editora.ui.RunPanel): stderr lines are tinted so error output — e.g. a Python
+   traceback — stands out from normal stdout. Applied via setStyleSpans, not a grammar. */
+.text.run-stderr { -fx-fill: -color-danger-fg; }
+
 /* CSV/TSV field separators (source.csv grammar): a muted tint so column boundaries stand out. */
 .text.csv-delimiter { -fx-fill: -color-fg-subtle; }
 

--- a/src/test/java/com/editora/ui/ConsoleFontFxTest.java
+++ b/src/test/java/com/editora/ui/ConsoleFontFxTest.java
@@ -1,22 +1,20 @@
 package com.editora.ui;
 
 import javafx.scene.Scene;
-import javafx.scene.control.TextArea;
 import javafx.scene.layout.StackPane;
-import javafx.scene.text.Font;
 
+import org.fxmisc.richtext.CodeArea;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
- * Guards that a tool-window console's programmatic font ({@code setOutputFont}/{@code setConsoleFont},
- * used to match the editor) survives a CSS pass. Regression test: a {@code -fx-font-size} rule on
- * {@code .run-output}/{@code .debug-console} used to override the control's font property on every
- * {@code applyCss}, so the consoles never matched the editor.
+ * Guards that the Run console's programmatic font ({@code setOutputFont}, used to match the editor) survives a
+ * CSS pass. The console is a RichTextFX {@link CodeArea} whose font is set via an inline {@code setStyle}
+ * (which beats any {@code .run-output} stylesheet rule in the CSS cascade), so {@code applyCss} must not strip it.
  */
 @Tag("fx")
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
@@ -32,7 +30,7 @@ class ConsoleFontFxTest {
         FxTestSupport.runOnFx(() -> {
             RunPanel run = new RunPanel(() -> {});
             run.setOutputFont("JetBrains Mono", 17);
-            TextArea out = FxTestSupport.field(run, "output");
+            CodeArea out = FxTestSupport.field(run, "output");
 
             StackPane root = new StackPane(out);
             Scene scene = new Scene(root, 400, 300);
@@ -43,9 +41,9 @@ class ConsoleFontFxTest {
             root.applyCss();
             root.layout();
 
-            Font f = out.getFont();
-            assertEquals("JetBrains Mono", f.getFamily(), "family kept after CSS pass");
-            assertEquals(17.0, f.getSize(), 0.001, "size kept after CSS pass (CSS must not override setFont)");
+            String style = out.getStyle();
+            assertTrue(style.contains("JetBrains Mono"), "family kept in the inline style after a CSS pass: " + style);
+            assertTrue(style.contains("17"), "size kept in the inline style after a CSS pass: " + style);
         });
     }
 }

--- a/src/test/java/com/editora/ui/RunConsoleStderrColorFxTest.java
+++ b/src/test/java/com/editora/ui/RunConsoleStderrColorFxTest.java
@@ -1,0 +1,47 @@
+package com.editora.ui;
+
+import java.util.Collection;
+
+import org.fxmisc.richtext.CodeArea;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Regression for #558: the Run console colors stderr. A program's error output (e.g. a Python traceback) arrives
+ * on the stderr stream ({@code appendOutput(line, true)}); those lines get the {@code run-stderr} style class so
+ * they stand out, while stdout lines stay unstyled.
+ */
+@Tag("fx")
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class RunConsoleStderrColorFxTest {
+
+    @BeforeAll
+    void setUp() throws Exception {
+        FxTestSupport.bootToolkit();
+    }
+
+    @Test
+    void stderrLinesAreColoredAndStdoutIsNot() throws Exception {
+        boolean[] flags = FxTestSupport.callOnFx(() -> {
+            RunPanel panel = new RunPanel(() -> {});
+            CodeArea out = FxTestSupport.field(panel, "output");
+
+            panel.appendOutput("Traceback (most recent call last):", true); // stderr
+            panel.appendOutput("hello from stdout", false); // stdout
+
+            Collection<String> stderrStyle = out.getStyleOfChar(0);
+            int stdoutStart = out.getText().indexOf("hello from stdout");
+            Collection<String> stdoutStyle = out.getStyleOfChar(stdoutStart);
+
+            return new boolean[] {stderrStyle.contains("run-stderr"), stdoutStyle.contains("run-stderr")};
+        });
+
+        assertTrue(flags[0], "a stderr line is tinted with run-stderr so error output stands out");
+        assertFalse(flags[1], "a stdout line is not tinted");
+    }
+}

--- a/src/test/java/com/editora/ui/RunPanelFxTest.java
+++ b/src/test/java/com/editora/ui/RunPanelFxTest.java
@@ -1,8 +1,8 @@
 package com.editora.ui;
 
 import javafx.scene.control.Button;
-import javafx.scene.control.TextArea;
 
+import org.fxmisc.richtext.CodeArea;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -29,7 +29,7 @@ class RunPanelFxTest {
     }
 
     private static String output(RunPanel p) throws Exception {
-        TextArea out = FxTestSupport.field(p, "output");
+        CodeArea out = FxTestSupport.field(p, "output");
         return FxTestSupport.callOnFx(out::getText);
     }
 


### PR DESCRIPTION
## Summary

Reported: the Run console's output (a Python `IndentationError` traceback) renders in flat, uncolored text — the error output doesn't stand out.

The console used a plain `TextArea`, which can't color individual lines. `appendOutput(line, boolean stderr)` already received the stderr flag but ignored it (the class comment even called per-stream coloring "a future enhancement").

## Fix

Switch the Run console from `TextArea` to a RichTextFX `CodeArea` — exactly like the build console (`BuildToolPanel`) already does — and color **stderr** lines with a new `.text.run-stderr` class (danger-fg tint) via `setStyleSpans`. Since a program's error output (a traceback) goes to stderr, the whole traceback now stands out from normal stdout.

Everything else carries over to the CodeArea path: the clickable stack-trace links (the `CodeArea` overload of `installLinkClicks` already existed), the char cap, and auto-scroll. The console font is now applied via inline `setStyle` (matching the build console; inline style beats a `.run-output` stylesheet rule).

## Test

`RunConsoleStderrColorFxTest` (FX): a stderr line gets the `run-stderr` style class; a stdout line doesn't. Verified to fail without the coloring. The two existing console tests were updated for the `CodeArea` (`RunPanelFxTest` reads `getText()` off it; `ConsoleFontFxTest` checks the inline-style font survives a CSS pass).

## Scope

The Run console (the reported one). The External Tools console (one-shot capture) and the Debug console (category-based append) use different output models — coloring those is a possible follow-up.

Closes #558

🤖 Generated with [Claude Code](https://claude.com/claude-code)
