### PR TITLE
Console copy menus + Test Runner status-icon tooltips

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Right-click Select All / Copy in the Build Output and Test Runner consoles** — copies the selection, or
+  all the output when nothing is selected. Both read-only consoles share one helper.
+- **Tooltips on the Test Runner's per-row status icons** — hovering a test's pass/fail/skip/running glyph
+  now says what it means. (The toolbar buttons already had tooltips.)
+
 - **Doctor — external-tool health screen** — `View: Doctor` in the palette (also on the Welcome page)
   opens a full-tab report, like `flutter doctor`, of every external CLI Editora's features rely on: Git
   and the GitHub CLI (including its sign-in state), ripgrep, the preview/diagram tools (mmdc, maid,

--- a/src/main/java/com/editora/ui/BuildToolPanel.java
+++ b/src/main/java/com/editora/ui/BuildToolPanel.java
@@ -76,6 +76,7 @@ public final class BuildToolPanel extends VBox implements ToolWindowContent {
         output.getStyleClass().addAll("editor-area", "run-output");
         RunPanel.installLinkClicks(output, () -> onLink);
         ConsoleNav.installShared(output);
+        ConsoleContextMenu.install(output); // right-click Select All / Copy
 
         VirtualizedScrollPane<CodeArea> scrollPane = new VirtualizedScrollPane<>(output);
         VBox.setVgrow(scrollPane, Priority.ALWAYS);

--- a/src/main/java/com/editora/ui/ConsoleContextMenu.java
+++ b/src/main/java/com/editora/ui/ConsoleContextMenu.java
@@ -1,0 +1,57 @@
+package com.editora.ui;
+
+import javafx.scene.control.ContextMenu;
+import javafx.scene.control.MenuItem;
+import javafx.scene.input.Clipboard;
+import javafx.scene.input.ClipboardContent;
+
+import org.fxmisc.richtext.CodeArea;
+
+import static com.editora.i18n.Messages.tr;
+
+/**
+ * A right-click <b>Select All</b> / <b>Copy</b> menu for a read-only console {@link CodeArea} (the Build
+ * Output tabs and the Test Runner detail pane). These areas are read-only, so keyboard select/copy already
+ * works; this adds the discoverable mouse affordance. <b>Copy</b> copies the current selection, or the whole
+ * buffer when nothing is selected (the common "grab all the output" case). Both items are disabled while the
+ * console is empty.
+ */
+final class ConsoleContextMenu {
+
+    private ConsoleContextMenu() {}
+
+    static void install(CodeArea area) {
+        MenuItem selectAll = new MenuItem(tr("editmenu.selectAll"));
+        selectAll.setGraphic(Icons.selectAll());
+        selectAll.setOnAction(e -> {
+            area.selectAll();
+            area.requestFocus();
+        });
+
+        MenuItem copy = new MenuItem(tr("editmenu.copy"));
+        copy.setGraphic(Icons.copy());
+        copy.setOnAction(e -> copySelectionOrAll(area));
+
+        ContextMenu menu = new ContextMenu(selectAll, copy);
+        area.setOnContextMenuRequested(e -> {
+            boolean empty = area.getLength() == 0;
+            selectAll.setDisable(empty);
+            copy.setDisable(empty);
+            menu.show(area, e.getScreenX(), e.getScreenY());
+            e.consume();
+        });
+    }
+
+    private static void copySelectionOrAll(CodeArea area) {
+        String text = area.getSelectedText();
+        if (text == null || text.isEmpty()) {
+            text = area.getText();
+        }
+        if (text.isEmpty()) {
+            return;
+        }
+        ClipboardContent content = new ClipboardContent();
+        content.putString(text);
+        Clipboard.getSystemClipboard().setContent(content);
+    }
+}

--- a/src/main/java/com/editora/ui/TestRunnerPanel.java
+++ b/src/main/java/com/editora/ui/TestRunnerPanel.java
@@ -136,6 +136,7 @@ final class TestRunnerPanel extends VBox implements ToolWindowContent {
         detail.setWrapText(false);
         detail.getStyleClass().addAll("editor-area", "test-detail");
         RunPanel.installLinkClicks(detail, () -> onLink);
+        ConsoleContextMenu.install(detail); // right-click Select All / Copy
 
         SplitPane split = new SplitPane(tree, new VirtualizedScrollPane<>(detail));
         split.setDividerPositions(0.5);
@@ -563,12 +564,16 @@ final class TestRunnerPanel extends VBox implements ToolWindowContent {
         }
 
         private static Node statusIcon(TestStatus status) {
-            return switch (status) {
-                case PASSED -> Icons.testPassed();
-                case FAILED, ERROR -> Icons.testFailed();
-                case SKIPPED -> Icons.testSkipped();
-                case RUNNING -> Icons.testRunning();
-            };
+            Node icon =
+                    switch (status) {
+                        case PASSED -> Icons.testPassed();
+                        case FAILED, ERROR -> Icons.testFailed();
+                        case SKIPPED -> Icons.testSkipped();
+                        case RUNNING -> Icons.testRunning();
+                    };
+            // Each row's status glyph is icon-only — a tooltip says what it means (Passed / Failed / …).
+            Tooltip.install(icon, new Tooltip(statusLabel(status)));
+            return icon;
         }
     }
 }


### PR DESCRIPTION
Fixes the first three Test Runner / Build Output issues.

## What changed

- **#697 / #698 — right-click Select All / Copy** on the Build Output console (`BuildToolPanel`) and the
  Test Runner detail pane (`TestRunnerPanel`). Both are read-only RichTextFX `CodeArea`s; the new menu is
  the discoverable mouse affordance. **Copy** copies the current selection, or the whole buffer when nothing
  is selected (the common "grab all the output" case). Extracted a shared `ui/ConsoleContextMenu` helper so
  the two consoles stay identical.
- **#699 — tooltips on the Test Runner status icons.** Each test row's status glyph (pass / fail / skip /
  running) now has a tooltip naming the status. The toolbar buttons and toggles already carried tooltips
  (via the `iconButton` helper), and the header count chips already show text ("5 passed"), so the per-row
  glyphs were the only icons left without one.

## Notes

- Menu items reuse the existing `editmenu.selectAll` / `editmenu.copy` strings and the `selectAll`/`copy`
  glyphs; the status tooltips reuse `testrunner.detail.status.*`. No new i18n keys.
- Scope kept to the two consoles named in the issues. The same one-line `ConsoleContextMenu.install(...)`
  would apply to the Run / External Tools / Debug consoles too if you want them consistent — say the word.

## Verification

- `mvn test` — all 2941 tests pass.
- `mvn compile` + `mvn spotless:check` clean.
- Desktop-JavaFX UI, so a quick manual look (right-click each console; hover a test row) is worth it before merge.

Closes #697, closes #698, closes #699

🤖 Generated with [Claude Code](https://claude.com/claude-code)