### PR TITLE
LSP workspace/didChangeWatchedFiles — external changes reach the servers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Language servers now track external file changes** — a `git checkout`/branch switch, a CLI build, or
+  an external editor touching project files is forwarded to the running language servers
+  (`workspace/didChangeWatchedFiles`), so their project models no longer go quietly stale until a
+  restart. Events come from the Project tree's filesystem watcher and the external-change reload paths,
+  coalesced so a branch switch lands as one batch. (#677)
+
 - **Rename symbol (LSP)** — `F2` (VS Code/Sublime/IntelliJ keymaps), the editor right-click menu, or
   `LSP: Rename Symbol…` in the palette renames the symbol under the caret across the whole workspace via
   the language server. The prompt comes pre-filled with the current name (the server validates the spot

--- a/TODO.md
+++ b/TODO.md
@@ -3,6 +3,19 @@
 A backlog of planned features and improvements. Unordered within each section.
 
 ## Recently shipped
+- [x] **LSP didChangeWatchedFiles** (#677) — external changes reach the servers instead of leaving their
+      project models stale until restart. Client declares `workspace.didChangeWatchedFiles` (static push,
+      no dynamic watcher registration). Sources: **(a)** the ProjectPanel filesystem watcher — the drain
+      loop now also emits typed `FsChange{path, CREATED/CHANGED/DELETED}` batches to an injected
+      `setFsChangeSink` (dir from `key.watchable()`, Editora temp names skipped, posted to FX); **(b)**
+      `reloadAllFromDiskSilently` (branch switch/pull) and the single-file external reload notify each
+      reloaded path as CHANGED — this path matters because the watcher only covers the root + expanded
+      dirs. `LspCoordinator.watchedFilesChanged` coalesces bursts (300 ms `PauseTransition`, latest kind
+      wins per path) → `LspManager.notifyWatchedFiles` routes one batch per live session filtered by the
+      pure/unit-tested `eventsUnderRoot` (path-component containment, so `/proj2` never matches `/proj`).
+      Editora's own saves also flow through the watcher — redundant beside didSave but harmless (VS Code
+      sends both). Ambient; no new command/setting. *Deferred: honoring servers' dynamic
+      `client/registerCapability` watcher globs (we send conservatively for all files under the root).*
 - [x] **LSP rename** (#676) — `prepareRename` + `textDocument/rename`, both stages. Client declares
       `prepareSupport` + `workspaceEdit.resourceOperations: ["rename"]` (create/delete stay undeclared and
       refused). Flow: prepare validates + supplies the placeholder (pure `LspManager.mapPrepare` handles

--- a/src/main/java/com/editora/lsp/LanguageServerSession.java
+++ b/src/main/java/com/editora/lsp/LanguageServerSession.java
@@ -387,6 +387,9 @@ final class LanguageServerSession implements LanguageClient {
         ws.setConfiguration(true);
         ws.setDidChangeConfiguration(new org.eclipse.lsp4j.DidChangeConfigurationCapabilities());
         ws.setSymbol(new org.eclipse.lsp4j.SymbolCapabilities()); // we answer workspace/symbol (Go to Symbol)
+        // We push watched-file events (#677) — without them a git checkout / CLI build leaves the server's
+        // project model stale until restart. Static push only (no dynamic watcher registration).
+        ws.setDidChangeWatchedFiles(new org.eclipse.lsp4j.DidChangeWatchedFilesCapabilities(false));
         // We answer workspace/applyEdit (#670) — how a server-side command (a jdtls quick fix routed
         // through executeCommand) actually lands its edits in the editor. documentChanges=true because
         // jdtls emits the modern TextDocumentEdit[] shape when the client accepts it.
@@ -711,6 +714,21 @@ final class LanguageServerSession implements LanguageClient {
         }
         var params = new org.eclipse.lsp4j.RenameParams(new TextDocumentIdentifier(uri), pos, newName);
         return server.getTextDocumentService().rename(params).exceptionally(t -> null);
+    }
+
+    /** Notifies the server of external file changes ({@code workspace/didChangeWatchedFiles}) so its
+     *  project model tracks a git checkout / CLI build / external editor (#677). Dropped when not ready —
+     *  a starting server reads the disk fresh anyway. */
+    void didChangeWatchedFiles(List<org.eclipse.lsp4j.FileEvent> events) {
+        if (!ready() || events == null || events.isEmpty()) {
+            return;
+        }
+        try {
+            server.getWorkspaceService()
+                    .didChangeWatchedFiles(new org.eclipse.lsp4j.DidChangeWatchedFilesParams(events));
+        } catch (RuntimeException ignored) {
+            // best effort — an advisory notification
+        }
     }
 
     CompletableFuture<Either<List<CompletionItem>, CompletionList>> completion(String uri, Position pos) {

--- a/src/main/java/com/editora/lsp/LspManager.java
+++ b/src/main/java/com/editora/lsp/LspManager.java
@@ -696,6 +696,59 @@ public final class LspManager {
         });
     }
 
+    // --- Watched files (#677) ------------------------------------------------------------------
+
+    /** An external file change to forward to the language servers. */
+    public enum WatchedKind {
+        CREATED,
+        CHANGED,
+        DELETED
+    }
+
+    /** One changed file + what happened to it. */
+    public record WatchedFile(Path file, WatchedKind kind) {}
+
+    /**
+     * Forwards external file changes to every live session whose root contains them
+     * ({@code workspace/didChangeWatchedFiles}) — how a git checkout / CLI build / external editor reaches
+     * the servers' project models instead of leaving them stale until restart (#677). Callers coalesce
+     * bursts (a branch switch touches hundreds of files); one notification per session per batch.
+     */
+    public void notifyWatchedFiles(List<WatchedFile> changes) {
+        if (!enabled || changes == null || changes.isEmpty()) {
+            return;
+        }
+        for (LanguageServerSession s : sessionsByRoot.values()) {
+            List<org.eclipse.lsp4j.FileEvent> events = eventsUnderRoot(changes, s.root());
+            if (!events.isEmpty()) {
+                s.didChangeWatchedFiles(events);
+            }
+        }
+    }
+
+    /** Pure: the {@code FileEvent}s for the changes under {@code root} (path-component containment). */
+    static List<org.eclipse.lsp4j.FileEvent> eventsUnderRoot(List<WatchedFile> changes, Path root) {
+        Path rootNorm = root.toAbsolutePath().normalize();
+        List<org.eclipse.lsp4j.FileEvent> out = new ArrayList<>();
+        for (WatchedFile c : changes) {
+            if (c == null || c.file() == null) {
+                continue;
+            }
+            Path p = c.file().toAbsolutePath().normalize();
+            if (!p.startsWith(rootNorm)) {
+                continue;
+            }
+            var type =
+                    switch (c.kind()) {
+                        case CREATED -> org.eclipse.lsp4j.FileChangeType.Created;
+                        case CHANGED -> org.eclipse.lsp4j.FileChangeType.Changed;
+                        case DELETED -> org.eclipse.lsp4j.FileChangeType.Deleted;
+                    };
+            out.add(new org.eclipse.lsp4j.FileEvent(p.toUri().toString(), type));
+        }
+        return out;
+    }
+
     /** True if {@code file}'s server is ready and advertises rename (#676). */
     public boolean supportsRename(Path file) {
         LanguageServerSession s = sessionFor(file);

--- a/src/main/java/com/editora/ui/LspCoordinator.java
+++ b/src/main/java/com/editora/ui/LspCoordinator.java
@@ -1529,6 +1529,61 @@ final class LspCoordinator {
         });
     }
 
+    // --- Watched files (#677) ------------------------------------------------------------------
+
+    /** Pending external file changes (latest kind wins per path), flushed coalesced to the servers. */
+    private final Map<Path, com.editora.lsp.LspManager.WatchedKind> pendingWatched = new LinkedHashMap<>();
+
+    /** Coalesces watcher bursts (a branch switch touches hundreds of files) into one flush. */
+    private final javafx.animation.PauseTransition watchedFlush =
+            new javafx.animation.PauseTransition(javafx.util.Duration.millis(300));
+
+    /**
+     * Queues external file changes for the language servers ({@code workspace/didChangeWatchedFiles}) —
+     * fed by the Project tree's filesystem watcher and the external-change/branch-switch reload paths.
+     * Without this a git checkout or a CLI build left every server's project model stale until restart
+     * (#677). FX thread; bursts coalesce (300 ms) into one notification per session.
+     */
+    void watchedFilesChanged(List<ProjectPanel.FsChange> changes) {
+        if (!ops.lspFeatureEnabled() || changes == null || changes.isEmpty()) {
+            return;
+        }
+        for (var c : changes) {
+            if (c == null || c.path() == null) {
+                continue;
+            }
+            pendingWatched.put(
+                    c.path(),
+                    switch (c.kind()) {
+                        case CREATED -> com.editora.lsp.LspManager.WatchedKind.CREATED;
+                        case DELETED -> com.editora.lsp.LspManager.WatchedKind.DELETED;
+                        case CHANGED -> com.editora.lsp.LspManager.WatchedKind.CHANGED;
+                    });
+        }
+        watchedFlush.setOnFinished(e -> flushWatchedFiles());
+        watchedFlush.playFromStart();
+    }
+
+    /** Convenience for the reload paths: a batch of files that changed on disk (kind CHANGED). */
+    void watchedFilesReloaded(List<Path> files) {
+        if (files == null || files.isEmpty()) {
+            return;
+        }
+        watchedFilesChanged(files.stream()
+                .map(f -> new ProjectPanel.FsChange(f, ProjectPanel.FsKind.CHANGED))
+                .toList());
+    }
+
+    private void flushWatchedFiles() {
+        if (pendingWatched.isEmpty()) {
+            return;
+        }
+        List<com.editora.lsp.LspManager.WatchedFile> batch = new java.util.ArrayList<>(pendingWatched.size());
+        pendingWatched.forEach((path, kind) -> batch.add(new com.editora.lsp.LspManager.WatchedFile(path, kind)));
+        pendingWatched.clear();
+        lspManager.notifyWatchedFiles(batch);
+    }
+
     /** Refreshes (or closes) a showing signature popup on the typing pause — called from the buffer's
      *  debounced change listener, so the active parameter tracks the arguments as they're typed. */
     private void refreshSignatureHelpIfShowing() {

--- a/src/main/java/com/editora/ui/MainController.java
+++ b/src/main/java/com/editora/ui/MainController.java
@@ -2164,6 +2164,9 @@ public class MainController implements com.editora.mcp.McpBridge {
             refreshBuildTools();
             diffCoordinator.refreshOpenDiffs();
         });
+        // Forward the watcher's raw events to the language servers (didChangeWatchedFiles) so a git
+        // checkout / CLI build / external editor doesn't leave their project models stale (#677).
+        projectPanel.setFsChangeSink(lspCoordinator::watchedFilesChanged);
         projectPanel.setOnReveal((p, dir) -> revealInFileManager(p, dir, com.editora.vfs.Vfs.isLocal(p)));
         projectPanel.setOnOpenTerminal((p, dir) -> openTerminalAt(p, dir, com.editora.vfs.Vfs.isLocal(p)));
         // Breadcrumb crumbs offer the same Reveal / Open Terminal as the Project tree (local files only).
@@ -5198,6 +5201,7 @@ public class MainController implements com.editora.mcp.McpBridge {
 
     /** After a branch switch/pull, silently reload any open buffer whose file changed on disk. */
     private void reloadAllFromDiskSilently() {
+        java.util.List<Path> reloaded = new java.util.ArrayList<>();
         for (Tab tab : tabPane.getTabs()) {
             EditorBuffer buffer = bufferOf(tab);
             if (buffer == null || buffer.getPath() == null || buffer.isDirty()) {
@@ -5206,8 +5210,13 @@ public class MainController implements com.editora.mcp.McpBridge {
             Path file = buffer.getPath();
             if (Files.exists(file) && buffer.diskChangedFrom(lastModifiedMillis(file), fileSize(file))) {
                 reloadFromDisk(tab, buffer);
+                reloaded.add(file);
             }
         }
+        // A branch switch / pull changed these on disk — tell the language servers too (#677). The open
+        // buffers' didChange covers their content, but the servers' project models (dependencies, indexes)
+        // key off watched-file events. The project watcher only covers expanded dirs, so this path matters.
+        lspCoordinator.watchedFilesReloaded(reloaded);
     }
 
     private void setupToolbar() {
@@ -6787,6 +6796,7 @@ public class MainController implements com.editora.mcp.McpBridge {
             buffer.markClean();
             area.moveTo(Math.min(caret, area.getLength()));
             updateTabMeta(tab, buffer);
+            lspCoordinator.watchedFilesReloaded(java.util.List.of(file)); // the server's model too (#677)
             setStatus(note.isEmpty() ? tr("status.reloaded", file.getFileName()) : note);
         } catch (IOException e) {
             setStatus(tr("status.failedReload", file.getFileName(), e.getMessage()));

--- a/src/main/java/com/editora/ui/ProjectPanel.java
+++ b/src/main/java/com/editora/ui/ProjectPanel.java
@@ -82,6 +82,8 @@ public class ProjectPanel extends VBox implements ToolWindowContent {
      *  the window can refresh things anchored to the working tree — Git status / the Commit stripe, build-tool
      *  markers, open diffs — which otherwise only re-evaluate on focus-regain / tab switch (#529). */
     private Runnable onExternalChange = () -> {};
+    /** Raw watcher events (path + kind), forwarded to LSP as didChangeWatchedFiles (#677); null = off. */
+    private volatile java.util.function.Consumer<List<FsChange>> fsChangeSink;
     /** Injected by MainController: "New From Template…" on a folder, given the target directory. */
     private Consumer<Path> onNewFromTemplate;
     /** Injected by MainController: reveal a path in the OS file manager. Args: (path, isDirectory). */
@@ -530,16 +532,36 @@ public class ProjectPanel extends VBox implements ToolWindowContent {
                 // input, created+deleted every render) doesn't spuriously rebuild the tree (#465). Otherwise we
                 // re-list from disk (individual events aren't applied) — an OVERFLOW or any real file forces it.
                 List<java.nio.file.WatchEvent<?>> events = key.pollEvents();
+                Path watchedDir = key.watchable() instanceof Path p ? p : null;
                 key.reset();
                 boolean overflow = false;
                 List<String> names = new java.util.ArrayList<>();
+                List<FsChange> changes = new java.util.ArrayList<>(); // typed, for the LSP sink (#677)
                 for (java.nio.file.WatchEvent<?> ev : events) {
                     if (ev.kind() == java.nio.file.StandardWatchEventKinds.OVERFLOW) {
                         overflow = true;
                         continue;
                     }
                     Object ctx = ev.context();
-                    names.add(ctx instanceof Path p ? p.getFileName().toString() : "");
+                    String name = ctx instanceof Path p ? p.getFileName().toString() : "";
+                    names.add(name);
+                    if (watchedDir != null && ctx instanceof Path child && !isEditoraTempName(name)) {
+                        FsKind kind = ev.kind() == java.nio.file.StandardWatchEventKinds.ENTRY_CREATE
+                                ? FsKind.CREATED
+                                : ev.kind() == java.nio.file.StandardWatchEventKinds.ENTRY_DELETE
+                                        ? FsKind.DELETED
+                                        : FsKind.CHANGED;
+                        changes.add(new FsChange(watchedDir.resolve(child), kind));
+                    }
+                }
+                var sink = fsChangeSink;
+                if (sink != null && !changes.isEmpty()) {
+                    List<FsChange> batch = List.copyOf(changes);
+                    Platform.runLater(() -> {
+                        if (!disposed) {
+                            sink.accept(batch);
+                        }
+                    });
                 }
                 if (!watchEventsWarrantRefresh(names, overflow)) {
                     continue; // only Editora's own temp files changed — no tree rebuild
@@ -776,6 +798,22 @@ public class ProjectPanel extends VBox implements ToolWindowContent {
     /** Injects the status-message sink used for drag-move / multi-delete feedback. */
     public void setOnStatus(Consumer<String> onStatus) {
         this.onStatus = onStatus == null ? m -> {} : onStatus;
+    }
+
+    /** One filesystem watcher event: what happened to which path (#677). */
+    public record FsChange(Path path, FsKind kind) {}
+
+    /** The watcher event kinds forwarded to the sink. */
+    public enum FsKind {
+        CREATED,
+        CHANGED,
+        DELETED
+    }
+
+    /** Injects the raw watcher-event sink (invoked on the FX thread with each drained batch) — how external
+     *  file changes reach the language servers (#677). {@code null} disables forwarding. */
+    public void setFsChangeSink(java.util.function.Consumer<List<FsChange>> sink) {
+        this.fsChangeSink = sink;
     }
 
     /** Injects the external-change hook (see {@link #onExternalChange}); {@code null} restores the no-op. */

--- a/src/test/java/com/editora/lsp/LspManagerTest.java
+++ b/src/test/java/com/editora/lsp/LspManagerTest.java
@@ -195,6 +195,23 @@ class LspManagerTest {
         assertEquals(Set.of(), LspManager.signatureTriggerCharsOf(null));
     }
 
+    // --- Watched files (#677) ------------------------------------------------------------------
+
+    @Test
+    void eventsUnderRootFilterByPathContainmentAndMapKinds() {
+        var changes = List.of(
+                new LspManager.WatchedFile(java.nio.file.Path.of("/proj/src/A.java"), LspManager.WatchedKind.CHANGED),
+                new LspManager.WatchedFile(java.nio.file.Path.of("/proj/pom.xml"), LspManager.WatchedKind.CREATED),
+                new LspManager.WatchedFile(java.nio.file.Path.of("/other/B.java"), LspManager.WatchedKind.DELETED),
+                // /proj2 must NOT be contained by /proj (component containment, not string prefix)
+                new LspManager.WatchedFile(java.nio.file.Path.of("/proj2/C.java"), LspManager.WatchedKind.CHANGED));
+        var events = LspManager.eventsUnderRoot(changes, java.nio.file.Path.of("/proj"));
+        assertEquals(2, events.size());
+        assertEquals(org.eclipse.lsp4j.FileChangeType.Changed, events.get(0).getType());
+        assertTrue(events.get(0).getUri().endsWith("A.java"));
+        assertEquals(org.eclipse.lsp4j.FileChangeType.Created, events.get(1).getType());
+    }
+
     // --- Rename (#676) -------------------------------------------------------------------------
 
     @Test


### PR DESCRIPTION
Implements #677 — fourth of the Java LSP feature queue. Correctness, not polish: a `git checkout`, a CLI build, or an external editor previously left every server's project model stale until restart.

- Client declares `workspace.didChangeWatchedFiles` (static push only; servers' dynamic watcher-glob registrations aren't honored — we send conservatively for all files under each session's root).
- **Sources:** the ProjectPanel filesystem watcher (drain loop now emits typed `FsChange` batches to an injected sink — dir from `key.watchable()`, Editora temp files skipped) + the branch-switch/external-change reload paths (each reloaded file → CHANGED; this matters because the watcher only covers the root + expanded dirs).
- **Coalescing:** 300 ms PauseTransition in the coordinator, latest kind wins per path → one notification per live session per batch, filtered by the pure `eventsUnderRoot` (path-**component** containment — `/proj2` never matches `/proj`; unit-tested).
- Editora's own saves also flow through the watcher — redundant beside didSave but harmless (VS Code sends both).
- Full `mvn verify`: **2906 tests green**; NUL-scan clean.

Device-test: with jdtls up, `git switch` to a branch that changes an un-opened class used by the open file — its diagnostics should update within a few seconds without `lsp.restartServers`.

Closes #677.

🤖 Generated with [Claude Code](https://claude.com/claude-code)