### PR TITLE
perf(lsp): incremental document sync (shadow-diff)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -146,6 +146,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Performance
 
+- **Incremental document sync (LSP).** For servers that accept incremental changes (jdtls, pyright,
+  tsserver, gopls, rust-analyzer — most of them), each typing pause now sends only the changed splice of
+  the document instead of the whole text — a fraction of the transport, and the server can process the
+  change incrementally. Computed as a shadow-vs-current diff (immune to event-ordering bugs by
+  construction, pinned by a 2,000-step randomized convergence test), with a periodic full-text resync as
+  a divergence safety net; full-only servers are unchanged. (#678)
+
 - **Semantic highlighting transfers only what changed.** For servers without viewport (range) requests —
   jdtls among them — every typing pause re-transferred the whole document's semantic tokens. When the
   server supports token deltas, Editora now sends the previous result id and splices the returned changes

--- a/TODO.md
+++ b/TODO.md
@@ -3,6 +3,20 @@
 A backlog of planned features and improvements. Unordered within each section.
 
 ## Recently shipped
+- [x] **LSP incremental document sync** (#678) — under `TextDocumentSyncKind.Incremental` the session now
+      sends the minimal splice instead of the whole document. **Shadow-diff, not event accumulation**: a
+      per-uri shadow of the text the server last received (`shadows`, invariant: always equals the server's
+      copy after every send) is diffed against the flush's full text by the pure **`TextSyncDiff`**
+      (common-prefix/suffix scan, O(n), surrogate-pair-safe boundaries — a split pair would put half a
+      surrogate in the JSON; UTF-16 line/col via `rangeOf`) — chosen over converting RichTextFX
+      `PlainTextChange`s because ordering bugs there corrupt the server copy silently and forever; the
+      diff is immune by construction (2,000-step seeded randomized convergence test). The full-vs-delta
+      decision happens INSIDE the queued send (capabilities post-initialize; shadow read in send order);
+      an identical-content flush now skips the send entirely (the pre-request `changeDocument` syncs
+      become free); every 256th delta goes out full as a divergence safety net; didClose/didOpen reset the
+      shadow; Full/unspecified servers keep the exact previous behavior. Client alloc note: the flush
+      still materializes `getText()` once — the win is transport + server-side processing; avoiding the
+      client-side string means accumulating editor events, deferred for the correctness reason above.
 - [x] **LSP inlay hints** (#681) — `textDocument/inlayHint` over the visible window (+ the semantic-tokens
       pad), on the same cadence (didChange debounce, scroll-settle, ready, syncBuffer). Rendering is
       **end-of-line aggregation**: `editor/InlayHintsOverlay` (the `InlineValuesOverlay` clone — lazy,

--- a/src/main/java/com/editora/lsp/LanguageServerSession.java
+++ b/src/main/java/com/editora/lsp/LanguageServerSession.java
@@ -95,6 +95,17 @@ final class LanguageServerSession implements LanguageClient {
         return t;
     });
     private final Map<String, Integer> versions = new ConcurrentHashMap<>();
+    /** Per-document shadow of the text the server last received — the diff base for incremental sync
+     *  (#678). Invariant: after every send, {@code shadows.get(uri)} equals the server's document. */
+    private final Map<String, String> shadows = new ConcurrentHashMap<>();
+    /** Incremental sends since the last full resync, per document (the divergence safety net, #678). */
+    private final Map<String, Integer> sendsSinceResync = new ConcurrentHashMap<>();
+
+    /** Every {@code RESYNC_EVERY}-th change goes out as a full-text event even under incremental sync — a
+     *  cheap safety net: if shadow and server ever diverged, every later delta would corrupt the server's
+     *  copy silently and forever; a periodic full write re-converges them (#678). */
+    private static final int RESYNC_EVERY = 256;
+
     private final List<Pending> pending = new ArrayList<>();
     private final AtomicInteger nextVersion = new AtomicInteger(1);
 
@@ -511,6 +522,7 @@ final class LanguageServerSession implements LanguageClient {
     // --- Document synchronization (full-text) ---------------------------------------------------
 
     void didOpen(String uri, String languageId, String text) {
+        shadows.put(uri, text); // the server now holds exactly this content (#678)
         versions.put(uri, 1);
         whenReady(() -> server.getTextDocumentService()
                 .didOpen(new DidOpenTextDocumentParams(new TextDocumentItem(uri, languageId, 1, text))));
@@ -521,14 +533,57 @@ final class LanguageServerSession implements LanguageClient {
             return; // server negotiated TextDocumentSyncKind.None — it doesn't track content changes
         }
         int version = versions.merge(uri, 1, Integer::sum);
-        // Collapse: a queued didChange for this uri is superseded by this one (full-text sync, so only the
-        // latest matters) — otherwise every typing pause before initialize pins another copy of the document.
-        whenReady(
-                "didChange:" + uri,
-                () -> server.getTextDocumentService()
-                        .didChange(new DidChangeTextDocumentParams(
-                                new VersionedTextDocumentIdentifier(uri, version),
-                                List.of(new TextDocumentContentChangeEvent(text)))));
+        // Collapse: a queued didChange for this uri is superseded by this one (only the latest content
+        // matters) — otherwise every typing pause before initialize pins another copy of the document.
+        // The full-vs-incremental decision happens INSIDE the queued action (#678): capabilities are only
+        // known post-initialize, and the shadow must be read in send order.
+        whenReady("didChange:" + uri, () -> {
+            List<TextDocumentContentChangeEvent> events = changeEventsFor(uri, text);
+            if (events.isEmpty()) {
+                return; // content identical to what the server already holds — nothing to sync
+            }
+            server.getTextDocumentService()
+                    .didChange(
+                            new DidChangeTextDocumentParams(new VersionedTextDocumentIdentifier(uri, version), events));
+        });
+    }
+
+    /**
+     * The change events for syncing {@code text}: under {@code TextDocumentSyncKind.Incremental} (and with
+     * a shadow held), the minimal splice vs. the server's last-known content — a fraction of the transport
+     * and lets the server process incrementally (#678); otherwise (Full/unspecified/no shadow) the whole
+     * text, exactly the previous behavior. Every {@link #RESYNC_EVERY}-th incremental send goes out full as
+     * a divergence safety net. The shadow updates unconditionally — it must always equal what the server
+     * holds after this send.
+     */
+    private List<TextDocumentContentChangeEvent> changeEventsFor(String uri, String text) {
+        String old = shadows.put(uri, text);
+        if (old == null || changeSyncKind(capabilities) != TextDocumentSyncKind.Incremental) {
+            return List.of(new TextDocumentContentChangeEvent(text));
+        }
+        int count = sendsSinceResync.merge(uri, 1, Integer::sum);
+        if (count >= RESYNC_EVERY) {
+            sendsSinceResync.put(uri, 0);
+            return List.of(new TextDocumentContentChangeEvent(text)); // periodic full re-convergence
+        }
+        TextSyncDiff.Delta d = TextSyncDiff.diff(old, text);
+        if (d == null) {
+            return List.of(); // identical (e.g. a redundant pre-request sync) — skip the send entirely
+        }
+        var range = TextSyncDiff.rangeOf(old, d.start(), d.end());
+        return List.of(new TextDocumentContentChangeEvent(range, d.replacement()));
+    }
+
+    /** Pure: the server's declared change-sync kind, or null when unspecified (either capability form). */
+    static TextDocumentSyncKind changeSyncKind(ServerCapabilities caps) {
+        if (caps == null || caps.getTextDocumentSync() == null) {
+            return null;
+        }
+        var sync = caps.getTextDocumentSync();
+        if (sync.isLeft()) {
+            return sync.getLeft();
+        }
+        return sync.getRight() == null ? null : sync.getRight().getChange();
     }
 
     /**
@@ -538,18 +593,9 @@ final class LanguageServerSession implements LanguageClient {
      * behavior (we still send), since omitting it is rare and a missed update is worse than a wasted one.
      */
     private boolean changeSyncDisabled() {
-        if (capabilities == null) {
-            return false;
-        }
-        var sync = capabilities.getTextDocumentSync();
-        if (sync == null) {
-            return false; // unspecified → keep sending full text (existing behavior)
-        }
-        if (sync.isLeft()) {
-            return sync.getLeft() == TextDocumentSyncKind.None;
-        }
-        // Detailed options form: an explicit change == None means no change notifications are wanted.
-        return sync.getRight() != null && sync.getRight().getChange() == TextDocumentSyncKind.None;
+        // Unspecified (null kind) keeps the current full-text behavior — a missed update is worse than a
+        // wasted one; only an explicit None turns change sync off.
+        return capabilities != null && changeSyncKind(capabilities) == TextDocumentSyncKind.None;
     }
 
     void didSave(String uri) {
@@ -559,6 +605,8 @@ final class LanguageServerSession implements LanguageClient {
 
     void didClose(String uri) {
         versions.remove(uri);
+        shadows.remove(uri); // the diff base dies with the document (#678)
+        sendsSinceResync.remove(uri);
         whenReady(() -> server.getTextDocumentService()
                 .didClose(new DidCloseTextDocumentParams(new TextDocumentIdentifier(uri))));
     }

--- a/src/main/java/com/editora/lsp/TextSyncDiff.java
+++ b/src/main/java/com/editora/lsp/TextSyncDiff.java
@@ -1,0 +1,75 @@
+package com.editora.lsp;
+
+import org.eclipse.lsp4j.Position;
+import org.eclipse.lsp4j.Range;
+
+/**
+ * The minimal single-splice difference between the server's last-known document text and the editor's
+ * current text — what incremental document sync ({@code TextDocumentSyncKind.Incremental}, #678) sends
+ * instead of the whole document. Common-prefix/common-suffix scan: O(n) char comparisons, zero allocation
+ * beyond the replacement substring, and — because it is computed <b>shadow vs. current</b> rather than by
+ * accumulating editor change events — immune to event-ordering bugs by construction.
+ *
+ * <p>Positions are LSP UTF-16 code-unit line/columns. The prefix/suffix never split a surrogate pair: a
+ * range boundary between a high and low surrogate would put half a pair into the replacement string —
+ * invalid JSON — so the scan backs off one unit at such a boundary. Pure; heavily unit-tested (including a
+ * seeded randomized convergence test).
+ */
+final class TextSyncDiff {
+
+    private TextSyncDiff() {}
+
+    /** One splice: replace {@code [start, end)} (offsets into the OLD text) with {@code replacement}. */
+    record Delta(int start, int end, String replacement) {}
+
+    /** The minimal splice turning {@code oldText} into {@code newText}, or null when they are identical. */
+    static Delta diff(String oldText, String newText) {
+        int lo = oldText.length();
+        int ln = newText.length();
+        int min = Math.min(lo, ln);
+        int p = 0;
+        while (p < min && oldText.charAt(p) == newText.charAt(p)) {
+            p++;
+        }
+        if (p == lo && p == ln) {
+            return null; // identical
+        }
+        // Don't let the prefix end between a surrogate pair (the replacement would start mid-pair).
+        if (p > 0 && Character.isHighSurrogate(oldText.charAt(p - 1))) {
+            p--;
+        }
+        int s = 0;
+        while (s < min - p && oldText.charAt(lo - 1 - s) == newText.charAt(ln - 1 - s)) {
+            s++;
+        }
+        // Don't let the suffix start between a surrogate pair.
+        if (s > 0 && Character.isLowSurrogate(oldText.charAt(lo - s))) {
+            s--;
+        }
+        return new Delta(p, lo - s, newText.substring(p, ln - s));
+    }
+
+    /** The LSP range of {@code [start, end)} within {@code text} — both positions in one scan. */
+    static Range rangeOf(String text, int start, int end) {
+        int line = 0;
+        int lineStart = 0;
+        Position startPos = null;
+        int limit = Math.min(end, text.length());
+        for (int i = 0; i <= limit; i++) {
+            if (startPos == null && i == start) {
+                startPos = new Position(line, start - lineStart);
+            }
+            if (i == limit) {
+                break;
+            }
+            if (text.charAt(i) == '\n') {
+                line++;
+                lineStart = i + 1;
+            }
+        }
+        if (startPos == null) {
+            startPos = new Position(line, Math.max(0, start - lineStart));
+        }
+        return new Range(startPos, new Position(line, Math.max(0, end - lineStart)));
+    }
+}

--- a/src/test/java/com/editora/lsp/TextSyncDiffTest.java
+++ b/src/test/java/com/editora/lsp/TextSyncDiffTest.java
@@ -1,0 +1,155 @@
+package com.editora.lsp;
+
+import java.util.Random;
+
+import org.eclipse.lsp4j.Position;
+import org.eclipse.lsp4j.Range;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * {@link TextSyncDiff} (#678): the single-splice diff behind incremental document sync. A wrong splice
+ * silently corrupts the server's copy of the document forever — hence the seeded randomized convergence
+ * test on top of the edge cases.
+ */
+class TextSyncDiffTest {
+
+    /** Applies a delta the way a server would — splice [start,end) of the old text with the replacement. */
+    private static String apply(String oldText, TextSyncDiff.Delta d) {
+        return oldText.substring(0, d.start()) + d.replacement() + oldText.substring(d.end());
+    }
+
+    private static void assertConverges(String oldText, String newText) {
+        TextSyncDiff.Delta d = TextSyncDiff.diff(oldText, newText);
+        if (d == null) {
+            assertEquals(oldText, newText, "null delta claims identity");
+            return;
+        }
+        assertEquals(newText, apply(oldText, d), "old=" + oldText + " new=" + newText);
+    }
+
+    @Test
+    void insertDeleteReplaceAtAllPositions() {
+        assertConverges("hello world", "hello brave world"); // insert middle
+        assertConverges("hello", "Xhello"); // insert start
+        assertConverges("hello", "helloX"); // insert end
+        assertConverges("hello world", "world"); // delete start
+        assertConverges("hello world", "hello"); // delete end
+        assertConverges("hello world", "hello_world"); // replace middle
+        assertConverges("", "abc"); // from empty
+        assertConverges("abc", ""); // to empty
+        assertConverges("aaaa", "aaaaa"); // repeated chars (prefix/suffix overlap trap)
+        assertConverges("abab", "ababab");
+    }
+
+    @Test
+    void identicalTextsDiffToNull() {
+        assertNull(TextSyncDiff.diff("same", "same"));
+        assertNull(TextSyncDiff.diff("", ""));
+    }
+
+    @Test
+    void surrogatePairsAreNeverSplit() {
+        // The emoji is two UTF-16 units; edits beside it must not put half a pair in the replacement.
+        String smile = "😀";
+        String rocket = "🚀";
+        assertConverges("a" + smile + "b", "a" + rocket + "b"); // pairs share the high surrogate!
+        assertConverges(smile, rocket);
+        assertConverges("x" + smile, "x" + smile + smile);
+        assertConverges(smile + "x", rocket + "x");
+        // The replacement string itself must be well-formed (no lone surrogate at its edges).
+        TextSyncDiff.Delta d = TextSyncDiff.diff("a" + smile + "b", "a" + rocket + "b");
+        String rep = d.replacement();
+        if (!rep.isEmpty()) {
+            assertFalse(Character.isLowSurrogate(rep.charAt(0)), "replacement starts mid-pair");
+            assertFalse(Character.isHighSurrogate(rep.charAt(rep.length() - 1)), "replacement ends mid-pair");
+        }
+    }
+
+    /** 2,000 random edit steps (seeded — reproducible) must all converge byte-for-byte. */
+    @Test
+    void randomizedConvergence() {
+        Random rnd = new Random(42);
+        String alphabet = "ab\ncd 😀xyz{}();\t";
+        String doc = "";
+        for (int i = 0; i < 2000; i++) {
+            String next = mutate(doc, rnd, alphabet);
+            assertConverges(doc, next);
+            doc = next;
+        }
+    }
+
+    private static String mutate(String doc, Random rnd, String alphabet) {
+        StringBuilder sb = new StringBuilder(doc);
+        int op = rnd.nextInt(3);
+        int at = doc.isEmpty() ? 0 : rnd.nextInt(doc.length() + 1);
+        // Never split a surrogate pair in the *generated* document (the editor never does either).
+        if (at > 0 && at < sb.length() && Character.isLowSurrogate(sb.charAt(at))) {
+            at--;
+        }
+        if (op == 0 || doc.isEmpty()) { // insert 1..8 units from the alphabet (pairs kept together)
+            int n = 1 + rnd.nextInt(4);
+            StringBuilder ins = new StringBuilder();
+            for (int i = 0; i < n; i++) {
+                int a = rnd.nextInt(alphabet.length());
+                if (Character.isLowSurrogate(alphabet.charAt(a))) {
+                    a--;
+                }
+                if (Character.isHighSurrogate(alphabet.charAt(a))) {
+                    ins.append(alphabet, a, a + 2);
+                } else {
+                    ins.append(alphabet.charAt(a));
+                }
+            }
+            sb.insert(at, ins);
+        } else { // delete (op 1) or replace (op 2) a short run
+            int len = Math.min(1 + rnd.nextInt(6), sb.length() - at);
+            int end = at + len;
+            if (end > 0 && end < sb.length() && Character.isLowSurrogate(sb.charAt(end))) {
+                end--;
+            }
+            if (end > at) {
+                sb.delete(at, end);
+            }
+            if (op == 2) {
+                sb.insert(Math.min(at, sb.length()), "R");
+            }
+        }
+        return sb.toString();
+    }
+
+    @Test
+    void rangeOfComputesUtf16LineColumns() {
+        String text = "one\ntwo\nthree";
+        assertEquals(range(0, 0, 0, 3), TextSyncDiff.rangeOf(text, 0, 3)); // "one"
+        assertEquals(range(1, 0, 1, 3), TextSyncDiff.rangeOf(text, 4, 7)); // "two"
+        assertEquals(range(0, 3, 1, 0), TextSyncDiff.rangeOf(text, 3, 4)); // the newline itself
+        assertEquals(range(2, 5, 2, 5), TextSyncDiff.rangeOf(text, 13, 13)); // empty at EOF
+        // Columns are UTF-16 units: the emoji counts as 2.
+        String emoji = "😀abc";
+        assertEquals(range(0, 2, 0, 3), TextSyncDiff.rangeOf(emoji, 2, 3)); // "a" sits at unit column 2
+    }
+
+    private static Range range(int sl, int sc, int el, int ec) {
+        return new Range(new Position(sl, sc), new Position(el, ec));
+    }
+
+    @Test
+    void changeSyncKindReadsBothCapabilityForms() {
+        assertNull(LanguageServerSession.changeSyncKind(null));
+        var caps = new org.eclipse.lsp4j.ServerCapabilities();
+        assertNull(LanguageServerSession.changeSyncKind(caps));
+        caps.setTextDocumentSync(org.eclipse.lsp4j.TextDocumentSyncKind.Incremental);
+        assertEquals(org.eclipse.lsp4j.TextDocumentSyncKind.Incremental, LanguageServerSession.changeSyncKind(caps));
+        var opts = new org.eclipse.lsp4j.TextDocumentSyncOptions();
+        opts.setChange(org.eclipse.lsp4j.TextDocumentSyncKind.Full);
+        var caps2 = new org.eclipse.lsp4j.ServerCapabilities();
+        caps2.setTextDocumentSync(opts);
+        assertEquals(org.eclipse.lsp4j.TextDocumentSyncKind.Full, LanguageServerSession.changeSyncKind(caps2));
+        assertTrue(true);
+    }
+}


### PR DESCRIPTION
Implements #678 — ninth of the Java LSP queue; the riskiest slice, engineered accordingly.

Under `TextDocumentSyncKind.Incremental` (jdtls, pyright, tsserver, gopls, rust-analyzer…), each typing pause now sends **only the changed splice** instead of the whole document.

## Why shadow-diff instead of accumulating editor events
A per-URI shadow of the text the server last received is diffed against the flush's full text (pure `TextSyncDiff`: common-prefix/suffix scan, O(n), surrogate-pair-safe boundaries, UTF-16 line/cols). Converting RichTextFX `PlainTextChange`s would be cheaper client-side but an ordering bug corrupts the server's copy **silently and forever**; the shadow diff is immune by construction. Pinned by a **2,000-step seeded randomized convergence test** plus edge cases (repeated-char overlap traps, emoji boundary splits, empty↔nonempty).

## Safety properties
- Invariant: after every send, `shadows.get(uri)` equals the server's document (didOpen seeds it; every send updates it unconditionally).
- The full-vs-delta decision happens **inside the queued send** — capabilities are post-initialize, and the shadow must be read in send order.
- Every 256th delta goes out as a full-text event (divergence safety net).
- An identical-content flush skips the send entirely — the pre-request `changeDocument` syncs (goto/refs/hover/format/codeAction/signature) become free.
- Full/unspecified servers: byte-identical previous behavior.

Honest note on client allocation: the flush still materializes `getText()` once — the win is transport + server-side processing. Avoiding that allocation means event accumulation, deferred for the correctness reason above (in TODO).

Full `mvn verify` green; NUL-scan clean.

Closes #678.

🤖 Generated with [Claude Code](https://claude.com/claude-code)