### PR TITLE
samples: add editing/ corpus for tabify, align-regexp, auto-fill

### DIFF
--- a/samples/README.md
+++ b/samples/README.md
@@ -48,6 +48,25 @@ Editor/Split/Preview toggle that renders the timeline). There is deliberately no
 - `samples/indent/blocks.py` — Enter after `:` indents; smart backspace on a blank indented line
   jumps back to the end of the previous line.
 
+## editing/ — Emacs-style editing commands (content-dependent)
+
+Fixtures for the editing commands where the *content* is the test. Set the keymap to **Emacs**.
+
+- `samples/editing/tabs.txt` — a block of tab-indented lines and a block of space-indented lines. Select
+  one, then run *Edit: Untabify Region* (tabs → spaces) or *Edit: Tabify Region* (spaces → tabs). Turn on
+  *Toggle Whitespace* to see which is which; the mixed block at the bottom checks the tab-then-spaces rule.
+- `samples/editing/align.txt` — assignment / key-value / comment blocks. Select a block and run
+  *Edit: Align Regexp* with `=`, `:` or `//`. The already-uneven block shows that it pads to the widest
+  match rather than collapsing existing whitespace (so it's idempotent).
+- `samples/editing/fill.txt` — long paragraphs for **auto-fill**. Turn on *View: Toggle Auto-Fill*, set a
+  small fill column (`C-x f`, e.g. 40), then keep typing past the margin and watch lines wrap at a word
+  boundary; the indented paragraph confirms the wrap keeps the indent. `M-q` reflows a whole paragraph.
+
+The other Emacs commands are keystroke-driven and need no special fixture — open any buffer and exercise
+them: kill ring (`C-k`/`C-y`/`M-y`), rectangles (`C-x r …`), narrowing (`C-x n n`/`C-x n w`), query-replace
+(`M-%`), the mark ring (`C-SPC`/`C-x C-SPC`), occur (`M-s o`), and the `C-u` prefix argument
+(`C-u 5 C-n`). Abbreviations need a dictionary — define one with `C-x a g`, then expand with `C-x a e`.
+
 ## markdown/ — preview, GFM, math, embedded Mermaid
 
 - `samples/markdown/gfm.md` — toggle preview (Editor/Split/Preview): bold/italic/code, a task list

--- a/samples/editing/align.txt
+++ b/samples/editing/align.txt
@@ -1,0 +1,23 @@
+Align a column across lines with Edit: Align Regexp (enter a regexp, e.g. = or :).
+Select each block first. It only adds spaces, so re-running it is a no-op.
+
+# align on =
+int a = 1;
+String name = "x";
+double ratio = 0.5;
+boolean ok = true;
+
+# align on : (key/value)
+host: localhost
+port: 8080
+scheme: https
+
+# already-uneven spacing before = : align pads to the widest, it does not collapse the extra
+a     = 1
+bb = 2
+ccc   = 3
+
+# align trailing comments on //
+foo();      // call foo
+barbaz();  // and bar
+q();   // q

--- a/samples/editing/fill.txt
+++ b/samples/editing/fill.txt
@@ -1,0 +1,8 @@
+Auto-fill breaks a line at a word boundary as you type past the fill column.
+Turn it on (View: Toggle Auto-Fill), set a small fill column (C-x f, e.g. 40),
+then type more words at the end of a paragraph line below and watch it wrap.
+It applies to plain text and Markdown only, never code. M-q reflows a whole paragraph.
+
+Keep typing at the end of this paragraph and it should wrap by itself once you go past the fill column without pressing Enter
+
+    an indented paragraph: keep typing here and the wrapped continuation lines should also start with this same indentation rather than jumping back to column zero

--- a/samples/editing/tabs.txt
+++ b/samples/editing/tabs.txt
@@ -1,0 +1,19 @@
+Two indentation styles below. Select a block, then run Edit: Untabify (tabs -> spaces)
+or Edit: Tabify (spaces -> tabs). Turn on Toggle Whitespace to see which is which.
+
+# tab-indented (Untabify turns these into spaces)
+	level one
+		level two
+			level three
+	back to one
+
+# space-indented at 4-space stops (Tabify turns the runs back into tabs)
+    level one
+        level two
+            level three
+    back to one
+
+# mixed / partial (Tabify: tabs to each stop, spaces for the remainder; a lone space stays)
+ab  x
+      y
+a b


### PR DESCRIPTION
A small **`samples/editing/`** category for the Emacs editing commands where the file content *is* the test — the scoped subset of this session's throwaway fixtures that actually earn a place in the corpus.

Three files, reworked to the corpus convention (neutral content; the how-to-test steps live in `samples/README.md`, like every other section):

- **`tabs.txt`** — a tab-indented block and a space-indented block (plus a mixed block for the tab-then-spaces rule), for *Tabify* / *Untabify*. The precise whitespace is the point (tabs verified preserved in the committed blob).
- **`align.txt`** — assignment / key-value / comment blocks for *Align Regexp*, including the already-uneven-spacing case that shows it pads to the widest match rather than collapsing existing whitespace.
- **`fill.txt`** — long paragraphs (flush and indented) for **auto-fill**.

## Why only these three

The corpus is "open the file and observe/act." Most of the new Emacs commands — kill ring, rectangles, narrowing, query-replace, mark ring, occur, the `C-u` prefix argument — are pure keystroke interactions that work on *any* buffer, so a fixture adds nothing; the README section says so and lists their chords. Abbreviations need a dictionary, which a static sample can't carry. So those are deliberately left as session throwaways.

`SamplesCorpusTest` (manifest ↔ files sync) passes; `mvn verify` green (2867 tests). No Java changed — samples + README only.