### PR TITLE
feat: add a Create Pull Request button to the GitHub tool window

### DIFF
--- a/src/main/java/com/editora/ui/GitHubCoordinator.java
+++ b/src/main/java/com/editora/ui/GitHubCoordinator.java
@@ -749,6 +749,8 @@ final class GitHubCoordinator {
             String url = r.out() == null ? "" : r.out().strip();
             if (r.ok()) {
                 host.setStatus(tr("status.github.createdPr"));
+                // The new PR belongs in the tool window's list — it's the surface the button was clicked from.
+                ops.reloadGitHubPanel();
                 if (!url.isEmpty()) {
                     host.openExternalUrl(lastUrl(url));
                 }

--- a/src/main/java/com/editora/ui/GitHubPanel.java
+++ b/src/main/java/com/editora/ui/GitHubPanel.java
@@ -51,6 +51,9 @@ public final class GitHubPanel extends VBox implements ToolWindowContent {
     public interface Actions {
         void refresh();
 
+        /** Opens the same create-pull-request form as the {@code github.createPr} palette command. */
+        void createPr();
+
         void showPrs();
 
         void showIssues();
@@ -124,10 +127,11 @@ public final class GitHubPanel extends VBox implements ToolWindowContent {
             actions.showRuns();
         });
 
+        Button createPr = iconButton(Icons.newFile(), tr("github.panel.createPrTip"), actions::createPr);
         Button refresh = iconButton(Icons.refresh(), tr("github.panel.refreshTip"), actions::refresh);
         HBox spacer = new HBox();
         HBox.setHgrow(spacer, Priority.ALWAYS);
-        HBox toolbar = new HBox(2, prsToggle, issuesToggle, runsToggle, spacer, refresh);
+        HBox toolbar = new HBox(2, prsToggle, issuesToggle, runsToggle, spacer, createPr, refresh);
         toolbar.getStyleClass().add("git-toolbar");
         toolbar.setAlignment(Pos.CENTER_LEFT);
 

--- a/src/main/java/com/editora/ui/MainController.java
+++ b/src/main/java/com/editora/ui/MainController.java
@@ -4634,6 +4634,11 @@ public class MainController implements com.editora.mcp.McpBridge {
             }
 
             @Override
+            public void createPr() {
+                github.createPr();
+            }
+
+            @Override
             public void showPrs() {
                 github.fetchPrs(githubPanel::setPrs);
             }

--- a/src/main/resources/com/editora/i18n/messages.properties
+++ b/src/main/resources/com/editora/i18n/messages.properties
@@ -3355,6 +3355,7 @@ command.tool.github.desc=Toggle the GitHub pull requests / issues tool window.
 github.panel.prs=Pull Requests
 github.panel.issues=Issues
 github.panel.refreshTip=Refresh
+github.panel.createPrTip=Create Pull Request…
 github.panel.noPrs=No open pull requests
 github.panel.noIssues=No open issues
 github.panel.menu.checkout=Check Out

--- a/src/main/resources/com/editora/i18n/messages_de.properties
+++ b/src/main/resources/com/editora/i18n/messages_de.properties
@@ -3346,6 +3346,7 @@ command.tool.github.desc=Das GitHub-Werkzeugfenster (Pull Requests / Issues) ums
 github.panel.prs=Pull Requests
 github.panel.issues=Issues
 github.panel.refreshTip=Aktualisieren
+github.panel.createPrTip=Pull Request erstellen…
 github.panel.noPrs=Keine offenen Pull Requests
 github.panel.noIssues=Keine offenen Issues
 github.panel.menu.checkout=Auschecken

--- a/src/main/resources/com/editora/i18n/messages_es.properties
+++ b/src/main/resources/com/editora/i18n/messages_es.properties
@@ -3346,6 +3346,7 @@ command.tool.github.desc=Muestra u oculta la ventana de herramientas de GitHub (
 github.panel.prs=Pull requests
 github.panel.issues=Issues
 github.panel.refreshTip=Actualizar
+github.panel.createPrTip=Crear pull request…
 github.panel.noPrs=No hay pull requests abiertas
 github.panel.noIssues=No hay issues abiertas
 github.panel.menu.checkout=Obtener

--- a/src/main/resources/com/editora/i18n/messages_fr.properties
+++ b/src/main/resources/com/editora/i18n/messages_fr.properties
@@ -3346,6 +3346,7 @@ command.tool.github.desc=Afficher/masquer la fenêtre d'outils GitHub (pull requ
 github.panel.prs=Pull requests
 github.panel.issues=Issues
 github.panel.refreshTip=Actualiser
+github.panel.createPrTip=Créer une pull request…
 github.panel.noPrs=Aucune pull request ouverte
 github.panel.noIssues=Aucune issue ouverte
 github.panel.menu.checkout=Récupérer

--- a/src/main/resources/com/editora/i18n/messages_it.properties
+++ b/src/main/resources/com/editora/i18n/messages_it.properties
@@ -3346,6 +3346,7 @@ command.tool.github.desc=Mostra/nascondi la finestra strumenti GitHub (pull requ
 github.panel.prs=Pull request
 github.panel.issues=Issue
 github.panel.refreshTip=Aggiorna
+github.panel.createPrTip=Crea pull request…
 github.panel.noPrs=Nessuna pull request aperta
 github.panel.noIssues=Nessuna issue aperta
 github.panel.menu.checkout=Effettua checkout

--- a/src/main/resources/com/editora/i18n/messages_pt.properties
+++ b/src/main/resources/com/editora/i18n/messages_pt.properties
@@ -3346,6 +3346,7 @@ command.tool.github.desc=Mostrar/ocultar a janela de ferramentas do GitHub (pull
 github.panel.prs=Pull requests
 github.panel.issues=Issues
 github.panel.refreshTip=Atualizar
+github.panel.createPrTip=Criar pull request…
 github.panel.noPrs=Nenhuma pull request aberta
 github.panel.noIssues=Nenhuma issue aberta
 github.panel.menu.checkout=Fazer checkout


### PR DESCRIPTION
Opening a PR was only reachable through the `github.createPr` palette command. The GitHub tool window is where PRs are already listed, so the entry point belongs there too: a **"+"** button in the panel toolbar, beside Refresh.

It routes to the same `GitHubCoordinator.createPr()` form the palette command uses — one flow, two entry points, no duplicated UI. Nothing about the form changed.

## Refresh after create

`runPrCreate` opened the new PR in a browser but never refreshed the panel, so the tool window was left showing a list that no longer matched the repo — most visible now that the create action can be launched from that very list. It now calls `ops.reloadGitHubPanel()` on success, which also picks up the spinner added in #612. The palette command benefits equally.

## Notes

- New i18n key `github.panel.createPrTip`, translated in all six catalogs (`MessagesTest` parity passes).
- Reuses `Icons.newFile()` (a plain plus glyph) and the existing `iconButton` helper — no new icon, no new CSS.
- The button is always visible rather than only in the Pull Requests segment: hiding it on segment switch would churn the toolbar layout for no real gain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)