### PR TITLE
LSP: chained navigation inside jdt:// library source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Navigate inside library source (LSP, Java)** — Go to Definition now also works *from within* an
+  opened JDK/dependency source tab: put the caret on a symbol inside `String.class`'s source and `M-.`
+  chains onward — into another library class (opened the same way) or back into your own code. (#684)
+
 - **Call & type hierarchy (LSP)** — `LSP: Call Hierarchy` shows who calls the method under the caret (or
   what it calls — flip with the Callers/Callees toggle) in a new **Hierarchy** tool window, each level
   fetched from the language server as you expand it; `LSP: Type Hierarchy` does the same for a type's

--- a/TODO.md
+++ b/TODO.md
@@ -3,6 +3,17 @@
 A backlog of planned features and improvements. Unordered within each section.
 
 ## Recently shipped
+- [x] **jdt:// chained navigation** (#684) — deferred from #665: the read-only library-source tab has no
+      filesystem path, so `M-.` inside it was dead. `LspCoordinator.librarySources` (weak-keyed) records
+      each library tab's own jdt URI + the workspace anchor file whose session produced it;
+      `gotoDefinition` branches to `libraryGotoDefinition`, which requests definition **with the jdt URI
+      as the document URI** on the anchor's session (`LspManager.definitionAt`, sharing the jdt-aware
+      target mapping via the extracted `requestDefinition`). Results chain: file targets open normally,
+      further library targets open/re-select their own tabs (each recorded as a new chain point).
+      **Device-test flag:** jdtls answering definition on a jdt document it served (without a didOpen) is
+      the live-verification item — on a server that refuses, the flow degrades to the "no definition"
+      status, nothing worse. *Deferred: hover/references inside library source; the right-click LSP menu
+      in library tabs (gated on isLspActive, which a path-less buffer deliberately isn't).*
 - [x] **LSP call/type hierarchy** (#682) — `prepareCallHierarchy` + incoming/outgoing calls and
       `prepareTypeHierarchy` + super/subtypes into a new **Hierarchy** tool window (`ui/HierarchyPanel`,
       the `ReferencesPanel` model; id `hierarchy`, default-hidden, opened by the commands, availability

--- a/src/main/java/com/editora/lsp/LspManager.java
+++ b/src/main/java/com/editora/lsp/LspManager.java
@@ -1452,12 +1452,26 @@ public final class LspManager {
     }
 
     public void definition(Path file, int line, int character, Consumer<List<Target>> cb) {
-        LanguageServerSession s = sessionFor(file);
-        if (s == null) {
-            cb.accept(List.of());
+        requestDefinition(sessionFor(file), file == null ? null : uri(file), line, character, cb);
+    }
+
+    /**
+     * Definition at an explicit document URI on {@code anchorFile}'s session — how navigation chains
+     * <b>inside</b> an opened {@code jdt://} library source (#684): the library tab has no filesystem path,
+     * but jdtls resolves positions in the jdt documents it has served. {@code anchorFile} is the original
+     * workspace file the library source was reached from.
+     */
+    public void definitionAt(Path anchorFile, String documentUri, int line, int character, Consumer<List<Target>> cb) {
+        requestDefinition(sessionFor(anchorFile), documentUri, line, character, cb);
+    }
+
+    private void requestDefinition(
+            LanguageServerSession s, String documentUri, int line, int character, Consumer<List<Target>> cb) {
+        if (s == null || documentUri == null) {
+            Platform.runLater(() -> cb.accept(List.of()));
             return;
         }
-        s.definition(uri(file), new Position(line, character)).whenComplete((result, error) -> {
+        s.definition(documentUri, new Position(line, character)).whenComplete((result, error) -> {
             List<Target> targets = new ArrayList<>();
             if (error == null && result != null) {
                 if (result.isLeft()) {

--- a/src/main/java/com/editora/ui/LspCoordinator.java
+++ b/src/main/java/com/editora/ui/LspCoordinator.java
@@ -1153,6 +1153,12 @@ final class LspCoordinator {
     }
 
     void gotoDefinition() {
+        EditorBuffer active = host.activeBuffer();
+        LibrarySource lib = active == null ? null : librarySources.get(active);
+        if (lib != null) {
+            libraryGotoDefinition(active, lib); // navigating INSIDE an opened jdt:// source (#684)
+            return;
+        }
         EditorBuffer b = activeLspBuffer();
         if (b == null) {
             return;
@@ -1167,7 +1173,7 @@ final class LspCoordinator {
                 if (t.file() != null) {
                     ops.openAndGoto(t.file(), t.line(), t.character());
                 } else {
-                    openLibraryDefinition(b, t); // a jdt:// class-file target (JDK/dependency source) — #665
+                    openLibraryDefinition(b.getPath(), t); // a jdt:// class-file target (library source) — #665
                 }
             }
         });
@@ -1180,6 +1186,12 @@ final class LspCoordinator {
      */
     private final Map<String, java.lang.ref.WeakReference<EditorBuffer>> libraryBuffers = new java.util.HashMap<>();
 
+    /** What a library-source (jdt://) tab was opened from: its own URI + the workspace file whose session
+     *  produced it — lets navigation chain from inside library code (#684). Weak keys: dies with the tab. */
+    private final Map<EditorBuffer, LibrarySource> librarySources = new java.util.WeakHashMap<>();
+
+    private record LibrarySource(String uri, Path anchor) {}
+
     /**
      * Opens the source of a JDK/dependency class the server reported under a {@code jdt://} URI: fetched via
      * jdtls's {@code java/classFileContents} into a read-only, Java-highlighted, path-less buffer (#665).
@@ -1187,7 +1199,7 @@ final class LspCoordinator {
      * reported "no definition". {@code anchor} is the buffer the navigation started from (it routes the
      * request to the right session).
      */
-    private void openLibraryDefinition(EditorBuffer anchor, LspManager.Target t) {
+    private void openLibraryDefinition(Path anchorPath, LspManager.Target t) {
         String uri = t.classFileUri();
         var ref = libraryBuffers.get(uri);
         EditorBuffer existing = ref == null ? null : ref.get();
@@ -1196,7 +1208,7 @@ final class LspCoordinator {
             return;
         }
         host.setStatus(tr("status.lsp.libraryLoading"));
-        lspManager.classFileContents(anchor.getPath(), uri, content -> {
+        lspManager.classFileContents(anchorPath, uri, content -> {
             if (content == null) {
                 host.setStatus(tr("status.lsp.libraryUnavailable"));
                 return;
@@ -1204,7 +1216,30 @@ final class LspCoordinator {
             EditorBuffer opened = ops.openReadOnlyDoc(LspManager.classFileTitle(uri), content, "java");
             if (opened != null) {
                 libraryBuffers.put(uri, new java.lang.ref.WeakReference<>(opened));
+                librarySources.put(opened, new LibrarySource(uri, anchorPath)); // chain point (#684)
                 gotoInBuffer(opened, t.line(), t.character());
+            }
+        });
+    }
+
+    /**
+     * Go-to-definition from INSIDE an opened {@code jdt://} library source (#684): the tab has no
+     * filesystem path, so the request goes out with the library document's own jdt URI on the anchor
+     * file's session — jdtls resolves positions in the jdt documents it has served. Results chain: a
+     * file target opens normally, another library target opens (or re-selects) its own read-only tab.
+     */
+    private void libraryGotoDefinition(EditorBuffer buffer, LibrarySource lib) {
+        CodeArea area = buffer.getFocusedArea();
+        lspManager.definitionAt(lib.anchor(), lib.uri(), area.getCurrentParagraph(), area.getCaretColumn(), targets -> {
+            if (targets.isEmpty()) {
+                host.setStatus(tr("status.lsp.noDefinition"));
+                return;
+            }
+            LspManager.Target t = targets.get(0);
+            if (t.file() != null) {
+                ops.openAndGoto(t.file(), t.line(), t.character());
+            } else {
+                openLibraryDefinition(lib.anchor(), t);
             }
         });
     }


### PR DESCRIPTION
Implements #684 — the last item of the Java LSP feature queue (#674–#684).

Go to Definition now works *from within* an opened JDK/dependency source tab (#665 made those tabs exist; this makes them navigable): caret on a symbol inside `String.class`'s source → `M-.` chains onward — into another library class (opened/re-selected the same way) or back into workspace code.

- `librarySources` (weak-keyed) records each library tab's jdt URI + the workspace anchor whose session produced it; `gotoDefinition` branches to `libraryGotoDefinition`, which sends the definition request with the **jdt URI as the document URI** on the anchor's session (`LspManager.definitionAt`, sharing the jdt-aware mapping via the extracted `requestDefinition`).
- Every further library target becomes a new chain point.
- **Device-test flag (from the issue):** jdtls answering `definition` on a jdt document it served, without a didOpen, is the live-verification item — a server that refuses degrades to the "no definition" status, nothing worse.
- Full `mvn verify` green; NUL-scan clean.

Deferred (TODO): hover/references inside library source; the right-click LSP menu in library tabs.

Closes #684.

🤖 Generated with [Claude Code](https://claude.com/claude-code)