### PR TITLE
perf(lsp): semantic-tokens delta (full/delta + resultId)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -142,6 +142,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Performance
 
+- **Semantic highlighting transfers only what changed.** For servers without viewport (range) requests —
+  jdtls among them — every typing pause re-transferred the whole document's semantic tokens. When the
+  server supports token deltas, Editora now sends the previous result id and splices the returned changes
+  onto its cached copy, falling back to a full request on any mismatch. Large Java files pay for their
+  edits, not their size. (#679)
+
 - **Cheaper diagnostics bursts.** Language servers publish project-wide diagnostics in bursts (jdtls
   especially, on workspace open); matching each publish to its open tab re-resolved every tab's canonical
   path with filesystem syscalls, on the UI thread. Successful resolutions are now cached (bounded LRU,

--- a/TODO.md
+++ b/TODO.md
@@ -3,6 +3,15 @@
 A backlog of planned features and improvements. Unordered within each section.
 
 ## Recently shipped
+- [x] **Semantic-tokens delta** (#679) — client declares `requests.full.delta`; the manager caches
+      `{resultId, data}` per document URI (cleared on close/shutdown; a crashed server's replacement
+      rejects the old id → error → fallback to full + state cleared, self-healing). The whole-document
+      branch (range-less servers like jdtls) asks `semanticTokens/full/delta` when state is held; the
+      pure/unit-tested **`SemanticTokensSplice`** applies the edits **descending by start** (they index
+      the OLD array) and refuses an out-of-range splice with null → plain full retry, so a stale delta
+      can never decode into a corrupted token array. A server answering a delta request with a fresh full
+      set (its right per spec) is handled. Range-capable servers are untouched (viewport requests already
+      bound their cost). *Deferred: `workspace/semanticTokens/refresh` (server-initiated invalidation).*
 - [x] **Canonical-path cache on the diagnostics path** (#680) — `PathKeys.canonical` now caches successful
       `toRealPath` resolutions (LRU 2048, access-ordered, synchronized) — the LSP publish path runs
       `PathKeys.key` for every open tab per publish, and jdtls bursts project-wide on open, so a cold

--- a/src/main/java/com/editora/lsp/LanguageServerSession.java
+++ b/src/main/java/com/editora/lsp/LanguageServerSession.java
@@ -376,7 +376,10 @@ final class LanguageServerSession implements LanguageClient {
         // distinguishes a parameter from a field from a type and flags deprecated/static/readonly. We
         // advertise both encodings (the decoder handles either); LspManager prefers range and falls back to
         // a full request for range-less servers (e.g. jdtls, which advertises range=false, full=true).
-        var stRequests = new org.eclipse.lsp4j.SemanticTokensClientCapabilitiesRequests(true, true); // full, range
+        // full (with delta — #679) + range: a range-less server (jdtls) otherwise re-sends the whole
+        // document's tokens on every 300 ms edit pulse; with delta it sends only the changed splice.
+        var stRequests = new org.eclipse.lsp4j.SemanticTokensClientCapabilitiesRequests(
+                new org.eclipse.lsp4j.SemanticTokensClientCapabilitiesRequestsFull(true), (Boolean) true);
         td.setSemanticTokens(new org.eclipse.lsp4j.SemanticTokensCapabilities(
                 stRequests, SEMANTIC_TOKEN_TYPES, SEMANTIC_TOKEN_MODIFIERS, java.util.List.of("relative")));
         ClientCapabilities cc = new ClientCapabilities();
@@ -880,6 +883,19 @@ final class LanguageServerSession implements LanguageClient {
                 .semanticTokensRange(
                         new org.eclipse.lsp4j.SemanticTokensRangeParams(new TextDocumentIdentifier(uri), range))
                 .exceptionally(t -> null);
+    }
+
+    /** Whole-document semantic-token <b>delta</b> ({@code semanticTokens/full/delta}) against a previous
+     *  {@code resultId} — the changed splices instead of the whole array (#679); null when not ready. */
+    CompletableFuture<
+                    org.eclipse.lsp4j.jsonrpc.messages.Either<
+                            org.eclipse.lsp4j.SemanticTokens, org.eclipse.lsp4j.SemanticTokensDelta>>
+            semanticTokensFullDelta(String uri, String previousResultId) {
+        if (!ready()) {
+            return CompletableFuture.completedFuture(null);
+        }
+        var params = new org.eclipse.lsp4j.SemanticTokensDeltaParams(new TextDocumentIdentifier(uri), previousResultId);
+        return server.getTextDocumentService().semanticTokensFullDelta(params).exceptionally(t -> null);
     }
 
     /** Whole-document semantic tokens ({@code textDocument/semanticTokens/full}), for servers that don't

--- a/src/main/java/com/editora/lsp/LspManager.java
+++ b/src/main/java/com/editora/lsp/LspManager.java
@@ -244,6 +244,7 @@ public final class LspManager {
         }
         String uri = uri(file);
         LanguageServerSession s = sessionByDocUri.remove(uri);
+        semanticTokenState.remove(uri); // the next open starts from a full request (#679)
         rawDiagnostics.remove(uri); // open-documents-only retention (#670); the symlink-form key, if any,
         try { //                       is dropped too so a closed file can't pin its diagnostics
             rawDiagnostics.remove(file.toRealPath().toUri().toString());
@@ -1102,11 +1103,23 @@ public final class LspManager {
         return e != null && (e.isRight() || Boolean.TRUE.equals(e.getLeft()));
     }
 
+    /** The cached whole-document token state for delta requests (#679): the server's {@code resultId} +
+     *  the full data array it identifies. Keyed by document URI; dropped on close/shutdown/error. */
+    private record TokenState(String resultId, List<Integer> data) {}
+
+    private final Map<String, TokenState> semanticTokenState = new ConcurrentHashMap<>();
+
     /**
      * Requests semantic tokens over the line window {@code [startLine..endLine]} (inclusive) and delivers
      * the decoded, CSS-classed {@link com.editora.editor.SemanticToken}s to {@code cb} on the FX thread
      * (empty when unsupported / on error). The window bounds cost on large files — the caller passes the
      * visible paragraph range. Decoding uses the server's effective legend, never hardcoded indices.
+     *
+     * <p>Range-less servers (jdtls advertises {@code range=false}) take the whole-document path, which —
+     * when the server supports {@code full.delta} and we hold its previous {@code resultId} — asks for a
+     * <b>delta</b> and splices it onto the cached array ({@link SemanticTokensSplice}) instead of
+     * re-transferring every token on each 300 ms edit pulse (#679). Any error/stale delta falls back to a
+     * plain full request.
      */
     public void requestSemanticTokens(
             Path file, int startLine, int endLine, Consumer<List<com.editora.editor.SemanticToken>> cb) {
@@ -1119,22 +1132,86 @@ public final class LspManager {
         var legend = prov.getLegend();
         // Prefer a range (viewport) request to bound cost; fall back to a whole-document request for a
         // server that advertises only `full` (no range).
-        java.util.concurrent.CompletableFuture<org.eclipse.lsp4j.SemanticTokens> fut;
         if (eitherTrue(prov.getRange())) {
             // [startLine,0) .. [endLine+1,0) covers whole lines startLine..endLine; clamp start to >= 0.
             var range = new org.eclipse.lsp4j.Range(
                     new Position(Math.max(0, startLine), 0), new Position(Math.max(0, endLine) + 1, 0));
-            fut = s.semanticTokensRange(uri(file), range);
-        } else {
-            fut = s.semanticTokensFull(uri(file));
+            s.semanticTokensRange(uri(file), range).whenComplete((tokens, error) -> {
+                List<com.editora.editor.SemanticToken> out = (error != null || tokens == null)
+                        ? List.of()
+                        : SemanticTokensDecoder.decode(
+                                tokens.getData(), legend.getTokenTypes(), legend.getTokenModifiers());
+                Platform.runLater(() -> cb.accept(out));
+            });
+            return;
         }
-        fut.whenComplete((tokens, error) -> {
-            List<com.editora.editor.SemanticToken> out = (error != null || tokens == null)
-                    ? List.of()
-                    : SemanticTokensDecoder.decode(
-                            tokens.getData(), legend.getTokenTypes(), legend.getTokenModifiers());
+        String uri = uri(file);
+        boolean deltaSupported = fullDeltaSupported(prov);
+        TokenState prev = deltaSupported ? semanticTokenState.get(uri) : null;
+        if (prev != null) {
+            s.semanticTokensFullDelta(uri, prev.resultId()).whenComplete((either, error) -> {
+                List<Integer> data = null;
+                String resultId = null;
+                if (error == null && either != null) {
+                    if (either.isLeft() && either.getLeft() != null) {
+                        data = either.getLeft().getData(); // server chose to answer with a fresh full set
+                        resultId = either.getLeft().getResultId();
+                    } else if (either.isRight() && either.getRight() != null) {
+                        data = SemanticTokensSplice.apply(
+                                prev.data(), either.getRight().getEdits());
+                        resultId = either.getRight().getResultId();
+                    }
+                }
+                if (data == null) {
+                    semanticTokenState.remove(uri); // stale/failed delta — re-request full
+                    requestSemanticTokensFull(s, file, legend, cb);
+                    return;
+                }
+                rememberTokenState(uri, resultId, data);
+                List<Integer> decoded = data;
+                List<com.editora.editor.SemanticToken> out =
+                        SemanticTokensDecoder.decode(decoded, legend.getTokenTypes(), legend.getTokenModifiers());
+                Platform.runLater(() -> cb.accept(out));
+            });
+            return;
+        }
+        requestSemanticTokensFull(s, file, legend, cb);
+    }
+
+    /** Plain whole-document request; caches {@code resultId}+data when the server supplies one (#679). */
+    private void requestSemanticTokensFull(
+            LanguageServerSession s,
+            Path file,
+            org.eclipse.lsp4j.SemanticTokensLegend legend,
+            Consumer<List<com.editora.editor.SemanticToken>> cb) {
+        String uri = uri(file);
+        s.semanticTokensFull(uri).whenComplete((tokens, error) -> {
+            if (error != null || tokens == null) {
+                Platform.runLater(() -> cb.accept(List.of()));
+                return;
+            }
+            rememberTokenState(uri, tokens.getResultId(), tokens.getData());
+            List<com.editora.editor.SemanticToken> out =
+                    SemanticTokensDecoder.decode(tokens.getData(), legend.getTokenTypes(), legend.getTokenModifiers());
             Platform.runLater(() -> cb.accept(out));
         });
+    }
+
+    private void rememberTokenState(String uri, String resultId, List<Integer> data) {
+        if (resultId != null && data != null) {
+            semanticTokenState.put(uri, new TokenState(resultId, List.copyOf(data)));
+        } else {
+            semanticTokenState.remove(uri); // no resultId ⇒ the server can't delta from this response
+        }
+    }
+
+    /** Pure: whether the provider's {@code full} form advertises delta support (null-safe). */
+    static boolean fullDeltaSupported(org.eclipse.lsp4j.SemanticTokensWithRegistrationOptions prov) {
+        var full = prov == null ? null : prov.getFull();
+        return full != null
+                && full.isRight()
+                && full.getRight() != null
+                && Boolean.TRUE.equals(full.getRight().getDelta());
     }
 
     public void hover(Path file, int line, int character, Consumer<String> cb) {
@@ -1472,6 +1549,7 @@ public final class LspManager {
     public void shutdownAll() {
         sessionByDocUri.clear();
         rawDiagnostics.clear();
+        semanticTokenState.clear();
         for (LanguageServerSession s : sessionsByRoot.values()) {
             s.dispose();
             releaseJdtlsWorkspace(s);

--- a/src/main/java/com/editora/lsp/SemanticTokensSplice.java
+++ b/src/main/java/com/editora/lsp/SemanticTokensSplice.java
@@ -1,0 +1,47 @@
+package com.editora.lsp;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+
+import org.eclipse.lsp4j.SemanticTokensEdit;
+
+/**
+ * Applies a {@code semanticTokens/full/delta} response's edits to the previously cached token data array
+ * (#679). Each {@link SemanticTokensEdit} is a splice — {@code start}/{@code deleteCount} index the
+ * <b>old</b> array, {@code data} is the replacement — so edits apply in descending-start order to keep
+ * earlier indices valid. Pure of JavaFX and I/O; unit-tested.
+ */
+final class SemanticTokensSplice {
+
+    private SemanticTokensSplice() {}
+
+    /**
+     * The new token data after applying {@code edits} to {@code previous}, or {@code null} when an edit is
+     * out of range (a stale/garbled delta — the caller falls back to a full request rather than decode a
+     * corrupted array).
+     */
+    static List<Integer> apply(List<Integer> previous, List<SemanticTokensEdit> edits) {
+        if (previous == null) {
+            return null;
+        }
+        List<Integer> out = new ArrayList<>(previous);
+        if (edits == null || edits.isEmpty()) {
+            return out;
+        }
+        List<SemanticTokensEdit> byStartDesc = new ArrayList<>(edits);
+        byStartDesc.sort(Comparator.comparingInt(SemanticTokensEdit::getStart).reversed());
+        for (SemanticTokensEdit e : byStartDesc) {
+            int start = e.getStart();
+            int delete = Math.max(0, e.getDeleteCount());
+            if (start < 0 || start + delete > out.size()) {
+                return null; // out of range — a stale delta; the caller re-requests full
+            }
+            out.subList(start, start + delete).clear();
+            if (e.getData() != null && !e.getData().isEmpty()) {
+                out.addAll(start, e.getData());
+            }
+        }
+        return out;
+    }
+}

--- a/src/test/java/com/editora/lsp/LspManagerTest.java
+++ b/src/test/java/com/editora/lsp/LspManagerTest.java
@@ -207,6 +207,23 @@ class LspManagerTest {
         assertEquals("…", LanguageServerSession.progressText(null, null, null), "no title still yields something");
     }
 
+    // --- Semantic-tokens delta (#679) ----------------------------------------------------------
+
+    @Test
+    void fullDeltaSupportDetectedOnlyFromTheOptionsFormWithDeltaTrue() {
+        assertFalse(LspManager.fullDeltaSupported(null));
+        var boolFull = stProvider(true, false, true); // full=true (boolean form) — no delta
+        assertFalse(LspManager.fullDeltaSupported(boolFull));
+        var opts = new SemanticTokensWithRegistrationOptions();
+        opts.setLegend(new SemanticTokensLegend(List.of("keyword"), List.of()));
+        var fullOpts = new org.eclipse.lsp4j.SemanticTokensServerFull(true); // delta=true
+        opts.setFull(fullOpts);
+        assertTrue(LspManager.fullDeltaSupported(opts));
+        var noDelta = new SemanticTokensWithRegistrationOptions();
+        noDelta.setFull(new org.eclipse.lsp4j.SemanticTokensServerFull(false));
+        assertFalse(LspManager.fullDeltaSupported(noDelta));
+    }
+
     // --- Watched files (#677) ------------------------------------------------------------------
 
     @Test

--- a/src/test/java/com/editora/lsp/SemanticTokensSpliceTest.java
+++ b/src/test/java/com/editora/lsp/SemanticTokensSpliceTest.java
@@ -1,0 +1,56 @@
+package com.editora.lsp;
+
+import java.util.List;
+
+import org.eclipse.lsp4j.SemanticTokensEdit;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+/** {@link SemanticTokensSplice}: delta edits splice onto the cached array; stale deltas are refused (#679). */
+class SemanticTokensSpliceTest {
+
+    private static SemanticTokensEdit edit(int start, int delete, Integer... data) {
+        SemanticTokensEdit e = new SemanticTokensEdit(start, delete, List.of(data));
+        return e;
+    }
+
+    @Test
+    void replaceInsertAndDeleteSplices() {
+        List<Integer> prev = List.of(0, 1, 2, 3, 4, 5, 6, 7, 8, 9);
+        // Replace [2..4) with {20,21,22}.
+        assertEquals(
+                List.of(0, 1, 20, 21, 22, 4, 5, 6, 7, 8, 9),
+                SemanticTokensSplice.apply(prev, List.of(edit(2, 2, 20, 21, 22))));
+        // Pure insert at 0.
+        assertEquals(
+                List.of(99, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9), SemanticTokensSplice.apply(prev, List.of(edit(0, 0, 99))));
+        // Pure delete of the tail.
+        assertEquals(
+                List.of(0, 1, 2, 3, 4), SemanticTokensSplice.apply(prev, List.of(new SemanticTokensEdit(5, 5, null))));
+    }
+
+    @Test
+    void multipleEditsApplyAgainstTheOldIndicesRegardlessOfOrder() {
+        List<Integer> prev = List.of(0, 1, 2, 3, 4, 5);
+        // Two edits given ascending — both index the OLD array; descending-start application keeps them valid.
+        List<Integer> out = SemanticTokensSplice.apply(prev, List.of(edit(1, 1, 10), edit(4, 1, 40)));
+        assertEquals(List.of(0, 10, 2, 3, 40, 5), out);
+    }
+
+    @Test
+    void emptyDeltaIsTheUnchangedArray() {
+        assertEquals(List.of(1, 2, 3), SemanticTokensSplice.apply(List.of(1, 2, 3), List.of()));
+        assertEquals(List.of(1, 2, 3), SemanticTokensSplice.apply(List.of(1, 2, 3), null));
+    }
+
+    @Test
+    void anOutOfRangeEditRefusesTheDelta() {
+        // A stale/garbled delta must not decode into a corrupted token array — null tells the caller to
+        // re-request full.
+        assertNull(SemanticTokensSplice.apply(List.of(1, 2, 3), List.of(edit(2, 5))));
+        assertNull(SemanticTokensSplice.apply(List.of(1, 2, 3), List.of(edit(-1, 0, 9))));
+        assertNull(SemanticTokensSplice.apply(null, List.of(edit(0, 0, 9))));
+    }
+}


### PR DESCRIPTION
Implements #679 — seventh of the Java LSP queue; the second performance item from the review's measurements.

Range-less servers (jdtls advertises `range=false`) re-transferred the whole document's semantic tokens on every 300 ms edit pulse + scroll settle. With `full.delta` support declared, the manager now caches `{resultId, data}` per document and requests only the changed splices.

- Pure `SemanticTokensSplice` (unit-tested): edits apply **descending by start** — they index the OLD array — and an out-of-range splice returns null so a stale/garbled delta can never decode into a corrupted token array (the caller re-requests full and re-warms).
- A delta answered with a fresh full set (allowed by spec) is handled; no `resultId` in a response ⇒ state dropped (the server can't delta from it).
- State cleared on document close and shutdown; a crashed server's replacement rejects the stale id → error path → fallback + clear (self-healing, no special-casing).
- Range-capable servers are completely untouched.
- Full `mvn verify` green; NUL-scan clean.

Deferred (TODO): `workspace/semanticTokens/refresh` (server-initiated invalidation).

Closes #679.

🤖 Generated with [Claude Code](https://claude.com/claude-code)