### PR TITLE
Popups: Emacs keybindings in every popup text field + no default selection

### DIFF
--- a/src/main/java/com/editora/App.java
+++ b/src/main/java/com/editora/App.java
@@ -97,6 +97,9 @@ public class App extends Application {
         KeymapManager keymap = new KeymapManager();
         keymap.loadNamed(settings.getKeymap());
         keymap.applyOverrides(settings.getKeybindings());
+        // Make the (single, shared) keymap available to generic popup text fields so they can install Emacs
+        // caret movement + basic editing without threading it through their constructors (see TextInputKeymap).
+        com.editora.command.TextInputKeymap.setShared(keymap);
 
         // Experiment: on macOS, render the UI chrome in the native system font (San Francisco) instead of
         // AtlantaFX's Inter — across every window. A listener on the live window list covers windows

--- a/src/main/java/com/editora/command/TextInputKeymap.java
+++ b/src/main/java/com/editora/command/TextInputKeymap.java
@@ -27,7 +27,24 @@ public final class TextInputKeymap {
 
     private static final Map<String, Consumer<TextInputControl>> ACTIONS = actions();
 
+    /**
+     * The single app-wide {@link KeymapManager} (one instance, reloaded in place on a keymap switch — see
+     * {@code WindowManager.reloadSharedKeymap}), set once at startup so generic popup text fields can install
+     * Emacs bindings via {@link #installShared} without threading the keymap through their constructors.
+     */
+    private static volatile KeymapManager shared;
+
     private TextInputKeymap() {}
+
+    /** Registers the app-wide keymap used by {@link #installShared}. Call once at startup. */
+    public static void setShared(KeymapManager keymap) {
+        shared = keymap;
+    }
+
+    /** Installs the shared configured-keymap bindings on {@code control} (no-op until {@link #setShared}). */
+    public static void installShared(TextInputControl control) {
+        install(control, shared);
+    }
 
     /** Installs configured-keymap caret movement + basic editing on {@code control}. */
     public static void install(TextInputControl control, KeymapManager keymap) {
@@ -37,6 +54,9 @@ public final class TextInputKeymap {
         boolean[] consumed = {false};
         control.addEventFilter(KeyEvent.KEY_PRESSED, e -> {
             consumed[0] = false;
+            if (e.isConsumed()) {
+                return; // an earlier filter (e.g. a picker's list navigation) already claimed this chord
+            }
             String token = KeyDispatcher.chord(e);
             if (token == null) {
                 return;

--- a/src/main/java/com/editora/ui/BranchPopup.java
+++ b/src/main/java/com/editora/ui/BranchPopup.java
@@ -84,6 +84,8 @@ public final class BranchPopup {
 
         search.textProperty().addListener((o, a, b) -> filter(b));
         search.addEventFilter(KeyEvent.KEY_PRESSED, this::onKey);
+        // Emacs caret movement + basic editing (list navigation stays with onKey, registered first).
+        com.editora.command.TextInputKeymap.installShared(search);
 
         titleLabel.getStyleClass().add("palette-title");
         remoteUrlLabel.getStyleClass().add("branch-remote-url");

--- a/src/main/java/com/editora/ui/CommandPalette.java
+++ b/src/main/java/com/editora/ui/CommandPalette.java
@@ -112,6 +112,9 @@ public class CommandPalette {
 
         input.textProperty().addListener((obs, old, now) -> filter(now));
         input.addEventFilter(KeyEvent.KEY_PRESSED, this::onKey);
+        // Emacs caret movement + basic editing in the query field. Registered after onKey so the palette's own
+        // list navigation / C-h docs (C-n/C-p/C-g/C-h) consume those chords first and the keymap yields to it.
+        com.editora.command.TextInputKeymap.install(input, keymap);
         // The opening chord (e.g. M-x) is Alt/Meta+key; on macOS that combination also emits a
         // KEY_TYPED for a special character (Option+x => "≈") that would land in the just-focused
         // field. Swallow any character typed while a chord modifier is held; plain query typing

--- a/src/main/java/com/editora/ui/FileFinder.java
+++ b/src/main/java/com/editora/ui/FileFinder.java
@@ -12,6 +12,7 @@ import java.util.function.Consumer;
 import java.util.function.Supplier;
 import java.util.stream.Stream;
 
+import javafx.application.Platform;
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
 import javafx.geometry.Pos;
@@ -25,6 +26,8 @@ import javafx.scene.layout.HBox;
 import javafx.scene.layout.Region;
 import javafx.scene.layout.VBox;
 import javafx.stage.Window;
+
+import com.editora.command.TextInputKeymap;
 
 import static com.editora.i18n.Messages.tr;
 
@@ -82,6 +85,9 @@ public class FileFinder {
 
         input.textProperty().addListener((obs, old, now) -> refresh(now));
         input.addEventFilter(KeyEvent.KEY_PRESSED, this::onKey);
+        // Emacs caret movement + basic editing in the path field. Registered after onKey so the finder's own
+        // list navigation (C-n/C-p/C-g) consumes those chords first and the keymap yields to it (isConsumed).
+        TextInputKeymap.installShared(input);
         // macOS Option-composed chars while a chord modifier is held are swallowed; the opening chord's
         // trailing KEY_TYPED is already swallowed by the global KeyDispatcher (card is in the main scene).
         if (IS_MAC) {
@@ -126,7 +132,12 @@ public class FileFinder {
                 content,
                 () -> {
                     input.requestFocus();
-                    input.positionCaret(input.getText().length());
+                    // A TextField selects all its text on focus-gain (asynchronously), which would highlight the
+                    // pre-filled path; clear the selection after focus settles and leave the caret at the end.
+                    Platform.runLater(() -> {
+                        input.deselect();
+                        input.positionCaret(input.getText().length());
+                    });
                 },
                 () -> showing = false);
     }

--- a/src/main/java/com/editora/ui/MainController.java
+++ b/src/main/java/com/editora/ui/MainController.java
@@ -982,9 +982,7 @@ public class MainController implements com.editora.mcp.McpBridge {
         snippetPalette.setOverlayHost(overlayHost);
         projectPicker.setOverlayHost(overlayHost);
         fileFinder.setOverlayHost(overlayHost);
-        fileFinder.setKeymap(keymap);
         folderFinder.setOverlayHost(overlayHost);
-        folderFinder.setKeymap(keymap);
         switcher.setOverlayHost(overlayHost);
         branchPopup.setOverlayHost(overlayHost);
         statusBar.setOverlayHost(overlayHost);

--- a/src/main/java/com/editora/ui/QuickOpen.java
+++ b/src/main/java/com/editora/ui/QuickOpen.java
@@ -143,6 +143,9 @@ public class QuickOpen<T> {
 
         input.textProperty().addListener((obs, old, now) -> filter(now));
         input.addEventFilter(KeyEvent.KEY_PRESSED, this::onKey);
+        // Emacs caret movement + basic editing in the query field. Registered after onKey so the picker's own
+        // list navigation (C-n/C-p/C-g) consumes those chords first and the keymap yields to it (isConsumed).
+        com.editora.command.TextInputKeymap.installShared(input);
         // On macOS the opening chord can emit an Option-composed character; swallow chars typed with a
         // chord modifier held (plain typing passes through). The opening chord's trailing KEY_TYPED is
         // already swallowed by the global KeyDispatcher (the card lives in the main scene now).

--- a/src/main/java/com/editora/ui/SearchInFilesPopup.java
+++ b/src/main/java/com/editora/ui/SearchInFilesPopup.java
@@ -113,6 +113,8 @@ final class SearchInFilesPopup {
         query.setPromptText(tr("search.queryPrompt"));
         query.textProperty().addListener((o, a, b) -> debounce.playFromStart());
         query.addEventFilter(KeyEvent.KEY_PRESSED, this::onQueryKey);
+        // Emacs caret movement + basic editing (registered after onQueryKey so its list navigation wins).
+        com.editora.command.TextInputKeymap.installShared(query);
         if (IS_MAC) {
             // Swallow Option-composed chars from the opening chord / chorded keys (mirrors QuickOpen).
             query.addEventFilter(KeyEvent.KEY_TYPED, e -> {
@@ -150,6 +152,9 @@ final class SearchInFilesPopup {
         exclude.setPromptText(tr("search.excludePrompt"));
         include.textProperty().addListener((o, a, b) -> debounce.playFromStart());
         exclude.textProperty().addListener((o, a, b) -> debounce.playFromStart());
+        com.editora.command.TextInputKeymap.installShared(rootField);
+        com.editora.command.TextInputKeymap.installShared(include);
+        com.editora.command.TextInputKeymap.installShared(exclude);
         HBox.setHgrow(include, Priority.ALWAYS);
         HBox.setHgrow(exclude, Priority.ALWAYS);
         HBox globRow = new HBox(6, include, exclude);

--- a/src/main/java/com/editora/ui/WorkspaceSymbolPopup.java
+++ b/src/main/java/com/editora/ui/WorkspaceSymbolPopup.java
@@ -74,6 +74,8 @@ final class WorkspaceSymbolPopup {
         query.setPromptText(tr("lsp.workspaceSymbols.prompt"));
         query.textProperty().addListener((o, a, b) -> debounce.playFromStart());
         query.addEventFilter(KeyEvent.KEY_PRESSED, this::onQueryKey);
+        // Emacs caret movement + basic editing (registered after onQueryKey so its list navigation wins).
+        com.editora.command.TextInputKeymap.installShared(query);
         if (IS_MAC) {
             query.addEventFilter(KeyEvent.KEY_TYPED, e -> {
                 if (e.isAltDown() || e.isMetaDown() || e.isControlDown() || e.isShortcutDown()) {


### PR DESCRIPTION
## Summary
Every in-scene picker/popup text field now supports basic Emacs caret movement + editing (`C-a`/`C-e`/`C-f`/`C-b`/`M-f`/`M-b`/`C-d`/`C-k`/…): **CommandPalette**, all **QuickOpen** pickers, **FileFinder** (file + folder), **BranchPopup**, **SearchInFilesPopup** (query/root/include/exclude), and **WorkspaceSymbolPopup**. OverlayInput forms (prompts, go-to-line, save-as, git clone, remote connect, note editor, template forms) were already covered by their existing per-field installs.

Also: the **Find File** popup no longer highlights its pre-filled path by default — the `TextField`'s focus-gain select-all is cleared and the caret parked at the end.

## How
- `command/TextInputKeymap`: the key filter now yields to any earlier filter that already consumed the chord (`isConsumed` guard), so a picker's own list navigation (`C-n`/`C-p`/`C-g`) keeps winning. Added a shared app-wide keymap (`setShared`/`installShared`) so generic pickers install bindings without threading the keymap through their constructors (the keymap is a single, in-place-reloaded, app-wide instance).
- `App`: registers the shared keymap at startup, before any window/picker is built.
- Each popup installs *after* its own key filter, so list-nav consumes first and the keymap defers.

## Performance
No hot-path impact — one `KEY_PRESSED` filter per popup field, active only while a popup is open.

## Testing
`mvn compile`, `spotless:apply`, `TextInputKeymapTest`. Not yet eyeballed in the running GUI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)