### PR TITLE
feat: show a spinner while the GitHub panel's segment loads

### DIFF
--- a/src/main/java/com/editora/ui/GitHubPanel.java
+++ b/src/main/java/com/editora/ui/GitHubPanel.java
@@ -10,6 +10,7 @@ import javafx.scene.control.Label;
 import javafx.scene.control.ListCell;
 import javafx.scene.control.ListView;
 import javafx.scene.control.MenuItem;
+import javafx.scene.control.ProgressIndicator;
 import javafx.scene.control.ToggleButton;
 import javafx.scene.control.ToggleGroup;
 import javafx.scene.control.Tooltip;
@@ -79,6 +80,13 @@ public final class GitHubPanel extends VBox implements ToolWindowContent {
     private final ToggleButton runsToggle = new ToggleButton(tr("github.panel.runs"));
     private final ListView<Object> list = new ListView<>();
     private final Label placeholder = new Label(tr("github.panel.noPrs"));
+    private final VBox loading = buildLoading();
+
+    /**
+     * The segment whose fetch is in flight. Each {@code gh} call takes seconds, so switching segments twice
+     * can land the first response after the second — this drops a result whose segment is no longer wanted.
+     */
+    private Mode requested = Mode.PRS;
 
     public GitHubPanel(Actions actions) {
         this.actions = actions;
@@ -100,16 +108,19 @@ public final class GitHubPanel extends VBox implements ToolWindowContent {
         prsToggle.setOnAction(e -> {
             prsToggle.setSelected(true);
             placeholder.setText(tr("github.panel.noPrs"));
+            beginLoading(Mode.PRS);
             actions.showPrs();
         });
         issuesToggle.setOnAction(e -> {
             issuesToggle.setSelected(true);
             placeholder.setText(tr("github.panel.noIssues"));
+            beginLoading(Mode.ISSUES);
             actions.showIssues();
         });
         runsToggle.setOnAction(e -> {
             runsToggle.setSelected(true);
             placeholder.setText(tr("github.panel.noRuns"));
+            beginLoading(Mode.RUNS);
             actions.showRuns();
         });
 
@@ -151,6 +162,36 @@ public final class GitHubPanel extends VBox implements ToolWindowContent {
         return b;
     }
 
+    private static VBox buildLoading() {
+        ProgressIndicator spinner = new ProgressIndicator();
+        spinner.setPrefSize(28, 28);
+        spinner.setMaxSize(28, 28);
+        Label label = new Label(tr("github.panel.loading"));
+        label.getStyleClass().add("tool-window-placeholder");
+        VBox box = new VBox(8, spinner, label);
+        box.setAlignment(Pos.CENTER);
+        return box;
+    }
+
+    /**
+     * Clears the stale list and shows a spinner while {@code gh} runs — a {@code gh pr list} round-trip takes
+     * seconds, and leaving the previous segment's rows on screen reads as a frozen window.
+     */
+    private void beginLoading(Mode mode) {
+        requested = mode;
+        list.getItems().clear();
+        list.setPlaceholder(loading);
+    }
+
+    /** Applies a fetch result only when its segment is still the one the user wants. */
+    private boolean accept(Mode mode) {
+        if (requested != mode) {
+            return false;
+        }
+        list.setPlaceholder(placeholder);
+        return true;
+    }
+
     /** Which segment is showing — the controller re-fetches that one on refresh. */
     public Mode mode() {
         if (issuesToggle.isSelected()) {
@@ -163,22 +204,37 @@ public final class GitHubPanel extends VBox implements ToolWindowContent {
     public void selectRuns() {
         runsToggle.setSelected(true);
         placeholder.setText(tr("github.panel.noRuns"));
+        beginLoading(Mode.RUNS);
+    }
+
+    /** Shows the spinner for the segment currently selected — used by a refresh that isn't a segment switch. */
+    public void showLoading() {
+        beginLoading(mode());
     }
 
     /** Replaces the list with pull requests. */
     public void setPrs(List<PullRequest> prs) {
+        if (!accept(Mode.PRS)) {
+            return;
+        }
         prsToggle.setSelected(true);
         list.getItems().setAll(prs);
     }
 
     /** Replaces the list with issues. */
     public void setIssues(List<Issue> issues) {
+        if (!accept(Mode.ISSUES)) {
+            return;
+        }
         issuesToggle.setSelected(true);
         list.getItems().setAll(issues);
     }
 
     /** Replaces the list with workflow runs. */
     public void setRuns(List<WorkflowRun> runs) {
+        if (!accept(Mode.RUNS)) {
+            return;
+        }
         runsToggle.setSelected(true);
         placeholder.setText(tr("github.panel.noRuns"));
         list.getItems().setAll(runs);

--- a/src/main/java/com/editora/ui/MainController.java
+++ b/src/main/java/com/editora/ui/MainController.java
@@ -4669,6 +4669,7 @@ public class MainController implements com.editora.mcp.McpBridge {
 
     /** Re-fetches the GitHub tool window's current segment (PRs, Issues, or Runs). */
     private void reloadGithubPanel() {
+        githubPanel.showLoading();
         switch (githubPanel.mode()) {
             case PRS -> github.fetchPrs(githubPanel::setPrs);
             case ISSUES -> github.fetchIssues(githubPanel::setIssues);

--- a/src/main/resources/com/editora/i18n/messages.properties
+++ b/src/main/resources/com/editora/i18n/messages.properties
@@ -3392,6 +3392,7 @@ command.github.viewRunLog=GitHub: View CI Failure Log…
 command.github.viewRunLog.desc=Pick a workflow run and dump its failure log into the Build Output console.
 github.panel.runs=Runs
 github.panel.noRuns=No workflow runs
+github.panel.loading=Loading…
 github.panel.menu.viewLog=View Failure Log
 github.panel.menu.rerun=Rerun
 github.panel.menu.rerunFailed=Rerun Failed Jobs

--- a/src/main/resources/com/editora/i18n/messages_de.properties
+++ b/src/main/resources/com/editora/i18n/messages_de.properties
@@ -3383,6 +3383,7 @@ command.github.viewRunLog=GitHub: CI-Fehlerprotokoll anzeigen…
 command.github.viewRunLog.desc=Einen Lauf auswählen und sein Fehlerprotokoll in der Build-Output-Konsole ausgeben.
 github.panel.runs=Läufe
 github.panel.noRuns=Keine Workflow-Läufe
+github.panel.loading=Wird geladen…
 github.panel.menu.viewLog=Fehlerprotokoll anzeigen
 github.panel.menu.rerun=Erneut ausführen
 github.panel.menu.rerunFailed=Fehlgeschlagene Jobs erneut ausführen

--- a/src/main/resources/com/editora/i18n/messages_es.properties
+++ b/src/main/resources/com/editora/i18n/messages_es.properties
@@ -3383,6 +3383,7 @@ command.github.viewRunLog=GitHub: Ver registro de fallos de CI…
 command.github.viewRunLog.desc=Elige una ejecución y vuelca su registro de fallos en la consola Build Output.
 github.panel.runs=Ejecuciones
 github.panel.noRuns=Sin ejecuciones de workflow
+github.panel.loading=Cargando…
 github.panel.menu.viewLog=Ver registro de fallos
 github.panel.menu.rerun=Volver a ejecutar
 github.panel.menu.rerunFailed=Volver a ejecutar los jobs fallidos

--- a/src/main/resources/com/editora/i18n/messages_fr.properties
+++ b/src/main/resources/com/editora/i18n/messages_fr.properties
@@ -3383,6 +3383,7 @@ command.github.viewRunLog=GitHub : Voir le journal des échecs CI…
 command.github.viewRunLog.desc=Choisir une exécution et afficher son journal des échecs dans la console Build Output.
 github.panel.runs=Exécutions
 github.panel.noRuns=Aucune exécution de workflow
+github.panel.loading=Chargement…
 github.panel.menu.viewLog=Voir le journal des échecs
 github.panel.menu.rerun=Relancer
 github.panel.menu.rerunFailed=Relancer les jobs en échec

--- a/src/main/resources/com/editora/i18n/messages_it.properties
+++ b/src/main/resources/com/editora/i18n/messages_it.properties
@@ -3383,6 +3383,7 @@ command.github.viewRunLog=GitHub: Mostra log degli errori CI…
 command.github.viewRunLog.desc=Scegli una esecuzione e mostra il suo log degli errori nella console Build Output.
 github.panel.runs=Esecuzioni
 github.panel.noRuns=Nessuna esecuzione
+github.panel.loading=Caricamento…
 github.panel.menu.viewLog=Mostra log degli errori
 github.panel.menu.rerun=Riesegui
 github.panel.menu.rerunFailed=Riesegui i job falliti

--- a/src/main/resources/com/editora/i18n/messages_pt.properties
+++ b/src/main/resources/com/editora/i18n/messages_pt.properties
@@ -3383,6 +3383,7 @@ command.github.viewRunLog=GitHub: Ver log de falhas do CI…
 command.github.viewRunLog.desc=Escolha uma execução e mostre o seu log de falhas no console Build Output.
 github.panel.runs=Execuções
 github.panel.noRuns=Nenhuma execução de workflow
+github.panel.loading=Carregando…
 github.panel.menu.viewLog=Ver log de falhas
 github.panel.menu.rerun=Executar novamente
 github.panel.menu.rerunFailed=Executar novamente os jobs com falha


### PR DESCRIPTION
Switching between **Pull Requests / Issues / Runs** in the GitHub tool window left the previous segment's rows on screen for the several seconds each `gh` call takes, which reads as a frozen window. The network latency itself isn't something we can fix — the feedback is.

Each toggle now clears the list and swaps the `ListView` placeholder for a spinner + "Loading…" until the fetch lands. `reloadGithubPanel()` does the same, so the panel's Refresh button, the window-open lazy load, and the post-rerun/cancel reload get it too.

## Stale-response guard

Added beyond the immediate ask, but needed for the spinner to actually mean anything. The toggles switch instantly while the fetches don't, so a fast double-switch (PRs → Issues → PRs) could land the first response *after* the second — repainting the wrong segment and, since `setPrs`/`setIssues`/`setRuns` each force their own toggle selected, visibly flipping the segment button back under the user. `requested` records the wanted segment and `accept(mode)` drops any result that no longer matches; without it a late arrival would also silently clear the spinner for a segment still loading.

## Notes

- New i18n key `github.panel.loading`, translated in all six catalogs (`MessagesTest` parity passes).
- No CSS added — the label reuses `.tool-window-placeholder` and the `ProgressIndicator` is AtlantaFX-themed, so it tracks light/dark for free.
- Performance: nil. The spinner node is built once per panel and only animates while it is the visible placeholder.

🤖 Generated with [Claude Code](https://claude.com/claude-code)