### PR TITLE
LSP: accept dynamic client/registerCapability instead of crashing

### DIFF
--- a/src/main/java/com/editora/lsp/LanguageServerSession.java
+++ b/src/main/java/com/editora/lsp/LanguageServerSession.java
@@ -45,6 +45,7 @@ import org.eclipse.lsp4j.PublishDiagnosticsParams;
 import org.eclipse.lsp4j.ReferenceContext;
 import org.eclipse.lsp4j.ReferenceParams;
 import org.eclipse.lsp4j.ReferencesCapabilities;
+import org.eclipse.lsp4j.RegistrationParams;
 import org.eclipse.lsp4j.ServerCapabilities;
 import org.eclipse.lsp4j.ShowMessageRequestParams;
 import org.eclipse.lsp4j.SynchronizationCapabilities;
@@ -54,6 +55,7 @@ import org.eclipse.lsp4j.TextDocumentIdentifier;
 import org.eclipse.lsp4j.TextDocumentItem;
 import org.eclipse.lsp4j.TextDocumentSyncKind;
 import org.eclipse.lsp4j.TextEdit;
+import org.eclipse.lsp4j.UnregistrationParams;
 import org.eclipse.lsp4j.VersionedTextDocumentIdentifier;
 import org.eclipse.lsp4j.WorkspaceFolder;
 import org.eclipse.lsp4j.jsonrpc.Launcher;
@@ -703,6 +705,26 @@ final class LanguageServerSession implements LanguageClient {
      */
     @Override
     public CompletableFuture<Void> refreshDiagnostics() {
+        return CompletableFuture.completedFuture(null);
+    }
+
+    /**
+     * Acknowledges {@code client/registerCapability} / {@code client/unregisterCapability}. Servers
+     * that use dynamic capability registration (e.g. tinymist, whose init reports
+     * {@code cfg_change_registration: true}) send these requests after initialize. lsp4j's default
+     * {@link LanguageClient#registerCapability}/{@link LanguageClient#unregisterCapability} throw
+     * {@code UnsupportedOperationException}, which lsp4j logs as a SEVERE "Internal error" and the
+     * server then reports back as a failed registration. We don't track dynamic registrations
+     * (capabilities are read from the initialize result), so accept-and-ignore is the correct
+     * minimal handling — it silences the crash without changing behavior.
+     */
+    @Override
+    public CompletableFuture<Void> registerCapability(RegistrationParams params) {
+        return CompletableFuture.completedFuture(null);
+    }
+
+    @Override
+    public CompletableFuture<Void> unregisterCapability(UnregistrationParams params) {
         return CompletableFuture.completedFuture(null);
     }
 


### PR DESCRIPTION
## Problem

Opening a `.typ` file (tinymist typst LSP) produced a `SEVERE` in the debug log:

```
SEVERE  RemoteEndpoint: Internal error: null
java.lang.UnsupportedOperationException
    at org.eclipse.lsp4j.services.LanguageClient.registerCapability(LanguageClient.java:52)
```

`LanguageServerSession implements LanguageClient` but never overrode `client/registerCapability` / `client/unregisterCapability`. lsp4j's default implementations throw `UnsupportedOperationException`. Servers using **dynamic capability registration** (tinymist reports `cfg_change_registration: true`) send these after `initialize`, so the client crashed the request and the server logged a matching `failed to register capability` error — silently dropping whatever tinymist tried to register.

## Fix

Override both methods to accept-and-ignore (return a completed future), mirroring the existing `refreshDiagnostics` override done for the same reason. Editora reads capabilities from the `initialize` result and doesn't track dynamic registrations, so this is the correct minimal handling — no behavior change, zero hot-path cost (fires once per session).

## Testing

- `mvn compile` clean.
- Manual: open a `.typ` file and confirm the debug log no longer shows the stack trace and tinymist no longer logs `failed to register capability`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)