### PR TITLE
Git Log: color the rows + use real file-type icons (#562)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **The Git Log tool window is colored and uses real file icons.** Each commit's short hash reads in the accent
+  color, and the changed-files list colors each row by its status (added/modified/deleted/renamed) with the
+  actual file-type icon — matching the Commit tool window and Project tree — instead of flat text and a generic
+  sheet icon. (#562)
 - **The Run, External Tools, and Debug consoles now color error output.** A program's stderr (e.g. a Python
   traceback) is tinted so it stands out from normal output, instead of appearing in the same plain color.
   (#558, #560)

--- a/src/main/java/com/editora/git/GitFileStatus.java
+++ b/src/main/java/com/editora/git/GitFileStatus.java
@@ -64,6 +64,19 @@ public enum GitFileStatus {
     }
 
     /**
+     * Classifies a {@code git diff-tree --name-status} letter (a commit's changed file): A/M/D/R/C/T. A copy
+     * (C) is treated like a rename (both are violet). Anything else is modified. Pure.
+     */
+    public static GitFileStatus fromLetter(char c) {
+        return switch (Character.toUpperCase(c)) {
+            case 'A' -> ADDED;
+            case 'D' -> DELETED;
+            case 'R', 'C' -> RENAMED;
+            default -> MODIFIED; // M, T, or anything unexpected
+        };
+    }
+
+    /**
      * Maps every changed file in {@code status} to its {@link GitFileStatus}, keyed by <b>absolute, normalized
      * path</b> resolved against {@code root} (the repo root Git reported paths relative to). A rename is keyed
      * by its new path. Returns an empty map for a non-repo / null input. Pure — no filesystem I/O.

--- a/src/main/java/com/editora/ui/GitLogPanel.java
+++ b/src/main/java/com/editora/ui/GitLogPanel.java
@@ -17,7 +17,10 @@ import javafx.scene.input.MouseButton;
 import javafx.scene.layout.HBox;
 import javafx.scene.layout.Priority;
 import javafx.scene.layout.VBox;
+import javafx.scene.text.Text;
+import javafx.scene.text.TextFlow;
 
+import com.editora.git.GitFileStatus;
 import com.editora.git.GitService.Commit;
 import com.editora.git.GitService.CommitFile;
 
@@ -167,11 +170,18 @@ public final class GitLogPanel extends VBox implements ToolWindowContent {
             super.updateItem(c, empty);
             if (empty || c == null) {
                 setText(null);
+                setGraphic(null);
                 setTooltip(null);
                 setContextMenu(null);
                 return;
             }
-            setText(c.shortHash() + "  " + c.subject());
+            // Color the short hash (accent) apart from the subject (default) so the log reads like a git graph.
+            setText(null);
+            Text hash = new Text(c.shortHash());
+            hash.getStyleClass().add("git-log-hash");
+            Text subject = new Text("  " + c.subject());
+            subject.getStyleClass().add("git-log-subject");
+            setGraphic(new TextFlow(hash, subject));
             setTooltip(new Tooltip(c.subject() + "\n" + c.author() + " · " + c.date() + "\n" + c.hash()));
             setContextMenu(buildMenu(c));
         }
@@ -207,15 +217,26 @@ public final class GitLogPanel extends VBox implements ToolWindowContent {
         @Override
         protected void updateItem(CommitFile f, boolean empty) {
             super.updateItem(f, empty);
+            clearStatusClasses();
             if (empty || f == null) {
                 setText(null);
                 setGraphic(null);
                 setTooltip(null);
                 return;
             }
+            // Color the row by its change status (matching the Commit tool window + Project tree), and use the
+            // real file-type icon (FileIcons) instead of a generic sheet — the .git-tree .git-status-* CSS also
+            // tints the icon (a .toolbar-icon).
+            getStyleClass().add(GitFileStatus.fromLetter(f.status()).cssClass());
             setText(f.status() + "  " + f.path());
-            setGraphic(Icons.fileSheet());
+            setGraphic(FileIcons.forFileName(f.path()));
             setTooltip(new Tooltip(f.origPath() != null ? f.origPath() + " → " + f.path() : f.path()));
+        }
+
+        private void clearStatusClasses() {
+            for (GitFileStatus s : GitFileStatus.values()) {
+                getStyleClass().remove(s.cssClass());
+            }
         }
     }
 }

--- a/src/main/resources/com/editora/styles/app.css
+++ b/src/main/resources/com/editora/styles/app.css
@@ -865,6 +865,9 @@
 .project-tree .git-status-deleted, .git-tree .git-status-deleted { -fx-text-fill: -color-fg-muted; }
 .project-tree .git-status-deleted .toolbar-icon, .git-tree .git-status-deleted .toolbar-icon { -fx-fill: -color-fg-muted; }
 .project-tree .git-status-dir-changed { -fx-text-fill: -color-accent-fg; }
+/* Git Log commit list: the short hash reads in the accent color, the subject in the default text color. */
+.git-log-panel .git-log-hash { -fx-fill: -color-accent-fg; }
+.git-log-panel .git-log-subject { -fx-fill: -color-fg-default; }
 /* Unsaved/dirty buffer name in the pickers (Open Files palette + Switcher) — mirrors the dirty-tab
    treatment (amber italic) so every surface that lists open files reads consistently. */
 .dirty-name { -fx-text-fill: #bf8700; -fx-font-style: italic; }

--- a/src/test/java/com/editora/git/GitFileStatusTest.java
+++ b/src/test/java/com/editora/git/GitFileStatusTest.java
@@ -32,6 +32,19 @@ class GitFileStatusTest {
     }
 
     @Test
+    void fromLetterMapsNameStatusCodesForTheGitLog() {
+        assertEquals(GitFileStatus.ADDED, GitFileStatus.fromLetter('A'));
+        assertEquals(GitFileStatus.MODIFIED, GitFileStatus.fromLetter('M'));
+        assertEquals(GitFileStatus.DELETED, GitFileStatus.fromLetter('D'));
+        assertEquals(GitFileStatus.RENAMED, GitFileStatus.fromLetter('R'));
+        assertEquals(GitFileStatus.RENAMED, GitFileStatus.fromLetter('C'), "a copy is colored like a rename");
+        assertEquals(GitFileStatus.MODIFIED, GitFileStatus.fromLetter('T'), "a type change is modified");
+        assertEquals(GitFileStatus.ADDED, GitFileStatus.fromLetter('a'), "case-insensitive");
+        assertEquals(
+                GitFileStatus.MODIFIED, GitFileStatus.fromLetter('X'), "an unexpected letter defaults to modified");
+    }
+
+    @Test
     void deletedAndAddedTakePrecedenceOverModified() {
         // A file staged-added but also worktree-deleted → deletion wins (it's gone).
         assertEquals(GitFileStatus.DELETED, GitFileStatus.of(new FileEntry("x", 'A', 'D', null)));

--- a/src/test/java/com/editora/ui/GitLogColorFxTest.java
+++ b/src/test/java/com/editora/ui/GitLogColorFxTest.java
@@ -1,0 +1,84 @@
+package com.editora.ui;
+
+import java.lang.reflect.Proxy;
+
+import javafx.scene.Node;
+import javafx.scene.control.ListCell;
+import javafx.scene.control.ListView;
+import javafx.scene.text.Text;
+import javafx.scene.text.TextFlow;
+
+import com.editora.git.GitService.Commit;
+import com.editora.git.GitService.CommitFile;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Regression for #562: the Git Log tool window colors its rows and uses real file icons. A changed-file row is
+ * tinted by its git status ({@code .git-status-*}) and shows the file-type icon (not a generic sheet); a commit
+ * row renders its short hash in the accent color ({@code .git-log-hash}).
+ */
+@Tag("fx")
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class GitLogColorFxTest {
+
+    @BeforeAll
+    void setUp() throws Exception {
+        FxTestSupport.bootToolkit();
+    }
+
+    private static GitLogPanel.Actions noopActions() {
+        return (GitLogPanel.Actions) Proxy.newProxyInstance(
+                GitLogPanel.Actions.class.getClassLoader(), new Class[] {GitLogPanel.Actions.class}, (p, m, a) -> null);
+    }
+
+    @Test
+    void changedFileRowIsStatusColoredWithARealIcon() throws Exception {
+        boolean[] r = FxTestSupport.callOnFx(() -> {
+            GitLogPanel panel = new GitLogPanel(noopActions());
+            ListView<CommitFile> files = FxTestSupport.field(panel, "files");
+            ListCell<CommitFile> cell = files.getCellFactory().call(files);
+            FxTestSupport.call(
+                    cell,
+                    "updateItem",
+                    new Class[] {Object.class, boolean.class},
+                    new CommitFile('A', "Foo.java", null),
+                    false);
+            boolean colored = cell.getStyleClass().contains("git-status-added");
+            boolean hasIcon = cell.getGraphic() != null;
+            return new boolean[] {colored, hasIcon};
+        });
+        assertTrue(r[0], "an added file row gets the git-status-added color class");
+        assertTrue(r[1], "the row shows a file-type icon");
+    }
+
+    @Test
+    void commitRowRendersTheShortHashInTheAccentColor() throws Exception {
+        Node[] graphic = new Node[1];
+        FxTestSupport.runOnFx(() -> {
+            GitLogPanel panel = new GitLogPanel(noopActions());
+            ListView<Commit> commits = FxTestSupport.field(panel, "commits");
+            ListCell<Commit> cell = commits.getCellFactory().call(commits);
+            FxTestSupport.call(
+                    cell,
+                    "updateItem",
+                    new Class[] {Object.class, boolean.class},
+                    new Commit("abc1234def", "abc1234", "Fix the thing", "Ada", "2026-07-18"),
+                    false);
+            graphic[0] = cell.getGraphic();
+        });
+
+        TextFlow flow =
+                assertInstanceOf(TextFlow.class, graphic[0], "commit row is a TextFlow (colored hash + subject)");
+        Text hash = (Text) flow.getChildren().get(0);
+        assertNotNull(hash);
+        assertTrue(hash.getStyleClass().contains("git-log-hash"), "the short hash carries the git-log-hash class");
+        assertTrue(hash.getText().startsWith("abc1234"), "the hash text is the short hash: " + hash.getText());
+    }
+}


### PR DESCRIPTION
## Summary

The Git Log tool window showed flat gray text and a generic sheet icon for every changed file. This colors it and uses the real file-type icons, consistent with the Commit tool window and Project tree.

- **Commit list:** each commit's short hash now renders in the accent color (`.git-log-hash`) apart from the subject (default text color), via a small `TextFlow` — so the log reads with structure like a git graph.
- **Changed-files list:** each row is colored by its change status — added/green, modified/blue, deleted/gray, renamed/violet — reusing the existing `.git-tree .git-status-*` classes that already color the Commit tool window and Project tree (and tint the icon). A new pure `GitFileStatus.fromLetter(char)` maps the `git diff-tree --name-status` letter (A/M/D/R/C/T) to the status.
- **Real icons:** rows use `FileIcons.forFileName(path)` (the Project-tree file-type glyphs) instead of `Icons.fileSheet()`; the status color also tints the glyph via the shared `.git-tree .git-status-* .toolbar-icon` CSS.

## Test

- `GitFileStatusTest` — new cases for `fromLetter` (A/M/D/R/C/T, case-insensitive, unknown→modified).
- `GitLogColorFxTest` (FX) — drives the `FileCell` (asserts the `git-status-added` class + a non-null icon) and the `CommitCell` (a `TextFlow` whose hash carries `git-log-hash`). Both verified to fail when the color/icon wiring is removed.

Closes #562

🤖 Generated with [Claude Code](https://claude.com/claude-code)
