### PR TITLE
Clear the selection after copy (#581)

### DIFF
--- a/src/main/java/com/editora/ui/MainController.java
+++ b/src/main/java/com/editora/ui/MainController.java
@@ -7348,6 +7348,9 @@ public class MainController implements com.editora.mcp.McpBridge {
             return;
         }
         area.copy();
+        if (had) {
+            area.deselect(); // collapse the selection once copied (leaves the caret in place)
+        }
         deactivateMark();
         refreshPasteState(); // clipboard now has content
         setStatus(tr(had ? "status.copied" : "status.nothingToCopy"));


### PR DESCRIPTION
## Summary
Fixes #581 — after copying a selected region, the text stayed visually highlighted.

`onCopy()` deactivated the Emacs mark but never collapsed the actual selection. Now, when a real selection was copied, `area.deselect()` collapses it (the caret stays put) so the highlight clears like in most editors.

## Scope
- Only the real-selection copy branch is affected. The empty-selection "copy current line" and multi-caret copy paths are untouched.
- No hot-path cost — runs once per copy command.

🤖 Generated with [Claude Code](https://claude.com/claude-code)