### PR TITLE
perf(lsp): canonical-path cache on the diagnostics path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -142,6 +142,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Performance
 
+- **Cheaper diagnostics bursts.** Language servers publish project-wide diagnostics in bursts (jdtls
+  especially, on workspace open); matching each publish to its open tab re-resolved every tab's canonical
+  path with filesystem syscalls, on the UI thread. Successful resolutions are now cached (bounded LRU,
+  dropped whenever the filesystem may have shifted — a rename/delete, an external change, window focus
+  regain), so a burst costs map lookups instead of stat chains. The not-exists fallback is deliberately
+  never cached, preserving the symlinked-path identity fix. (#680)
+
 - **Find bar's "Replace All" can no longer freeze the editor.** A valid-but-pathological regular expression
   (catastrophic backtracking, e.g. `(a+)+b`) ran unbounded on the UI thread during Replace All and could hang
   the whole editor with no way out — the incremental *search* was already time-budgeted, but the *replace*

--- a/TODO.md
+++ b/TODO.md
@@ -3,6 +3,15 @@
 A backlog of planned features and improvements. Unordered within each section.
 
 ## Recently shipped
+- [x] **Canonical-path cache on the diagnostics path** (#680) — `PathKeys.canonical` now caches successful
+      `toRealPath` resolutions (LRU 2048, access-ordered, synchronized) — the LSP publish path runs
+      `PathKeys.key` for every open tab per publish, and jdtls bursts project-wide on open, so a cold
+      multi-tab open paid N_publishes × N_tabs per-component stat chains on the FX thread. Invalidated
+      wholesale on rename/delete/project-watcher external change/window focus regain. **The not-exists
+      fallback is deliberately never cached** — a Save-As target resolves normalized pre-creation and its
+      real form can differ post-creation (macOS `/tmp`→`/private/tmp`); caching it would re-introduce the
+      #470 silent diagnostics drop (unit test pins this with a real symlink). All other `canonical()`
+      callers (notes/history keying) share the win.
 - [x] **LSP $/progress** (#683) — client declares `window.workDoneProgress`; the session implements
       `createProgress` (accept the token; lsp4j's default throws) + `notifyProgress`: a Begin routes
       `onStatus("Progress", title — message (pct%))` (pure/unit-tested `progressText`), an End routes

--- a/src/main/java/com/editora/config/PathKeys.java
+++ b/src/main/java/com/editora/config/PathKeys.java
@@ -15,6 +15,8 @@ import com.editora.vfs.Vfs;
  * and silently dropped diagnostics — so it's worth isolating and testing.
  *
  * <p>Touches the filesystem ({@code toRealPath}) but is otherwise dependency-light; verify with a temp dir.
+ * Holds one piece of state: the bounded canonical-path cache (#680), invalidated by the window on
+ * filesystem-shifting events.
  */
 public final class PathKeys {
 
@@ -48,17 +50,54 @@ public final class PathKeys {
         }
     }
 
+    /** Bound on the canonical-path cache (entries are a string key + a Path — a few hundred bytes each). */
+    private static final int CANONICAL_CACHE_MAX = 2048;
+
+    /**
+     * Successful {@code toRealPath} resolutions, LRU-bounded. {@code toRealPath} is a per-component stat
+     * syscall chain, and the LSP diagnostics path runs {@link #key} for <b>every open tab per publish</b> —
+     * jdtls bursts project-wide publishes on workspace open, so a cold multi-tab open paid
+     * N_publishes × N_tabs syscall chains on the FX thread (#680). Access-ordered so hot paths stay.
+     * Invalidated wholesale on rename/delete/external-change/focus-regain (see
+     * {@link #invalidateCanonicalCache}); only <em>successful</em> resolutions are cached — see below.
+     */
+    private static final Map<String, Path> CANONICAL_CACHE =
+            java.util.Collections.synchronizedMap(new java.util.LinkedHashMap<>(256, 0.75f, true) {
+                @Override
+                protected boolean removeEldestEntry(Map.Entry<String, Path> eldest) {
+                    return size() > CANONICAL_CACHE_MAX;
+                }
+            });
+
     /**
      * A path for cross-source identity comparison: the real (symlink-resolved) path when it exists, else the
      * absolute-normalized form. Matching by {@code normalize()} alone misses a symlinked path that a tool
      * reports under its real URI.
+     *
+     * <p>Cached ({@link #CANONICAL_CACHE}) — but the not-exists <b>fallback is deliberately never cached</b>:
+     * a file that doesn't exist yet resolves to its normalized form, and once created (Save-As) its real
+     * form can differ (macOS {@code /tmp} → {@code /private/tmp}); a cached fallback would re-introduce the
+     * exact identity mismatch that silently dropped diagnostics (#470).
      */
     public static Path canonical(Path p) {
-        try {
-            return p.toRealPath();
-        } catch (java.io.IOException | RuntimeException e) {
-            return p.toAbsolutePath().normalize();
+        String cacheKey = p.toString();
+        Path hit = CANONICAL_CACHE.get(cacheKey);
+        if (hit != null) {
+            return hit;
         }
+        try {
+            Path real = p.toRealPath();
+            CANONICAL_CACHE.put(cacheKey, real);
+            return real;
+        } catch (java.io.IOException | RuntimeException e) {
+            return p.toAbsolutePath().normalize(); // NOT cached — see the javadoc
+        }
+    }
+
+    /** Drops every cached canonical resolution — called when the filesystem may have shifted under us
+     *  (rename/delete/external change/window focus regain). Cheap: the next lookups re-resolve + re-warm. */
+    public static void invalidateCanonicalCache() {
+        CANONICAL_CACHE.clear();
     }
 
     /**

--- a/src/main/java/com/editora/ui/MainController.java
+++ b/src/main/java/com/editora/ui/MainController.java
@@ -447,6 +447,8 @@ public class MainController implements com.editora.mcp.McpBridge {
         // Detect files changed by another program: re-check open files whenever the window regains focus.
         stage.focusedProperty().addListener((obs, was, now) -> {
             if (Boolean.TRUE.equals(now)) {
+                // The filesystem may have shifted while we were away — drop cached canonical paths (#680).
+                com.editora.config.PathKeys.invalidateCanonicalCache();
                 checkExternalChanges();
                 git.refresh(); // another tool may have changed the repo while we were away
                 refreshBuildTools(); // a marker file (or the active file's project) may have changed while away
@@ -1831,6 +1833,7 @@ public class MainController implements com.editora.mcp.McpBridge {
 
     /** Syncs editor/session state after the Project tree renames a file on disk (old → target). */
     private void onProjectFileRenamed(Path old, Path target) {
+        com.editora.config.PathKeys.invalidateCanonicalCache(); // stale resolutions must not survive a move (#680)
         Tab tab = tabForPath(old);
         if (tab != null) {
             EditorBuffer buffer = bufferOf(tab);
@@ -1895,6 +1898,7 @@ public class MainController implements com.editora.mcp.McpBridge {
 
     /** Syncs editor/session state after the Project tree deletes a file on disk. */
     private void onProjectFileDeleted(Path path) {
+        com.editora.config.PathKeys.invalidateCanonicalCache(); // (#680)
         Tab tab = tabForPath(path);
         if (tab != null) {
             tabPane.getTabs().remove(tab); // file is gone; close without a save prompt
@@ -2160,6 +2164,7 @@ public class MainController implements com.editora.mcp.McpBridge {
         // Editora already had focus: re-evaluate the working-tree-anchored surfaces the focus-regain handler
         // also refreshes — Git status + the Commit stripe, build-tool markers, and open diffs (#529).
         projectPanel.setOnExternalChange(() -> {
+            com.editora.config.PathKeys.invalidateCanonicalCache(); // files moved on disk under us (#680)
             git.refresh();
             refreshBuildTools();
             diffCoordinator.refreshOpenDiffs();

--- a/src/test/java/com/editora/config/PathKeysTest.java
+++ b/src/test/java/com/editora/config/PathKeysTest.java
@@ -143,4 +143,47 @@ class PathKeysTest {
         assertNull(PathKeys.resolveUserInput("   ", base, home));
         assertNull(PathKeys.resolveUserInput(null, base, home));
     }
+
+    // --- Canonical-path cache (#680) -----------------------------------------------------------
+
+    @Test
+    void canonicalCachesSuccessfulResolutions(@TempDir Path dir) throws Exception {
+        PathKeys.invalidateCanonicalCache();
+        Path real = Files.writeString(dir.resolve("real.txt"), "x");
+        Path first = PathKeys.canonical(real);
+        assertEquals(first, PathKeys.canonical(real), "second lookup returns the cached resolution");
+    }
+
+    /**
+     * The not-exists fallback must NEVER be cached: a Save-As target resolves normalized before it exists,
+     * and once created its real form can differ (macOS /tmp → /private/tmp). A cached fallback would
+     * re-introduce the #470 identity mismatch that silently dropped diagnostics.
+     */
+    @Test
+    void theNotExistsFallbackIsNotCached(@TempDir Path dir) throws Exception {
+        PathKeys.invalidateCanonicalCache();
+        Path realDir = Files.createDirectory(dir.resolve("realdir"));
+        Path link = dir.resolve("link");
+        try {
+            Files.createSymbolicLink(link, realDir);
+        } catch (UnsupportedOperationException | java.io.IOException e) {
+            return; // platform without symlink support — nothing to prove here
+        }
+        Path throughLink = link.resolve("file.txt");
+        // Not created yet → fallback (normalized, symlink NOT resolved).
+        Path before = PathKeys.canonical(throughLink);
+        assertEquals(throughLink.toAbsolutePath().normalize(), before);
+        // Now create it — canonical must re-resolve through the symlink, proving no stale cache entry.
+        Files.writeString(realDir.resolve("file.txt"), "x");
+        Path after = PathKeys.canonical(throughLink);
+        assertEquals(realDir.toRealPath().resolve("file.txt"), after, "created file resolves through the link");
+    }
+
+    @Test
+    void invalidateClearsTheCache(@TempDir Path dir) throws Exception {
+        Path f = Files.writeString(dir.resolve("f.txt"), "x");
+        Path cached = PathKeys.canonical(f);
+        PathKeys.invalidateCanonicalCache();
+        assertEquals(cached, PathKeys.canonical(f), "re-resolves to the same identity after a clear");
+    }
 }


### PR DESCRIPTION
Implements #680 — sixth of the Java LSP queue; a performance fix from the original review's measurements.

`onDiagnostics → bufferForPath → tabForPath` runs `PathKeys.key` (→ `toRealPath`, a per-component stat chain) for **every open tab per publish**, plus one more canonicalization of the published file — all on the FX thread. jdtls bursts project-wide publishes on workspace open, so a cold multi-tab project open paid N_publishes × (N_tabs + 1) syscall chains.

- `PathKeys.canonical` caches successful resolutions (LRU 2048, access-ordered, synchronized map); every `canonical()` caller (notes/history keying included) shares the win.
- Invalidation: rename/delete hooks, the project watcher's external-change event, and window focus regain.
- **The not-exists fallback is never cached** — a Save-As target resolves normalized pre-creation, and its real form can differ post-creation (macOS `/tmp` → `/private/tmp`); caching it would re-introduce the #470 silent-diagnostics-drop. Pinned by a unit test with a real symlink (fallback before creation, real resolution after — no stale entry).
- Full `mvn verify` green; NUL-scan clean.

Closes #680.

🤖 Generated with [Claude Code](https://claude.com/claude-code)