### PR TITLE
Multi-window SFTP: a registry of remote resolvers, not one static slot (#436)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Two windows connected to different SFTP servers no longer strand each other's remote files.** With more than
+  one window open, the last one to connect took over remote-path resolution, so the first window's remote recent
+  files and session paths stopped resolving — and closing the second window broke them for the first even while it
+  was still connected. Each window's SFTP engine is now registered independently, so every open connection keeps
+  resolving its own paths. (#436)
 - **Undo inside a snippet no longer half-reverts a repeated field.** When a snippet field appears more than once
   (e.g. `$1 = $1;`), typing into it mirrored the text to every occurrence — but each mirror was a separate change,
   so one Ctrl-Z reverted only the mirror and left the field half-reverted (`x = ;`), cancelling the snippet. The

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -250,8 +250,8 @@ icon (`Icons.findInFiles()`, `onFindInFiles → openSearchInFiles`) sits beside 
   cb)` (auth precedence **default `~/.ssh` keys → key file → password**; the secret `char[]` is wiped after
   use, and the password is removed from the SSH session the instant the handshake finishes —
   `RemoteFileSystems.authenticate`'s `finally` — so MINA's String-only `addPasswordIdentity` copy isn't
-  retained on the session for the whole connection), `pathFor(SftpUri)`/`disconnect`/`shutdown`, and wires `Vfs.setRemoteResolver` so remote URIs in
-  recent-files reconstruct to live Paths. **Local-only gating** (all inert for local files, so zero
+  retained on the session for the whole connection), `pathFor(SftpUri)`/`disconnect`/`shutdown`, and **registers itself in the `Vfs` provider registry** so remote URIs in
+  recent-files reconstruct to live Paths. **Multi-window (#436):** `RemoteFileSystems` is per-window but `Vfs`'s remote hooks are `static`, so they're a **registry of `Vfs.RemoteProvider`s (one per window)**, not a single slot — `Vfs.registerRemoteProvider(this)` in the ctor, `unregisterRemoteProvider(this)` in `shutdown`. `RemoteFileSystems implements Vfs.RemoteProvider`: `resolve(uri)` returns a live Path only for an authority it has connected (`pathFor` → `byAuthority.get(authority)`, else null), and `storable(path)` returns an `sftp://` string only for a Path whose `FileSystem` it owns (else null). `Vfs.parseStorable` tries each provider until one resolves (first non-null wins); `Vfs.toStorableString` dispatches to the provider owning the path's `FileSystem`. So a second window connecting to another host no longer clobbers the first's resolution, and closing one window only removes *its* provider — the others' remote paths keep resolving. **Local-only gating** (all inert for local files, so zero
   behavior change): `MainController.isLocalBuffer` + `Vfs.isLocal` guards on LSP (`syncBufferLsp`
   eligibility), DAP/breakpoints (`isDebuggableBuffer`), run/shell-run/HTTP (`addBuffer`), git
   (`refreshGit` → `RepoState.NONE` for a remote context), and external-change polling

--- a/src/main/java/com/editora/vfs/RemoteFileSystems.java
+++ b/src/main/java/com/editora/vfs/RemoteFileSystems.java
@@ -36,7 +36,7 @@ import org.apache.sshd.sftp.client.fs.SftpFileSystem;
  * the rest of the app keeps using {@link Path} unchanged. Connect/auth run off the FX thread (the
  * {@code GitService} idiom: a daemon executor + {@link Platform#runLater} callbacks).
  */
-public final class RemoteFileSystems {
+public final class RemoteFileSystems implements Vfs.RemoteProvider {
 
     /** The result of a connect attempt: {@code root} is the remote start directory (the connection's last
      *  path, else the SFTP home) when {@code ok}, else {@code error} explains the failure. */
@@ -112,9 +112,9 @@ public final class RemoteFileSystems {
         // refused outright, without asking. That last case is the man-in-the-middle, and it is the point.
         client.setServerKeyVerifier(new KnownHostsServerKeyVerifier(unknownHostVerifier(prompt), knownHosts));
         client.start();
-        Vfs.setRemoteResolver(this::resolve); // remote sftp:// strings → live Paths
-        Vfs.setRemoteStorable(this::storableFor); // remote Path → sftp:// string (Path.toUri() throws for SFTP)
-        Vfs.setRemoteOwner(this); // so shutdown() can un-pin these statics (see Vfs.clearRemoteHooksIf)
+        // Register this window's engine in the Vfs provider registry (one per window). resolve()/storable() only
+        // answer for authorities/filesystems this instance owns, so windows never clobber each other (#436).
+        Vfs.registerRemoteProvider(this);
     }
 
     /** {@code ~/.ssh/known_hosts} — shared with OpenSSH deliberately (see the constructor). */
@@ -147,14 +147,19 @@ public final class RemoteFileSystems {
         };
     }
 
-    /** The {@code sftp://user@host:port/path} string for a remote Path, by finding its owning connection. */
-    private String storableFor(Path path) {
+    /**
+     * The {@code sftp://user@host:port/path} string for a Path on a connection <b>this</b> engine owns, else
+     * {@code null} (the {@link Vfs.RemoteProvider} contract — the caller tries the next provider). Matching by
+     * {@code FileSystem} identity is exact, so in a multi-window session a path is stored by its owning window.
+     */
+    @Override
+    public String storable(Path path) {
         for (Map.Entry<String, SftpFileSystem> e : byAuthority.entrySet()) {
             if (path.getFileSystem() == e.getValue()) {
                 return "sftp://" + e.getKey() + path; // key is user@host:port; path starts with '/'
             }
         }
-        return path.toString(); // unknown filesystem (disconnected) — best-effort
+        return null; // not one of this engine's filesystems
     }
 
     /** Connects (off-thread) and posts the {@link Result} on the FX thread; {@code secret} (a password or
@@ -329,7 +334,12 @@ public final class RemoteFileSystems {
         return fs == null ? null : fs.getPath(uri.path());
     }
 
-    private Path resolve(String storable) {
+    /**
+     * A live {@link Path} for a remote URI whose authority this engine has connected, else {@code null} (the
+     * {@link Vfs.RemoteProvider} contract — an unowned authority falls through to the next registered provider).
+     */
+    @Override
+    public Path resolve(String storable) {
         return pathFor(SftpUri.parse(storable));
     }
 
@@ -345,14 +355,13 @@ public final class RemoteFileSystems {
     /**
      * Closes every connection + the client. Called when the owning window closes (and on app exit).
      *
-     * <p>Also clears the app-wide {@link Vfs} resolver hooks this instance installed in its constructor — they
-     * are {@code static}, so without this a closed window's instance (its SSH client, NIO threads, and every
-     * open SFTP session) stays strongly reachable for the life of the process and can never be collected.
-     * Only clears them if they still point at <em>this</em> instance, so a newer window's hooks aren't
-     * unhooked from under it.
+     * <p>Also deregisters this engine from the app-wide {@link Vfs} provider registry — it is {@code static}, so
+     * without this a closed window's instance (its SSH client, NIO threads, and every open SFTP session) stays
+     * strongly reachable for the life of the process and can never be collected. Only <em>this</em> provider is
+     * removed, so every other window's stays live (a closed window no longer strands another's remote paths).
      */
     public void shutdown() {
-        Vfs.clearRemoteHooksIf(this);
+        Vfs.unregisterRemoteProvider(this);
         byAuthority.values().forEach(RemoteFileSystems::close);
         byAuthority.clear();
         client.stop();

--- a/src/main/java/com/editora/vfs/Vfs.java
+++ b/src/main/java/com/editora/vfs/Vfs.java
@@ -2,7 +2,8 @@ package com.editora.vfs;
 
 import java.nio.file.FileSystems;
 import java.nio.file.Path;
-import java.util.function.Function;
+import java.util.Set;
+import java.util.concurrent.CopyOnWriteArraySet;
 
 /**
  * Small helpers for the virtual-filesystem abstraction. Editora keeps using {@link Path} everywhere, but a
@@ -13,43 +14,40 @@ import java.util.function.Function;
  */
 public final class Vfs {
 
-    /** Injected by {@code RemoteFileSystems} (once SFTP support is wired) to turn a remote URI back into a
-     *  live {@link Path}; {@code null} until then (and remote URIs then deserialize to {@code null}). */
-    private static volatile Function<String, Path> remoteResolver;
-    /** Injected by {@code RemoteFileSystems} to turn a remote {@link Path} into its {@code sftp://} URI —
-     *  we can't use {@code Path.toUri()} because MINA SSHD's implementation throws for SFTP paths. */
-    private static volatile Function<Path, String> remoteStorable;
+    /**
+     * A remote-filesystem engine ({@code RemoteFileSystems}) that can resolve the URIs / paths it owns. There is
+     * one <b>per window</b>, so this is a <b>registry</b>, not a single slot: window B connecting to a second host
+     * must not clobber window A's resolution, and closing B must not strand A's still-live remote paths (#436).
+     * Resolution dispatches to the provider that owns the authority (for a URI) or the {@code FileSystem} (for a
+     * path); a provider returns {@code null} for anything it doesn't own.
+     */
+    public interface RemoteProvider {
+        /** A live {@link Path} for a remote URI whose authority this provider has connected, else {@code null}. */
+        Path resolve(String uri);
+
+        /** The {@code sftp://} storable for a {@link Path} on a filesystem this provider owns, else {@code null}. */
+        String storable(Path path);
+    }
+
+    /** Live remote engines (one per window). Copy-on-write: registration/lookup races are harmless and rare. */
+    private static final Set<RemoteProvider> providers = new CopyOnWriteArraySet<>();
 
     private Vfs() {}
 
-    /** The object whose hooks are currently installed, so only it may clear them (see {@link #clearRemoteHooksIf}). */
-    private static volatile Object remoteOwner;
-
-    /**
-     * Clears the remote hooks if {@code owner} is the one that installed them. The hooks are static, so a
-     * closed window's {@code RemoteFileSystems} would otherwise be pinned here (with its SSH client and open
-     * sessions) for the rest of the process. Guarded by identity so a *newer* window's hooks survive an older
-     * window closing after it.
-     */
-    public static void clearRemoteHooksIf(Object owner) {
-        if (remoteOwner == owner) {
-            remoteResolver = null;
-            remoteStorable = null;
-            remoteOwner = null;
+    /** Registers a window's remote engine so its {@code sftp://} paths resolve (see {@link RemoteProvider}). */
+    public static void registerRemoteProvider(RemoteProvider provider) {
+        if (provider != null) {
+            providers.add(provider);
         }
     }
 
-    /** Records who installed the hooks (call with the owner right after setting them). */
-    public static void setRemoteOwner(Object owner) {
-        remoteOwner = owner;
-    }
-
-    public static void setRemoteResolver(Function<String, Path> resolver) {
-        remoteResolver = resolver;
-    }
-
-    public static void setRemoteStorable(Function<Path, String> fn) {
-        remoteStorable = fn;
+    /**
+     * Deregisters a window's remote engine (on window close / app exit). The registry is {@code static}, so
+     * without this a closed window's engine (its SSH client, NIO threads, open sessions) would stay reachable
+     * for the process's life. Only this window's provider is removed — every other window's stays live.
+     */
+    public static void unregisterRemoteProvider(RemoteProvider provider) {
+        providers.remove(provider);
     }
 
     /** True when {@code path} is on the local default filesystem (a {@code null} path — untitled — counts
@@ -72,19 +70,30 @@ public final class Vfs {
         if (isLocal(path)) {
             return path.toString();
         }
-        Function<Path, String> fn = remoteStorable;
-        return fn != null ? fn.apply(path) : path.toString(); // never Path.toUri() — it throws for SFTP
+        // Dispatch to the provider that owns this path's FileSystem (never Path.toUri() — it throws for SFTP).
+        for (RemoteProvider p : providers) {
+            String s = p.storable(path);
+            if (s != null) {
+                return s;
+            }
+        }
+        return path.toString(); // no live owner (disconnected) — best-effort
     }
 
-    /** Reconstructs a path from {@link #toStorableString}: a local path directly, or a remote path via the
-     *  injected resolver ({@code null} when not connected / no resolver yet). */
+    /** Reconstructs a path from {@link #toStorableString}: a local path directly, or a remote path via whichever
+     *  registered engine owns its authority ({@code null} when none is connected to that host). */
     public static Path parseStorable(String stored) {
         if (stored == null || stored.isBlank()) {
             return null;
         }
         if (isRemoteUri(stored)) {
-            Function<String, Path> resolver = remoteResolver;
-            return resolver == null ? null : resolver.apply(stored);
+            for (RemoteProvider p : providers) {
+                Path r = p.resolve(stored);
+                if (r != null) {
+                    return r;
+                }
+            }
+            return null;
         }
         return Path.of(stored);
     }

--- a/src/test/java/com/editora/vfs/RemoteFileSystemsHostKeyFxTest.java
+++ b/src/test/java/com/editora/vfs/RemoteFileSystemsHostKeyFxTest.java
@@ -20,6 +20,7 @@ import org.junit.jupiter.api.io.TempDir;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
@@ -72,14 +73,56 @@ class RemoteFileSystemsHostKeyFxTest {
 
     /** Runs a connect and waits for the Result the FX callback delivers. */
     private RemoteFileSystems.Result connectAndWait(int port) throws Exception {
+        return connectAndWait(fs, port);
+    }
+
+    private static RemoteFileSystems.Result connectAndWait(RemoteFileSystems engine, int port) throws Exception {
         AtomicReference<RemoteFileSystems.Result> got = new AtomicReference<>();
         CountDownLatch done = new CountDownLatch(1);
-        fs.connect(connection(port), "pw".toCharArray(), r -> {
+        engine.connect(connection(port), "pw".toCharArray(), r -> {
             got.set(r);
             done.countDown();
         });
         assertTrue(done.await(30, TimeUnit.SECONDS), "the connect attempt should have reported back");
         return got.get();
+    }
+
+    /**
+     * Two windows connecting to different SFTP hosts don't strand each other (#436). Each {@link RemoteFileSystems}
+     * registers its own {@link Vfs.RemoteProvider}, so both hosts' {@code sftp://} paths keep resolving — and
+     * closing one window's engine leaves the other's paths resolvable.
+     */
+    @Test
+    void twoWindowsToDifferentHostsDoNotStrandEachOther(@TempDir Path dir) throws Exception {
+        SshServer serverA = sftpServer(dir.resolve("a.ser"), 0);
+        SshServer serverB = sftpServer(dir.resolve("b.ser"), 0);
+        RemoteFileSystems fsA = new RemoteFileSystems((h, p, t, f) -> true, dir.resolve("known_hosts"));
+        RemoteFileSystems fsB = new RemoteFileSystems((h, p, t, f) -> true, dir.resolve("known_hosts"));
+        try {
+            // Connect on the test thread (the Result callback fires on the FX thread and releases the latch).
+            connectAndWait(fsA, serverA.getPort());
+            connectAndWait(fsB, serverB.getPort());
+            String uriA = "sftp://tester@127.0.0.1:" + serverA.getPort() + "/srv/app.js";
+            String uriB = "sftp://tester@127.0.0.1:" + serverB.getPort() + "/srv/app.js";
+
+            // Both hosts resolve through the shared registry, and a resolved path round-trips back to its URI
+            // via the owning engine's storable (Vfs is pure, so this runs on the test thread).
+            Path pathA = Vfs.parseStorable(uriA);
+            Path pathB = Vfs.parseStorable(uriB);
+            assertNotNull(pathA, "window A's host resolves");
+            assertNotNull(pathB, "window B's host resolves");
+            assertEquals(uriA, Vfs.toStorableString(pathA), "A's path stores back via its own engine");
+            assertEquals(uriB, Vfs.toStorableString(pathB), "B's path stores back via its own engine");
+
+            fsB.shutdown(); // window B closes
+            assertNotNull(Vfs.parseStorable(uriA), "A still resolves after B closed (the single-slot bug stranded it)");
+            assertNull(Vfs.parseStorable(uriB), "B's host no longer resolves once its window is gone");
+        } finally {
+            fsA.shutdown();
+            fsB.shutdown();
+            serverA.stop(true);
+            serverB.stop(true);
+        }
     }
 
     @Test

--- a/src/test/java/com/editora/vfs/VfsTest.java
+++ b/src/test/java/com/editora/vfs/VfsTest.java
@@ -10,12 +10,34 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-/** Unit tests for the pure VFS helpers (local branches; remote reconstruction tested via an injected resolver). */
+/** Unit tests for the pure VFS helpers (local branches; remote reconstruction tested via registered providers). */
 class VfsTest {
 
+    /** A test remote engine that resolves exactly the URIs it's told to (and owns no paths). */
+    private record StubProvider(java.util.function.Function<String, Path> resolver) implements Vfs.RemoteProvider {
+        @Override
+        public Path resolve(String uri) {
+            return resolver.apply(uri);
+        }
+
+        @Override
+        public String storable(Path path) {
+            return null;
+        }
+    }
+
+    private final java.util.List<Vfs.RemoteProvider> registered = new java.util.ArrayList<>();
+
+    private void register(java.util.function.Function<String, Path> resolver) {
+        Vfs.RemoteProvider p = new StubProvider(resolver);
+        Vfs.registerRemoteProvider(p);
+        registered.add(p);
+    }
+
     @AfterEach
-    void clearResolver() {
-        Vfs.setRemoteResolver(null);
+    void clearProviders() {
+        registered.forEach(Vfs::unregisterRemoteProvider);
+        registered.clear();
     }
 
     @Test
@@ -38,10 +60,32 @@ class VfsTest {
     }
 
     @Test
-    void remoteUriUsesTheInjectedResolver() {
+    void remoteUriUsesTheRegisteredProvider() {
         Path stub = Path.of("/marker");
-        Vfs.setRemoteResolver(s -> "sftp://ada@host/srv/app.js".equals(s) ? stub : null);
+        register(s -> "sftp://ada@host/srv/app.js".equals(s) ? stub : null);
         assertEquals(stub, Vfs.parseStorable("sftp://ada@host/srv/app.js"));
+    }
+
+    @Test
+    void multipleWindowsResolveTheirOwnHostsAndSurviveEachOtherClosing() {
+        // #436: two windows connect to different hosts; each provider owns only its authority.
+        Path pa = Path.of("/on-a");
+        Path pb = Path.of("/on-b");
+        Vfs.RemoteProvider a = new StubProvider(s -> s.contains("@hostA") ? pa : null);
+        Vfs.RemoteProvider b = new StubProvider(s -> s.contains("@hostB") ? pb : null);
+        Vfs.registerRemoteProvider(a);
+        Vfs.registerRemoteProvider(b);
+        registered.add(a);
+        registered.add(b);
+
+        assertEquals(pa, Vfs.parseStorable("sftp://ada@hostA/x"), "window A's host resolves");
+        assertEquals(pb, Vfs.parseStorable("sftp://ada@hostB/x"), "window B's host resolves");
+
+        // Window B closes → A's paths must still resolve (the single-slot bug stranded them here).
+        Vfs.unregisterRemoteProvider(b);
+        registered.remove(b);
+        assertEquals(pa, Vfs.parseStorable("sftp://ada@hostA/x"), "A still resolves after B closed");
+        assertNull(Vfs.parseStorable("sftp://ada@hostB/x"), "B's host no longer resolves (its window is gone)");
     }
 
     @Test


### PR DESCRIPTION
## Summary

Fixes #436. `RemoteFileSystems` is per-window (each `MainController`/`RemoteCoordinator` owns one), but the hooks it installed on `Vfs` — the remote-URI resolver and the storable-path handler — were a **single static slot**, so the last window to connect won:

- Window A connects to `hostA`; window B connects to `hostB` → the resolver is overwritten, and window A's remote recent files / session paths now resolve against B's engine and fail.
- Closing window B nulled the hooks entirely while A was still connected, so A's remote entries stopped resolving even though its session was live.

## Change

- `Vfs` now keeps a **registry** of `Vfs.RemoteProvider` (one per window) instead of a single resolver/storable slot. `registerRemoteProvider` / `unregisterRemoteProvider` add and remove one window's engine without touching the others.
- `RemoteFileSystems implements Vfs.RemoteProvider`: `resolve(uri)` returns a live `Path` only for an authority it has connected (else `null`); `storable(path)` returns an `sftp://` string only for a `Path` whose `FileSystem` it owns (else `null`). It registers in its constructor and unregisters in `shutdown()`.
- `Vfs.parseStorable` tries each provider until one resolves (first non-null); `Vfs.toStorableString` dispatches to the provider owning the path's `FileSystem` (exact, by identity), falling back to `path.toString()` when nothing is connected.

So a second window connecting to another host no longer clobbers the first's resolution, and closing one window only removes *its* provider — every other window's remote paths keep resolving.

## Tests

- `VfsTest` — pure registry dispatch: two providers each own their own host; both resolve; after one is unregistered the other still resolves and the removed one goes null. Existing single-provider round-trip retained.
- `RemoteFileSystemsHostKeyFxTest.twoWindowsToDifferentHostsDoNotStrandEachOther` — two real in-process SFTP servers + two `RemoteFileSystems`; both hosts' `sftp://` paths resolve and round-trip (`storable` ↔ `parse`) through the shared registry; after closing engine B, A still resolves and B goes null.
- Both proven to fail with the registry neutered to single-slot last-writer-wins. Full `mvn verify` green.

## Performance

None — remote resolution happens on file open / session restore, not on any hot path. The registry is a small copy-on-write set (one entry per open SFTP window).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
