### PR TITLE
Fix master: #564 broke the build (FileFinder.setKeymap) + LSP disable-clear

### DIFF
--- a/src/main/java/com/editora/ui/LspCoordinator.java
+++ b/src/main/java/com/editora/ui/LspCoordinator.java
@@ -331,9 +331,16 @@ final class LspCoordinator {
     private void clearDiagnosticsForServer(String serverId) {
         host.forEachBuffer(b -> {
             Path p = b.getPath();
-            // Match by the server actually managing the buffer, not a re-derivation — so it stays correct when
-            // the server is mid-disable (its enable flag already flipped) and for a filename-routed pom.xml.
-            if (p == null || !serverId.equals(lspManager.managedServerId(p))) {
+            if (p == null) {
+                return;
+            }
+            // Prefer the server actually managing the buffer (correct for a filename-routed pom.xml). But when no
+            // live session manages it — the disable path shuts the session down, and diagnostics can exist without
+            // a running server — fall back to the buffer's statically-resolved server id, so a disabled server's
+            // diagnostics still get cleared (#469, regressed by #564's managedServerId-only match).
+            String managing = lspManager.managedServerId(p);
+            String resolved = managing != null ? managing : serverIdForBuffer(b);
+            if (!serverId.equals(resolved)) {
                 return;
             }
             b.setLspActive(false); // drop the editor squiggle overlay/stripes immediately

--- a/src/main/java/com/editora/ui/MainController.java
+++ b/src/main/java/com/editora/ui/MainController.java
@@ -1014,9 +1014,7 @@ public class MainController implements com.editora.mcp.McpBridge {
         snippetPalette.setOverlayHost(overlayHost);
         projectPicker.setOverlayHost(overlayHost);
         fileFinder.setOverlayHost(overlayHost);
-        fileFinder.setKeymap(keymap);
         folderFinder.setOverlayHost(overlayHost);
-        folderFinder.setKeymap(keymap);
         switcher.setOverlayHost(overlayHost);
         branchPopup.setOverlayHost(overlayHost);
         statusBar.setOverlayHost(overlayHost);


### PR DESCRIPTION
## Hotfix: master is red

PR #564 ("LSP: Maven-aware pom.xml server", commit `b1c309aa`) was **merged with failing CI** and broke `master`. My bookmarks PR #566 merged on top and inherited it. Two problems (the compile error masked the second):

**1. Build broken.** `MainController.wireOverlayHost` calls `fileFinder.setKeymap(keymap)` / `folderFinder.setKeymap(keymap)`, but `FileFinder` has **no `setKeymap` method** (and never has — its key hint is a hardcoded string, nothing in it is keymap-driven). These calls are a stale-base artifact. Removed.

**2. LSP regression.** #564 changed `clearDiagnosticsForServer` to match a buffer only by `lspManager.managedServerId(p)`. When a server is being *disabled*, its session is already gone (and diagnostics can exist without a live session), so `managedServerId` returns `null`, nothing matches, and diagnostics aren't cleared — regressing #469's guarantee (`LspDisableClearsDiagnosticsFxTest`). Fix: fall back to the buffer's statically-resolved server id (`serverIdForBuffer`, which already handles `pom.xml → maven-pom`) when no live session manages it — keeping #564's pom-routing intent while restoring the disable-clear.

Both verified: `LspDisableClearsDiagnosticsFxTest` passes, full suite green (2318).

Note for the #564 author: this repairs your merge forward rather than reverting it, so the Maven-pom feature stays. Please double-check the `clearDiagnosticsForServer` fallback matches your routing intent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
