### PR TITLE
Debug panel: keep focus in the panel when stepping via single-key controls

### DIFF
--- a/src/main/java/com/editora/ui/DebugCoordinator.java
+++ b/src/main/java/com/editora/ui/DebugCoordinator.java
@@ -14,6 +14,7 @@ import java.util.function.Function;
 import java.util.function.Predicate;
 
 import javafx.application.Platform;
+import javafx.scene.Node;
 import javafx.scene.control.CheckBox;
 import javafx.scene.control.Label;
 import javafx.scene.control.TextField;
@@ -644,6 +645,12 @@ final class DebugCoordinator {
             return;
         }
         clearExecHighlight();
+        // Revealing the line focuses the editor (openPath calls requestFocus on the buffer). When the user
+        // is driving the session from the Debug panel — the single-key step shortcuts — that yanks focus to
+        // the code after every step, so the next key press is lost and they must re-focus the panel each
+        // time. Preserve the panel's focus across the reveal in that case only; a fresh breakpoint hit while
+        // editing (focus not in the panel) still lands in the code at the stopped line, as before.
+        Node keepFocus = debugPanelFocusOwner();
         ops.openPath(frame.file()); // opens or focuses the tab
         // Take the frame's OWN buffer, not whatever is active: openPath opens nothing when the source
         // isn't on disk (a frame in a dependency, or a path baked in by a build on another machine — it
@@ -654,6 +661,23 @@ final class DebugCoordinator {
             execHighlightBuffer = b;
             b.setExecutionLine(frame.line());
         }
+        if (keepFocus != null) {
+            Platform.runLater(keepFocus::requestFocus); // after openPath's own requestFocus, so the panel wins
+        }
+    }
+
+    /** The Debug-panel descendant that currently owns keyboard focus (so it can be restored across an
+     *  editor-focusing reveal), or {@code null} when focus is elsewhere. */
+    private Node debugPanelFocusOwner() {
+        var window = host.window();
+        var scene = window == null ? null : window.getScene();
+        Node owner = scene == null ? null : scene.getFocusOwner();
+        for (Node n = owner; n != null; n = n.getParent()) {
+            if (n == debugPanel) {
+                return owner;
+            }
+        }
+        return null;
     }
 
     private void clearExecHighlight() {

--- a/src/test/java/com/editora/ui/DebugPanelFocusRetentionFxTest.java
+++ b/src/test/java/com/editora/ui/DebugPanelFocusRetentionFxTest.java
@@ -1,0 +1,88 @@
+package com.editora.ui;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import javafx.scene.Node;
+import javafx.stage.Stage;
+
+import com.editora.dap.DapModels;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Regression: stepping from the Debug panel's single-key shortcuts must keep keyboard focus in the panel.
+ * The execution-line reveal ({@code highlightFrame} → {@code openPath}) focuses the editor to show the
+ * stopped line; when the user is driving from the panel, that focus must be handed straight back, or every
+ * step steals focus to the code and the next key press is lost.
+ *
+ * <p>Self-guarding: headless focus can't always be granted, so the test skips (JUnit assumption) unless the
+ * panel can actually take focus first.
+ */
+@Tag("fx")
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class DebugPanelFocusRetentionFxTest {
+
+    private FxWindowFixture fx;
+
+    @BeforeAll
+    void setUp() throws Exception {
+        FxTestSupport.bootToolkit();
+        fx = FxWindowFixture.create();
+    }
+
+    @AfterAll
+    void tearDown() throws Exception {
+        if (fx != null) {
+            fx.dispose();
+        }
+    }
+
+    private boolean focusWithinDebugPanel() throws Exception {
+        return FxTestSupport.callOnFx(() -> {
+            DebugPanel panel =
+                    FxTestSupport.field(FxTestSupport.field(fx.controller, "debugCoordinator"), "debugPanel");
+            Stage stage = FxTestSupport.field(fx.controller, "stage");
+            Node owner = stage.getScene() == null ? null : stage.getScene().getFocusOwner();
+            for (Node n = owner; n != null; n = n.getParent()) {
+                if (n == panel) {
+                    return true;
+                }
+            }
+            return false;
+        });
+    }
+
+    @Test
+    void steppingFromThePanelKeepsFocusInThePanel() throws Exception {
+        Object debug = FxTestSupport.field(fx.controller, "debugCoordinator");
+        Path real = fx.configDir.resolve("Focus.java");
+        Files.writeString(real, "class Focus {\n  void go() {}\n}\n");
+
+        FxTestSupport.runOnFx(() -> {
+            FxTestSupport.call(fx.controller, "openPath", new Class[] {Path.class}, real);
+            ToolWindow tw = FxTestSupport.field(fx.controller, "debugToolWindow");
+            ToolWindowManager tws = FxTestSupport.field(fx.controller, "toolWindows");
+            tws.setAvailable(tw, true); // buffer-gated; make its stripe/panel available for the test
+            tws.open(tw); // opens + moves focus into the panel (focusFirstItem, deferred)
+        });
+
+        // The deferred focusFirstItem has run by now (FIFO on the FX queue). If the headless window can't
+        // hold focus, there's nothing to regress — skip rather than assert on an ungrantable focus.
+        Assumptions.assumeTrue(focusWithinDebugPanel(), "headless window could not focus the Debug panel");
+
+        // The debugger stops in the open file (as a step would). The reveal focuses the editor…
+        DapModels.StackFrameInfo frame = new DapModels.StackFrameInfo(1, "Focus.go", real, 1, 0);
+        FxTestSupport.runOnFx(
+                () -> FxTestSupport.call(debug, "highlightFrame", new Class[] {DapModels.StackFrameInfo.class}, frame));
+
+        // …but the panel-focus restore (Platform.runLater in highlightFrame) has since run, so focus is back.
+        assertTrue(focusWithinDebugPanel(), "focus must return to the Debug panel after a step-driven reveal");
+    }
+}


### PR DESCRIPTION
Closes #592. Follow-up to #583.

## Problem
Driving a debug session from the Debug panel's single-key controls (`n` step over, `s` step into, …) stole focus back to the code editor after every step, so you had to re-focus the panel before each press.

## Cause
A step re-suspends the debugger → `onStopped` → `selectFrame` → `highlightFrame` → `ops.openPath(frame.file())`, which calls `requestFocus()` on the editor buffer to reveal the execution line.

## Fix
`DebugCoordinator.highlightFrame` now captures the Debug panel's focus owner **before** the reveal and restores it afterwards (`Platform.runLater`, so it wins over `openPath`'s own `requestFocus`) — but **only when focus was already in the panel**. A fresh breakpoint hit while editing still lands you in the code at the stopped line, unchanged.

## Test
`DebugPanelFocusRetentionFxTest` drives a real window: opens a file, focuses the Debug panel, calls `highlightFrame`, and asserts focus returns to the panel (self-skips if the headless window can't take focus — here it did, so it asserts). Green alongside the existing debug FX tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)