### PR TITLE
LSP $/progress — real server work drives the loading bar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Real language-server progress** — servers that report their long-running work through the standard
+  LSP progress channel (jdtls importing/indexing a project, gopls loading packages, rust-analyzer's first
+  check) now drive the status-bar loading bar and show what they're doing (title + percentage) in the
+  echo area, instead of Editora guessing with a bare spinner that only covered startup. (#683)
+
 - **Language servers now track external file changes** — a `git checkout`/branch switch, a CLI build, or
   an external editor touching project files is forwarded to the running language servers
   (`workspace/didChangeWatchedFiles`), so their project models no longer go quietly stale until a

--- a/TODO.md
+++ b/TODO.md
@@ -3,6 +3,13 @@
 A backlog of planned features and improvements. Unordered within each section.
 
 ## Recently shipped
+- [x] **LSP $/progress** (#683) — client declares `window.workDoneProgress`; the session implements
+      `createProgress` (accept the token; lsp4j's default throws) + `notifyProgress`: a Begin routes
+      `onStatus("Progress", title — message (pct%))` (pure/unit-tested `progressText`), an End routes
+      `("ProgressEnd", message)`. Per-step Report notifications are deliberately NOT echoed — jdtls emits
+      hundreds and the echo is one line; the bar alone says "still working". `onServerStatus` maps
+      Progress → bar on, ProgressEnd → bar off (a boolean bar, so overlap with the startup lifecycle is
+      benign). *Deferred: a determinate (percentage) loading bar — needs a StatusBar API change.*
 - [x] **LSP didChangeWatchedFiles** (#677) — external changes reach the servers instead of leaving their
       project models stale until restart. Client declares `workspace.didChangeWatchedFiles` (static push,
       no dynamic watcher registration). Sources: **(a)** the ProjectPanel filesystem watcher — the drain

--- a/src/main/java/com/editora/lsp/LanguageServerSession.java
+++ b/src/main/java/com/editora/lsp/LanguageServerSession.java
@@ -381,6 +381,12 @@ final class LanguageServerSession implements LanguageClient {
                 stRequests, SEMANTIC_TOKEN_TYPES, SEMANTIC_TOKEN_MODIFIERS, java.util.List.of("relative")));
         ClientCapabilities cc = new ClientCapabilities();
         cc.setTextDocument(td);
+        // $/progress (#683): the standard progress channel every server speaks (jdtls indexing, gopls
+        // setup, rust-analyzer's cargo check) — drives the status-bar loading bar + echo, replacing the
+        // guessed indeterminate spinner for servers that report real progress.
+        var window = new org.eclipse.lsp4j.WindowClientCapabilities();
+        window.setWorkDoneProgress(true);
+        cc.setWindow(window);
         // Declare we answer workspace/configuration — otherwise Pyright never asks for
         // python.analysis.autoImportCompletions and keeps its (off) default, so no auto-imports.
         org.eclipse.lsp4j.WorkspaceClientCapabilities ws = new org.eclipse.lsp4j.WorkspaceClientCapabilities();
@@ -649,6 +655,44 @@ final class LanguageServerSession implements LanguageClient {
 
     void setOnApplyEdit(java.util.function.BiConsumer<org.eclipse.lsp4j.WorkspaceEdit, Consumer<Boolean>> handler) {
         this.onApplyEdit = handler == null ? (edit, respond) -> respond.accept(false) : handler;
+    }
+
+    /** {@code window/workDoneProgress/create} — the server allocates a progress token. Accepted (we key
+     *  nothing off tokens; begin/report/end arrive via {@code $/progress}). lsp4j's default throws. */
+    @Override
+    public CompletableFuture<Void> createProgress(org.eclipse.lsp4j.WorkDoneProgressCreateParams params) {
+        return CompletableFuture.completedFuture(null);
+    }
+
+    /**
+     * {@code $/progress} (#683): a server's long-running work — jdtls project import/indexing, gopls
+     * loading, rust-analyzer's initial check. Begin starts the status-bar loading bar (with the title in
+     * the echo area); End stops it. Per-step Report notifications are deliberately NOT echoed — jdtls
+     * emits hundreds and the echo area is one line — the bar alone signals "still working".
+     */
+    @Override
+    public void notifyProgress(org.eclipse.lsp4j.ProgressParams params) {
+        if (params == null || params.getValue() == null || !params.getValue().isLeft()) {
+            return;
+        }
+        var n = params.getValue().getLeft();
+        if (n instanceof org.eclipse.lsp4j.WorkDoneProgressBegin begin) {
+            onStatus.accept("Progress", progressText(begin.getTitle(), begin.getMessage(), begin.getPercentage()));
+        } else if (n instanceof org.eclipse.lsp4j.WorkDoneProgressEnd end) {
+            onStatus.accept("ProgressEnd", end.getMessage()); // null message ⇒ just stop the bar
+        }
+    }
+
+    /** Pure: the echo-area text for a progress Begin — title, plus the message and/or percentage. */
+    static String progressText(String title, String message, Integer percentage) {
+        StringBuilder sb = new StringBuilder(title == null || title.isBlank() ? "…" : title.strip());
+        if (message != null && !message.isBlank()) {
+            sb.append(" — ").append(message.strip());
+        }
+        if (percentage != null) {
+            sb.append(" (").append(percentage).append("%)");
+        }
+        return sb.toString();
     }
 
     /**

--- a/src/main/java/com/editora/ui/LspCoordinator.java
+++ b/src/main/java/com/editora/ui/LspCoordinator.java
@@ -849,6 +849,15 @@ final class LspCoordinator {
         }
         if (type != null) {
             String t = type.toLowerCase(Locale.ROOT);
+            // $/progress (#683): a Begin spins the loading bar for long server work (jdtls indexing, a
+            // gradle sync) — not just startup; its End stops it. The bar is a plain boolean, so an overlap
+            // with the startup lifecycle is benign (worst case it stops a beat early and ServiceReady or
+            // the next Begin corrects it).
+            if (t.equals("progress")) {
+                ops.setLspLoading(true);
+            } else if (t.equals("progressend")) {
+                ops.setLspLoading(false);
+            }
             if (t.contains("ready") || t.contains("error")) {
                 ops.setLspLoading(false); // server finished starting (or failed)
             }

--- a/src/test/java/com/editora/lsp/LspManagerTest.java
+++ b/src/test/java/com/editora/lsp/LspManagerTest.java
@@ -195,6 +195,18 @@ class LspManagerTest {
         assertEquals(Set.of(), LspManager.signatureTriggerCharsOf(null));
     }
 
+    // --- $/progress (#683) ---------------------------------------------------------------------
+
+    @Test
+    void progressTextComposesTitleMessageAndPercentage() {
+        assertEquals("Importing projects", LanguageServerSession.progressText("Importing projects", null, null));
+        assertEquals(
+                "Importing projects — 3/10 (30%)",
+                LanguageServerSession.progressText("Importing projects", "3/10", 30));
+        assertEquals("Build (75%)", LanguageServerSession.progressText("Build", "  ", 75));
+        assertEquals("…", LanguageServerSession.progressText(null, null, null), "no title still yields something");
+    }
+
     // --- Watched files (#677) ------------------------------------------------------------------
 
     @Test


### PR DESCRIPTION
Implements #683 — fifth of the Java LSP feature queue. Small slice.

Servers reporting work through the standard `$/progress` channel (jdtls importing/indexing, gopls loading, rust-analyzer's first check) now drive the status-bar loading bar and put their title + percentage in the echo area — replacing the bare spinner that only covered startup, and covering mid-session work (a Gradle sync, a re-index) that previously had no feedback at all.

- `window.workDoneProgress` declared; session implements `createProgress` (lsp4j's default throws) + `notifyProgress`.
- Begin → bar on + echo (`title — message (pct%)`, pure `progressText`, unit-tested); End → bar off. Per-step Reports deliberately not echoed (jdtls emits hundreds; the one-line echo would churn).
- Full `mvn verify` green; NUL-scan clean.

Deferred (TODO): a determinate percentage bar — needs a StatusBar API change.

Closes #683.

🤖 Generated with [Claude Code](https://claude.com/claude-code)