### PR TITLE
Bookmarks & Notes: per-project delete + cross-project window navigation

### DIFF
--- a/src/main/java/com/editora/ui/BookmarkCoordinator.java
+++ b/src/main/java/com/editora/ui/BookmarkCoordinator.java
@@ -7,7 +7,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.function.Consumer;
 
-import javafx.application.Platform;
 import javafx.scene.control.Alert;
 import javafx.scene.control.ButtonType;
 
@@ -32,6 +31,13 @@ final class BookmarkCoordinator {
         void openPath(Path file);
 
         void navigateToLine(int line);
+
+        /**
+         * Opens {@code file} at 0-based {@code line} in {@code projectKey}'s window ({@code ""} = the
+         * general/no-project window), focusing or creating that window — so activating a bookmark from a
+         * different project switches to (or opens) that project's window instead of opening it out of context.
+         */
+        void openInProjectWindow(String projectKey, Path file, int line);
 
         /** The open buffer for {@code file}, or {@code null} if it isn't open. */
         EditorBuffer bufferForPath(Path file);
@@ -76,23 +82,23 @@ final class BookmarkCoordinator {
         persistDebounce.setOnFinished(e -> flushPendingPersist());
         this.panel = new BookmarksPanel(this::scope, new BookmarksPanel.Actions() {
             @Override
-            public void openAndJump(Path file, int line) {
-                bookmarkActivate(file, line);
+            public void openAndJump(String projectKey, Path file, int line) {
+                bookmarkActivate(projectKey, file, line);
             }
 
             @Override
-            public void setNote(Path file, int line, String note) {
-                bookmarkSetNote(file, line, note);
+            public void setNote(String projectKey, Path file, int line, String note) {
+                bookmarkSetNote(projectKey, file, line, note);
             }
 
             @Override
-            public void delete(Path file, int line) {
-                bookmarkDelete(file, line);
+            public void delete(String projectKey, Path file, int line) {
+                bookmarkDelete(projectKey, file, line);
             }
 
             @Override
-            public void deleteAll(Path file) {
-                bookmarkDeleteAll(file);
+            public void deleteAll(String projectKey, Path file) {
+                bookmarkDeleteAll(projectKey, file);
             }
 
             @Override
@@ -112,7 +118,8 @@ final class BookmarkCoordinator {
                 this::allBookmarkEntries,
                 e -> bookmarkLabel(e.bm()),
                 e -> e.file().getFileName() + ":" + (e.bm().line() + 1),
-                e -> bookmarkActivate(e.file(), e.bm().line()));
+                // The jump picker is scoped to the active project's bookmarks, so they open in this window.
+                e -> bookmarkActivate(ops.currentProjectKey(), e.file(), e.bm().line()));
     }
 
     BookmarksPanel panel() {
@@ -341,48 +348,77 @@ final class BookmarkCoordinator {
         return bm.lineText().isEmpty() ? "line " + (bm.line() + 1) : bm.lineText();
     }
 
-    /** Opens the file (if needed) and jumps to the bookmarked line. */
-    private void bookmarkActivate(Path file, int line) {
-        ops.openPath(file);
-        Platform.runLater(() -> ops.navigateToLine(line));
+    /**
+     * Opens the bookmark's file and jumps to its line — in {@code projectKey}'s window. When the bookmark
+     * belongs to the active window's project this lands in place (same behavior as before); for a General or
+     * cross-project bookmark it focuses (or opens) that project's window (see {@link Ops#openInProjectWindow}).
+     */
+    private void bookmarkActivate(String projectKey, Path file, int line) {
+        ops.openInProjectWindow(projectKey, file, line);
     }
 
-    /** Sets a bookmark's note — via the open buffer if loaded, else directly in the persisted map. */
-    private void bookmarkSetNote(Path file, int line, String note) {
-        EditorBuffer open = ops.bufferForPath(file);
-        if (open != null) {
-            open.getBookmarkManager().setNote(line, note);
-        } else {
-            updateClosedFileBookmarks(
-                    file, marks -> marks.replaceAll(bm -> bm.line() == line ? bm.withNote(note) : bm));
+    /** Sets a bookmark's note — via the open buffer if loaded (active bucket only), else directly in the map. */
+    private void bookmarkSetNote(String projectKey, Path file, int line, String note) {
+        if (isActiveBucket(projectKey)) {
+            EditorBuffer open = ops.bufferForPath(file);
+            if (open != null) {
+                open.getBookmarkManager().setNote(line, note);
+                return;
+            }
         }
+        updateBucketBookmarks(
+                projectKey, file, marks -> marks.replaceAll(bm -> bm.line() == line ? bm.withNote(note) : bm));
     }
 
-    /** Deletes one bookmark — via the open buffer if loaded, else directly in the persisted map. */
-    private void bookmarkDelete(Path file, int line) {
-        EditorBuffer open = ops.bufferForPath(file);
-        if (open != null) {
-            open.removeBookmark(line);
-        } else {
-            updateClosedFileBookmarks(file, marks -> marks.removeIf(bm -> bm.line() == line));
+    /** Deletes one bookmark — via the open buffer if loaded (active bucket only), else directly in the map. */
+    private void bookmarkDelete(String projectKey, Path file, int line) {
+        if (isActiveBucket(projectKey)) {
+            EditorBuffer open = ops.bufferForPath(file);
+            if (open != null) {
+                open.removeBookmark(line);
+                return;
+            }
         }
+        updateBucketBookmarks(projectKey, file, marks -> marks.removeIf(bm -> bm.line() == line));
     }
 
-    /** Deletes all bookmarks in a file — via the open buffer if loaded, else the persisted map. */
-    private void bookmarkDeleteAll(Path file) {
-        EditorBuffer open = ops.bufferForPath(file);
-        if (open != null) {
-            open.clearBookmarks();
-        } else {
-            ops.bookmarks().remove(file.toString());
+    /** Deletes all bookmarks in a file — via the open buffer if loaded (active bucket only), else the map. */
+    private void bookmarkDeleteAll(String projectKey, Path file) {
+        if (isActiveBucket(projectKey)) {
+            EditorBuffer open = ops.bufferForPath(file);
+            if (open != null) {
+                open.clearBookmarks();
+                return;
+            }
+        }
+        Map<String, List<Bookmark>> bucket = bucketFor(projectKey);
+        if (bucket != null && bucket.remove(file.toString()) != null) {
             ops.saveBookmarks();
             panel.refresh();
         }
     }
 
-    /** Applies a mutation to a closed file's bookmark list in the persisted map, then saves + refreshes. */
-    private void updateClosedFileBookmarks(Path file, Consumer<List<Bookmark>> mutator) {
-        var map = ops.bookmarks();
+    /** Whether {@code projectKey} is this window's active bucket — the only one whose files can be open here. */
+    private boolean isActiveBucket(String projectKey) {
+        return (projectKey == null ? "" : projectKey).equals(ops.currentProjectKey());
+    }
+
+    /** The bookmark bucket (path → bookmarks) for a project key, or {@code null} if that bucket has no bookmarks. */
+    private Map<String, List<Bookmark>> bucketFor(String projectKey) {
+        return ops.allBookmarks().get(projectKey == null ? "" : projectKey);
+    }
+
+    /**
+     * Applies a mutation to a file's bookmark list in the given project bucket, then saves + refreshes. Used
+     * for closed files, and for any bookmark in a bucket other than this window's active one (a General or
+     * cross-project row shown in the panel while a different project is active) — those are never routed
+     * through a live buffer, whose manager is tied to the active bucket.
+     */
+    private void updateBucketBookmarks(String projectKey, Path file, Consumer<List<Bookmark>> mutator) {
+        Map<String, List<Bookmark>> map = bucketFor(projectKey);
+        if (map == null) {
+            return;
+        }
         List<Bookmark> marks = map.get(file.toString());
         if (marks == null) {
             return;

--- a/src/main/java/com/editora/ui/BookmarksPanel.java
+++ b/src/main/java/com/editora/ui/BookmarksPanel.java
@@ -54,15 +54,20 @@ public class BookmarksPanel extends VBox implements ToolWindowContent {
     public record Scope(
             Map<String, Map<String, List<Bookmark>>> byProject, String currentKey, Function<String, String> nameFor) {}
 
-    /** Mutations the panel asks the controller to perform (it knows which files are open). */
+    /**
+     * Mutations the panel asks the controller to perform (it knows which files are open). Each mutation carries
+     * the row's {@code projectKey} — the bucket it lives in ({@code ""} = General) — because the panel shows more
+     * than one bucket at once (General + current + others), so the controller must target the right one rather
+     * than always the active project's.
+     */
     public interface Actions {
-        void openAndJump(Path file, int line);
+        void openAndJump(String projectKey, Path file, int line);
 
-        void setNote(Path file, int line, String note);
+        void setNote(String projectKey, Path file, int line, String note);
 
-        void delete(Path file, int line);
+        void delete(String projectKey, Path file, int line);
 
-        void deleteAll(Path file);
+        void deleteAll(String projectKey, Path file);
         /** Reorder a bookmark within its file (indices into that file's stored list, in the current project). */
         void moveBookmark(Path file, int fromIndex, int toIndex);
         /** Reorder a whole file group among the file headers (indices into the current project's file order). */
@@ -74,9 +79,9 @@ public class BookmarksPanel extends VBox implements ToolWindowContent {
 
     private record ProjectRow(String key, String name, boolean current) implements Row {}
 
-    private record FileRow(Path file) implements Row {}
+    private record FileRow(String projectKey, Path file) implements Row {}
 
-    private record MarkRow(Path file, Bookmark bm) implements Row {}
+    private record MarkRow(String projectKey, Path file, Bookmark bm) implements Row {}
 
     private static final String SCOPE_HINT = tr("bookmarks.scopeTip");
 
@@ -195,21 +200,22 @@ public class BookmarksPanel extends VBox implements ToolWindowContent {
             boolean current = key.equals(currentKey);
             TreeItem<Row> projectNode =
                     new TreeItem<>(new ProjectRow(key, scope.nameFor().apply(key), current));
-            // Expand the buckets you care about (General + current); collapse other projects.
-            projectNode.setExpanded(key.isEmpty() || current);
+            // Expand only the current project's group by default; General and every other project start
+            // collapsed (in the no-project window, General *is* the current group, so it expands there).
+            projectNode.setExpanded(current);
             for (Map.Entry<String, List<Bookmark>> e : bucket.entrySet()) {
                 if (e.getValue() == null || e.getValue().isEmpty()) {
                     continue;
                 }
                 Path file = Path.of(e.getKey());
                 boolean fileMatches = fileName(file).toLowerCase().contains(query);
-                TreeItem<Row> fileNode = new TreeItem<>(new FileRow(file));
+                TreeItem<Row> fileNode = new TreeItem<>(new FileRow(key, file));
                 fileNode.setExpanded(true);
                 for (Bookmark bm : e.getValue()) {
                     if (query.isEmpty()
                             || fileMatches
                             || markLabel(bm).toLowerCase().contains(query)) {
-                        fileNode.getChildren().add(new TreeItem<>(new MarkRow(file, bm)));
+                        fileNode.getChildren().add(new TreeItem<>(new MarkRow(key, file, bm)));
                     }
                 }
                 if (!fileNode.getChildren().isEmpty()) {
@@ -404,7 +410,7 @@ public class BookmarksPanel extends VBox implements ToolWindowContent {
             return;
         }
         if (item.getValue() instanceof MarkRow m) {
-            actions.openAndJump(m.file(), m.bm().line());
+            actions.openAndJump(m.projectKey(), m.file(), m.bm().line());
         } else {
             item.setExpanded(!item.isExpanded()); // a project or file header toggles
         }
@@ -510,7 +516,7 @@ public class BookmarksPanel extends VBox implements ToolWindowContent {
                 tr("dialog.bookmarkNote.title"),
                 tr("dialog.bookmarkNote.content"),
                 m.bm().note(),
-                note -> actions.setNote(m.file(), m.bm().line(), note.strip()));
+                note -> actions.setNote(m.projectKey(), m.file(), m.bm().line(), note.strip()));
     }
 
     /** Injects the in-scene prompt used to edit a bookmark's note (so the panel needs no overlay host). */
@@ -519,7 +525,7 @@ public class BookmarksPanel extends VBox implements ToolWindowContent {
     }
 
     private void deleteMark(MarkRow m) {
-        actions.delete(m.file(), m.bm().line());
+        actions.delete(m.projectKey(), m.file(), m.bm().line());
     }
 
     private void deleteFile(FileRow f) {
@@ -532,7 +538,7 @@ public class BookmarksPanel extends VBox implements ToolWindowContent {
         confirm.setTitle(tr("bookmarks.deleteFileTitle"));
         confirm.setHeaderText(null);
         if (confirm.showAndWait().orElse(ButtonType.CANCEL) == ButtonType.OK) {
-            actions.deleteAll(f.file());
+            actions.deleteAll(f.projectKey(), f.file());
         }
     }
 

--- a/src/main/java/com/editora/ui/MainController.java
+++ b/src/main/java/com/editora/ui/MainController.java
@@ -465,6 +465,11 @@ public class MainController implements com.editora.mcp.McpBridge {
             }
 
             @Override
+            public void openInProjectWindow(String projectKey, java.nio.file.Path file, int line) {
+                MainController.this.openInProjectWindow(projectKey, file, line);
+            }
+
+            @Override
             public String noteKey(EditorBuffer buffer) {
                 return MainController.noteKey(buffer);
             }
@@ -520,6 +525,11 @@ public class MainController implements com.editora.mcp.McpBridge {
             @Override
             public void navigateToLine(int line) {
                 MainController.this.navigateToLine(line);
+            }
+
+            @Override
+            public void openInProjectWindow(String projectKey, java.nio.file.Path file, int line) {
+                MainController.this.openInProjectWindow(projectKey, file, line);
             }
 
             @Override
@@ -1813,6 +1823,35 @@ public class MainController implements com.editora.mcp.McpBridge {
         });
         area.requestFollowCaret();
         area.requestFocus();
+    }
+
+    /**
+     * Opens a bookmark/note's file at 0-based {@code line} in the window for {@code projectKey} ({@code ""} =
+     * general/no-project). When the entry belongs to <em>this</em> window's project (or Projects are off, or
+     * there's no window manager), it opens in place — the original behavior. Otherwise it hands off to
+     * {@link WindowManager#openInWindow} so the user lands in that project's window (focused if already open,
+     * else built), rather than opening the file out of context in the current window.
+     */
+    private void openInProjectWindow(String projectKey, Path file, int line) {
+        String key = projectKey == null ? "" : projectKey;
+        if (windowManager == null || !projectsEnabled() || key.equals(config.currentProjectKey())) {
+            openPath(file);
+            Platform.runLater(() -> navigateToLine(line));
+            return;
+        }
+        windowManager.openInWindow(key, file, line);
+    }
+
+    /**
+     * Cross-window landing for a bookmark/note activated from another project's bucket: opens {@code file} in
+     * <em>this</em> (now-focused) window and jumps to 0-based {@code line}. Called by
+     * {@link WindowManager#openInWindow} on the target window's controller once it exists and is restored.
+     */
+    public void openAndNavigate(Path file, int line) {
+        openPath(file);
+        if (line >= 0) {
+            Platform.runLater(() -> navigateToLine(line));
+        }
     }
 
     /** Repopulates the recent-files menu from the persisted list (most-recent first). */

--- a/src/main/java/com/editora/ui/NotesCoordinator.java
+++ b/src/main/java/com/editora/ui/NotesCoordinator.java
@@ -8,7 +8,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.function.Consumer;
 
-import javafx.application.Platform;
 import javafx.scene.control.Alert;
 import javafx.scene.control.ButtonType;
 import javafx.scene.control.Label;
@@ -44,6 +43,13 @@ final class NotesCoordinator {
         void openPath(Path file);
 
         void navigateToLine(int line);
+
+        /**
+         * Opens {@code file} at 0-based {@code line} in {@code projectKey}'s window ({@code ""} = the
+         * general/no-project window), focusing or creating that window — so activating a note from a different
+         * project switches to (or opens) that project's window instead of opening it out of context.
+         */
+        void openInProjectWindow(String projectKey, Path file, int line);
 
         /** Canonical-path store key for a buffer's notes (shared with the rename-migration path). */
         String noteKey(EditorBuffer buffer);
@@ -95,28 +101,28 @@ final class NotesCoordinator {
         persistDebounce.setOnFinished(e -> flushPendingPersist());
         this.panel = new NotesPanel(this::scope, new NotesPanel.Actions() {
             @Override
-            public void openAndJump(String fileKey, PersonalNote note) {
-                noteActivate(fileKey, note);
+            public void openAndJump(String projectKey, String fileKey, PersonalNote note) {
+                noteActivate(projectKey, fileKey, note);
             }
 
             @Override
-            public void editBody(String fileKey, PersonalNote note) {
-                noteEditBody(fileKey, note);
+            public void editBody(String projectKey, String fileKey, PersonalNote note) {
+                noteEditBody(projectKey, fileKey, note);
             }
 
             @Override
-            public void setStatus(String fileKey, PersonalNote note, NoteStatus status) {
-                noteSetStatus(fileKey, note, status);
+            public void setStatus(String projectKey, String fileKey, PersonalNote note, NoteStatus status) {
+                noteSetStatus(projectKey, fileKey, note, status);
             }
 
             @Override
-            public void delete(String fileKey, PersonalNote note) {
-                noteDelete(fileKey, note);
+            public void delete(String projectKey, String fileKey, PersonalNote note) {
+                noteDelete(projectKey, fileKey, note);
             }
 
             @Override
-            public void deleteAll(String fileKey) {
-                noteDeleteAll(fileKey);
+            public void deleteAll(String projectKey, String fileKey) {
+                noteDeleteAll(projectKey, fileKey);
             }
         });
         this.jumpPalette = new QuickOpen<>(
@@ -126,7 +132,8 @@ final class NotesCoordinator {
                 e -> noteEntryLabel(e.note()),
                 e -> Path.of(e.fileKey()).getFileName() + ":"
                         + (e.note().anchor().line() + 1),
-                e -> noteActivate(e.fileKey(), e.note()));
+                // The jump/search pickers are scoped to the active project's notes, so they open in this window.
+                e -> noteActivate(ops.currentProjectKey(), e.fileKey(), e.note()));
         // Search Notes: same picker, but the query matches the full body + tags + file (not just the
         // first line) so you can find a note by any word in it.
         this.searchPalette = new QuickOpen<>(
@@ -137,7 +144,8 @@ final class NotesCoordinator {
                 e -> Path.of(e.fileKey()).getFileName() + ":"
                         + (e.note().anchor().line() + 1),
                 NotesCoordinator::noteSearchText,
-                e -> noteActivate(e.fileKey(), e.note()));
+                // The jump/search pickers are scoped to the active project's notes, so they open in this window.
+                e -> noteActivate(ops.currentProjectKey(), e.fileKey(), e.note()));
     }
 
     NotesPanel panel() {
@@ -471,62 +479,90 @@ final class NotesCoordinator {
 
     // --- NotesPanel.Actions (open buffer if loaded, else mutate the persisted closed-file list) -------
 
-    private void noteActivate(String fileKey, PersonalNote note) {
+    /**
+     * Opens the note's file and jumps to its line — in {@code projectKey}'s window. When the note belongs to
+     * the active window's project this lands in place (same behavior as before); for a General or cross-project
+     * note it focuses (or opens) that project's window (see {@link Ops#openInProjectWindow}).
+     */
+    private void noteActivate(String projectKey, String fileKey, PersonalNote note) {
         String path = note.file() != null && !note.file().path().isBlank()
                 ? note.file().path()
                 : fileKey;
-        ops.openPath(Path.of(path));
-        int line = note.anchor().line();
-        Platform.runLater(() -> ops.navigateToLine(line));
+        ops.openInProjectWindow(projectKey, Path.of(path), note.anchor().line());
     }
 
-    private void noteEditBody(String fileKey, PersonalNote note) {
-        EditorBuffer open = ops.bufferForKey(fileKey);
+    private void noteEditBody(String projectKey, String fileKey, PersonalNote note) {
+        EditorBuffer open = isActiveBucket(projectKey) ? ops.bufferForKey(fileKey) : null;
         if (open != null) {
             editOpenBufferNote(open, note);
         } else {
             showNoteDialog(
                     note.body(),
-                    body -> updateClosedFileNotes(
-                            fileKey, list -> list.replaceAll(n -> n.id().equals(note.id()) ? n.withBody(body) : n)),
-                    () -> updateClosedFileNotes(fileKey, list -> list.removeIf(n -> n.id().equals(note.id()))));
+                    body -> updateBucketNotes(
+                            projectKey,
+                            fileKey,
+                            list -> list.replaceAll(n -> n.id().equals(note.id()) ? n.withBody(body) : n)),
+                    () -> updateBucketNotes(projectKey, fileKey, list -> list.removeIf(n -> n.id().equals(note.id()))));
         }
     }
 
-    private void noteSetStatus(String fileKey, PersonalNote note, NoteStatus status) {
-        EditorBuffer open = ops.bufferForKey(fileKey);
+    private void noteSetStatus(String projectKey, String fileKey, PersonalNote note, NoteStatus status) {
+        EditorBuffer open = isActiveBucket(projectKey) ? ops.bufferForKey(fileKey) : null;
         if (open != null) {
             open.getNoteManager().setStatus(note.id(), status);
         } else {
-            updateClosedFileNotes(
-                    fileKey, list -> list.replaceAll(n -> n.id().equals(note.id()) ? n.withStatus(status) : n));
+            updateBucketNotes(
+                    projectKey,
+                    fileKey,
+                    list -> list.replaceAll(n -> n.id().equals(note.id()) ? n.withStatus(status) : n));
         }
     }
 
-    private void noteDelete(String fileKey, PersonalNote note) {
-        EditorBuffer open = ops.bufferForKey(fileKey);
+    private void noteDelete(String projectKey, String fileKey, PersonalNote note) {
+        EditorBuffer open = isActiveBucket(projectKey) ? ops.bufferForKey(fileKey) : null;
         if (open != null) {
             open.getNoteManager().remove(note.id());
             open.refreshGutter();
         } else {
-            updateClosedFileNotes(fileKey, list -> list.removeIf(n -> n.id().equals(note.id())));
+            updateBucketNotes(projectKey, fileKey, list -> list.removeIf(n -> n.id().equals(note.id())));
         }
     }
 
-    private void noteDeleteAll(String fileKey) {
-        EditorBuffer open = ops.bufferForKey(fileKey);
+    private void noteDeleteAll(String projectKey, String fileKey) {
+        EditorBuffer open = isActiveBucket(projectKey) ? ops.bufferForKey(fileKey) : null;
         if (open != null) {
             open.getNoteManager().clear();
             open.refreshGutter();
         } else {
-            ops.notes().remove(fileKey);
-            ops.saveNotes();
-            panel.refresh();
+            Map<String, List<PersonalNote>> bucket = bucketFor(projectKey);
+            if (bucket != null && bucket.remove(fileKey) != null) {
+                ops.saveNotes();
+                panel.refresh();
+            }
         }
     }
 
-    private void updateClosedFileNotes(String fileKey, Consumer<List<PersonalNote>> mutator) {
-        var map = ops.notes();
+    /** Whether {@code projectKey} is this window's active bucket — the only one whose files can be open here. */
+    private boolean isActiveBucket(String projectKey) {
+        return (projectKey == null ? "" : projectKey).equals(ops.currentProjectKey());
+    }
+
+    /** The notes bucket (path → notes) for a project key, or {@code null} if that bucket has no notes. */
+    private Map<String, List<PersonalNote>> bucketFor(String projectKey) {
+        return ops.allNotes().get(projectKey == null ? "" : projectKey);
+    }
+
+    /**
+     * Applies a mutation to a file's note list in the given project bucket, then saves + refreshes. Used for
+     * closed files, and for any note in a bucket other than this window's active one (a General or cross-project
+     * row shown in the panel while a different project is active) — those are never routed through a live buffer,
+     * whose manager is tied to the active bucket.
+     */
+    private void updateBucketNotes(String projectKey, String fileKey, Consumer<List<PersonalNote>> mutator) {
+        Map<String, List<PersonalNote>> map = bucketFor(projectKey);
+        if (map == null) {
+            return;
+        }
         List<PersonalNote> list = map.get(fileKey);
         if (list == null) {
             return;

--- a/src/main/java/com/editora/ui/NotesPanel.java
+++ b/src/main/java/com/editora/ui/NotesPanel.java
@@ -46,26 +46,31 @@ public class NotesPanel extends VBox implements ToolWindowContent {
             String currentKey,
             Function<String, String> nameFor) {}
 
-    /** Mutations the panel asks the controller to perform (file key = canonical path in the notes map). */
+    /**
+     * Mutations the panel asks the controller to perform (file key = canonical path in the notes map). Each
+     * mutation carries the row's {@code projectKey} — the bucket it lives in ({@code ""} = General) — because the
+     * panel shows more than one bucket at once (General + current + others), so the controller must target the
+     * right one rather than always the active project's.
+     */
     public interface Actions {
-        void openAndJump(String fileKey, PersonalNote note);
+        void openAndJump(String projectKey, String fileKey, PersonalNote note);
 
-        void editBody(String fileKey, PersonalNote note);
+        void editBody(String projectKey, String fileKey, PersonalNote note);
 
-        void setStatus(String fileKey, PersonalNote note, NoteStatus status);
+        void setStatus(String projectKey, String fileKey, PersonalNote note, NoteStatus status);
 
-        void delete(String fileKey, PersonalNote note);
+        void delete(String projectKey, String fileKey, PersonalNote note);
 
-        void deleteAll(String fileKey);
+        void deleteAll(String projectKey, String fileKey);
     }
 
     private sealed interface Row permits ProjectRow, FileRow, NoteRow {}
 
     private record ProjectRow(String key, String name, boolean current) implements Row {}
 
-    private record FileRow(String fileKey) implements Row {}
+    private record FileRow(String projectKey, String fileKey) implements Row {}
 
-    private record NoteRow(String fileKey, PersonalNote note) implements Row {}
+    private record NoteRow(String projectKey, String fileKey, PersonalNote note) implements Row {}
 
     private final Supplier<Scope> source;
     private final Actions actions;
@@ -171,7 +176,9 @@ public class NotesPanel extends VBox implements ToolWindowContent {
             boolean current = key.equals(currentKey);
             TreeItem<Row> projectNode =
                     new TreeItem<>(new ProjectRow(key, scope.nameFor().apply(key), current));
-            projectNode.setExpanded(key.isEmpty() || current);
+            // Expand only the current project's group by default; General and every other project start
+            // collapsed (in the no-project window, General *is* the current group, so it expands there).
+            projectNode.setExpanded(current);
             bucket.forEach((fileKey, notes) -> {
                 if (notes == null || notes.isEmpty()) {
                     return;
@@ -179,11 +186,11 @@ public class NotesPanel extends VBox implements ToolWindowContent {
                 List<TreeItem<Row>> kids = new ArrayList<>();
                 for (PersonalNote note : notes) {
                     if (filter.isEmpty() || matches(fileKey, note, filter)) {
-                        kids.add(new TreeItem<>(new NoteRow(fileKey, note)));
+                        kids.add(new TreeItem<>(new NoteRow(key, fileKey, note)));
                     }
                 }
                 if (!kids.isEmpty()) {
-                    TreeItem<Row> fileItem = new TreeItem<>(new FileRow(fileKey));
+                    TreeItem<Row> fileItem = new TreeItem<>(new FileRow(key, fileKey));
                     fileItem.setExpanded(true);
                     fileItem.getChildren().setAll(kids);
                     projectNode.getChildren().add(fileItem);
@@ -225,7 +232,7 @@ public class NotesPanel extends VBox implements ToolWindowContent {
             return;
         }
         if (sel.getValue() instanceof NoteRow n) {
-            actions.openAndJump(n.fileKey(), n.note());
+            actions.openAndJump(n.projectKey(), n.fileKey(), n.note());
         } else {
             sel.setExpanded(!sel.isExpanded());
         }
@@ -282,7 +289,7 @@ public class NotesPanel extends VBox implements ToolWindowContent {
                 setTooltip(new Tooltip(f.fileKey()));
                 MenuItem deleteAll = new MenuItem(tr("notes.deleteAllInFile"));
                 deleteAll.setGraphic(Icons.trash());
-                deleteAll.setOnAction(e -> actions.deleteAll(f.fileKey()));
+                deleteAll.setOnAction(e -> actions.deleteAll(f.projectKey(), f.fileKey()));
                 setContextMenu(new ContextMenu(deleteAll));
             } else if (item instanceof NoteRow n) {
                 setText(noteLabel(n.note()));
@@ -299,15 +306,15 @@ public class NotesPanel extends VBox implements ToolWindowContent {
         private ContextMenu noteMenu(NoteRow n) {
             MenuItem edit = new MenuItem(tr("notes.editBody"));
             edit.setGraphic(Icons.edit());
-            edit.setOnAction(e -> actions.editBody(n.fileKey(), n.note()));
+            edit.setOnAction(e -> actions.editBody(n.projectKey(), n.fileKey(), n.note()));
             boolean resolved = n.note().status() == NoteStatus.RESOLVED;
             MenuItem toggle = new MenuItem(resolved ? tr("notes.reopen") : tr("notes.resolve"));
             toggle.setGraphic(resolved ? Icons.refresh() : Icons.check());
-            toggle.setOnAction(
-                    e -> actions.setStatus(n.fileKey(), n.note(), resolved ? NoteStatus.ACTIVE : NoteStatus.RESOLVED));
+            toggle.setOnAction(e -> actions.setStatus(
+                    n.projectKey(), n.fileKey(), n.note(), resolved ? NoteStatus.ACTIVE : NoteStatus.RESOLVED));
             MenuItem delete = new MenuItem(tr("notes.delete"));
             delete.setGraphic(Icons.trash());
-            delete.setOnAction(e -> actions.delete(n.fileKey(), n.note()));
+            delete.setOnAction(e -> actions.delete(n.projectKey(), n.fileKey(), n.note()));
             return new ContextMenu(edit, toggle, new SeparatorMenuItem(), delete);
         }
     }

--- a/src/main/java/com/editora/ui/WindowManager.java
+++ b/src/main/java/com/editora/ui/WindowManager.java
@@ -343,6 +343,36 @@ public class WindowManager {
         return stage;
     }
 
+    /**
+     * Opens {@code file} at 0-based {@code line} in the window for {@code projectKey} ({@code ""} = the global
+     * no-project window): focuses the window if it's already open and opens the file there now, else builds the
+     * window and opens the file after its session restores (passing it as a startup target, like a CLI file).
+     * Used when a bookmark/note belonging to another project is activated, so the user lands in that project's
+     * window rather than having the file opened out of context in the current one. A deleted project falls back
+     * to the global window.
+     */
+    public void openInWindow(String projectKey, Path file, int line) {
+        String key = projectKey == null ? "" : projectKey;
+        Project project = key.isEmpty() ? null : findProject(key);
+        if (!key.isEmpty() && project == null) {
+            key = ""; // the project was deleted — fall back to the global window
+        }
+        Holder existing = findHolder(key);
+        if (existing != null && existing.controller() != null) {
+            focus(existing.stage());
+            setActiveAndSave(key);
+            existing.controller().openAndNavigate(file, line);
+            return;
+        }
+        // Not open — build it, passing the file as a startup target (1-based line) so it opens + jumps after
+        // this window's own session restore, exactly like a command-line FILE:line argument.
+        List<MainController.OpenTarget> targets = List.of(new MainController.OpenTarget(file, line + 1, 1));
+        Path stateFile = key.isEmpty() ? null : projects().stateFile(project);
+        buildWindow(key, project, stateFile, targets, false, false, null, false);
+        projects().markOpen(key);
+        setActiveAndSave(key);
+    }
+
     private void setActiveAndSave(String key) {
         projects().setActive(key);
         projects().save();

--- a/src/test/java/com/editora/ui/BookmarksPanelFxTest.java
+++ b/src/test/java/com/editora/ui/BookmarksPanelFxTest.java
@@ -30,16 +30,16 @@ class BookmarksPanelFxTest {
 
     private static final BookmarksPanel.Actions NOOP = new BookmarksPanel.Actions() {
         @Override
-        public void openAndJump(Path file, int line) {}
+        public void openAndJump(String projectKey, Path file, int line) {}
 
         @Override
-        public void setNote(Path file, int line, String note) {}
+        public void setNote(String projectKey, Path file, int line, String note) {}
 
         @Override
-        public void delete(Path file, int line) {}
+        public void delete(String projectKey, Path file, int line) {}
 
         @Override
-        public void deleteAll(Path file) {}
+        public void deleteAll(String projectKey, Path file) {}
 
         @Override
         public void moveBookmark(Path file, int fromIndex, int toIndex) {}

--- a/src/test/java/com/editora/ui/MarkerPersistDebounceFxTest.java
+++ b/src/test/java/com/editora/ui/MarkerPersistDebounceFxTest.java
@@ -48,6 +48,9 @@ class MarkerPersistDebounceFxTest {
                 public void navigateToLine(int line) {}
 
                 @Override
+                public void openInProjectWindow(String projectKey, Path file, int line) {}
+
+                @Override
                 public EditorBuffer bufferForPath(Path file) {
                     return null;
                 }

--- a/src/test/java/com/editora/ui/NotesPanelFxTest.java
+++ b/src/test/java/com/editora/ui/NotesPanelFxTest.java
@@ -30,19 +30,19 @@ class NotesPanelFxTest {
 
     private static final NotesPanel.Actions NOOP = new NotesPanel.Actions() {
         @Override
-        public void openAndJump(String fileKey, PersonalNote note) {}
+        public void openAndJump(String projectKey, String fileKey, PersonalNote note) {}
 
         @Override
-        public void editBody(String fileKey, PersonalNote note) {}
+        public void editBody(String projectKey, String fileKey, PersonalNote note) {}
 
         @Override
-        public void setStatus(String fileKey, PersonalNote note, NoteStatus status) {}
+        public void setStatus(String projectKey, String fileKey, PersonalNote note, NoteStatus status) {}
 
         @Override
-        public void delete(String fileKey, PersonalNote note) {}
+        public void delete(String projectKey, String fileKey, PersonalNote note) {}
 
         @Override
-        public void deleteAll(String fileKey) {}
+        public void deleteAll(String projectKey, String fileKey) {}
     };
 
     private final Map<String, List<PersonalNote>> source = new LinkedHashMap<>();


### PR DESCRIPTION
## Problem

The Bookmarks and Notes tool windows render entries from **every** project bucket (General + current project + others under "Show all projects"), but the coordinators assumed the **active window's bucket** for every operation. That caused three issues:

1. **Right-click → Delete did nothing** for any entry outside the active project's bucket — most commonly General-scoped bookmarks/notes shown while a project is open. Delete, delete-all, edit-note, and resolve/reopen all looked in the wrong bucket, found nothing, and silently returned. (This is the originally-reported bug — deletes only worked for the currently-active project.)
2. Both General **and** the current project expanded by default, cluttering the tree.
3. Clicking a bookmark/note from a **different** project opened its file out of context in the current window.

## Fixes

1. **Per-project mutations.** Each panel `Actions` mutation now carries the row's `projectKey`; the coordinators mutate that specific bucket (`allBookmarks()`/`allNotes().get(key)`). Only active-bucket rows still route through a live open buffer (whose manager is tied to that bucket).
2. **Expand only the current project** by default — General and other projects start collapsed and fold/unfold as you switch project windows (in the no-project window, General *is* current, so it expands there).
3. **Cross-project navigation.** Activating an entry from another project routes through the new `WindowManager.openInWindow`: an already-open project window is focused and the file opened there; otherwise the window is built and the file opened after its session restores (like a CLI `FILE:line` argument). The `M-g` jump/search pickers stay scoped to the active project, so they open in place.

## Performance

Everything here fires only on explicit click/menu actions — no per-keystroke, per-scroll, or per-pulse cost. Cross-window builds reuse the existing deferred-restore mechanism.

## Testing

- Main + tests compile clean; Spotless green.
- All 228 `com.editora.ui.*FxTest` pass, including the Bookmarks/Notes panel tests and the window-build path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)