### PR TITLE
Close plugin class loaders instead of leaking them (#442)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Reloading or uninstalling plugins no longer leaks jar file handles.** Each plugin's class loader was never
+  closed, so every Settings → Plugins reload (and every install/uninstall) left the old loader — and its open jar
+  handles — behind; on Windows that also kept the jar locked, blocking uninstall/update while the app ran. Loaders
+  are now closed once no window is using them (on reload, and at shutdown), while a plugin still running in another
+  window keeps its loader until that window closes. (#442)
 - **Two windows connected to different SFTP servers no longer strand each other's remote files.** With more than
   one window open, the last one to connect took over remote-path resolution, so the first window's remote recent
   files and session paths stopped resolving — and closing the second window broke them for the first even while it

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -366,8 +366,15 @@ icon (`Icons.findInFiles()`, `onFindInFiles → openSearchInFiles`) sits beside 
   (`togglePluginSupport` — persists + `syncPluginsCheck`, reports a restart is needed). `module-info`
   `exports com.editora.plugin;` + `opens com.editora.plugin to com.fasterxml.jackson.databind;` (the manifest
   DTO). **Plugins load at startup only** — enable/disable + the master gate take effect on the next launch (no
-  hot classloader/UI unload; per-window `stop()` on close is the only teardown). **One new exported package; no
-  new Maven dependency.** Plugin-API Javadoc (the author-facing surface) builds + doclint-validates via the `apidocs` profile: `./mvnw -Papidocs javadoc:javadoc` (scoped to `com.editora.plugin`, `doclint=all,-missing` so broken `@link`/HTML fail). Example: `examples/example-plugin/` (a complete Java + declarative plugin with a
+  hot classloader/UI unload; per-window `stop()` on close is the only teardown). **Class-loader lifecycle (#442):**
+  `PluginManager` tracks every `URLClassLoader` it builds in a `live` set and ref-counts them in `pins`. Each
+  window's `PluginCoordinator` `pin`s a loader per started plugin (in `applyPlugins`) and `release`s it in
+  `disposePlugins`; `discover()` closes any previously-built loader that's now orphaned (unpinned and not carried
+  into the new descriptor set — the Reload/install/uninstall leak that held jar handles + locked the jar on
+  Windows), `release` closes a loader once its last pin drops **and** it's no longer a current descriptor's
+  loader, and `WindowManager.onWindowClosed` calls `closeAll()` when the last window closes. A loader still in use
+  by a plugin running in another window is never closed (pinned), so this is safe without hot-reload. **One new
+  exported package; no new Maven dependency.** Plugin-API Javadoc (the author-facing surface) builds + doclint-validates via the `apidocs` profile: `./mvnw -Papidocs javadoc:javadoc` (scoped to `com.editora.plugin`, `doclint=all,-missing` so broken `@link`/HTML fail). Example: `examples/example-plugin/` (a complete Java + declarative plugin with a
   `build.sh`) + `docs/plugins.md`. **Registry / install (browse + from-disk):** a plugin is distributed as a
   **`.zip`** whose top level is the plugin folder contents. **`RegistryIndex`/`RegistryEntry`** (lenient
   Jackson, static `parse`) model a curated **`index.json`**; **`PluginRegistry`** fetches it over HTTPS

--- a/src/main/java/com/editora/plugin/PluginManager.java
+++ b/src/main/java/com/editora/plugin/PluginManager.java
@@ -8,9 +8,13 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Predicate;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import com.fasterxml.jackson.databind.DeserializationFeature;
@@ -37,6 +41,18 @@ public final class PluginManager {
     private final ObjectMapper mapper = new ObjectMapper().disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
 
     private volatile List<PluginDescriptor> descriptors = List.of();
+
+    /**
+     * Every {@link URLClassLoader} this manager has built and not yet closed. A loader holds its plugin's jar
+     * file handles open (and on Windows locks the jar), so it must be {@code close()}d when it is no longer used
+     * — but never while a plugin is still running in some window (#442). {@link #pins} ref-counts how many live
+     * {@link Plugin} instances (across windows) use each loader; a loader is closed only when it's both unpinned
+     * and no longer the current one for its plugin (superseded by a re-{@link #discover()}), or by {@link
+     * #closeAll()} at app shutdown. Concurrent because {@code discover()} runs off the FX thread.
+     */
+    private final Set<URLClassLoader> live = ConcurrentHashMap.newKeySet();
+
+    private final Map<URLClassLoader, Integer> pins = new ConcurrentHashMap<>();
 
     /**
      * @param pluginsDir {@code <configDir>/plugins}
@@ -66,6 +82,82 @@ public final class PluginManager {
             }
         }
         descriptors = List.copyOf(found);
+        closeOrphanedLoaders(currentLoaders());
+    }
+
+    /** The {@link URLClassLoader}s of the current descriptor set (freshly built by the latest discover). */
+    private Set<URLClassLoader> currentLoaders() {
+        return descriptors.stream()
+                .map(PluginDescriptor::classLoader)
+                .filter(URLClassLoader.class::isInstance)
+                .map(URLClassLoader.class::cast)
+                .collect(Collectors.toSet());
+    }
+
+    /**
+     * Closes every open loader that is neither in {@code keep} (the current descriptors' loaders) nor pinned by a
+     * live plugin instance — the loaders a re-discover just orphaned (Reload / install / uninstall previously
+     * leaked one per discover, holding jar handles and locking the jar on Windows). A loader still running in a
+     * window stays open (pinned) and is released later, so this never breaks a live plugin.
+     */
+    private void closeOrphanedLoaders(Set<URLClassLoader> keep) {
+        for (URLClassLoader l : new ArrayList<>(live)) {
+            if (!keep.contains(l) && pins.getOrDefault(l, 0) <= 0) {
+                closeLoader(l);
+            }
+        }
+    }
+
+    private void closeLoader(URLClassLoader l) {
+        live.remove(l);
+        pins.remove(l);
+        try {
+            l.close();
+        } catch (IOException e) {
+            LOG.log(Level.WARNING, "Failed to close plugin class loader " + l.getName(), e);
+        }
+    }
+
+    /**
+     * Pins {@code loader} while a {@link Plugin} instance built from it is live in a window (call once per
+     * successful start). A pinned loader is never closed by {@link #discover()}; releasing balances it.
+     */
+    public void pin(ClassLoader loader) {
+        if (loader instanceof URLClassLoader ucl) {
+            pins.merge(ucl, 1, Integer::sum);
+        }
+    }
+
+    /**
+     * Releases a pin taken by {@link #pin} (call once per plugin {@code stop()} on window close). When the last
+     * pin is released <em>and</em> the loader is no longer a current descriptor's loader (it was superseded by a
+     * re-discover while the window was open), the loader is closed — otherwise it stays open for its still-current
+     * plugin and is closed by the next {@link #discover()} or {@link #closeAll()}.
+     */
+    public void release(ClassLoader loader) {
+        if (!(loader instanceof URLClassLoader ucl)) {
+            return;
+        }
+        int remaining = pins.merge(ucl, -1, Integer::sum);
+        if (remaining <= 0) {
+            pins.remove(ucl);
+            if (!currentLoaders().contains(ucl)) {
+                closeLoader(ucl);
+            }
+        }
+    }
+
+    /** Closes every open loader (app shutdown / last window closing). Idempotent. */
+    public void closeAll() {
+        for (URLClassLoader l : new ArrayList<>(live)) {
+            closeLoader(l);
+        }
+        pins.clear();
+    }
+
+    /** How many class loaders this manager currently holds open — for tests + lifecycle assertions. */
+    int liveLoaderCount() {
+        return live.size();
     }
 
     private PluginDescriptor loadDescriptor(Path dir, Path manifestFile) {
@@ -96,14 +188,16 @@ public final class PluginManager {
     }
 
     /** Builds a child loader from the plugin's {@code *.jar} and {@code lib/*.jar}; parent = the app loader. */
-    private ClassLoader buildClassLoader(Path dir) {
+    private URLClassLoader buildClassLoader(Path dir) {
         List<URL> urls = new ArrayList<>();
         collectJars(dir, urls);
         collectJars(dir.resolve("lib"), urls);
-        return new URLClassLoader(
+        URLClassLoader loader = new URLClassLoader(
                 "plugin:" + dir.getFileName(),
                 urls.toArray(new URL[0]),
                 getClass().getClassLoader());
+        live.add(loader); // tracked so discover()/closeAll() can close it (see the `live`/`pins` note above)
+        return loader;
     }
 
     private static void collectJars(Path dir, List<URL> out) {

--- a/src/main/java/com/editora/ui/PluginCoordinator.java
+++ b/src/main/java/com/editora/ui/PluginCoordinator.java
@@ -86,6 +86,9 @@ final class PluginCoordinator {
     private final PluginRegistry pluginRegistry;
     private final PluginInstaller pluginInstaller;
     private final List<Plugin> startedPlugins = new ArrayList<>();
+    /** The class loaders this window pinned (one per started Java plugin), released on window close (#442). */
+    private final List<ClassLoader> pinnedLoaders = new ArrayList<>();
+
     private final List<EditorMenuContribution> pluginMenuItems = new ArrayList<>();
     private final List<ToolWindow> pluginToolWindows = new ArrayList<>();
 
@@ -147,6 +150,12 @@ final class PluginCoordinator {
             }
         }
         startedPlugins.clear();
+        // Release this window's loader pins; a loader with no remaining pins that a re-discover superseded is
+        // closed now, freeing its jar handles (#442).
+        for (ClassLoader l : pinnedLoaders) {
+            pluginManager.release(l);
+        }
+        pinnedLoaders.clear();
     }
 
     /** Gates the plugin-contributed tool windows on an open buffer (called from updateBufferToolWindows). */
@@ -231,6 +240,10 @@ final class PluginCoordinator {
                     if (plugin != null) {
                         plugin.start(new PluginContextImpl(d));
                         startedPlugins.add(plugin);
+                        // Pin the shared loader so a re-discover (Reload/uninstall) can't close it out from
+                        // under this running plugin; released in disposePlugins on window close (#442).
+                        pluginManager.pin(d.classLoader());
+                        pinnedLoaders.add(d.classLoader());
                     }
                 }
             } catch (Throwable t) {

--- a/src/main/java/com/editora/ui/WindowManager.java
+++ b/src/main/java/com/editora/ui/WindowManager.java
@@ -401,6 +401,9 @@ public class WindowManager {
         }
         controller.disposePlugins(); // stop() the window's plugins
         windows.remove(holder);
+        if (windows.isEmpty()) {
+            pluginManager.closeAll(); // last window gone — close every plugin class loader, freeing jar handles (#442)
+        }
         openSetReconcile.playFromStart();
     }
 

--- a/src/test/java/com/editora/plugin/PluginManagerTest.java
+++ b/src/test/java/com/editora/plugin/PluginManagerTest.java
@@ -119,6 +119,62 @@ class PluginManagerTest {
         assertTrue(pm.descriptors().isEmpty());
     }
 
+    // --- #442: class-loader lifecycle (close leaked loaders; never close a pinned one) -------------------
+
+    private static PluginManager oneEnabledPlugin(Path pluginsDir) throws Exception {
+        Path a = Files.createDirectories(pluginsDir.resolve("alpha"));
+        Files.writeString(a.resolve("plugin.json"), "{ \"id\": \"alpha\", \"name\": \"Alpha\", \"main\": \"x.Y\" }");
+        return new PluginManager(pluginsDir, id -> true);
+    }
+
+    @Test
+    void reDiscoverClosesTheOrphanedLoaderInsteadOfLeakingIt(@TempDir Path pluginsDir) throws Exception {
+        PluginManager pm = oneEnabledPlugin(pluginsDir);
+        pm.discover();
+        assertEquals(1, pm.liveLoaderCount(), "one loader for the enabled plugin");
+
+        // A Settings Reload / install / uninstall re-discovers. With nothing pinned, the previous loader was
+        // orphaned (never re-instantiated) — it must be closed, not accumulated (the leak).
+        pm.discover();
+        assertEquals(1, pm.liveLoaderCount(), "the old loader is closed; only the freshly-built one remains");
+    }
+
+    @Test
+    void aPinnedLoaderSurvivesReDiscoverAndIsClosedOnceReleased(@TempDir Path pluginsDir) throws Exception {
+        PluginManager pm = oneEnabledPlugin(pluginsDir);
+        pm.discover();
+        ClassLoader running = pm.descriptors().get(0).classLoader(); // a window instantiated this
+        pm.pin(running);
+
+        pm.discover(); // a Settings Reload while the plugin is live in a window
+        assertEquals(2, pm.liveLoaderCount(), "the running (pinned) loader stays open beside the new one");
+        assertTrue(pm.descriptors().get(0).classLoader() != running, "a fresh loader was built");
+
+        pm.release(running); // the window closes → the superseded, now-unpinned loader is closed
+        assertEquals(1, pm.liveLoaderCount(), "the released, superseded loader is closed");
+
+        pm.closeAll();
+        assertEquals(0, pm.liveLoaderCount(), "shutdown closes everything");
+    }
+
+    @Test
+    void releasingTheCurrentLoaderKeepsItOpenForItsStillLivePlugin(@TempDir Path pluginsDir) throws Exception {
+        // Two windows share one loader; closing one window must not close the loader the other still uses.
+        PluginManager pm = oneEnabledPlugin(pluginsDir);
+        pm.discover();
+        ClassLoader shared = pm.descriptors().get(0).classLoader();
+        pm.pin(shared); // window A
+        pm.pin(shared); // window B
+
+        pm.release(shared); // window B closes
+        assertEquals(1, pm.liveLoaderCount(), "still open — window A is using it and it's the current loader");
+
+        pm.release(shared); // window A closes; still the current descriptor's loader → kept until closeAll
+        assertEquals(1, pm.liveLoaderCount(), "kept open (still current) until shutdown");
+        pm.closeAll();
+        assertEquals(0, pm.liveLoaderCount());
+    }
+
     @Test
     void storeIsDisabledByDefaultAndTogglable() {
         com.editora.config.PluginStore store = new com.editora.config.PluginStore();


### PR DESCRIPTION
## Summary

Fixes #442. `PluginManager.discover()` built one `URLClassLoader` per enabled Java plugin and never `close()`d the previous ones — so every Settings → Plugins reload (and every install/uninstall) leaked the old loader and its open jar handles. On **Windows** this also kept the jar file locked, so uninstalling or updating a plugin couldn't overwrite/delete `plugins/<id>/*.jar` while the app ran.

The loader is shared app-wide (classes load once; only the `Plugin` instance + its tool-window Node are per-window), so a loader still in use by a plugin running in another window must not be closed. This ships the **safe slice** the issue describes — close on genuine unload, never while live — leaving hot-reload deferred.

## Change

- `PluginManager` tracks every `URLClassLoader` it builds in a `live` set and ref-counts them in `pins`:
  - `pin(loader)` / `release(loader)` — each window's `PluginCoordinator` pins a loader per started plugin (`applyPlugins`) and releases it on window close (`disposePlugins`).
  - `discover()` closes any previously-built loader now **orphaned** — unpinned and not carried into the new descriptor set (the Reload/install/uninstall leak).
  - `release()` closes a loader once its last pin drops **and** it's no longer a current descriptor's loader (superseded while a window was open).
  - `WindowManager.onWindowClosed` calls `closeAll()` when the last window closes.
- A loader still pinned by a plugin running in another window is **never** closed — so nothing breaks a live plugin.

## Tests

- `PluginManagerTest` (temp dirs):
  - a re-`discover()` closes the orphaned loader instead of accumulating it (proven to leak `2` loaders when the close is neutered);
  - a **pinned** loader survives a re-`discover()` and is closed only once released (then `closeAll()` clears the rest);
  - releasing a loader still used by another window (and still current) keeps it open until shutdown.
- Full `mvn verify` green.

## Performance

None — loader bookkeeping happens only on discover / window open+close, never on a hot path. The `live`/`pins` structures are small (one entry per open plugin).

## Deferred

Hot classloader/UI reload (applying enable/disable/update without a restart) stays deferred as documented; this change only makes the existing "load at startup, teardown on close" lifecycle stop leaking handles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
