### PR TITLE
Reserve a 2-digit minimum line-number gutter width (#590)

### DIFF
--- a/src/main/java/com/editora/editor/FoldManager.java
+++ b/src/main/java/com/editora/editor/FoldManager.java
@@ -52,6 +52,9 @@ public final class FoldManager {
     private String language = "plaintext";
     /** Max number of lines shown in a collapsed region's hover preview. */
     private static final int PREVIEW_LINES = 40;
+    /** Minimum digit width the line-number gutter pads to, so a file of fewer than 10 lines still reserves
+     *  2-digit width — adding the 10th line then doesn't widen the gutter and shift the text rightward. */
+    private static final int MIN_LINE_DIGITS = 2;
     /** Fixed width of the gutter's bookmark-marker column, reserved on every row so the gutter (and
      *  thus each line's text indentation) keeps a constant width whether or not the line is bookmarked. */
     private static final double BOOKMARK_SLOT_WIDTH = 12;
@@ -844,8 +847,18 @@ public final class FoldManager {
         return String.format("%1$" + digits(total) + "s", line);
     }
 
-    /** Number of decimal digits needed for {@code total} (>= 1). */
+    /**
+     * Digit width the line-number gutter pads to. This is the source of the gutter's (and thus each line's
+     * text-indent) width, so we clamp it to a {@link #MIN_LINE_DIGITS} floor: a file of &lt;10 lines still
+     * reserves 2-digit width, so adding the 10th line no longer widens the gutter and shifts the text
+     * rightward. (Crossing a higher power of ten — 99→100 — still steps once, matching VS Code/IntelliJ.)
+     */
     private static int digits(int total) {
+        return Math.max(MIN_LINE_DIGITS, rawDigits(total));
+    }
+
+    /** Number of decimal digits needed for {@code total} (>= 1). */
+    private static int rawDigits(int total) {
         return (int) Math.floor(Math.log10(Math.max(1, total))) + 1;
     }
 }


### PR DESCRIPTION
## Summary

Fixes the line-number gutter widening (and shifting all editor text rightward) when a file crosses from 9 to 10 lines.

`FoldManager` padded each line number to `digits(total)`, so a 9-line file reserved 1 character and adding the 10th line widened the gutter to 2 — moving the text, since the paragraph graphic's width is the text's left inset.

This clamps the padding width to `MIN_LINE_DIGITS = 2`, so files under 10 lines already reserve 2-digit width and the 9→10 transition no longer moves the text. Higher power-of-ten crossings (99→100) still step once, matching VS Code/IntelliJ. Mirrors the `Math.max(2, …)` convention already in `CodePdfWriter`.

## Verification

Digit width at crossings — 1, 9, 10, 99 all pad to 2 (no shift); 99→100 steps to 3 as expected. Compiles clean.

## Performance

Negligible — same code path with an added `Math.max`, only exercised on the debounced fold recompute (never per keystroke/scroll).

Fixes #590

🤖 Generated with [Claude Code](https://claude.com/claude-code)