### PR TITLE
LSP inlay hints (end-of-line aggregated)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Inlay hints (LSP)** — the language server's parameter-name and inferred-type hints, drawn as grey
+  italic annotations after each line (aggregated per line). Off by default — toggle in Settings → Code
+  Completion or with `Toggle Inlay Hints` in the palette; costs nothing while off. (#681)
+
 - **Real language-server progress** — servers that report their long-running work through the standard
   LSP progress channel (jdtls importing/indexing a project, gopls loading packages, rust-analyzer's first
   check) now drive the status-bar loading bar and show what they're doing (title + percentage) in the

--- a/TODO.md
+++ b/TODO.md
@@ -3,6 +3,16 @@
 A backlog of planned features and improvements. Unordered within each section.
 
 ## Recently shipped
+- [x] **LSP inlay hints** (#681) — `textDocument/inlayHint` over the visible window (+ the semantic-tokens
+      pad), on the same cadence (didChange debounce, scroll-settle, ready, syncBuffer). Rendering is
+      **end-of-line aggregation**: `editor/InlayHintsOverlay` (the `InlineValuesOverlay` clone — lazy,
+      coalesced, 1×1 when empty) draws each line's hints joined in (line,col) order (pure
+      `LspCoordinator.aggregateInlayHints`, unit-tested) after the line's last glyph — deliberately NOT
+      mid-line, which would overdraw following glyphs; true inline placement needs document-model segments
+      (deferred). `Settings.inlayHints` default **off** (they're divisive), schema 84→85 additive;
+      Settings → Code Completion checkbox (disabled while LSP is off) + palette `view.toggleInlayHints`;
+      `docVersion` guard drops stale responses. `inlayLabel` joins label parts. *Deferred: true inline
+      (mid-line) rendering, `inlayHint/resolve` tooltips, `workspace/inlayHint/refresh`.*
 - [x] **Semantic-tokens delta** (#679) — client declares `requests.full.delta`; the manager caches
       `{resultId, data}` per document URI (cleared on close/shutdown; a crashed server's replacement
       rejects the old id → error → fallback to full + state cleared, self-healing). The whole-document

--- a/src/main/java/com/editora/config/Settings.java
+++ b/src/main/java/com/editora/config/Settings.java
@@ -40,7 +40,7 @@ public class Settings {
     }
 
     /** Current on-disk schema version of {@code settings.toml}; bump when the format changes (+ a migration). */
-    public static final int SCHEMA_VERSION = 84;
+    public static final int SCHEMA_VERSION = 85;
 
     private int schemaVersion = SCHEMA_VERSION;
 
@@ -132,6 +132,8 @@ public class Settings {
     /** Overlay LSP semantic tokens on the syntax highlight (resolved types/params/deprecated, …); on by
      *  default but only effective when LSP is enabled and the server advertises range semantic tokens. */
     private boolean semanticHighlight = true;
+    /** LSP inlay hints (parameter names / inferred types) drawn after each line; default off (#681). */
+    private boolean inlayHints = false;
     /** Honor a project's {@code .editorconfig} (indent, EOL, charset, trim/final-newline, max line length). */
     private boolean editorConfigSupport = true;
     /** Highlight configured patterns (TODO/FIXME/…) in the editor + list them in the TODO tool window. */
@@ -1035,6 +1037,14 @@ public class Settings {
 
     public void setSemanticHighlight(boolean semanticHighlight) {
         this.semanticHighlight = semanticHighlight;
+    }
+
+    public boolean isInlayHints() {
+        return inlayHints;
+    }
+
+    public void setInlayHints(boolean inlayHints) {
+        this.inlayHints = inlayHints;
     }
 
     public boolean isEditorConfigSupport() {

--- a/src/main/java/com/editora/config/migration/ConfigSchema.java
+++ b/src/main/java/com/editora/config/migration/ConfigSchema.java
@@ -143,7 +143,8 @@ public enum ConfigSchema {
                     Map.entry(81, (Migration) ConfigMigrations::identity), // v81→82: + githubSupport/ghPath (additive)
                     Map.entry(82, (Migration) ConfigMigrations::identity), // v82→83: + autoFill (additive)
                     Map.entry(83, (Migration)
-                            ConfigMigrations::identity))), // v83→84: + abbreviations/abbrevMode (additive)
+                            ConfigMigrations::identity), // v83→84: + abbreviations/abbrevMode (additive)
+                    Map.entry(84, (Migration) ConfigMigrations::identity))), // v84→85: + inlayHints (additive)
     WORKSPACE(WorkspaceState.SCHEMA_VERSION, 1, Map.of()),
     BOOKMARKS(BookmarkStore.SCHEMA_VERSION, 1, Map.of()),
     BREAKPOINTS(BreakpointStore.SCHEMA_VERSION, 1, Map.of()),

--- a/src/main/java/com/editora/editor/EditorBuffer.java
+++ b/src/main/java/com/editora/editor/EditorBuffer.java
@@ -488,6 +488,7 @@ public class EditorBuffer implements TabContent {
 
     private SearchHighlightOverlay searchOverlay; // lazily attached — see searchOverlay()
     private OccurrenceHighlightOverlay occurrenceOverlay; // lazily attached — see occurrenceOverlay() (#675)
+    private InlayHintsOverlay inlayHintsOverlay; // lazily attached — see inlayHintsOverlay() (#681)
     /** Highlights configured TODO/FIXME-style patterns (per-pattern color), behind the text. */
     private final TodoHighlightOverlay todoOverlay = new TodoHighlightOverlay(area);
     /** Injected matcher (compiled patterns) + on/off gate; null/false = no highlight. */
@@ -2205,6 +2206,14 @@ public class EditorBuffer implements TabContent {
         return occurrenceOverlay;
     }
 
+    private InlayHintsOverlay inlayHintsOverlay() {
+        if (inlayHintsOverlay == null) {
+            inlayHintsOverlay = attachLazyOverlay(new InlayHintsOverlay(area), todoOverlay);
+            inlayHintsOverlay.setFont(fontFamily, fontSize);
+        }
+        return inlayHintsOverlay;
+    }
+
     private LogHighlightOverlay logOverlay() {
         if (logOverlay == null) {
             logOverlay = attachLazyOverlay(new LogHighlightOverlay(area), whitespace);
@@ -2278,6 +2287,18 @@ public class EditorBuffer implements TabContent {
         if (occurrenceOverlay != null) {
             occurrenceOverlay.setSpans(java.util.List.of());
         }
+    }
+
+    /** Sets the per-line LSP inlay-hint annotations (0-based line → aggregated text, drawn after the
+     *  line); null/empty clears + releases the overlay texture (#681). */
+    public void setInlayHints(java.util.Map<Integer, String> hints) {
+        if (largeFile || hints == null || hints.isEmpty()) {
+            if (inlayHintsOverlay != null) {
+                inlayHintsOverlay.setHints(java.util.Map.of());
+            }
+            return;
+        }
+        inlayHintsOverlay().setHints(hints);
     }
 
     /** Injects the document-highlight request (the coordinator asks the server and pushes spans back);
@@ -5591,6 +5612,9 @@ public class EditorBuffer implements TabContent {
         }
         whitespace.setFont(family, size);
         inlineValues.setFont(family, size);
+        if (inlayHintsOverlay != null) {
+            inlayHintsOverlay.setFont(family, size);
+        }
         if (blameLines != null) {
             // The blame annotation column width is font-relative — recompute + rebuild so it stays aligned.
             blameColumnWidth = measureBlameColumnWidth(blameLines);

--- a/src/main/java/com/editora/editor/InlayHintsOverlay.java
+++ b/src/main/java/com/editora/editor/InlayHintsOverlay.java
@@ -1,0 +1,148 @@
+package com.editora.editor;
+
+import java.util.Map;
+
+import javafx.application.Platform;
+import javafx.geometry.Bounds;
+import javafx.geometry.VPos;
+import javafx.scene.canvas.Canvas;
+import javafx.scene.canvas.GraphicsContext;
+import javafx.scene.layout.Region;
+import javafx.scene.paint.Color;
+import javafx.scene.text.Font;
+import javafx.scene.text.FontPosture;
+import javafx.scene.text.TextAlignment;
+
+import org.fxmisc.richtext.CodeArea;
+
+/**
+ * LSP inlay hints (#681), rendered as grey italic annotations <b>after each line's text</b> — the
+ * per-line aggregate of the server's hints (parameter names, inferred types). A structural clone of
+ * {@link InlineValuesOverlay}: mouse-transparent {@link Canvas}, coalesced redraws, visible paragraphs
+ * only, 1×1 texture while empty. End-of-line placement is deliberate: a mid-line overlay would overdraw
+ * the following glyphs, and truly inline hints require document-model segments (deferred).
+ */
+final class InlayHintsOverlay extends Region {
+
+    private static final Color HINT_COLOR = Color.web("#808a93");
+    private static final int MAX_LINE_CHARS = 120;
+
+    private final CodeArea area;
+    private final Canvas canvas = new Canvas(1, 1);
+    /** 0-based line → the aggregated hint annotation for that line; null = inactive. */
+    private Map<Integer, String> byLine;
+
+    private boolean redrawPending;
+    private Font font = Font.font("monospace", FontPosture.ITALIC, 13);
+
+    InlayHintsOverlay(CodeArea area) {
+        this.area = area;
+        getStyleClass().add("inlay-hints-overlay");
+        setMouseTransparent(true);
+        setVisible(false);
+        getChildren().add(canvas);
+        area.viewportDirtyEvents().subscribe(ignore -> scheduleRedraw());
+        area.estimatedScrollXProperty().addListener((o, a, b) -> scheduleRedraw());
+        area.estimatedScrollYProperty().addListener((o, a, b) -> scheduleRedraw());
+    }
+
+    /** Sets the per-line hint annotations (null or empty clears + releases the canvas). */
+    void setHints(Map<Integer, String> hints) {
+        this.byLine = (hints == null || hints.isEmpty()) ? null : Map.copyOf(hints);
+        boolean active = byLine != null;
+        setVisible(active);
+        if (active) {
+            requestLayout();
+            scheduleRedraw();
+        } else {
+            canvas.getGraphicsContext2D().clearRect(0, 0, canvas.getWidth(), canvas.getHeight());
+            canvas.setWidth(1); // release the full-viewport texture while inactive
+            canvas.setHeight(1);
+        }
+    }
+
+    /** Keeps the hint font in step with the editor font (italic, slightly smaller). */
+    void setFont(String family, int size) {
+        this.font = Font.font(family, FontPosture.ITALIC, Math.max(9, size - 1));
+        scheduleRedraw();
+    }
+
+    @Override
+    protected void layoutChildren() {
+        canvas.relocate(0, 0);
+        if (byLine == null) {
+            return;
+        }
+        double w = CanvasGuards.clampDim(getWidth());
+        double h = CanvasGuards.clampDim(getHeight());
+        if (canvas.getWidth() != w || canvas.getHeight() != h) {
+            canvas.setWidth(w);
+            canvas.setHeight(h);
+        }
+        scheduleRedraw();
+    }
+
+    private void scheduleRedraw() {
+        if (byLine == null || redrawPending) {
+            return;
+        }
+        redrawPending = true;
+        Platform.runLater(() -> {
+            redrawPending = false;
+            redraw();
+        });
+    }
+
+    private void redraw() {
+        GraphicsContext g = canvas.getGraphicsContext2D();
+        double w = canvas.getWidth();
+        double h = canvas.getHeight();
+        g.clearRect(0, 0, w, h);
+        Map<Integer, String> hints = byLine;
+        if (hints == null || !CanvasGuards.paintable(getWidth(), getHeight())) {
+            return;
+        }
+        try {
+            int total = area.getParagraphs().size();
+            if (total == 0) {
+                return;
+            }
+            int first = Math.max(0, area.firstVisibleParToAllParIndex());
+            int last = Math.min(total - 1, area.lastVisibleParToAllParIndex());
+            g.setFill(HINT_COLOR);
+            g.setFont(font);
+            g.setTextBaseline(VPos.CENTER);
+            g.setTextAlign(TextAlignment.LEFT);
+            for (int p = first; p <= last; p++) {
+                if (area.isFolded(p)) {
+                    continue;
+                }
+                String annotation = hints.get(p);
+                if (annotation == null || annotation.isBlank()) {
+                    continue;
+                }
+                String line = area.getParagraph(p).getText();
+                if (line.isEmpty()) {
+                    continue; // no anchor glyph to place after
+                }
+                int abs = area.getAbsolutePosition(p, line.length() - 1);
+                Bounds b = area.getCharacterBoundsOnScreen(abs, abs + 1)
+                        .map(canvas::screenToLocal)
+                        .orElse(null);
+                if (b == null) {
+                    continue;
+                }
+                double x = b.getMaxX() + 16;
+                if (x < 0 || x > w) {
+                    continue;
+                }
+                String text = annotation.length() > MAX_LINE_CHARS
+                        ? annotation.substring(0, MAX_LINE_CHARS) + "…"
+                        : annotation;
+                g.fillText(text, x, b.getMinY() + b.getHeight() / 2);
+            }
+        } catch (RuntimeException ignored) {
+            // Viewport mid-layout — skip this frame; a later event redraws.
+        }
+    }
+}

--- a/src/main/java/com/editora/lsp/LanguageServerSession.java
+++ b/src/main/java/com/editora/lsp/LanguageServerSession.java
@@ -337,6 +337,7 @@ final class LanguageServerSession implements LanguageClient {
         td.setDefinition(new DefinitionCapabilities());
         td.setReferences(new ReferencesCapabilities());
         td.setDocumentHighlight(new org.eclipse.lsp4j.DocumentHighlightCapabilities()); // occurrences (#675)
+        td.setInlayHint(new org.eclipse.lsp4j.InlayHintCapabilities()); // parameter/type hints (#681)
         // Rename (#676): prepareSupport lets the server validate the position + hand us the placeholder.
         var rename = new org.eclipse.lsp4j.RenameCapabilities();
         rename.setPrepareSupport(true);
@@ -776,6 +777,19 @@ final class LanguageServerSession implements LanguageClient {
         } catch (RuntimeException ignored) {
             // best effort — an advisory notification
         }
+    }
+
+    /** Inlay hints ({@code textDocument/inlayHint}) over {@code range} — parameter names / inferred
+     *  types — or empty (#681). */
+    CompletableFuture<List<org.eclipse.lsp4j.InlayHint>> inlayHint(String uri, org.eclipse.lsp4j.Range range) {
+        if (!ready()) {
+            return CompletableFuture.completedFuture(List.of());
+        }
+        var params = new org.eclipse.lsp4j.InlayHintParams(new TextDocumentIdentifier(uri), range);
+        return server.getTextDocumentService()
+                .inlayHint(params)
+                .<List<org.eclipse.lsp4j.InlayHint>>thenApply(l -> l == null ? List.of() : List.copyOf(l))
+                .exceptionally(t -> List.of());
     }
 
     CompletableFuture<Either<List<CompletionItem>, CompletionList>> completion(String uri, Position pos) {

--- a/src/main/java/com/editora/lsp/LspManager.java
+++ b/src/main/java/com/editora/lsp/LspManager.java
@@ -750,6 +750,71 @@ public final class LspManager {
         return out;
     }
 
+    /** A single inlay hint: 0-based position + the rendered label ({@code x:} for a parameter name). */
+    public record InlayHintSpan(int line, int col, String label) {}
+
+    /** True if {@code file}'s server is ready and advertises inlay hints (#681). */
+    public boolean supportsInlayHints(Path file) {
+        LanguageServerSession s = sessionFor(file);
+        return s != null && inlayHintProvider(s.capabilities());
+    }
+
+    /** Pure: whether a server's capabilities include {@code inlayHintProvider} (null-safe, either form). */
+    static boolean inlayHintProvider(org.eclipse.lsp4j.ServerCapabilities caps) {
+        if (caps == null) {
+            return false;
+        }
+        var p = caps.getInlayHintProvider();
+        return p != null && (p.isRight() || Boolean.TRUE.equals(p.getLeft()));
+    }
+
+    /** Requests inlay hints over the line window {@code [startLine..endLine]} (inclusive), delivered as
+     *  neutral spans on the FX thread — empty when unsupported/failed (#681). */
+    public void requestInlayHints(Path file, int startLine, int endLine, Consumer<List<InlayHintSpan>> cb) {
+        LanguageServerSession s = sessionFor(file);
+        if (s == null) {
+            Platform.runLater(() -> cb.accept(List.of()));
+            return;
+        }
+        var range = new org.eclipse.lsp4j.Range(
+                new Position(Math.max(0, startLine), 0), new Position(Math.max(0, endLine) + 1, 0));
+        s.inlayHint(uri(file), range).whenComplete((hints, error) -> {
+            List<InlayHintSpan> out = new ArrayList<>();
+            if (error == null && hints != null) {
+                for (var h : hints) {
+                    if (h == null || h.getPosition() == null) {
+                        continue;
+                    }
+                    String label = inlayLabel(h);
+                    if (!label.isBlank()) {
+                        out.add(new InlayHintSpan(
+                                h.getPosition().getLine(), h.getPosition().getCharacter(), label));
+                    }
+                }
+            }
+            Platform.runLater(() -> cb.accept(out));
+        });
+    }
+
+    /** Pure: an inlay hint's display label — the plain string, or its label parts joined. */
+    static String inlayLabel(org.eclipse.lsp4j.InlayHint h) {
+        if (h.getLabel() == null) {
+            return "";
+        }
+        if (h.getLabel().isLeft()) {
+            return h.getLabel().getLeft() == null ? "" : h.getLabel().getLeft().strip();
+        }
+        StringBuilder sb = new StringBuilder();
+        if (h.getLabel().getRight() != null) {
+            for (var part : h.getLabel().getRight()) {
+                if (part != null && part.getValue() != null) {
+                    sb.append(part.getValue());
+                }
+            }
+        }
+        return sb.toString().strip();
+    }
+
     /** True if {@code file}'s server is ready and advertises rename (#676). */
     public boolean supportsRename(Path file) {
         LanguageServerSession s = sessionFor(file);

--- a/src/main/java/com/editora/ui/LspCoordinator.java
+++ b/src/main/java/com/editora/ui/LspCoordinator.java
@@ -606,6 +606,47 @@ final class LspCoordinator {
      * and pushes them into the buffer when the response lands — but only if it's still the active buffer
      * (a background tab's tokens would overlay nothing useful and waste an apply).
      */
+    /**
+     * Inlay hints (#681): requests the server's parameter-name/type hints over the visible window and
+     * pushes the per-line aggregate into the buffer's end-of-line overlay. Gated on the (default-off)
+     * setting + the server's capability; clears when the gate fails so a toggle-off empties the overlay.
+     * Rides the same cadence as semantic tokens (didChange debounce, scroll-settle, ready, syncBuffer).
+     */
+    void requestInlayHints(EditorBuffer buffer) {
+        Path path = buffer.getPath();
+        if (path == null
+                || !host.settings().isInlayHints()
+                || !lspManager.isManaged(path)
+                || !lspManager.supportsInlayHints(path)) {
+            buffer.setInlayHints(null);
+            return;
+        }
+        int[] window = buffer.visibleLineWindow();
+        long version = buffer.docVersion();
+        lspManager.requestInlayHints(path, window[0] - SEMANTIC_WINDOW_PAD, window[1] + SEMANTIC_WINDOW_PAD, spans -> {
+            if (buffer == host.activeBuffer() && buffer.docVersion() == version) {
+                buffer.setInlayHints(aggregateInlayHints(spans));
+            }
+        });
+    }
+
+    /** Pure: hints grouped per line in (line, col) order, labels joined — the end-of-line aggregate. */
+    static Map<Integer, String> aggregateInlayHints(List<com.editora.lsp.LspManager.InlayHintSpan> spans) {
+        List<com.editora.lsp.LspManager.InlayHintSpan> sorted = new java.util.ArrayList<>(spans);
+        sorted.sort(java.util.Comparator.comparingInt(com.editora.lsp.LspManager.InlayHintSpan::line)
+                .thenComparingInt(com.editora.lsp.LspManager.InlayHintSpan::col));
+        Map<Integer, String> out = new java.util.HashMap<>();
+        for (var s : sorted) {
+            out.merge(s.line(), s.label(), (a, b) -> a + "  " + b);
+        }
+        return out;
+    }
+
+    /** Re-applies the inlay-hints gate to every open buffer (the palette/Settings toggle's apply). */
+    void applyInlayHints() {
+        host.forEachBuffer(this::requestInlayHints); // the gate inside clears buffers when toggled off
+    }
+
     void requestSemanticTokens(EditorBuffer buffer) {
         Path path = buffer.getPath();
         if (path == null || !buffer.isSemanticActive() || !lspManager.isManaged(path)) {
@@ -707,6 +748,7 @@ final class LspCoordinator {
             if (semantic) {
                 requestSemanticTokens(buffer);
             }
+            requestInlayHints(buffer); // gated internally on the setting + capability (#681)
         } else {
             buffer.setLspActive(false);
             buffer.setLspTriggerChars(java.util.Set.of());
@@ -716,6 +758,7 @@ final class LspCoordinator {
             buffer.setLspRenameAvailable(false);
             buffer.setLspSignatureTriggerChars(java.util.Set.of());
             buffer.clearOccurrenceSpans();
+            buffer.setInlayHints(null);
             buffer.setSemanticActive(false);
             if (path != null && lspManager.isManaged(path)) {
                 lspManager.closeDocument(path);
@@ -881,6 +924,7 @@ final class LspCoordinator {
                         if (sem) {
                             requestSemanticTokens(b);
                         }
+                        requestInlayHints(b); // capabilities known now (#681)
                     }
                 });
                 requestStructureSymbols(host.activeBuffer()); // the outline can now be populated from the server
@@ -924,7 +968,10 @@ final class LspCoordinator {
             }
         });
         // Semantic tokens re-request (fired on the same debounce as didChange + on scroll-settle).
-        buffer.setSemanticTokensRequester(() -> requestSemanticTokens(buffer));
+        buffer.setSemanticTokensRequester(() -> {
+            requestSemanticTokens(buffer);
+            requestInlayHints(buffer); // same cadence: didChange debounce + scroll-settle (#681)
+        });
         buffer.setLspCompletionProvider((pos, cb) -> {
             if (buffer.getPath() != null && lspManager.isManaged(buffer.getPath())) {
                 lspManager.completion(

--- a/src/main/java/com/editora/ui/MainController.java
+++ b/src/main/java/com/editora/ui/MainController.java
@@ -13658,6 +13658,13 @@ public class MainController implements com.editora.mcp.McpBridge {
                         () -> config.getSettings().isSemanticHighlight(),
                         config.getSettings()::setSemanticHighlight,
                         lspCoordinator::applySemanticHighlight)));
+        registry.register(Command.of(
+                "view.toggleInlayHints",
+                () -> toggleSetting(
+                        "view.toggleInlayHints",
+                        () -> config.getSettings().isInlayHints(),
+                        config.getSettings()::setInlayHints,
+                        lspCoordinator::applyInlayHints)));
         registry.register(Command.of("tool.commit", () -> git.ifEnabled(() -> toolWindows.toggle(commitToolWindow))));
         // Git (native CLI). Gated by the "Enable Git" setting (default off); also no-op when Git is
         // absent / not in a repo. The ifGit wrapper disables the commands + keybindings when Git is off.

--- a/src/main/java/com/editora/ui/SettingsWindow.java
+++ b/src/main/java/com/editora/ui/SettingsWindow.java
@@ -204,6 +204,7 @@ public class SettingsWindow {
     private CheckBox autocompleteMermaidCheck;
     private CheckBox completionDocCheck;
     private CheckBox semanticHighlightCheck;
+    private CheckBox inlayHintsCheck;
     private CheckBox spellCheckBox;
     private ComboBox<String> spellLanguageCombo;
     /** The Personal Dictionary list on the Spell Check page; refreshed from {@code dictionary.txt} on show. */
@@ -920,6 +921,7 @@ public class SettingsWindow {
         autocompleteMermaidCheck = viewCheck(tr("settings.autocomplete.mermaid"), Settings::setAutocompleteMermaid);
         completionDocCheck = viewCheck(tr("settings.completionDoc"), Settings::setCompletionDoc);
         semanticHighlightCheck = viewCheck(tr("settings.semanticHighlight"), Settings::setSemanticHighlight);
+        inlayHintsCheck = viewCheck(tr("settings.inlayHints"), Settings::setInlayHints);
         // The per-source toggles are only meaningful while the master switch is on.
         autocompleteCheck.selectedProperty().addListener((obs, was, now) -> {
             autocompleteProseCheck.setDisable(!now);
@@ -2713,6 +2715,13 @@ public class SettingsWindow {
                 completion,
                 semanticHighlightCheck,
                 "semantic highlighting lsp tokens types parameters fields deprecated");
+        row(
+                p,
+                Category.COMPLETION,
+                completion,
+                inlayHintsCheck,
+                "inlay hints parameter names inferred types lsp annotations");
+        inlayHintsCheck.disableProperty().bind(lspCheck.selectedProperty().not());
         // Semantic highlighting comes from LSP: disable it (+ explain why) when LSP is off.
         semanticHighlightCheck
                 .disableProperty()
@@ -6050,6 +6059,7 @@ public class SettingsWindow {
             autocompleteMermaidCheck.setDisable(!settings.isAutocomplete());
             completionDocCheck.setSelected(settings.isCompletionDoc());
             semanticHighlightCheck.setSelected(settings.isSemanticHighlight());
+            inlayHintsCheck.setSelected(settings.isInlayHints());
             pdfLineNumbersCheck.setSelected(settings.isPdfLineNumbers());
             pdfHighlightCheck.setSelected(settings.isPdfSyntaxHighlighting());
             pdfPageSizeCombo.setValue(settings.getPdfPageSize());
@@ -6619,6 +6629,7 @@ public class SettingsWindow {
             autocompleteMermaidCheck.setDisable(!s.isAutocomplete());
             completionDocCheck.setSelected(s.isCompletionDoc());
             semanticHighlightCheck.setSelected(s.isSemanticHighlight());
+            inlayHintsCheck.setSelected(s.isInlayHints());
         } finally {
             loading = prev;
         }

--- a/src/main/resources/com/editora/i18n/messages.properties
+++ b/src/main/resources/com/editora/i18n/messages.properties
@@ -2095,6 +2095,9 @@ structure.sort.name=Name
 structure.sort.kind=Kind
 structure.filter.kinds=Filter by kind
 command.view.toggleSemanticHighlight=View: Toggle Semantic Highlighting
+command.view.toggleInlayHints=View: Toggle Inlay Hints
+command.view.toggleInlayHints.desc=Show or hide the language server’s parameter-name and type hints drawn after each line (off by default)
+settings.inlayHints=Inlay hints (parameter names / types, after the line)
 command.view.toggleSemanticHighlight.desc=Turn LSP semantic token highlighting on or off.
 settings.semanticHighlight=Semantic highlighting (LSP)
 # TODO / highlight patterns

--- a/src/main/resources/com/editora/i18n/messages_de.properties
+++ b/src/main/resources/com/editora/i18n/messages_de.properties
@@ -2087,6 +2087,9 @@ structure.sort.name=Name
 structure.sort.kind=Art
 structure.filter.kinds=Nach Art filtern
 command.view.toggleSemanticHighlight=Ansicht: Semantische Hervorhebung umschalten
+command.view.toggleInlayHints=Ansicht: Inlay-Hinweise umschalten
+command.view.toggleInlayHints.desc=Zeigt oder verbirgt die Parameternamen- und Typ-Hinweise des Sprachservers, die nach jeder Zeile gezeichnet werden (standardmäßig aus)
+settings.inlayHints=Inlay-Hinweise (Parameternamen / Typen, nach der Zeile)
 command.view.toggleSemanticHighlight.desc=Die semantische Token-Hervorhebung über LSP ein- oder ausschalten.
 settings.semanticHighlight=Semantische Hervorhebung (LSP)
 # TODO / highlight patterns

--- a/src/main/resources/com/editora/i18n/messages_es.properties
+++ b/src/main/resources/com/editora/i18n/messages_es.properties
@@ -2087,6 +2087,9 @@ structure.sort.name=Nombre
 structure.sort.kind=Tipo
 structure.filter.kinds=Filtrar por tipo
 command.view.toggleSemanticHighlight=Ver: Activar/desactivar resaltado semántico
+command.view.toggleInlayHints=Ver: Alternar sugerencias en línea
+command.view.toggleInlayHints.desc=Muestra u oculta las sugerencias de nombres de parámetros y tipos del servidor de lenguaje dibujadas al final de cada línea (desactivado por defecto)
+settings.inlayHints=Sugerencias en línea (nombres de parámetros / tipos, al final de la línea)
 command.view.toggleSemanticHighlight.desc=Activar o desactivar el resaltado mediante tokens semánticos de LSP.
 settings.semanticHighlight=Resaltado semántico (LSP)
 # TODO / highlight patterns

--- a/src/main/resources/com/editora/i18n/messages_fr.properties
+++ b/src/main/resources/com/editora/i18n/messages_fr.properties
@@ -2087,6 +2087,9 @@ structure.sort.name=Nom
 structure.sort.kind=Type
 structure.filter.kinds=Filtrer par type
 command.view.toggleSemanticHighlight=Affichage : Activer/désactiver la coloration sémantique
+command.view.toggleInlayHints=Affichage : Basculer les indications en ligne
+command.view.toggleInlayHints.desc=Affiche ou masque les indications de noms de paramètres et de types du serveur de langage dessinées après chaque ligne (désactivé par défaut)
+settings.inlayHints=Indications en ligne (noms de paramètres / types, après la ligne)
 command.view.toggleSemanticHighlight.desc=Activer ou désactiver la coloration par jetons sémantiques LSP.
 settings.semanticHighlight=Coloration sémantique (LSP)
 # TODO / highlight patterns

--- a/src/main/resources/com/editora/i18n/messages_it.properties
+++ b/src/main/resources/com/editora/i18n/messages_it.properties
@@ -2087,6 +2087,9 @@ structure.sort.name=Nome
 structure.sort.kind=Tipo
 structure.filter.kinds=Filtra per tipo
 command.view.toggleSemanticHighlight=Vista: Attiva/disattiva evidenziazione semantica
+command.view.toggleInlayHints=Vista: Attiva/disattiva suggerimenti inline
+command.view.toggleInlayHints.desc=Mostra o nasconde i suggerimenti di nomi parametro e tipi del language server disegnati dopo ogni riga (disattivato per impostazione predefinita)
+settings.inlayHints=Suggerimenti inline (nomi parametro / tipi, dopo la riga)
 command.view.toggleSemanticHighlight.desc=Attiva o disattiva l'evidenziazione tramite token semantici LSP.
 settings.semanticHighlight=Evidenziazione semantica (LSP)
 # TODO / highlight patterns

--- a/src/main/resources/com/editora/i18n/messages_pt.properties
+++ b/src/main/resources/com/editora/i18n/messages_pt.properties
@@ -2087,6 +2087,9 @@ structure.sort.name=Nome
 structure.sort.kind=Tipo
 structure.filter.kinds=Filtrar por tipo
 command.view.toggleSemanticHighlight=Exibir: Ativar/desativar realce semântico
+command.view.toggleInlayHints=Exibir: Alternar dicas inline
+command.view.toggleInlayHints.desc=Mostra ou oculta as dicas de nomes de parâmetros e tipos do servidor de linguagem desenhadas após cada linha (desativado por padrão)
+settings.inlayHints=Dicas inline (nomes de parâmetros / tipos, após a linha)
 command.view.toggleSemanticHighlight.desc=Ativa ou desativa o realce por tokens semânticos do LSP.
 settings.semanticHighlight=Realce semântico (LSP)
 # TODO / highlight patterns

--- a/src/test/java/com/editora/lsp/LspManagerTest.java
+++ b/src/test/java/com/editora/lsp/LspManagerTest.java
@@ -241,6 +241,33 @@ class LspManagerTest {
         assertEquals(org.eclipse.lsp4j.FileChangeType.Created, events.get(1).getType());
     }
 
+    // --- Inlay hints (#681) --------------------------------------------------------------------
+
+    @Test
+    void inlayHintProviderDetectedFromEitherForm() {
+        assertFalse(LspManager.inlayHintProvider(null));
+        assertFalse(LspManager.inlayHintProvider(new ServerCapabilities()));
+        ServerCapabilities bool = new ServerCapabilities();
+        bool.setInlayHintProvider(true);
+        assertTrue(LspManager.inlayHintProvider(bool));
+        ServerCapabilities opts = new ServerCapabilities();
+        opts.setInlayHintProvider(new org.eclipse.lsp4j.InlayHintRegistrationOptions());
+        assertTrue(LspManager.inlayHintProvider(opts));
+    }
+
+    @Test
+    void inlayLabelJoinsPartsAndStrips() {
+        var plain = new org.eclipse.lsp4j.InlayHint(
+                new org.eclipse.lsp4j.Position(0, 0), org.eclipse.lsp4j.jsonrpc.messages.Either.forLeft(" x: "));
+        assertEquals("x:", LspManager.inlayLabel(plain));
+        var parts = new org.eclipse.lsp4j.InlayHint(
+                new org.eclipse.lsp4j.Position(0, 0),
+                org.eclipse.lsp4j.jsonrpc.messages.Either.forRight(List.of(
+                        new org.eclipse.lsp4j.InlayHintLabelPart("a"),
+                        new org.eclipse.lsp4j.InlayHintLabelPart(": int"))));
+        assertEquals("a: int", LspManager.inlayLabel(parts));
+    }
+
     // --- Rename (#676) -------------------------------------------------------------------------
 
     @Test

--- a/src/test/java/com/editora/ui/InlayHintAggregateTest.java
+++ b/src/test/java/com/editora/ui/InlayHintAggregateTest.java
@@ -1,0 +1,30 @@
+package com.editora.ui;
+
+import java.util.List;
+import java.util.Map;
+
+import com.editora.lsp.LspManager;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/** The per-line end-of-line aggregation behind the inlay-hints overlay (#681). */
+class InlayHintAggregateTest {
+
+    @Test
+    void hintsGroupPerLineInColumnOrder() {
+        var spans = List.of(
+                new LspManager.InlayHintSpan(2, 20, "b:"),
+                new LspManager.InlayHintSpan(2, 10, "a:"),
+                new LspManager.InlayHintSpan(5, 0, ": String"));
+        Map<Integer, String> out = LspCoordinator.aggregateInlayHints(spans);
+        assertEquals("a:  b:", out.get(2), "same-line hints join in column order");
+        assertEquals(": String", out.get(5));
+        assertEquals(2, out.size());
+    }
+
+    @Test
+    void emptyInputAggregatesToEmpty() {
+        assertEquals(Map.of(), LspCoordinator.aggregateInlayHints(List.of()));
+    }
+}


### PR DESCRIPTION
Implements #681 — eighth of the Java LSP feature queue.

Parameter-name / inferred-type hints from the language server, drawn as grey italic annotations **after each line** (the per-line aggregate in column order). **Off by default** — Settings → Code Completion (checkbox disabled while LSP is off) or `View: Toggle Inlay Hints`.

- Requested over the visible window (+ pad) on the semantic-tokens cadence (didChange debounce, scroll-settle, ready, syncBuffer); `docVersion` guard drops stale responses; schema 84→85 additive.
- `editor/InlayHintsOverlay` = the `InlineValuesOverlay` clone: lazy, coalesced, visible-paragraphs-only, 1×1 texture while empty. **End-of-line placement is deliberate** — a mid-line overlay would overdraw the following glyphs; true inline placement needs document-model segments (deferred, noted in TODO along with `inlayHint/resolve` tooltips and `workspace/inlayHint/refresh`).
- Pure `aggregateInlayHints` + `inlayLabel` (label-parts join) unit-tested; i18n ×6 (caught by the family-prefix parity test and fixed to `View:` convention).
- Full `mvn verify` green; NUL-scan clean. Zero cost while off (the default).

Device-test: enable the toggle with jdtls up — `String.format("%s", x)` should grow a trailing `format: arg0:` style annotation (jdtls parameter hints), appearing ~300 ms after edits settle.

Closes #681.

🤖 Generated with [Claude Code](https://claude.com/claude-code)