### PR TITLE
fix: don't echo "Already open" for a command-line file the restore just opened

### DIFF
--- a/src/main/java/com/editora/ui/MainController.java
+++ b/src/main/java/com/editora/ui/MainController.java
@@ -5598,7 +5598,7 @@ public class MainController implements com.editora.mcp.McpBridge {
         }
         if (targets != null) {
             for (OpenTarget t : targets) {
-                openPath(t.file().toAbsolutePath().normalize());
+                openPath(t.file().toAbsolutePath().normalize(), true);
             }
             if (targets.stream().anyMatch(t -> t.line() > 0)) {
                 // Defer once more so it runs after openPath's own goToStart for any newly-opened file.
@@ -6217,6 +6217,18 @@ public class MainController implements com.editora.mcp.McpBridge {
     }
 
     private void openPath(Path file) {
+        openPath(file, false);
+    }
+
+    /**
+     * Opens a file, or re-selects its tab when it is already open.
+     *
+     * <p>{@code quietIfOpen} suppresses the "Already open" echo for the startup path: a command-line
+     * {@code FILE} that is also part of the restored session has its tab created + selected by
+     * {@link #openInitialBuffer()} a pulse earlier, so the CLI action's own {@code openPath} always finds it
+     * there — reporting "Already open" for a tab Editora itself just made is noise, not information.
+     */
+    private void openPath(Path file, boolean quietIfOpen) {
         Tab existing = tabForPath(file);
         if (existing != null) {
             // Already open — switch to its tab instead of opening a duplicate.
@@ -6228,7 +6240,9 @@ public class MainController implements com.editora.mcp.McpBridge {
             if (recentFiles != null) {
                 recentFiles.add(file);
             }
-            setStatus(tr("status.alreadyOpen", file.getFileName()));
+            if (!quietIfOpen) {
+                setStatus(tr("status.alreadyOpen", file.getFileName()));
+            }
             return;
         }
         // A raster image opens in the read-only image viewer instead of dumping its bytes into a text buffer.


### PR DESCRIPTION
Opening a file that is **also** part of the restored session — e.g. `editora cv.typ`, or a desktop "Open With" launch, which delivers the path as argv — always echoed `Already open: cv.typ` on launch, even though it was the only file open.

## Why

`openInitialBuffer` deliberately front-loads a command-line `FILE` that is part of the session: its tab becomes the selected one and is filled first, so it is on screen from the first frame instead of the user watching the session's own active file appear first. Right after that first fill, `runPendingStartupAction` runs the CLI action anyway, and `applyStartupTargets` calls `openPath`, which finds the tab already there and echoes the status.

Nothing was actually opened twice — the tab is just re-selected — but reporting "Already open" for a tab Editora itself created a pulse earlier is noise, not information.

## Change

`openPath` gains a `quietIfOpen` overload, passed `true` only by `applyStartupTargets`. The re-select, focus, recent-files and `:line:col` behavior are unchanged, and all 57 other callers keep the echo.

The flag is scoped to the *already-open* case only: a command-line file that is **not** in the session is genuinely opened and still reports `Opened <path>`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)