### PR TITLE
Debug tool window: active-focus highlight + gdb-style single-key controls

### DIFF
--- a/src/main/java/com/editora/ui/DebugPanel.java
+++ b/src/main/java/com/editora/ui/DebugPanel.java
@@ -20,6 +20,7 @@ import javafx.scene.control.Tooltip;
 import javafx.scene.control.TreeCell;
 import javafx.scene.control.TreeItem;
 import javafx.scene.control.TreeView;
+import javafx.scene.input.KeyEvent;
 import javafx.scene.layout.HBox;
 import javafx.scene.layout.Priority;
 import javafx.scene.layout.Region;
@@ -148,19 +149,23 @@ public final class DebugPanel extends VBox implements ToolWindowContent {
         // IntelliJ-style grouped, icon-only toolbar; the session state + file sit at the right edge.
         HBox toolbar = new HBox(
                 2,
-                btn(start, "debug.start", actions::start, Icons.run()),
-                btn(pause, "debug.pause", actions::pause, Icons.debugPause()),
-                btn(stop, "debug.stop", actions::stop, Icons.debugStop()),
-                btn(restart, "debug.restart", actions::restart, Icons.refresh()),
+                btn(start, "debug.start", "C", actions::start, Icons.run()),
+                btn(pause, "debug.pause", "P", actions::pause, Icons.debugPause()),
+                btn(stop, "debug.stop", "K", actions::stop, Icons.debugStop()),
+                btn(restart, "debug.restart", "R", actions::restart, Icons.refresh()),
                 groupSeparator(),
-                btn(stepOver, "debug.stepOver", actions::stepOver, Icons.debugStepOver()),
-                btn(stepInto, "debug.stepInto", actions::stepInto, Icons.debugStepInto()),
-                btn(stepOut, "debug.stepOut", actions::stepOut, Icons.debugStepOut()),
-                btn(runToCursor, "debug.runToCursor", actions::runToCursor, Icons.debugRunToCursor()),
+                btn(stepOver, "debug.stepOver", "N", actions::stepOver, Icons.debugStepOver()),
+                btn(stepInto, "debug.stepInto", "S", actions::stepInto, Icons.debugStepInto()),
+                btn(stepOut, "debug.stepOut", "F", actions::stepOut, Icons.debugStepOut()),
+                btn(runToCursor, "debug.runToCursor", "U", actions::runToCursor, Icons.debugRunToCursor()),
                 spacer(),
                 status);
         start.getStyleClass().add("debug-start"); // green play accent
         toolbar.setAlignment(Pos.CENTER_LEFT);
+        // gdb-style single-key shortcuts, live only while focus is somewhere in this panel (the eval field
+        // is exempt so the REPL types normally). Bare letters aren't bound in any keymap, so the scene
+        // KeyDispatcher lets them fall through to this capture-phase filter untouched.
+        addEventFilter(KeyEvent.KEY_PRESSED, this::handleDebugKey);
 
         // Thread selector (IntelliJ's dropdown over the frames list).
         threads.getStyleClass().add("debug-threads");
@@ -323,14 +328,50 @@ public final class DebugPanel extends VBox implements ToolWindowContent {
         return l;
     }
 
-    /** An icon-only toolbar button: the full command title lives in the tooltip (IntelliJ-style). */
-    private Button btn(Button b, String key, Runnable action, Node icon) {
+    /** An icon-only toolbar button: the full command title + its single-key shortcut live in the tooltip
+     *  (IntelliJ-style), so the shortcut is discoverable on hover. */
+    private Button btn(Button b, String key, String shortcut, Runnable action, Node icon) {
         b.setGraphic(icon);
-        b.setTooltip(new Tooltip(tr("command." + key)));
+        b.setTooltip(new Tooltip(tr("command." + key) + "  (" + shortcut + ")"));
         b.getStyleClass().addAll("flat", "debug-toolbar-button");
         b.setFocusTraversable(false);
         b.setOnAction(e -> action.run());
         return b;
+    }
+
+    /**
+     * gdb/lldb-style single-key control while the Debug panel is focused: c=continue, p=pause, k=kill/stop,
+     * r=restart, n=next/step-over, s=step-into, f=finish/step-out, u=until/run-to-cursor. Fires the matching
+     * toolbar button (respecting its enabled state) and swallows the key so the stack/variables lists don't
+     * treat it as type-ahead. Exempts the evaluate REPL field and any modified chord so normal typing and
+     * global chords (e.g. C-x o to leave the panel) still work.
+     */
+    private void handleDebugKey(KeyEvent e) {
+        if (e.isControlDown() || e.isAltDown() || e.isMetaDown() || e.isShortcutDown()) {
+            return; // leave modified chords (incl. C-x o focus cycling) to the global dispatcher
+        }
+        if (evalInput.isFocused() || e.getTarget() == evalInput) {
+            return; // typing an expression in the REPL
+        }
+        Button target =
+                switch (e.getCode()) {
+                    case C -> start;
+                    case P -> pause;
+                    case K -> stop;
+                    case R -> restart;
+                    case N -> stepOver;
+                    case S -> stepInto;
+                    case F -> stepOut;
+                    case U -> runToCursor;
+                    default -> null;
+                };
+        if (target == null) {
+            return;
+        }
+        if (!target.isDisabled()) {
+            target.fire();
+        }
+        e.consume(); // reserve these letters in the panel even when the action is currently disabled
     }
 
     private static Separator groupSeparator() {

--- a/src/main/java/com/editora/ui/MainController.java
+++ b/src/main/java/com/editora/ui/MainController.java
@@ -8464,6 +8464,11 @@ public class MainController implements com.editora.mcp.McpBridge {
     private static void focusWindow(Node target) {
         if (target instanceof StructurePanel structure) {
             structure.focusContent();
+        } else if (target instanceof ToolWindowContent content) {
+            // Focus a real focusable child (e.g. the Debug stack list) rather than the panel container —
+            // a bare VBox isn't focus-traversable, so requestFocus() on it wouldn't move focus in, leaving
+            // the panel's local key shortcuts (e.g. the Debug toolbar keys) inert after C-x o.
+            content.focusFirstItem();
         } else {
             target.requestFocus();
         }

--- a/src/main/java/com/editora/ui/ToolWindowManager.java
+++ b/src/main/java/com/editora/ui/ToolWindowManager.java
@@ -46,6 +46,10 @@ import static com.editora.i18n.Messages.tr;
 public class ToolWindowManager {
 
     private static final PseudoClass OPEN = PseudoClass.getPseudoClass("open");
+    /** Set on the stripe button of the tool window that currently holds keyboard focus (IntelliJ-style
+     *  "active" highlight, stronger than the merely-{@link #OPEN} tint). Custom name to avoid colliding
+     *  with JavaFX's built-in {@code :active}/{@code :focused} button pseudo-classes. */
+    private static final PseudoClass ACTIVE = PseudoClass.getPseudoClass("tw-active");
 
     private final ConfigManager config;
     private final KeymapManager keymap;
@@ -112,11 +116,22 @@ public class ToolWindowManager {
         });
     }
 
-    /** Marks the tool window panel that contains the scene's focus owner as active (others inactive). */
+    /**
+     * Marks the tool window that contains the scene's focus owner as active (others inactive): its panel
+     * gets the active border and its stripe button gets the {@link #ACTIVE} highlight. Iterates every
+     * registered window so a window that just lost focus is cleared too (closed windows have no panel and
+     * so are never active).
+     */
     private void updateActivePanel(Node focusOwner) {
-        for (Region panel : panels.values()) {
+        for (ToolWindow tw : byId.values()) {
+            Region panel = panels.get(tw); // non-null only while the window is open
+            boolean active = panel != null && focusOwner != null && isDescendant(focusOwner, panel);
             if (panel instanceof ToolWindowPanel p) {
-                p.setActive(focusOwner != null && isDescendant(focusOwner, p));
+                p.setActive(active);
+            }
+            Button button = stripeButtons.get(tw);
+            if (button != null) {
+                button.pseudoClassStateChanged(ACTIVE, active);
             }
         }
     }

--- a/src/main/resources/com/editora/styles/app.css
+++ b/src/main/resources/com/editora/styles/app.css
@@ -933,6 +933,16 @@
     -fx-fill: -color-accent-fg;
 }
 
+/* Stronger highlight when the tool window holds keyboard focus (IntelliJ-style "active"), distinct from
+   the subtle merely-open tint above. Listed after :open so it wins the background when both apply. */
+.tool-stripe-button:tw-active {
+    -fx-background-color: -color-accent-muted;
+}
+
+.tool-stripe-button:tw-active .toolbar-icon {
+    -fx-fill: -color-accent-fg;
+}
+
 /* Stripe-icon reordering (mirrors the tab-strip drag UI): dim the dragged icon, draw an accent
    insertion line on the side the dropped icon would land (top/bottom for vertical stripes,
    left/right for the horizontal bottom stripe). */

--- a/src/test/java/com/editora/ui/DebugPanelShortcutFxTest.java
+++ b/src/test/java/com/editora/ui/DebugPanelShortcutFxTest.java
@@ -1,0 +1,118 @@
+package com.editora.ui;
+
+import java.lang.reflect.Proxy;
+import java.util.ArrayList;
+import java.util.List;
+
+import javafx.scene.input.KeyCode;
+import javafx.scene.input.KeyEvent;
+
+import com.editora.dap.DapManager;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * The Debug panel's gdb-style single-key shortcuts (live only while the panel is focused): c=continue,
+ * p=pause, k=stop, r=restart, n=step over, s=step into, f=step out, u=run to cursor. They fire the matching
+ * toolbar control (respecting its enabled state), swallow the key so the stack/variables lists don't treat
+ * it as type-ahead, and leave modified chords (e.g. C-x o focus cycling) to the global dispatcher.
+ */
+@Tag("fx")
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class DebugPanelShortcutFxTest {
+
+    @BeforeAll
+    void setUp() throws Exception {
+        FxTestSupport.bootToolkit();
+    }
+
+    /** A {@link DebugPanel.Actions} proxy that records the name of each control method invoked. */
+    private static DebugPanel.Actions recording(List<String> calls) {
+        return (DebugPanel.Actions) Proxy.newProxyInstance(
+                DebugPanel.Actions.class.getClassLoader(), new Class[] {DebugPanel.Actions.class}, (p, m, a) -> {
+                    calls.add(m.getName());
+                    Class<?> rt = m.getReturnType();
+                    if (rt == boolean.class) {
+                        return false;
+                    }
+                    if (rt == int.class) {
+                        return 0;
+                    }
+                    if (rt == long.class) {
+                        return 0L;
+                    }
+                    return null;
+                });
+    }
+
+    private static KeyEvent key(KeyCode code, boolean control) {
+        return new KeyEvent(KeyEvent.KEY_PRESSED, KeyEvent.CHAR_UNDEFINED, "", code, false, control, false, false);
+    }
+
+    @Test
+    void suspendedSingleKeysFireTheMatchingControls() throws Exception {
+        List<String> calls = FxTestSupport.callOnFx(() -> {
+            List<String> invoked = new ArrayList<>();
+            DebugPanel panel = new DebugPanel(recording(invoked));
+            panel.setState(DapManager.State.SUSPENDED); // enables continue + the step controls + run-to-cursor
+            for (KeyCode c : List.of(KeyCode.C, KeyCode.N, KeyCode.S, KeyCode.F, KeyCode.U)) {
+                panel.fireEvent(key(c, false)); // goes through the real installed event filter
+            }
+            return invoked;
+        });
+        assertTrue(calls.contains("start"), "c → resume/continue (start)");
+        assertTrue(calls.contains("stepOver"), "n → step over");
+        assertTrue(calls.contains("stepInto"), "s → step into");
+        assertTrue(calls.contains("stepOut"), "f → step out");
+        assertTrue(calls.contains("runToCursor"), "u → run to cursor");
+    }
+
+    @Test
+    void runningSingleKeysFirePauseAndStopButNotDisabledSteps() throws Exception {
+        List<String> calls = FxTestSupport.callOnFx(() -> {
+            List<String> invoked = new ArrayList<>();
+            DebugPanel panel = new DebugPanel(recording(invoked));
+            panel.setState(DapManager.State.RUNNING); // pause + stop enabled; the step controls are disabled
+            panel.fireEvent(key(KeyCode.P, false));
+            panel.fireEvent(key(KeyCode.K, false));
+            panel.fireEvent(key(KeyCode.N, false)); // step over is disabled while running
+            return invoked;
+        });
+        assertTrue(calls.contains("pause"), "p → pause");
+        assertTrue(calls.contains("stop"), "k → stop");
+        assertFalse(calls.contains("stepOver"), "a disabled control does not fire");
+    }
+
+    @Test
+    void aDisabledKeyIsConsumedWhileAModifiedChordAndUnmappedLetterAreLeftAlone() throws Exception {
+        boolean[] r = FxTestSupport.callOnFx(() -> {
+            List<String> invoked = new ArrayList<>();
+            DebugPanel panel = new DebugPanel(recording(invoked));
+            panel.setState(DapManager.State.INACTIVE); // the step controls are disabled; start is enabled
+            // Invoke the handler directly so we can assert on the very event object (Event.fireEvent copies it).
+            KeyEvent disabledStep = key(KeyCode.N, false);
+            FxTestSupport.call(panel, "handleDebugKey", new Class[] {KeyEvent.class}, disabledStep);
+            KeyEvent ctrlC = key(KeyCode.C, true); // C-c: a global chord, not our bare-c resume
+            FxTestSupport.call(panel, "handleDebugKey", new Class[] {KeyEvent.class}, ctrlC);
+            KeyEvent unmapped = key(KeyCode.A, false);
+            FxTestSupport.call(panel, "handleDebugKey", new Class[] {KeyEvent.class}, unmapped);
+            return new boolean[] {
+                disabledStep.isConsumed(),
+                invoked.contains("stepOver"),
+                ctrlC.isConsumed(),
+                invoked.contains("start"),
+                unmapped.isConsumed()
+            };
+        });
+        assertTrue(r[0], "a mapped-but-disabled debug key is swallowed (no stray list type-ahead)");
+        assertFalse(r[1], "…but its action does not fire while disabled");
+        assertFalse(r[2], "a modified chord (C-c) is not consumed here — the global dispatcher gets it");
+        assertFalse(r[3], "…and it does not trigger the bare-c resume");
+        assertFalse(r[4], "an unmapped letter falls through untouched");
+    }
+}

--- a/src/test/java/com/editora/ui/ToolWindowActiveHighlightFxTest.java
+++ b/src/test/java/com/editora/ui/ToolWindowActiveHighlightFxTest.java
@@ -1,0 +1,80 @@
+package com.editora.ui;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Map;
+
+import javafx.css.PseudoClass;
+import javafx.scene.Node;
+import javafx.scene.control.Button;
+import javafx.scene.control.Label;
+import javafx.scene.layout.BorderPane;
+import javafx.scene.layout.Region;
+
+import com.editora.command.KeymapManager;
+import com.editora.config.ConfigManager;
+import com.editora.config.SharedConfig;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * A tool window's stripe button gets the {@code tw-active} highlight (IntelliJ-style, stronger than the
+ * merely-open tint) exactly while its panel holds keyboard focus, and loses it when focus moves elsewhere.
+ * This is what makes the Debug icon read as "selected" while the Debug panel is active.
+ */
+@Tag("fx")
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class ToolWindowActiveHighlightFxTest {
+
+    private static final PseudoClass ACTIVE = PseudoClass.getPseudoClass("tw-active");
+
+    @BeforeAll
+    void setUp() throws Exception {
+        FxTestSupport.bootToolkit();
+    }
+
+    private record Rig(ToolWindowManager manager, ToolWindow tw, Node content) {}
+
+    private static Rig rig() throws Exception {
+        Path dir = Files.createTempDirectory("editora-tw-active");
+        SharedConfig shared = new SharedConfig(dir, false);
+        shared.load();
+        ConfigManager config = new ConfigManager(shared);
+        ToolWindowManager m = new ToolWindowManager(new BorderPane(), new Label("editor"), config, new KeymapManager());
+        Region content = new Label("content");
+        ToolWindow tw =
+                new ToolWindow("probe", "Probe", ToolWindow.Side.RIGHT, () -> new Label("i"), content, "tool.probe");
+        m.register(tw);
+        m.open(tw);
+        return new Rig(m, tw, content);
+    }
+
+    private static Button stripeButton(ToolWindowManager m, ToolWindow tw) {
+        Map<ToolWindow, Button> buttons = FxTestSupport.field(m, "stripeButtons");
+        return buttons.get(tw);
+    }
+
+    @Test
+    void theButtonIsActiveOnlyWhileFocusIsWithinItsPanel() throws Exception {
+        boolean[] r = FxTestSupport.callOnFx(() -> {
+            Rig rig = rig();
+            Button button = stripeButton(rig.manager(), rig.tw());
+            boolean beforeFocus = button.getPseudoClassStates().contains(ACTIVE);
+            // Focus lands inside the open panel (the content node is a descendant of the ToolWindowPanel).
+            FxTestSupport.call(rig.manager(), "updateActivePanel", new Class[] {Node.class}, rig.content());
+            boolean whileFocused = button.getPseudoClassStates().contains(ACTIVE);
+            // Focus leaves every tool window (e.g. back to the editor).
+            FxTestSupport.call(rig.manager(), "updateActivePanel", new Class[] {Node.class}, (Node) null);
+            boolean afterBlur = button.getPseudoClassStates().contains(ACTIVE);
+            return new boolean[] {beforeFocus, whileFocused, afterBlur};
+        });
+        assertFalse(r[0], "merely opening a window does not make its button active");
+        assertTrue(r[1], "the button is active while focus is within its panel");
+        assertFalse(r[2], "the button clears its active state once focus leaves");
+    }
+}


### PR DESCRIPTION
Closes #583.

## What
- **Active-focus stripe highlight (all tool windows).** `ToolWindowManager.updateActivePanel` now toggles a `tw-active` pseudo-class on the focused window's stripe button; new CSS gives it a stronger `-color-accent-muted` background than the subtle `:open` tint. The Debug icon now reads as clearly selected while the Debug panel is focused.
- **gdb-style single-key controls in the Debug panel.** A focus-scoped `KEY_PRESSED` filter maps `c`=resume · `p`=pause · `k`=stop · `r`=restart · `n`=step over · `s`=step into · `f`=step out · `u`=run to cursor. Fires the matching toolbar control (respecting its enabled state), swallows the key so the stack/vars lists don't type-ahead, and exempts the eval REPL + modified chords. Each button's tooltip shows the letter.
- **Focus movement.** `focusWindow` now calls `focusFirstItem()` for any `ToolWindowContent` so `C-x o` (`window.other`) lands focus on a real child of the panel — making the panel shortcuts live after cycling in, and improving `C-x o` for every tool window.

## Tests
- `DebugPanelShortcutFxTest` — the 8 shortcuts fire the right controls; disabled controls are swallowed but not fired; modified chords / unmapped letters pass through.
- `ToolWindowActiveHighlightFxTest` — the stripe button gets `tw-active` only while its panel holds focus.

🤖 Generated with [Claude Code](https://claude.com/claude-code)