### PR TITLE
External Tools + Debug consoles: color stderr too (#560)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,8 +36,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- **The Run console now colors error output.** A program's stderr (e.g. a Python traceback) is tinted so it
-  stands out from normal output, instead of appearing in the same plain color. (#558)
+- **The Run, External Tools, and Debug consoles now color error output.** A program's stderr (e.g. a Python
+  traceback) is tinted so it stands out from normal output, instead of appearing in the same plain color.
+  (#558, #560)
 - **The command palette now shows commands that can't run in the current context, grayed out**, instead of
   hiding them. A command for a disabled feature (e.g. Git commands while Git is off) is listed with its
   keybinding but dimmed and non-actionable, so you can see it exists. (#532)

--- a/src/main/java/com/editora/ui/DebugPanel.java
+++ b/src/main/java/com/editora/ui/DebugPanel.java
@@ -1,5 +1,6 @@
 package com.editora.ui;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.function.Consumer;
 
@@ -14,7 +15,6 @@ import javafx.scene.control.ListCell;
 import javafx.scene.control.ListView;
 import javafx.scene.control.Separator;
 import javafx.scene.control.SplitPane;
-import javafx.scene.control.TextArea;
 import javafx.scene.control.TextField;
 import javafx.scene.control.Tooltip;
 import javafx.scene.control.TreeCell;
@@ -30,6 +30,10 @@ import javafx.util.StringConverter;
 
 import com.editora.dap.DapManager;
 import com.editora.dap.DapModels;
+import org.fxmisc.flowless.VirtualizedScrollPane;
+import org.fxmisc.richtext.CodeArea;
+import org.fxmisc.richtext.model.StyleSpans;
+import org.fxmisc.richtext.model.StyleSpansBuilder;
 
 import static com.editora.i18n.Messages.tr;
 
@@ -98,7 +102,7 @@ public final class DebugPanel extends VBox implements ToolWindowContent {
     private final ComboBox<DapModels.ThreadInfo> threads = new ComboBox<>();
     private final ListView<DapModels.StackFrameInfo> stack = new ListView<>();
     private final TreeView<VarRow> variables = new TreeView<>();
-    private final TextArea console = new TextArea();
+    private final CodeArea console = new CodeArea();
     private final TextField evalInput = new TextField();
 
     private int selectedFrameId = -1;
@@ -253,7 +257,7 @@ public final class DebugPanel extends VBox implements ToolWindowContent {
 
         console.setEditable(false);
         console.setWrapText(false);
-        console.getStyleClass().add("debug-console");
+        console.getStyleClass().addAll("editor-area", "debug-console");
         RunPanel.installLinkClicks(console, () -> onLink); // double-click a stack-trace line → jump
         evalInput.getStyleClass().add("debug-eval");
         evalInput.setPromptText(tr("debugpanel.evalPrompt"));
@@ -269,8 +273,9 @@ public final class DebugPanel extends VBox implements ToolWindowContent {
         top.setOrientation(Orientation.HORIZONTAL);
         top.setDividerPositions(0.42);
 
-        VBox consoleBox = new VBox(2, sectionLabel("debugpanel.console"), console, evalInput);
-        VBox.setVgrow(console, Priority.ALWAYS);
+        VirtualizedScrollPane<CodeArea> consoleScroll = new VirtualizedScrollPane<>(console);
+        VBox consoleBox = new VBox(2, sectionLabel("debugpanel.console"), consoleScroll, evalInput);
+        VBox.setVgrow(consoleScroll, Priority.ALWAYS);
         SplitPane main = new SplitPane(top, consoleBox);
         main.setOrientation(Orientation.VERTICAL);
         main.setDividerPositions(0.6);
@@ -584,24 +589,31 @@ public final class DebugPanel extends VBox implements ToolWindowContent {
         }
     }
 
-    /** Matches the console font to the editor's code-area font (family + effective size). Sets the
-     *  control's {@code font} property directly (user-set, so the {@code .debug-console} stylesheet rule
-     *  can't override it) rather than {@code -fx-font-size} via setStyle, which a TextArea ignores. */
+    /** Matches the console font to the editor's code-area font (family + effective size). */
     public void setConsoleFont(String family, int size) {
-        console.setFont(javafx.scene.text.Font.font(family, size));
+        console.setStyle("-fx-font-family: \"" + family + "\"; -fx-font-size: " + size + "px;");
     }
 
-    /** Appends program/console output (trimmed to a cap), auto-scrolling to the bottom. */
+    /** Appends program/console output (trimmed to a cap), auto-scrolling to the bottom. The DAP {@code stderr}
+     *  category is tinted ({@code .text.run-stderr}) so error output stands out from normal program output. */
     public void appendOutput(String text, String category) {
         if (text == null) {
             return;
         }
+        int start = console.getLength();
         console.appendText(text);
+        if ("stderr".equals(category) && !text.isEmpty()) {
+            StyleSpans<Collection<String>> spans = new StyleSpansBuilder<Collection<String>>()
+                    .add(List.of("run-stderr"), text.length())
+                    .create();
+            console.setStyleSpans(start, spans);
+        }
         int len = console.getLength();
         if (len > MAX_CONSOLE_CHARS) {
             console.deleteText(0, len - MAX_CONSOLE_CHARS);
         }
-        console.positionCaret(console.getLength());
+        console.moveTo(console.getLength());
+        console.requestFollowCaret();
     }
 
     private void runEval() {

--- a/src/main/java/com/editora/ui/ExternalToolPanel.java
+++ b/src/main/java/com/editora/ui/ExternalToolPanel.java
@@ -1,18 +1,23 @@
 package com.editora.ui;
 
+import java.util.Collection;
+import java.util.List;
 import java.util.function.Consumer;
 
 import javafx.geometry.Insets;
 import javafx.geometry.Pos;
 import javafx.scene.control.Button;
 import javafx.scene.control.Label;
-import javafx.scene.control.TextArea;
 import javafx.scene.layout.HBox;
 import javafx.scene.layout.Priority;
 import javafx.scene.layout.Region;
 import javafx.scene.layout.VBox;
 
 import com.editora.run.StackTraceLinks;
+import org.fxmisc.flowless.VirtualizedScrollPane;
+import org.fxmisc.richtext.CodeArea;
+import org.fxmisc.richtext.model.StyleSpans;
+import org.fxmisc.richtext.model.StyleSpansBuilder;
 
 import static com.editora.i18n.Messages.tr;
 
@@ -20,15 +25,16 @@ import static com.editora.i18n.Messages.tr;
  * The "External Tools" output tool window: a read-only console showing the captured stdout/stderr of a
  * one-shot external-tool run, with a header (tool — command, exit code) and a Clear action. A
  * {@link ToolWindowContent} modeled on {@link RunPanel} but without the Stop/stdin controls (External Tools
- * runs are one-shot; stdin, if any, is fed at launch). Reuses the {@code run-*} styles + the shared
- * double-click stack-trace link handler so paths in output are clickable.
+ * runs are one-shot; stdin, if any, is fed at launch). A RichTextFX {@link CodeArea} so stderr is colored
+ * ({@code .text.run-stderr}); reuses the {@code run-*} styles + the shared double-click stack-trace link
+ * handler so paths in output are clickable.
  */
 public final class ExternalToolPanel extends VBox implements ToolWindowContent {
 
     private static final int MAX_CHARS = 200_000;
 
     private final Label status = new Label();
-    private final TextArea output = new TextArea();
+    private final CodeArea output = new CodeArea();
     private Consumer<StackTraceLinks.Link> onLink;
 
     public ExternalToolPanel() {
@@ -47,22 +53,21 @@ public final class ExternalToolPanel extends VBox implements ToolWindowContent {
 
         output.setEditable(false);
         output.setWrapText(false);
-        output.getStyleClass().add("run-output");
+        output.getStyleClass().addAll("editor-area", "run-output");
         RunPanel.installLinkClicks(output, () -> onLink);
 
-        VBox.setVgrow(output, Priority.ALWAYS);
-        getChildren().addAll(header, output);
+        VirtualizedScrollPane<CodeArea> scroll = new VirtualizedScrollPane<>(output);
+        VBox.setVgrow(scroll, Priority.ALWAYS);
+        getChildren().addAll(header, scroll);
     }
 
     public void setOnLink(Consumer<StackTraceLinks.Link> onLink) {
         this.onLink = onLink;
     }
 
-    /** Matches the console font to the editor's code-area font (family + effective size). Sets the
-     *  control's {@code font} property directly (user-set, so the {@code .run-output} stylesheet rule
-     *  can't override it) rather than {@code -fx-font-size} via setStyle, which a TextArea ignores. */
+    /** Matches the console font to the editor's code-area font (family + effective size). */
     public void setOutputFont(String family, int size) {
-        output.setFont(javafx.scene.text.Font.font(family, size));
+        output.setStyle("-fx-font-family: \"" + family + "\"; -fx-font-size: " + size + "px;");
     }
 
     /** Clears the output console (the Clear button + the {@code externalTool.clearOutput} palette command). */
@@ -71,7 +76,8 @@ public final class ExternalToolPanel extends VBox implements ToolWindowContent {
         status.setText(tr("externalTool.idle"));
     }
 
-    /** Shows one tool run's output: a header (name + command), then stdout, then stderr, then the status line. */
+    /** Shows one tool run's output: a header (name + command), then stdout, then stderr (colored), then the
+     *  status line. */
     public void show(String toolName, String commandLine, String out, String err, int exit) {
         status.setText(exit == 0 ? tr("externalTool.done", toolName) : tr("externalTool.exited", toolName, exit));
         StringBuilder sb = new StringBuilder();
@@ -82,23 +88,34 @@ public final class ExternalToolPanel extends VBox implements ToolWindowContent {
                 sb.append('\n');
             }
         }
+        int errStart = sb.length();
         if (err != null && !err.isEmpty()) {
             sb.append(err);
             if (!err.endsWith("\n")) {
                 sb.append('\n');
             }
         }
-        setText(sb.toString());
+        setText(sb.toString(), errStart, sb.length() - errStart);
     }
 
-    private void setText(String text) {
-        String t = text;
-        if (t.length() > MAX_CHARS) {
-            t = t.substring(t.length() - MAX_CHARS);
+    /** Replaces the console text and tints the {@code [errStart, errStart+errLen)} stderr range, accounting for
+     *  any front-trim done to honor the char cap. */
+    private void setText(String text, int errStart, int errLen) {
+        int cut = Math.max(0, text.length() - MAX_CHARS);
+        String t = cut > 0 ? text.substring(cut) : text;
+        output.replaceText(t);
+        if (errLen > 0) {
+            int start = Math.max(0, errStart - cut);
+            int end = Math.min(t.length(), errStart + errLen - cut);
+            if (end > start) {
+                StyleSpans<Collection<String>> spans = new StyleSpansBuilder<Collection<String>>()
+                        .add(List.of("run-stderr"), end - start)
+                        .create();
+                output.setStyleSpans(start, spans);
+            }
         }
-        output.setText(t);
-        output.positionCaret(output.getLength());
-        output.setScrollTop(Double.MAX_VALUE);
+        output.moveTo(output.getLength());
+        output.requestFollowCaret();
     }
 
     private static Region spacer() {

--- a/src/test/java/com/editora/ui/DebugConsoleColorFxTest.java
+++ b/src/test/java/com/editora/ui/DebugConsoleColorFxTest.java
@@ -1,0 +1,64 @@
+package com.editora.ui;
+
+import java.lang.reflect.Proxy;
+import java.util.Collection;
+
+import org.fxmisc.richtext.CodeArea;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Regression for #560: the Debug console colors the DAP {@code stderr} category. A debuggee's stderr output gets
+ * the {@code run-stderr} style so it stands out from normal ({@code stdout}/{@code console}) output.
+ */
+@Tag("fx")
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class DebugConsoleColorFxTest {
+
+    @BeforeAll
+    void setUp() throws Exception {
+        FxTestSupport.bootToolkit();
+    }
+
+    /** A no-op {@link DebugPanel.Actions} (14 methods) via a dynamic proxy — appendOutput never invokes it. */
+    private static DebugPanel.Actions noopActions() {
+        return (DebugPanel.Actions) Proxy.newProxyInstance(
+                DebugPanel.Actions.class.getClassLoader(), new Class[] {DebugPanel.Actions.class}, (p, m, a) -> {
+                    Class<?> rt = m.getReturnType();
+                    if (rt == boolean.class) {
+                        return false;
+                    }
+                    if (rt == int.class) {
+                        return 0;
+                    }
+                    if (rt == long.class) {
+                        return 0L;
+                    }
+                    return null;
+                });
+    }
+
+    @Test
+    void stderrCategoryIsColoredAndStdoutIsNot() throws Exception {
+        boolean[] flags = FxTestSupport.callOnFx(() -> {
+            DebugPanel panel = new DebugPanel(noopActions());
+            CodeArea console = FxTestSupport.field(panel, "console");
+
+            panel.appendOutput("Exception in thread main\n", "stderr");
+            panel.appendOutput("normal program output\n", "stdout");
+
+            String text = console.getText();
+            Collection<String> stderrStyle = console.getStyleOfChar(text.indexOf("Exception in thread main"));
+            Collection<String> stdoutStyle = console.getStyleOfChar(text.indexOf("normal program output"));
+            return new boolean[] {stderrStyle.contains("run-stderr"), stdoutStyle.contains("run-stderr")};
+        });
+
+        assertTrue(flags[0], "the DAP stderr category is tinted with run-stderr");
+        assertFalse(flags[1], "the stdout category is not tinted");
+    }
+}

--- a/src/test/java/com/editora/ui/ExternalToolConsoleColorFxTest.java
+++ b/src/test/java/com/editora/ui/ExternalToolConsoleColorFxTest.java
@@ -1,0 +1,44 @@
+package com.editora.ui;
+
+import java.util.Collection;
+
+import org.fxmisc.richtext.CodeArea;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Regression for #560: the External Tools console colors stderr. {@code show(...)} receives stdout and stderr as
+ * separate strings; the stderr region gets the {@code run-stderr} style so a tool's error output stands out.
+ */
+@Tag("fx")
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class ExternalToolConsoleColorFxTest {
+
+    @BeforeAll
+    void setUp() throws Exception {
+        FxTestSupport.bootToolkit();
+    }
+
+    @Test
+    void stderrRangeIsColoredAndStdoutIsNot() throws Exception {
+        boolean[] flags = FxTestSupport.callOnFx(() -> {
+            ExternalToolPanel panel = new ExternalToolPanel();
+            CodeArea out = FxTestSupport.field(panel, "output");
+
+            panel.show("fmt", "fmt file.txt", "clean stdout line\n", "error: something broke\n", 1);
+
+            String text = out.getText();
+            Collection<String> stderrStyle = out.getStyleOfChar(text.indexOf("error: something broke"));
+            Collection<String> stdoutStyle = out.getStyleOfChar(text.indexOf("clean stdout line"));
+            return new boolean[] {stderrStyle.contains("run-stderr"), stdoutStyle.contains("run-stderr")};
+        });
+
+        assertTrue(flags[0], "the stderr region is tinted with run-stderr");
+        assertFalse(flags[1], "the stdout region is not tinted");
+    }
+}

--- a/src/test/java/com/editora/ui/ExternalToolPanelFxTest.java
+++ b/src/test/java/com/editora/ui/ExternalToolPanelFxTest.java
@@ -1,7 +1,6 @@
 package com.editora.ui;
 
-import javafx.scene.control.TextArea;
-
+import org.fxmisc.richtext.CodeArea;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -28,7 +27,7 @@ class ExternalToolPanelFxTest {
     }
 
     private static String output(ExternalToolPanel p) throws Exception {
-        TextArea out = FxTestSupport.field(p, "output");
+        CodeArea out = FxTestSupport.field(p, "output");
         return FxTestSupport.callOnFx(out::getText);
     }
 


### PR DESCRIPTION
## Summary

Follow-up to #559 — extends stderr coloring to the other two program-output consoles.

- The **External Tools** console (`ExternalToolPanel`) showed a one-shot run's stdout + stderr in a plain `TextArea`, so errors weren't distinguished. It already receives stdout and stderr as separate strings.
- The **Debug** console (`DebugPanel`) streamed the debuggee's output in a plain `TextArea`, so a DAP `stderr` event looked identical to `stdout`. The stream is already known (the DAP output `category`).

## Fix

Switch both consoles from `TextArea` to a RichTextFX `CodeArea` (like the Run and build consoles) and tint stderr with the shared `.text.run-stderr` class:
- `ExternalToolPanel.show(...)` styles the stderr region (offset-tracked, and cap-aware — it adjusts the range if the front is trimmed to honor the char cap).
- `DebugPanel.appendOutput(text, category)` styles the line when `category == "stderr"`; `stdout`/`console` (the eval REPL echo) stay default.

Clickable stack-trace links, the char cap, and auto-scroll carry over to the `CodeArea` path; the console font moves to inline `setStyle` (matching the Run/build consoles).

## Test

`ExternalToolConsoleColorFxTest` and `DebugConsoleColorFxTest` (FX): the stderr region/category gets the `run-stderr` class while stdout doesn't. Both verified to fail without the coloring. `ExternalToolPanelFxTest` updated to read `getText()` off the `CodeArea`.

Closes #560
Now all three run-style consoles (Run, External Tools, Debug) color error output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
