### PR TITLE
fix(test): wait for a build to exit before the next run in the trust tests

### DIFF
--- a/src/main/java/com/editora/ui/BuildCoordinator.java
+++ b/src/main/java/com/editora/ui/BuildCoordinator.java
@@ -154,6 +154,11 @@ final class BuildCoordinator {
         return detectedLabel;
     }
 
+    /** Whether a launched build is still alive — the same state {@link #runTask} / {@link #rerunLast} gate on. */
+    boolean isRunning() {
+        return service.isRunning();
+    }
+
     /** The path whose project drives this tool's UI: the active local file, else the active project root. */
     Path contextPath() {
         EditorBuffer b = host.activeBuffer();

--- a/src/test/java/com/editora/ui/BuildCoordinatorFxTest.java
+++ b/src/test/java/com/editora/ui/BuildCoordinatorFxTest.java
@@ -473,9 +473,11 @@ class BuildCoordinatorFxTest {
         BuildCoordinator c = detectedWithWrapper(host, ops, dir);
         host.settings.setMavenCommand("editora-test-nonexistent-maven-binary-zzz");
 
-        FxTestSupport.runOnFx(() -> c.runTask(List.of("compile"), List.of()));
-        FxTestSupport.runOnFx(() -> c.runTask(List.of("test"), List.of()));
-        FxTestSupport.runOnFx(() -> c.runTask(List.of("package"), List.of()));
+        // Each run really forks the wrapper script, and runTask refuses to start while one is alive — so the
+        // next run has to wait for the previous to exit or it is dropped by the busy guard, not the trust gate.
+        runToCompletion(c, "compile");
+        runToCompletion(c, "test");
+        runToCompletion(c, "package");
 
         assertEquals(1, ops.promptCount, "three builds, one prompt");
         assertEquals(3, ops.openConsoleCount);
@@ -489,7 +491,9 @@ class BuildCoordinatorFxTest {
         BuildCoordinator c = detectedWithWrapper(host, ops, dir);
         host.settings.setMavenCommand("editora-test-nonexistent-maven-binary-zzz");
 
-        FxTestSupport.runOnFx(() -> c.runTask(List.of("compile"), List.of()));
+        // Must finish before the rerun: rerunLast's busy guard returns ahead of the trust gate, so a still-live
+        // first build would make the rerun skip the prompt for the wrong reason and pass the assertion below.
+        runToCompletion(c, "compile");
         assertEquals(1, ops.promptCount);
 
         // Trust revoked between runs (Settings → Workspace): the remembered rerun must re-ask, not slip past.
@@ -499,6 +503,20 @@ class BuildCoordinatorFxTest {
 
         assertEquals(2, ops.promptCount, "rerunLast goes through the same gate");
         assertEquals(1, ops.openConsoleCount, "and the declined rerun never ran");
+    }
+
+    /**
+     * Runs one task and waits for its process to die.
+     *
+     * <p>The wrapper fixture is a real {@code #!/bin/sh\nexit 0} script, so a run is a genuine fork whose exit
+     * lands asynchronously — and {@code runTask}/{@code rerunLast} both refuse to start while one is alive.
+     * Firing them back to back therefore raced: on an idle machine the {@code sh} exited within the FX
+     * round-trip and every run proceeded, but under CI load the busy guard swallowed one, which surfaced as an
+     * off-by-one on the prompt/console counters ("expected 3 but was 2") — a flake that reached master.
+     */
+    private static void runToCompletion(BuildCoordinator c, String task) throws Exception {
+        FxTestSupport.runOnFx(() -> c.runTask(List.of(task), List.of()));
+        waitUntil(() -> !c.isRunning(), "the '" + task + "' build finished");
     }
 
     /** Polls {@code condition} (each check on the FX thread) until it's true or a few seconds elapse. */


### PR DESCRIPTION
`BuildCoordinatorFxTest`'s trust tests are flaky, and the flake has been failing unrelated PRs:

- **#614** — `trustIsAskedOnceThenRemembered` (expected 3 console opens, got 2). Merged red.
- **#616** — `rerunLastIsGatedToo` (expected 2 prompts, got 1). Passed on a re-run.

Same defect both times; the differing assertion is why it read as noise rather than a bug.

## Cause

The two multi-run tests fire `runTask` (and `rerunLast`) back to back with no wait. The wrapper fixture is a **real** `#!/bin/sh\nexit 0` script, and a repo wrapper wins over the Settings command — so the bogus `editora-test-nonexistent-maven-binary-zzz` is never argv[0] here and **each run genuinely forks a process**. Both `runTask` and `rerunLast` return early via `service.isRunning()` while one is alive:

```java
if (service.isRunning()) {
    host.setStatus(tr("status.build.busy", tool.displayName()));
    return;   // ← before allowRun(), so no trust prompt and no openConsole()
}
```

On an idle machine the `sh` exits inside the FX round-trip and every run proceeds. Under CI load it doesn't, the busy guard swallows a run, and a prompt or console-open goes missing. In `rerunLastIsGatedToo` this is particularly misleading: the rerun skips the prompt for the *wrong reason*, so the test was asserting the trust gate while actually measuring the busy guard.

## Fix

Tests only — the busy guard is correct production behaviour. Each build now runs to completion via a `runToCompletion` helper that polls the same predicate the guard uses. Adds a package-private `BuildCoordinator.isRunning()` alongside the existing `isDetected()`/`detectedLabel()` accessors so a test can observe it.

## Verification

Not just "it passes now" — the diagnosis was confirmed in both directions by temporarily making the wrapper `sleep 0.5`:

| | old tests | fixed tests |
|---|---|---|
| slow wrapper | **fail** — `rerunLastIsGatedToo:500 expected: <2> but was: <1>`, `trustIsAskedOnceThenRemembered:481 expected: <3> but was: <1>` | **pass** |

Those are the exact assertions CI produced. The temporary `sleep` is not in this diff; the class also passes 3/3 consecutive local runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)