### PR TITLE
PDF viewer: stop the Fit-mode zoom oscillation loop

### DIFF
--- a/src/main/java/com/editora/ui/PdfViewerPane.java
+++ b/src/main/java/com/editora/ui/PdfViewerPane.java
@@ -53,6 +53,15 @@ public final class PdfViewerPane implements TabContent {
     private static final double MAX_ZOOM = 20.0;
     private static final double ZOOM_STEP = 1.25;
 
+    /**
+     * Space reserved around the page when fitting: the holder's 12px padding on each side (24) plus a small
+     * slack so the fitted page stays <b>strictly</b> inside the viewport. Without the slack the fitted page's
+     * preferred size lands exactly at the scrollbar threshold, so the {@link ScrollPane} toggles a scrollbar
+     * every layout pass; each toggle nudges {@code viewportBounds}, re-firing the listener → {@link #relayout()}
+     * → re-fit → … forever (the 73%↔74% oscillation seen on a portrait PDF, burning the FX thread).
+     */
+    private static final double FIT_INSET = 28;
+
     private final Path path;
     private final String title;
     private final BorderPane root = new BorderPane();
@@ -82,6 +91,11 @@ public final class PdfViewerPane implements TabContent {
     private Image image;
     private double zoom = 1.0;
     private boolean fitMode = true;
+
+    /** Viewport size the last fit was computed against; lets {@link #relayout()} ignore self-induced jitter. */
+    private double lastFitViewW = -1;
+
+    private double lastFitViewH = -1;
 
     public PdfViewerPane(Path path) {
         this.path = path;
@@ -267,8 +281,10 @@ public final class PdfViewerPane implements TabContent {
         double natW = image.getWidth();
         double natH = image.getHeight();
         if (fitMode) {
-            double viewW = scroll.getViewportBounds().getWidth() - 24;
-            double viewH = scroll.getViewportBounds().getHeight() - 24;
+            lastFitViewW = scroll.getViewportBounds().getWidth();
+            lastFitViewH = scroll.getViewportBounds().getHeight();
+            double viewW = lastFitViewW - FIT_INSET;
+            double viewH = lastFitViewH - FIT_INSET;
             if (viewW > 1 && viewH > 1) {
                 zoom = Math.min(1.0, Math.min(viewW / natW, viewH / natH));
             } else {
@@ -284,9 +300,17 @@ public final class PdfViewerPane implements TabContent {
 
     /** Re-fits when the tab is first shown / the window resizes (call after the node is in a laid-out scene). */
     void relayout() {
-        if (fitMode) {
-            apply();
+        if (!fitMode) {
+            return;
         }
+        // Only re-fit on a genuine resize: a sub-pixel viewport change is the feedback from our own re-fit
+        // (a scrollbar flickering on/off), and reacting to it re-opens the oscillation loop.
+        double vw = scroll.getViewportBounds().getWidth();
+        double vh = scroll.getViewportBounds().getHeight();
+        if (Math.abs(vw - lastFitViewW) < 1.0 && Math.abs(vh - lastFitViewH) < 1.0) {
+            return;
+        }
+        apply();
     }
 
     /** The page count once loaded (0 while loading / on failure). Test accessor. */


### PR DESCRIPTION
## Bug

Opening a PDF renders fine, but in the default **Fit** mode the zoom label oscillates 73% ↔ 74% forever, keeping the JavaFX thread busy for the lifetime of the tab. Reported with a screencast (the zoom % visibly alternates across every frame).

## Root cause

In `PdfViewerPane.apply()` the fit math subtracts exactly `24` — the holder's `12`+`12` padding — so the fitted page's preferred size lands *exactly* at the `ScrollPane`'s scrollbar threshold on the binding axis. The scrollbar toggles on one layout pass and off the next; each toggle nudges `viewportBounds`, which fires the `viewportBoundsProperty` listener → `relayout()` → `apply()` → recompute fit → new width → toggle again → … a limit cycle (the visible flicker).

## Fix

1. **Reserve slack** (`FIT_INSET = 28` vs the `-24` that exactly cancelled the padding) so the fitted page stays *strictly* inside the viewport and never triggers a scrollbar — removing the loop's driver. Visually imperceptible (~4px).
2. **Guard `relayout()`** to ignore sub-pixel viewport jitter (`< 1px` since the last fit), so only a genuine window resize re-fits.

Net **performance win** — removes a per-pulse relayout that ran continuously while any PDF was open — with zero added hot-path cost (two comparisons on the resize path only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)