### PR TITLE
Run/Debug projects (1/6): Debug any Maven/Gradle main class

### DIFF
--- a/src/main/java/com/editora/dap/DapManager.java
+++ b/src/main/java/com/editora/dap/DapManager.java
@@ -395,6 +395,17 @@ public final class DapManager implements DapClient.Host {
     }
 
     private void resolveAndLaunch(Path file, MainClassOption opt) {
+        resolveAndLaunch(
+                file, opt, file.getParent() == null ? null : file.getParent().toString());
+    }
+
+    /**
+     * Resolves {@code opt}'s classpath + java executable via jdtls, then launches the debug session with the
+     * given working directory. {@code file} routes the jdtls {@code executeCommand}s (must be an open,
+     * LSP-managed document in the same project); {@code cwd} is the debuggee's working directory (the project
+     * root for a project main class, else the file's own folder).
+     */
+    private void resolveAndLaunch(Path file, MainClassOption opt, String cwd) {
         String proj = opt.projectName() == null ? "" : opt.projectName();
         lsp.executeCommand(file, "vscode.java.resolveClasspath", List.of(opt.mainClass(), proj), (res, err) -> {
             if (err != null) {
@@ -412,7 +423,6 @@ public final class DapManager implements DapClient.Host {
             }
             lsp.executeCommand(file, "vscode.java.resolveJavaExecutable", List.of(opt.mainClass(), proj), (jx, e2) -> {
                 String javaExec = asString(jx);
-                String cwd = file.getParent() == null ? null : file.getParent().toString();
                 startDebugSessionAndConnect(
                         file,
                         LaunchConfig.launch(
@@ -420,6 +430,40 @@ public final class DapManager implements DapClient.Host {
                         false);
             });
         });
+    }
+
+    /**
+     * Enumerates <b>every</b> main class in {@code routingFile}'s jdtls project (not just the file's own),
+     * for a project-level "Run/Debug Main Class…" picker. {@code routingFile} must be an open, LSP-managed
+     * Java document (jdtls's {@code executeCommand} routes by open-document URI). Delivers an empty list on
+     * any error / when debugging isn't available. Callback runs on the FX thread.
+     */
+    public void resolveMainClasses(Path routingFile, Consumer<List<MainClassOption>> cb) {
+        if (!enabled || bundlePaths.isEmpty() || routingFile == null) {
+            cb.accept(List.of());
+            return;
+        }
+        lsp.executeCommand(
+                routingFile,
+                "vscode.java.resolveMainClass",
+                List.of(),
+                (res, err) -> cb.accept(err != null ? List.of() : parseMainClasses(res)));
+    }
+
+    /**
+     * Launches a Java debug session for an explicitly chosen {@code opt} (a project main class picked by the
+     * user), with {@code cwd} as the working directory. Unlike {@link #startLaunch(Path, MainClassPicker)}
+     * this is not tied to the active file: {@code routingFile} only routes the jdtls commands (any open,
+     * LSP-managed Java file in the same project).
+     */
+    public void startLaunchMainClass(Path routingFile, MainClassOption opt, Path cwd) {
+        if (!ready(routingFile)) {
+            return;
+        }
+        restartAction = () -> startLaunchMainClass(routingFile, opt, cwd);
+        debugFile = routingFile;
+        setState(State.STARTING);
+        resolveAndLaunch(routingFile, opt, cwd == null ? null : cwd.toString());
     }
 
     /**

--- a/src/main/java/com/editora/ui/DebugCoordinator.java
+++ b/src/main/java/com/editora/ui/DebugCoordinator.java
@@ -728,6 +728,74 @@ final class DebugCoordinator {
         withClosedBreakpoints(() -> dapManager.startLaunch(b.getPath(), language, this::pickMainClass));
     }
 
+    /**
+     * {@code debug.mainClass}: debug an arbitrary main class in the active file's Maven/Gradle project (not
+     * just the active file's own). Requires a Java file open in a Maven/Gradle project to route jdtls; jdtls
+     * enumerates every project main class, the user picks one (when several), and it launches with the project
+     * root as the working directory.
+     */
+    void debugMainClass() {
+        if (!debugEffectiveFor("java")) {
+            host.setStatus(tr("status.debug.unavailable"));
+            return;
+        }
+        EditorBuffer b = host.activeBuffer();
+        if (b == null || b.getPath() == null || !host.isLocalBuffer(b) || !"java".equals(b.getLanguage())) {
+            host.setStatus(tr("status.debug.needJavaFile"));
+            return;
+        }
+        Path routing = b.getPath();
+        Path root = JavaProjectRoot.find(routing);
+        if (root == null) {
+            host.setStatus(tr("status.debug.noProject"));
+            return;
+        }
+        if (b.isDirty() && !ops.saveBuffer(b)) {
+            return;
+        }
+        dapManager.resolveMainClasses(routing, options -> {
+            if (options.isEmpty()) {
+                host.setStatus(tr("status.debug.noMainClass"));
+                return;
+            }
+            Consumer<DapManager.MainClassOption> launch = opt -> {
+                if (opt == null) {
+                    return;
+                }
+                ops.openToolWindow();
+                debugPanel.setSessionFile(shortName(opt.mainClass()));
+                dapManager.setProgramArgs(ProgramArgs.tokenize(programArgsForMain(opt)));
+                withClosedBreakpoints(() -> dapManager.startLaunchMainClass(routing, opt, root));
+            };
+            if (options.size() == 1) {
+                launch.accept(options.get(0));
+            } else {
+                pickMainClass(options, launch);
+            }
+        });
+    }
+
+    /** Per-main-class program args, reusing the per-file store keyed by the main class's own source file. */
+    private String programArgsForMain(DapManager.MainClassOption opt) {
+        if (opt.filePath() == null || opt.filePath().isBlank()) {
+            return "";
+        }
+        try {
+            return ops.programArgs(Path.of(opt.filePath()));
+        } catch (RuntimeException e) {
+            return "";
+        }
+    }
+
+    /** The simple class name of a fully-qualified main class (for the session label). */
+    private static String shortName(String fqn) {
+        if (fqn == null) {
+            return "";
+        }
+        int dot = fqn.lastIndexOf('.');
+        return dot < 0 ? fqn : fqn.substring(dot + 1);
+    }
+
     /** Whether two paths refer to the same file (normalized absolute comparison; null-safe). */
     private static boolean samePath(Path a, Path b) {
         return PathKeys.sameNormalized(a, b);

--- a/src/main/java/com/editora/ui/JavaProjectRoot.java
+++ b/src/main/java/com/editora/ui/JavaProjectRoot.java
@@ -1,0 +1,31 @@
+package com.editora.ui;
+
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+
+import com.editora.build.BuildTool;
+import com.editora.lsp.RootResolver;
+
+/**
+ * Finds the Maven/Gradle project root that owns a file — the working directory (and gate) for running or
+ * debugging a project main class. Walks up from the file to the nearest directory holding a Maven or Gradle
+ * build marker ({@code pom.xml} / {@code build.gradle[.kts]} / {@code settings.gradle[.kts]}), matched as a
+ * regular <i>file</i> (a directory merely named like a marker doesn't count). Returns {@code null} when the
+ * file is outside any such project.
+ */
+final class JavaProjectRoot {
+
+    private JavaProjectRoot() {}
+
+    /** The nearest Maven/Gradle project root above {@code file}, or {@code null} if there is none. */
+    static Path find(Path file) {
+        if (file == null) {
+            return null;
+        }
+        List<String> markers = new ArrayList<>();
+        markers.addAll(BuildTool.MAVEN.markers());
+        markers.addAll(BuildTool.GRADLE.markers());
+        return RootResolver.findMarkerRoot(file, markers, true);
+    }
+}

--- a/src/main/java/com/editora/ui/MainController.java
+++ b/src/main/java/com/editora/ui/MainController.java
@@ -13733,6 +13733,8 @@ public class MainController implements com.editora.mcp.McpBridge {
         registry.register(Command.of("http.openResponseInTab", httpClient::openActiveResponseInTab));
         // Debugging (DAP). Gated by the "Enable Java debugging" setting (default off).
         registry.register(Command.of("debug.start", () -> debugCoordinator.ifDebug(debugCoordinator::debugStart)));
+        registry.register(
+                Command.of("debug.mainClass", () -> debugCoordinator.ifDebug(debugCoordinator::debugMainClass)));
         registry.register(Command.of("debug.stop", () -> debugCoordinator.ifDebug(dapManager::stop)));
         registry.register(Command.of("debug.restart", () -> debugCoordinator.ifDebug(dapManager::restart)));
         registry.register(Command.of("debug.attach", () -> debugCoordinator.ifDebug(debugCoordinator::debugAttach)));

--- a/src/main/resources/com/editora/i18n/messages.properties
+++ b/src/main/resources/com/editora/i18n/messages.properties
@@ -212,6 +212,7 @@ command.debug.pause.desc=Pause the running program.
 command.debug.restart.desc=Restart the current debug session.
 command.debug.runToCursor.desc=Resume and stop at the caret line.
 command.debug.start.desc=Start debugging the current file, or continue when paused.
+command.debug.mainClass.desc=Pick and debug a main class in the active file's Maven or Gradle project.
 command.debug.stepInto.desc=Step into the call at the current line.
 command.debug.stepOut.desc=Step out of the current method.
 command.debug.stepOver.desc=Step over the current line.
@@ -706,6 +707,7 @@ dialog.defineAbbrev.expansionLabel=Expansion for “{0}”:
 
 # Debugging (DAP)
 command.debug.start=Debug: Start / Continue
+command.debug.mainClass=Debug: Debug Main Class…
 command.debug.stop=Debug: Stop
 command.debug.restart=Debug: Restart
 command.debug.attach=Debug: Attach to JVM…
@@ -759,6 +761,9 @@ debugpanel.setValueTitle=Set Value
 status.debug.error=Debug error: {0}
 status.debug.saveFirst=Open and save a file to debug first.
 status.debug.unavailable=Debugging is unavailable for this file (check Settings → Debugging).
+status.debug.needJavaFile=Open a Java file in the project first.
+status.debug.noProject=This file isn't in a Maven or Gradle project.
+status.debug.noMainClass=No main class was found in this project.
 status.debug.badAddress=Invalid host:port: {0}
 status.debug.exceptionsOn=Exception breakpoints on (uncaught).
 status.debug.exceptionsOff=Exception breakpoints off.

--- a/src/main/resources/com/editora/i18n/messages_de.properties
+++ b/src/main/resources/com/editora/i18n/messages_de.properties
@@ -208,6 +208,7 @@ command.debug.pause.desc=Das laufende Programm pausieren.
 command.debug.restart.desc=Die aktuelle Debug-Sitzung neu starten.
 command.debug.runToCursor.desc=Fortsetzen und in der Cursorzeile anhalten.
 command.debug.start.desc=Das Debuggen der aktuellen Datei starten oder bei Pause fortsetzen.
+command.debug.mainClass.desc=Eine Hauptklasse im Maven- oder Gradle-Projekt der aktiven Datei auswählen und debuggen.
 command.debug.stepInto.desc=In den Aufruf in der aktuellen Zeile hineinspringen.
 command.debug.stepOut.desc=Aus der aktuellen Methode heraustreten.
 command.debug.stepOver.desc=Die aktuelle Zeile überspringen.
@@ -702,6 +703,7 @@ dialog.defineAbbrev.expansionLabel=Erweiterung für „{0}“:
 
 # Debugging (DAP)
 command.debug.start=Debuggen: Starten / Fortsetzen
+command.debug.mainClass=Debuggen: Hauptklasse debuggen…
 command.debug.stop=Debuggen: Stoppen
 command.debug.restart=Debuggen: Neu starten
 command.debug.attach=Debuggen: An JVM anhängen…
@@ -755,6 +757,9 @@ debugpanel.setValueTitle=Wert setzen
 status.debug.error=Debug-Fehler: {0}
 status.debug.saveFirst=Öffnen und speichern Sie zuerst eine Datei zum Debuggen.
 status.debug.unavailable=Debuggen für diese Datei nicht verfügbar (siehe Einstellungen → Debuggen).
+status.debug.needJavaFile=Öffne zuerst eine Java-Datei im Projekt.
+status.debug.noProject=Diese Datei gehört zu keinem Maven- oder Gradle-Projekt.
+status.debug.noMainClass=In diesem Projekt wurde keine Hauptklasse gefunden.
 status.debug.badAddress=Ungültiger Host:Port: {0}
 status.debug.exceptionsOn=Ausnahme-Haltepunkte aktiviert (nicht abgefangen).
 status.debug.exceptionsOff=Ausnahme-Haltepunkte deaktiviert.

--- a/src/main/resources/com/editora/i18n/messages_es.properties
+++ b/src/main/resources/com/editora/i18n/messages_es.properties
@@ -208,6 +208,7 @@ command.debug.pause.desc=Pausar el programa en ejecución.
 command.debug.restart.desc=Reiniciar la sesión de depuración actual.
 command.debug.runToCursor.desc=Reanudar y detenerse en la línea del cursor.
 command.debug.start.desc=Empezar a depurar el archivo actual, o continuar si está en pausa.
+command.debug.mainClass.desc=Elegir y depurar una clase principal del proyecto Maven o Gradle del archivo activo.
 command.debug.stepInto.desc=Entrar en la llamada de la línea actual.
 command.debug.stepOut.desc=Salir del método actual.
 command.debug.stepOver.desc=Saltar la línea actual.
@@ -702,6 +703,7 @@ dialog.defineAbbrev.expansionLabel=Expansión para “{0}”:
 
 # Debugging (DAP)
 command.debug.start=Depurar: Iniciar / Continuar
+command.debug.mainClass=Depurar: Depurar clase principal…
 command.debug.stop=Depurar: Detener
 command.debug.restart=Depurar: Reiniciar
 command.debug.attach=Depurar: Conectar a la JVM…
@@ -755,6 +757,9 @@ debugpanel.setValueTitle=Establecer valor
 status.debug.error=Error de depuración: {0}
 status.debug.saveFirst=Abre y guarda primero un archivo para depurar.
 status.debug.unavailable=La depuración no está disponible para este archivo (revisa Ajustes → Depuración).
+status.debug.needJavaFile=Abre primero un archivo Java del proyecto.
+status.debug.noProject=Este archivo no pertenece a un proyecto Maven o Gradle.
+status.debug.noMainClass=No se encontró ninguna clase principal en este proyecto.
 status.debug.badAddress=Host:puerto no válido: {0}
 status.debug.exceptionsOn=Puntos de interrupción de excepciones activados (no capturadas).
 status.debug.exceptionsOff=Puntos de interrupción de excepciones desactivados.

--- a/src/main/resources/com/editora/i18n/messages_fr.properties
+++ b/src/main/resources/com/editora/i18n/messages_fr.properties
@@ -208,6 +208,7 @@ command.debug.pause.desc=Mettre en pause le programme en cours.
 command.debug.restart.desc=Redémarrer la session de débogage actuelle.
 command.debug.runToCursor.desc=Reprendre et s'arrêter à la ligne du curseur.
 command.debug.start.desc=Démarrer le débogage du fichier actuel, ou continuer si en pause.
+command.debug.mainClass.desc=Choisir et déboguer une classe principale du projet Maven ou Gradle du fichier actif.
 command.debug.stepInto.desc=Entrer dans l'appel à la ligne actuelle.
 command.debug.stepOut.desc=Sortir de la méthode actuelle.
 command.debug.stepOver.desc=Passer par-dessus la ligne actuelle.
@@ -702,6 +703,7 @@ dialog.defineAbbrev.expansionLabel=Développement pour « {0} » :
 
 # Debugging (DAP)
 command.debug.start=Débogage : Démarrer / Continuer
+command.debug.mainClass=Débogage : Déboguer la classe principale…
 command.debug.stop=Débogage : Arrêter
 command.debug.restart=Débogage : Redémarrer
 command.debug.attach=Débogage : Attacher à la JVM…
@@ -755,6 +757,9 @@ debugpanel.setValueTitle=Définir la valeur
 status.debug.error=Erreur de débogage : {0}
 status.debug.saveFirst=Ouvrez et enregistrez d'abord un fichier à déboguer.
 status.debug.unavailable=Le débogage est indisponible pour ce fichier (voir Paramètres → Débogage).
+status.debug.needJavaFile=Ouvrez d'abord un fichier Java du projet.
+status.debug.noProject=Ce fichier n'appartient pas à un projet Maven ou Gradle.
+status.debug.noMainClass=Aucune classe principale trouvée dans ce projet.
 status.debug.badAddress=Hôte:port invalide : {0}
 status.debug.exceptionsOn=Points d'arrêt sur exceptions activés (non capturées).
 status.debug.exceptionsOff=Points d'arrêt sur exceptions désactivés.

--- a/src/main/resources/com/editora/i18n/messages_it.properties
+++ b/src/main/resources/com/editora/i18n/messages_it.properties
@@ -208,6 +208,7 @@ command.debug.pause.desc=Mette in pausa il programma in esecuzione.
 command.debug.restart.desc=Riavvia la sessione di debug corrente.
 command.debug.runToCursor.desc=Riprende e si ferma alla riga del cursore.
 command.debug.start.desc=Avvia il debug del file corrente, o continua se in pausa.
+command.debug.mainClass.desc=Scegli ed esegui il debug di una classe principale nel progetto Maven o Gradle del file attivo.
 command.debug.stepInto.desc=Entra nella chiamata alla riga corrente.
 command.debug.stepOut.desc=Esce dal metodo corrente.
 command.debug.stepOver.desc=Salta la riga corrente.
@@ -702,6 +703,7 @@ dialog.defineAbbrev.expansionLabel=Espansione per “{0}”:
 
 # Debugging (DAP)
 command.debug.start=Debug: Avvia / Continua
+command.debug.mainClass=Debug: Esegui il debug della classe principale…
 command.debug.stop=Debug: Interrompi
 command.debug.restart=Debug: Riavvia
 command.debug.attach=Debug: Collega alla JVM…
@@ -755,6 +757,9 @@ debugpanel.setValueTitle=Imposta valore
 status.debug.error=Errore di debug: {0}
 status.debug.saveFirst=Apri e salva prima un file da debuggare.
 status.debug.unavailable=Debug non disponibile per questo file (controlla Impostazioni → Debug).
+status.debug.needJavaFile=Apri prima un file Java del progetto.
+status.debug.noProject=Questo file non appartiene a un progetto Maven o Gradle.
+status.debug.noMainClass=Nessuna classe principale trovata in questo progetto.
 status.debug.badAddress=Host:porta non valido: {0}
 status.debug.exceptionsOn=Breakpoint sulle eccezioni attivi (non catturate).
 status.debug.exceptionsOff=Breakpoint sulle eccezioni disattivati.

--- a/src/main/resources/com/editora/i18n/messages_pt.properties
+++ b/src/main/resources/com/editora/i18n/messages_pt.properties
@@ -208,6 +208,7 @@ command.debug.pause.desc=Pausa o programa em execução.
 command.debug.restart.desc=Reinicia a sessão de depuração atual.
 command.debug.runToCursor.desc=Retoma e para na linha do cursor.
 command.debug.start.desc=Inicia a depuração do arquivo atual ou continua se pausado.
+command.debug.mainClass.desc=Escolher e depurar uma classe principal no projeto Maven ou Gradle do arquivo ativo.
 command.debug.stepInto.desc=Entra na chamada na linha atual.
 command.debug.stepOut.desc=Sai do método atual.
 command.debug.stepOver.desc=Avança sobre a linha atual.
@@ -702,6 +703,7 @@ dialog.defineAbbrev.expansionLabel=Expansão para “{0}”:
 
 # Debugging (DAP)
 command.debug.start=Depurar: Iniciar / Continuar
+command.debug.mainClass=Depurar: Depurar classe principal…
 command.debug.stop=Depurar: Parar
 command.debug.restart=Depurar: Reiniciar
 command.debug.attach=Depurar: Anexar à JVM…
@@ -755,6 +757,9 @@ debugpanel.setValueTitle=Definir valor
 status.debug.error=Erro de depuração: {0}
 status.debug.saveFirst=Abra e salve primeiro um arquivo para depurar.
 status.debug.unavailable=Depuração indisponível para este arquivo (verifique Configurações → Depuração).
+status.debug.needJavaFile=Abra primeiro um ficheiro Java do projeto.
+status.debug.noProject=Este ficheiro não pertence a um projeto Maven ou Gradle.
+status.debug.noMainClass=Nenhuma classe principal encontrada neste projeto.
 status.debug.badAddress=Host:porta inválido: {0}
 status.debug.exceptionsOn=Pontos de interrupção de exceções ativados (não capturadas).
 status.debug.exceptionsOff=Pontos de interrupção de exceções desativados.

--- a/src/test/java/com/editora/ui/JavaProjectRootTest.java
+++ b/src/test/java/com/editora/ui/JavaProjectRootTest.java
@@ -1,0 +1,48 @@
+package com.editora.ui;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+class JavaProjectRootTest {
+
+    @Test
+    void findsMavenRootWalkingUp(@TempDir Path dir) throws IOException {
+        Files.writeString(dir.resolve("pom.xml"), "<project/>");
+        Path src = Files.createDirectories(dir.resolve("src/main/java/app"));
+        Path file = Files.writeString(src.resolve("Main.java"), "class Main {}");
+        assertEquals(dir, JavaProjectRoot.find(file));
+    }
+
+    @Test
+    void findsGradleRoot(@TempDir Path dir) throws IOException {
+        Files.writeString(dir.resolve("build.gradle"), "");
+        Path file = Files.writeString(dir.resolve("App.java"), "class App {}");
+        assertEquals(dir, JavaProjectRoot.find(file));
+    }
+
+    @Test
+    void findsGradleKtsSettingsRoot(@TempDir Path dir) throws IOException {
+        Files.writeString(dir.resolve("settings.gradle.kts"), "");
+        Path sub = Files.createDirectories(dir.resolve("app/src"));
+        Path file = Files.writeString(sub.resolve("A.java"), "class A {}");
+        assertEquals(dir, JavaProjectRoot.find(file));
+    }
+
+    @Test
+    void nullOutsideAnyProject(@TempDir Path dir) throws IOException {
+        Path file = Files.writeString(dir.resolve("Loose.java"), "class Loose {}");
+        assertNull(JavaProjectRoot.find(file));
+    }
+
+    @Test
+    void nullForNullFile() {
+        assertNull(JavaProjectRoot.find(null));
+    }
+}


### PR DESCRIPTION
First slice of #700. Adds **Debug Main Class…** — pick and debug any main class in the active file's Maven/Gradle project, not just the active file's own.

## Why it's small
jdtls (with the java-debug bundle) already answers `vscode.java.resolveMainClass` for the **whole project** and resolves the full classpath + java executable per main class. The existing debug path just filtered that list down to the active file. This adds a project-level entry that drops the filter.

## Changes
- `DapManager.resolveMainClasses(routingFile, cb)` — enumerate every project main class.
- `DapManager.startLaunchMainClass(routingFile, opt, cwd)` — launch a chosen `MainClassOption` with the project root as the working directory (`resolveAndLaunch` gains a `cwd` parameter; the old 2-arg form delegates unchanged).
- `ui/JavaProjectRoot.find(file)` — nearest Maven/Gradle root (walks up to a `pom.xml` / `build.gradle[.kts]` / `settings.gradle[.kts]` file). Gate + working directory.
- `DebugCoordinator.debugMainClass()` — resolve → `QuickOpen` pick (0/1/N) → launch. Reuses the per-file program-args store keyed by the main class's own source file.
- Command `debug.mainClass` ("Debug: Debug Main Class…"); i18n in all six catalogs.

## Constraint (documented)
jdtls's `executeCommand` routes by open-document URI, so this needs a **Java file open in the project** to route through; it reports a clear status otherwise. The picked main class can be any in the project.

## Verification
- `mvn test` — 2946 pass (incl. new `JavaProjectRootTest`, `MessagesTest` key parity).
- `mvn compile` + `mvn spotless:check` clean.

Part of #700 (PR 1 of 6). Run-in-console (PR 2), gutter ▶ (PR 3), build-tool fallback (PR 4), persistent run configs (PR 5), framework awareness (PR 6) follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)