### PR TITLE
LSP document highlight — occurrences of the symbol under the caret

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Occurrence highlighting (LSP)** — rest the caret on a symbol and every occurrence in the file gets a
+  subtle wash, with **writes** (assignments) shaded warmer than reads — the IntelliJ/VS Code idle
+  affordance, powered by the language server so it's semantic (a local `x` doesn't light up an unrelated
+  field `x`). Clears the moment the caret moves; zero cost while the caret is typing or LSP is off. (#675)
+
 - **Signature help (LSP)** — typing `(` or `,` in a call pops the server's overload list at the caret:
   the active signature with the **current parameter highlighted**, an "n/m" overload counter, and the
   signature's documentation. It follows your typing (the highlighted parameter advances as arguments are

--- a/README.md
+++ b/README.md
@@ -173,7 +173,8 @@ Editora is built with the help of AI coding tools.
   Inline diagnostics + a Problems tool window (`M-8`) + minimap/scrollbar stripes, go-to-definition
   (`M-.` — for Java this includes JDK/dependency classes, opened as read-only library source), find
   references (`M-?`), hover docs (`C-c h`), **signature help** (overloads + active parameter as you
-  type a call), LSP-backed completion, auto-imports,
+  type a call), **occurrence highlighting** (rest the caret on a symbol — reads and writes wash
+  differently), LSP-backed completion, auto-imports,
   **Code Actions / quick fixes** (`Ctrl-.` in the VS Code/Sublime/IntelliJ keymaps, or the palette /
   right-click menu — apply the server's fixes, organize imports, refactorings), and
   **Format Document** (whole-file reformat via the server, when it advertises formatting — palette or the

--- a/TODO.md
+++ b/TODO.md
@@ -3,6 +3,17 @@
 A backlog of planned features and improvements. Unordered within each section.
 
 ## Recently shipped
+- [x] **LSP document highlight** (#675) — `textDocument/documentHighlight`: occurrences of the symbol
+      under the resting caret, Read vs Write shaded differently. Neutral `editor/OccurrenceSpan` record
+      (editor stays lsp4j-free); `editor/OccurrenceHighlightOverlay` is a structural clone of
+      `SearchHighlightOverlay` (mouse-transparent Canvas, coalesced per pulse, visible-paragraphs-only,
+      1×1 texture when empty — the common case). Trigger: a 300 ms `PauseTransition` caret-idle timer per
+      buffer (`installOccurrenceTrigger`, both views; three field checks per caret move when off); any
+      caret move clears the wash at once (stale spans paint the wrong word) and re-arms. The coordinator's
+      `requestOccurrences` gates on `documentHighlightProvider` and drops a response whose `docVersion`
+      moved (in-flight edit ⇒ meaningless offsets). No command/setting — ambient, riding the LSP master
+      toggle. *Deferred: a visibility toggle if the wash proves noisy; split-view second-area overlay
+      (matches the search overlay's primary-view-only behavior).*
 - [x] **LSP signature help** (#674) — `textDocument/signatureHelp`. Client declares markdown docs +
       `labelOffsetSupport` + `activeParameterSupport`; the pure/unit-tested **`lsp/SignatureFormat`**
       resolves the active signature + the active parameter's `[start,end)` span (label offsets win;

--- a/src/main/java/com/editora/editor/EditorBuffer.java
+++ b/src/main/java/com/editora/editor/EditorBuffer.java
@@ -487,6 +487,7 @@ public class EditorBuffer implements TabContent {
     private Runnable onRunnableChanged = () -> {};
 
     private SearchHighlightOverlay searchOverlay; // lazily attached — see searchOverlay()
+    private OccurrenceHighlightOverlay occurrenceOverlay; // lazily attached — see occurrenceOverlay() (#675)
     /** Highlights configured TODO/FIXME-style patterns (per-pattern color), behind the text. */
     private final TodoHighlightOverlay todoOverlay = new TodoHighlightOverlay(area);
     /** Injected matcher (compiled patterns) + on/off gate; null/false = no highlight. */
@@ -724,6 +725,7 @@ public class EditorBuffer implements TabContent {
         addAutoIndent(area); // Enter auto-indents; closers de-indent (per-language smart indent)
         addCompletionKeys(area); // registered last → runs first, so popup nav/accept beats Tab/Enter
         installCompletionTrigger(area);
+        installOccurrenceTrigger(area); // LSP document highlight (#675)
         // When an edit shifts bookmarks, repaint the affected lines' gutter markers after the edit's own
         // graphic rebuild settles (deferred to the next pulse), so the moved marker follows its line.
         bookmarks.setOnLinesRepaint(lines -> Platform.runLater(() -> lines.forEach(this::refreshGutterLine)));
@@ -2184,6 +2186,13 @@ public class EditorBuffer implements TabContent {
         return searchOverlay;
     }
 
+    private OccurrenceHighlightOverlay occurrenceOverlay() {
+        if (occurrenceOverlay == null) {
+            occurrenceOverlay = attachLazyOverlay(new OccurrenceHighlightOverlay(area), todoOverlay);
+        }
+        return occurrenceOverlay;
+    }
+
     private LogHighlightOverlay logOverlay() {
         if (logOverlay == null) {
             logOverlay = attachLazyOverlay(new LogHighlightOverlay(area), whitespace);
@@ -2229,6 +2238,67 @@ public class EditorBuffer implements TabContent {
         if (searchOverlay != null) {
             searchOverlay.setMatches(java.util.List.of(), -1);
         }
+    }
+
+    /**
+     * Washes every occurrence of the symbol under the caret (LSP document highlight, #675) — Read vs Write
+     * shaded differently. Positions are converted to offsets against the document as it is NOW, so the
+     * caller drops a response whose {@code docVersion} moved. Empty clears + releases the overlay texture.
+     */
+    public void setOccurrenceSpans(java.util.List<OccurrenceSpan> spans) {
+        if (largeFile || spans == null || spans.isEmpty()) {
+            clearOccurrenceSpans();
+            return;
+        }
+        java.util.List<int[]> triples = new java.util.ArrayList<>(spans.size());
+        for (OccurrenceSpan s : spans) {
+            int from = lspOffset(area, s.startLine(), s.startCol());
+            int to = lspOffset(area, s.endLine(), s.endCol());
+            if (to > from) {
+                triples.add(new int[] {from, to, s.write() ? 1 : 0});
+            }
+        }
+        occurrenceOverlay().setSpans(triples);
+    }
+
+    /** Clears the occurrence wash (no symbol under the caret / LSP off / buffer deactivated). */
+    public void clearOccurrenceSpans() {
+        if (occurrenceOverlay != null) {
+            occurrenceOverlay.setSpans(java.util.List.of());
+        }
+    }
+
+    /** Injects the document-highlight request (the coordinator asks the server and pushes spans back);
+     *  null disables the caret-idle trigger entirely. */
+    public void setOccurrenceRequester(Runnable requester) {
+        this.occurrenceRequester = requester;
+    }
+
+    /** Fired ~300 ms after the caret comes to rest while LSP-active; null = feature off. */
+    private Runnable occurrenceRequester;
+
+    /** Debounces the caret-rest trigger for document highlight (#675) — one per buffer, both views. */
+    private final javafx.animation.PauseTransition occurrenceIdle =
+            new javafx.animation.PauseTransition(javafx.util.Duration.millis(300));
+
+    /**
+     * Caret-idle trigger for document highlight: any caret move clears the wash at once (the old spans
+     * are for the old symbol — leaving them paints the wrong word) and re-arms the 300 ms idle timer;
+     * on rest, the injected requester asks the server. Three field checks per caret move when off.
+     */
+    private void installOccurrenceTrigger(CodeArea a) {
+        a.caretPositionProperty().addListener((o, ov, nv) -> {
+            if (occurrenceRequester == null || !lspActive || largeFile) {
+                return;
+            }
+            clearOccurrenceSpans();
+            occurrenceIdle.setOnFinished(ev -> {
+                if (occurrenceRequester != null && lspActive && a.isFocused()) {
+                    occurrenceRequester.run();
+                }
+            });
+            occurrenceIdle.playFromStart();
+        });
     }
 
     /** Enables/disables the TODO-pattern highlight for this buffer and re-scans (the controller pushes the
@@ -5447,6 +5517,7 @@ public class EditorBuffer implements TabContent {
         addAutoIndent(area2);
         addCompletionKeys(area2);
         installCompletionTrigger(area2);
+        installOccurrenceTrigger(area2); // LSP document highlight (#675)
         installImageDrop(area2);
         if (multiCaretEnabled && !hugeFile && multiCaret2 == null) {
             multiCaret2 = MultiCaretController.install(area2); // same multi-caret add-on in the split view

--- a/src/main/java/com/editora/editor/OccurrenceHighlightOverlay.java
+++ b/src/main/java/com/editora/editor/OccurrenceHighlightOverlay.java
@@ -1,0 +1,161 @@
+package com.editora.editor;
+
+import java.util.List;
+
+import javafx.application.Platform;
+import javafx.geometry.Bounds;
+import javafx.scene.canvas.Canvas;
+import javafx.scene.canvas.GraphicsContext;
+import javafx.scene.layout.Region;
+import javafx.scene.paint.Color;
+
+import org.fxmisc.richtext.CodeArea;
+import org.fxmisc.richtext.model.TwoDimensional.Bias;
+
+/**
+ * A transparent overlay washing every occurrence of the symbol under the caret (LSP document highlight,
+ * #675) — Read occurrences in a neutral tint, Write occurrences (assignments) warmer with a thin border —
+ * behind the text, never touching the style spans.
+ *
+ * <p>A structural clone of {@link SearchHighlightOverlay} (itself modeled on {@link SpellCheckOverlay}):
+ * mouse-transparent {@link Canvas} sized to the viewport, redraws coalesced to one per pulse on
+ * scroll/edit/resize, visible paragraphs only, released to a 1×1 texture while empty (the common case —
+ * the caret is rarely resting on a highlightable symbol).
+ */
+final class OccurrenceHighlightOverlay extends Region {
+
+    private static final Color READ = Color.web("#90a4ae", 0.28); // neutral blue-gray wash
+    private static final Color WRITE = Color.web("#ffb74d", 0.32); // warmer — the symbol is assigned here
+    private static final Color WRITE_BORDER = Color.web("#ffb74d", 0.9);
+
+    private final CodeArea area;
+    private final Canvas canvas = new Canvas(1, 1);
+    /** {startOffset, endOffset, write(0/1)} triples, precomputed to offsets by the buffer. */
+    private List<int[]> spans = List.of();
+
+    private boolean active;
+    private boolean redrawPending;
+
+    OccurrenceHighlightOverlay(CodeArea area) {
+        this.area = area;
+        getStyleClass().add("occurrence-overlay");
+        setMouseTransparent(true);
+        setVisible(false);
+        getChildren().add(canvas);
+        area.viewportDirtyEvents().subscribe(ignore -> scheduleRedraw());
+        area.estimatedScrollXProperty().addListener((o, a, b) -> scheduleRedraw());
+        area.estimatedScrollYProperty().addListener((o, a, b) -> scheduleRedraw());
+    }
+
+    /** Sets the occurrence spans (offset triples) to wash; empty hides + releases the texture. */
+    void setSpans(List<int[]> spans) {
+        this.spans = spans == null ? List.of() : spans;
+        boolean show = !this.spans.isEmpty();
+        if (active != show) {
+            active = show;
+            setVisible(show);
+        }
+        if (show) {
+            requestLayout();
+            scheduleRedraw();
+        } else {
+            canvas.getGraphicsContext2D().clearRect(0, 0, canvas.getWidth(), canvas.getHeight());
+            canvas.setWidth(1); // release the full-viewport texture while hidden
+            canvas.setHeight(1);
+        }
+    }
+
+    @Override
+    protected void layoutChildren() {
+        canvas.relocate(0, 0);
+        if (!active) {
+            return;
+        }
+        double w = CanvasGuards.clampDim(getWidth());
+        double h = CanvasGuards.clampDim(getHeight());
+        if (canvas.getWidth() != w || canvas.getHeight() != h) {
+            canvas.setWidth(w);
+            canvas.setHeight(h);
+        }
+        scheduleRedraw();
+    }
+
+    private void scheduleRedraw() {
+        if (!active || redrawPending) {
+            return;
+        }
+        redrawPending = true;
+        Platform.runLater(() -> {
+            redrawPending = false;
+            redraw();
+        });
+    }
+
+    private void redraw() {
+        GraphicsContext g = canvas.getGraphicsContext2D();
+        double w = canvas.getWidth();
+        double h = canvas.getHeight();
+        g.clearRect(0, 0, w, h);
+        if (!active || !CanvasGuards.paintable(getWidth(), getHeight())) {
+            return;
+        }
+        try {
+            int total = area.getParagraphs().size();
+            if (total == 0) {
+                return;
+            }
+            int first = Math.max(0, area.firstVisibleParToAllParIndex());
+            int last = Math.min(total - 1, area.lastVisibleParToAllParIndex());
+            int firstOffset = area.getAbsolutePosition(first, 0);
+            int lastOffset = area.getAbsolutePosition(
+                    last, area.getParagraph(last).getText().length());
+            for (int[] s : spans) {
+                if (s[1] < firstOffset || s[0] > lastOffset) {
+                    continue; // cheap off-screen rejection before the costlier bounds lookups
+                }
+                paintSpan(g, s, first, last, w, h);
+            }
+        } catch (RuntimeException ignored) {
+            // Viewport mid-layout — skip this frame; a later event will redraw.
+        }
+    }
+
+    private void paintSpan(GraphicsContext g, int[] span, int first, int last, double w, double h) {
+        var startPos = area.offsetToPosition(span[0], Bias.Forward);
+        var endPos = area.offsetToPosition(Math.max(span[1], span[0]), Bias.Backward);
+        boolean write = span[2] != 0;
+        int startLine = startPos.getMajor();
+        int endLine = endPos.getMajor();
+        if (endLine < first || startLine > last) {
+            return;
+        }
+        for (int line = Math.max(startLine, first); line <= Math.min(endLine, last); line++) {
+            if (area.isFolded(line)) {
+                continue;
+            }
+            int lineLen = area.getParagraph(line).getText().length();
+            int c0 = line == startLine ? startPos.getMinor() : 0;
+            int c1 = line == endLine ? endPos.getMinor() : lineLen;
+            if (c1 <= c0) {
+                continue;
+            }
+            int absStart = area.getAbsolutePosition(line, c0);
+            int absEnd = area.getAbsolutePosition(line, c1);
+            Bounds b = toLocal(area.getCharacterBoundsOnScreen(absStart, absEnd).orElse(null));
+            if (b == null || b.getMaxX() < 0 || b.getMinX() > w || b.getMaxY() < 0 || b.getMinY() > h) {
+                continue;
+            }
+            g.setFill(write ? WRITE : READ);
+            g.fillRect(b.getMinX(), b.getMinY(), b.getWidth(), b.getHeight());
+            if (write) {
+                g.setStroke(WRITE_BORDER);
+                g.setLineWidth(1);
+                g.strokeRect(b.getMinX() + 0.5, b.getMinY() + 0.5, b.getWidth() - 1, b.getHeight() - 1);
+            }
+        }
+    }
+
+    private Bounds toLocal(Bounds screen) {
+        return screen == null ? null : canvas.screenToLocal(screen);
+    }
+}

--- a/src/main/java/com/editora/editor/OccurrenceSpan.java
+++ b/src/main/java/com/editora/editor/OccurrenceSpan.java
@@ -1,0 +1,9 @@
+package com.editora.editor;
+
+/**
+ * One occurrence of the symbol under the caret, as reported by the language server's
+ * {@code textDocument/documentHighlight} (#675) — 0-based LSP line/columns plus whether the occurrence
+ * <b>writes</b> the symbol (an assignment) rather than reads it, which the overlay shades differently.
+ * Neutral so {@code editor} stays lsp4j-free (the {@code LspDiagnostic}/{@code LspTextEdit} idiom).
+ */
+public record OccurrenceSpan(int startLine, int startCol, int endLine, int endCol, boolean write) {}

--- a/src/main/java/com/editora/lsp/LanguageServerSession.java
+++ b/src/main/java/com/editora/lsp/LanguageServerSession.java
@@ -336,6 +336,7 @@ final class LanguageServerSession implements LanguageClient {
         td.setHover(new HoverCapabilities());
         td.setDefinition(new DefinitionCapabilities());
         td.setReferences(new ReferencesCapabilities());
+        td.setDocumentHighlight(new org.eclipse.lsp4j.DocumentHighlightCapabilities()); // occurrences (#675)
         // Signature help (#674): declare markdown docs + label offsets (servers send precise active-parameter
         // ranges only when the client says it can render them) + per-signature activeParameter.
         var sigInfo =
@@ -669,6 +670,16 @@ final class LanguageServerSession implements LanguageClient {
         }
         var params = new org.eclipse.lsp4j.SignatureHelpParams(new TextDocumentIdentifier(uri), pos);
         return server.getTextDocumentService().signatureHelp(params).exceptionally(t -> null);
+    }
+
+    /** Occurrences of the symbol at a position ({@code textDocument/documentHighlight}) → highlights with
+     *  their Read/Write kind, or empty (#675). */
+    CompletableFuture<List<? extends org.eclipse.lsp4j.DocumentHighlight>> documentHighlight(String uri, Position pos) {
+        if (!ready()) {
+            return CompletableFuture.completedFuture(List.of());
+        }
+        var params = new org.eclipse.lsp4j.DocumentHighlightParams(new TextDocumentIdentifier(uri), pos);
+        return server.getTextDocumentService().documentHighlight(params).exceptionally(t -> List.of());
     }
 
     CompletableFuture<Either<List<CompletionItem>, CompletionList>> completion(String uri, Position pos) {

--- a/src/main/java/com/editora/lsp/LspManager.java
+++ b/src/main/java/com/editora/lsp/LspManager.java
@@ -652,6 +652,50 @@ public final class LspManager {
                 .whenComplete((r, e) -> Platform.runLater(() -> cb.accept(e == null ? r : null)));
     }
 
+    /** True if {@code file}'s server is ready and advertises document highlight (occurrences — #675). */
+    public boolean supportsDocumentHighlight(Path file) {
+        LanguageServerSession s = sessionFor(file);
+        return s != null && documentHighlightProvider(s.capabilities());
+    }
+
+    /** Pure: whether a server's capabilities include {@code documentHighlightProvider} (null-safe). */
+    static boolean documentHighlightProvider(org.eclipse.lsp4j.ServerCapabilities caps) {
+        if (caps == null) {
+            return false;
+        }
+        var p = caps.getDocumentHighlightProvider();
+        return p != null && (p.isRight() || Boolean.TRUE.equals(p.getLeft()));
+    }
+
+    /** Occurrences of the symbol at a 0-based position, mapped to neutral {@link OccurrenceSpan}s
+     *  (Write kind flagged) and delivered on the FX thread — empty when unavailable (#675). */
+    public void documentHighlights(
+            Path file, int line, int character, Consumer<List<com.editora.editor.OccurrenceSpan>> cb) {
+        LanguageServerSession s = sessionFor(file);
+        if (s == null) {
+            Platform.runLater(() -> cb.accept(List.of()));
+            return;
+        }
+        s.documentHighlight(uri(file), new Position(line, character)).whenComplete((result, error) -> {
+            List<com.editora.editor.OccurrenceSpan> spans = new ArrayList<>();
+            if (error == null && result != null) {
+                for (var h : result) {
+                    if (h == null || h.getRange() == null) {
+                        continue;
+                    }
+                    var r = h.getRange();
+                    spans.add(new com.editora.editor.OccurrenceSpan(
+                            r.getStart().getLine(),
+                            r.getStart().getCharacter(),
+                            r.getEnd().getLine(),
+                            r.getEnd().getCharacter(),
+                            h.getKind() == org.eclipse.lsp4j.DocumentHighlightKind.Write));
+                }
+            }
+            Platform.runLater(() -> cb.accept(spans));
+        });
+    }
+
     /** True if {@code file}'s server is ready and advertises code actions (quick fixes — #670). */
     public boolean supportsCodeActions(Path file) {
         LanguageServerSession s = sessionFor(file);

--- a/src/main/java/com/editora/ui/LspCoordinator.java
+++ b/src/main/java/com/editora/ui/LspCoordinator.java
@@ -709,6 +709,7 @@ final class LspCoordinator {
             buffer.setLspRangeFormatAvailable(false);
             buffer.setLspCodeActionsAvailable(false);
             buffer.setLspSignatureTriggerChars(java.util.Set.of());
+            buffer.clearOccurrenceSpans();
             buffer.setSemanticActive(false);
             if (path != null && lspManager.isManaged(path)) {
                 lspManager.closeDocument(path);
@@ -892,6 +893,7 @@ final class LspCoordinator {
     void wireBuffer(EditorBuffer buffer) {
         // Debounced didChange sink + keep the Structure outline live as the document changes.
         buffer.setSignatureHelpRequester(() -> signatureHelp(false)); // '(' or ',' typed (#674)
+        buffer.setOccurrenceRequester(() -> requestOccurrences(buffer)); // caret at rest (#675)
         buffer.setLspChangeListener(text -> {
             if (buffer.getPath() != null) {
                 lspManager.changeDocument(buffer.getPath(), text);
@@ -1401,6 +1403,30 @@ final class LspCoordinator {
         if (signaturePopup != null) {
             signatureHelp(false);
         }
+    }
+
+    /**
+     * Document highlight (#675): asks the server for the occurrences of the symbol under the resting caret
+     * and pushes them into the buffer's occurrence overlay. Fired by the buffer's 300 ms caret-idle timer;
+     * silent (an empty result just leaves the wash cleared). The {@code docVersion} guard drops a response
+     * computed against a document that moved while the request was in flight — its offsets are meaningless.
+     */
+    private void requestOccurrences(EditorBuffer buffer) {
+        Path path = buffer.getPath();
+        if (buffer != host.activeBuffer()
+                || path == null
+                || !lspManager.isManaged(path)
+                || !lspManager.supportsDocumentHighlight(path)) {
+            buffer.clearOccurrenceSpans();
+            return;
+        }
+        CodeArea area = buffer.getFocusedArea();
+        long version = buffer.docVersion();
+        lspManager.documentHighlights(path, area.getCurrentParagraph(), area.getCaretColumn(), spans -> {
+            if (buffer == host.activeBuffer() && buffer.docVersion() == version) {
+                buffer.setOccurrenceSpans(spans);
+            }
+        });
     }
 
     /**

--- a/src/test/java/com/editora/lsp/LspManagerTest.java
+++ b/src/test/java/com/editora/lsp/LspManagerTest.java
@@ -195,6 +195,23 @@ class LspManagerTest {
         assertEquals(Set.of(), LspManager.signatureTriggerCharsOf(null));
     }
 
+    // --- Document highlight (#675) -------------------------------------------------------------
+
+    @Test
+    void documentHighlightProviderDetectedFromEitherForm() {
+        assertFalse(LspManager.documentHighlightProvider(null));
+        assertFalse(LspManager.documentHighlightProvider(new ServerCapabilities()));
+        ServerCapabilities bool = new ServerCapabilities();
+        bool.setDocumentHighlightProvider(true);
+        assertTrue(LspManager.documentHighlightProvider(bool));
+        ServerCapabilities off = new ServerCapabilities();
+        off.setDocumentHighlightProvider(false);
+        assertFalse(LspManager.documentHighlightProvider(off));
+        ServerCapabilities opts = new ServerCapabilities();
+        opts.setDocumentHighlightProvider(new org.eclipse.lsp4j.DocumentHighlightOptions());
+        assertTrue(LspManager.documentHighlightProvider(opts));
+    }
+
     // --- Code actions (#670) -------------------------------------------------------------------
 
     @Test

--- a/src/test/java/com/editora/ui/OccurrenceHighlightFxTest.java
+++ b/src/test/java/com/editora/ui/OccurrenceHighlightFxTest.java
@@ -1,0 +1,62 @@
+package com.editora.ui;
+
+import java.util.List;
+
+import javafx.scene.layout.Region;
+
+import com.editora.editor.EditorBuffer;
+import com.editora.editor.OccurrenceSpan;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/** LSP document highlight (#675): the occurrence overlay attaches lazily, shows on spans, clears on empty. */
+@Tag("fx")
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class OccurrenceHighlightFxTest {
+
+    @BeforeAll
+    void setUp() throws Exception {
+        FxTestSupport.bootToolkit();
+    }
+
+    @Test
+    void spansShowTheOverlayAndEmptyClearsIt() throws Exception {
+        boolean[] state = FxTestSupport.callOnFx(() -> {
+            EditorBuffer b = new EditorBuffer();
+            b.setLanguageOverride("java");
+            b.setContent("int a = 1;\nint b = a + a;\n");
+            b.getNode();
+            assertNull(FxTestSupport.field(b, "occurrenceOverlay"), "lazy: no overlay before first spans");
+            b.setOccurrenceSpans(List.of(
+                    new OccurrenceSpan(0, 4, 0, 5, true), // the assignment — Write
+                    new OccurrenceSpan(1, 8, 1, 9, false),
+                    new OccurrenceSpan(1, 12, 1, 13, false)));
+            Region overlay = (Region) FxTestSupport.field(b, "occurrenceOverlay");
+            boolean shown = overlay != null && overlay.isVisible();
+            b.setOccurrenceSpans(List.of());
+            boolean clearedHidden = overlay != null && !overlay.isVisible();
+            return new boolean[] {shown, clearedHidden};
+        });
+        assertTrue(state[0], "overlay visible while spans are set");
+        assertTrue(state[1], "overlay hidden (texture released) once cleared");
+    }
+
+    @Test
+    void largeFileModeIgnoresSpans() throws Exception {
+        boolean created = FxTestSupport.callOnFx(() -> {
+            EditorBuffer b = new EditorBuffer();
+            b.setContent("x\n");
+            b.getNode();
+            b.setLargeFile(true);
+            b.setOccurrenceSpans(List.of(new OccurrenceSpan(0, 0, 0, 1, false)));
+            return FxTestSupport.field(b, "occurrenceOverlay") != null;
+        });
+        assertFalse(created, "large-file mode never builds the overlay");
+    }
+}


### PR DESCRIPTION
Implements #675 — second of the Java LSP feature queue.

Rest the caret on a symbol and every occurrence in the file gets a subtle wash — **Write** occurrences (assignments) warmer with a thin border, **Reads** a neutral tint. Server-resolved, so it's semantic: a local `x` doesn't light up an unrelated field `x`.

- `editor/OccurrenceSpan` (neutral record — `editor` stays lsp4j-free) + `editor/OccurrenceHighlightOverlay`, a structural clone of `SearchHighlightOverlay`: mouse-transparent Canvas, redraws coalesced to one per pulse, visible-paragraphs-only, released to a 1×1 texture while empty (the common case).
- Trigger: a 300 ms `PauseTransition` caret-idle timer per buffer, installed on both views; any caret move **clears the wash immediately** (stale spans would paint the wrong word) and re-arms. Hot-path cost when off: three field checks per caret move.
- `LspCoordinator.requestOccurrences` gates on `documentHighlightProvider` and drops a response whose `docVersion` moved mid-flight.
- Ambient — no new command/setting; rides the LSP master toggle.
- Tests: `documentHighlightProvider` either-form (unit); FX test for lazy overlay attach / show / clear-releases-texture / large-file refusal. Full `mvn verify`: 2899 tests green. NUL-scan clean.

Closes #675.

🤖 Generated with [Claude Code](https://claude.com/claude-code)