### PR TITLE
Run/Debug projects (3/6): main-method gutter ▶ + scanner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Run & debug Maven/Gradle project main classes** — beyond single-file scripts, you can now run or debug
+  a real project's `main` class. **Run Main Class…** / **Debug Main Class…** (command palette) pick any main
+  class in the active file's Maven or Gradle project (via the Java language server), run it in the Run
+  console or debug it with breakpoints. A green ▶ also appears in the gutter next to every `public static
+  void main`, and the editor right-click menu offers *Run '…​.main()'* / *Debug '…​.main()'*. Requires the
+  Java language server + debugging to be set up (a build-tool classpath fallback for plain Run follows).
+
 - **Right-click Select All / Copy in the Build Output and Test Runner consoles** — copies the selection, or
   all the output when nothing is selected. Both read-only consoles share one helper.
 - **Tooltips on the Test Runner's per-row status icons** — hovering a test's pass/fail/skip/running glyph

--- a/src/main/java/com/editora/editor/EditorBuffer.java
+++ b/src/main/java/com/editora/editor/EditorBuffer.java
@@ -477,6 +477,15 @@ public class EditorBuffer implements TabContent {
     private java.util.Map<Integer, com.editora.test.JavaTestScanner.TestTarget> testLines = java.util.Map.of();
     /** Fired with a test target when its gutter ▶ is clicked (runs one class/method via the build tool). */
     private java.util.function.Consumer<com.editora.test.JavaTestScanner.TestTarget> testRunHandler = t -> {};
+    /** Main-method gutter gate (a Java file in a Maven/Gradle project with run/debug available), pushed by
+     *  MainController. When on, {@code public static void main} lines get a green ▶ to run the project class. */
+    private boolean mainGutterEnabled;
+    /** 0-based line → project {@code main} entry point for the gutter ▶; empty otherwise. */
+    private java.util.Map<Integer, com.editora.run.MainMethodScanner.MainMethod> mainLines = java.util.Map.of();
+    /** Fired with a main method when its gutter ▶ is clicked (runs that project main class). */
+    private java.util.function.Consumer<com.editora.run.MainMethodScanner.MainMethod> mainRunHandler = m -> {};
+    /** Fired with a main method for the editor right-click "Debug Main Class" item. */
+    private java.util.function.Consumer<com.editora.run.MainMethodScanner.MainMethod> mainDebugHandler = m -> {};
     /** Whether this file is runnable (a Java 25 compact source file, a Python script, or — when the Bash
      *  LSP is enabled — a shell script) — drives the gutter Run glyph + the Run tool window. */
     private boolean runnable;
@@ -704,7 +713,7 @@ public class EditorBuffer implements TabContent {
         // Gutter Run glyph: reserved for a runnable file — one entry line for a script, or one per
         // request for a .http file.
         folds.setRunHooks(
-                () -> runnable,
+                () -> runnable || !mainLines.isEmpty(),
                 this::isRunGlyphLine,
                 this::onRunGlyph,
                 line -> testLines.containsKey(line) ? "test-run-marker" : null,
@@ -1764,6 +1773,21 @@ public class EditorBuffer implements TabContent {
                 run.setOnAction(ev -> runHandler.run());
                 items.add(run);
                 items.add(new SeparatorMenuItem());
+            } else {
+                // A Java class with a project main() gets Run/Debug Main Class items (green ▶ + bug icon).
+                com.editora.run.MainMethodScanner.MainMethod mainTarget = mainTargetAtCaret();
+                if (mainTarget != null) {
+                    String simple = com.editora.test.TestSourceLocator.simpleName(mainTarget.fqn());
+                    MenuItem runMain = new MenuItem(tr("editmenu.runMainClass", simple));
+                    runMain.setGraphic(FoldManager.runGlyph());
+                    runMain.setOnAction(ev -> mainRunHandler.accept(mainTarget));
+                    MenuItem debugMain = new MenuItem(tr("editmenu.debugMainClass", simple));
+                    debugMain.setGraphic(MenuIcons.debug());
+                    debugMain.setOnAction(ev -> mainDebugHandler.accept(mainTarget));
+                    items.add(runMain);
+                    items.add(debugMain);
+                    items.add(new SeparatorMenuItem());
+                }
             }
             // LSP navigation (only when this buffer is served by a language server). Move the caret to the
             // right-clicked position first so go-to-definition/references/hover target that symbol.
@@ -3196,6 +3220,41 @@ public class EditorBuffer implements TabContent {
         this.testRunHandler = handler == null ? t -> {} : handler;
     }
 
+    /** Gate for the project {@code main}-method gutter ▶ (a Java file in a Maven/Gradle project with run/debug
+     *  available); pushed by MainController. */
+    public void setMainGutterEnabled(boolean enabled) {
+        if (enabled != mainGutterEnabled) {
+            mainGutterEnabled = enabled;
+            recomputeRun();
+        }
+    }
+
+    /** Injects the handler run with a clicked {@code main}-method gutter ▶ (runs that project main class). */
+    public void setMainRunHandler(java.util.function.Consumer<com.editora.run.MainMethodScanner.MainMethod> handler) {
+        this.mainRunHandler = handler == null ? m -> {} : handler;
+    }
+
+    /** Injects the handler for the editor "Debug Main Class" item on a {@code main} method. */
+    public void setMainDebugHandler(java.util.function.Consumer<com.editora.run.MainMethodScanner.MainMethod> handler) {
+        this.mainDebugHandler = handler == null ? m -> {} : handler;
+    }
+
+    /** The project {@code main} entry point at (or nearest above) the caret, else the file's first main, else
+     *  {@code null} — backs the editor right-click Run/Debug Main Class items. */
+    public com.editora.run.MainMethodScanner.MainMethod mainTargetAtCaret() {
+        if (mainLines.isEmpty()) {
+            return null;
+        }
+        int caret = area.getCurrentParagraph();
+        com.editora.run.MainMethodScanner.MainMethod best = null;
+        for (var e : mainLines.entrySet()) {
+            if (e.getKey() <= caret && (best == null || e.getKey() > best.line())) {
+                best = e.getValue();
+            }
+        }
+        return best != null ? best : mainLines.values().iterator().next();
+    }
+
     /**
      * The whole-class JUnit target for this buffer (the "Run Tests" context-menu item), or {@code null} when
      * this isn't a test file / the test gutter is off.
@@ -3233,6 +3292,9 @@ public class EditorBuffer implements TabContent {
     /** Whether {@code line} draws a Run glyph: every request line for an enabled {@code .http} buffer,
      *  else the single script entry line. */
     private boolean isRunGlyphLine(int line) {
+        if (mainLines.containsKey(line)) {
+            return true; // a project main ▶ draws independently of `runnable` (see recomputeRun)
+        }
         if (!runnable) {
             return false;
         }
@@ -3252,6 +3314,10 @@ public class EditorBuffer implements TabContent {
      *  target runner (with the clicked target's name), else the script run handler. */
     /** Hover text for a gutter Run glyph: explains what the blue JUnit ▶ runs (class vs method). */
     private String runGlyphTooltip(int line) {
+        com.editora.run.MainMethodScanner.MainMethod m = mainLines.get(line);
+        if (m != null) {
+            return tr("editmenu.runMainTooltip", com.editora.test.TestSourceLocator.simpleName(m.fqn()));
+        }
         com.editora.test.JavaTestScanner.TestTarget t = testLines.get(line);
         if (t == null) {
             return null; // the plain script/Makefile/.http ▶ keeps its untooltipped look
@@ -3263,8 +3329,11 @@ public class EditorBuffer implements TabContent {
 
     private void onRunGlyph(int line) {
         com.editora.test.JavaTestScanner.TestTarget testTarget = testLines.get(line);
+        com.editora.run.MainMethodScanner.MainMethod mainTarget = mainLines.get(line);
         if (testTarget != null) {
             testRunHandler.accept(testTarget); // a JUnit class/method ▶ (never coincides with a compact-source main)
+        } else if (mainTarget != null) {
+            mainRunHandler.accept(mainTarget); // a project main class ▶ (disjoint from test/compact-source lines)
         } else if (httpFeatureEnabled && isHttpFile()) {
             httpRunHandler.accept(line);
         } else if (isMakefile()) {
@@ -3288,10 +3357,13 @@ public class EditorBuffer implements TabContent {
         // in a JVM project with the Test Runner on). Additive — a test file also keeps any compact-source ▶.
         boolean testEligible =
                 testGutterEnabled && !largeFile && "java".equals(language) && area.getLength() <= COMPACT_SCAN_LIMIT;
-        // Only materialize the whole document when we actually scan it (compact-source / .http / test detection).
-        // Otherwise editing a moderately large file (256 KB–5 MB) would allocate the full text on every
-        // 150 ms edit pulse just to discard it as run-ineligible.
-        String text = (eligible || httpEligible || testEligible) ? area.getText() : "";
+        // Project main-method gutter: a Java file in a Maven/Gradle project (gated by MainController).
+        boolean mainEligible =
+                mainGutterEnabled && !largeFile && "java".equals(language) && area.getLength() <= COMPACT_SCAN_LIMIT;
+        // Only materialize the whole document when we actually scan it (compact-source / .http / test/main
+        // detection). Otherwise editing a moderately large file (256 KB–5 MB) would allocate the full text on
+        // every 150 ms edit pulse just to discard it as run-ineligible.
+        String text = (eligible || httpEligible || testEligible || mainEligible) ? area.getText() : "";
         boolean nowRunnable;
         int nowLine;
         java.util.List<Integer> nowHttpLines = java.util.List.of();
@@ -3339,21 +3411,34 @@ public class EditorBuffer implements TabContent {
             nowTestLines = tl;
             nowRunnable = nowRunnable || !tl.isEmpty();
         }
+        // Project main-method glyphs — deliberately do NOT flip `runnable` (that stays "single-file/script/test
+        // runnable", so the generic Run File / file.run never mis-launches a project class as one source file);
+        // the gutter draws these via a separate gate (see the run-slot `enabled` supplier + isRunGlyphLine).
+        java.util.Map<Integer, com.editora.run.MainMethodScanner.MainMethod> nowMainLines = java.util.Map.of();
+        if (mainEligible) {
+            java.util.Map<Integer, com.editora.run.MainMethodScanner.MainMethod> ml = new java.util.LinkedHashMap<>();
+            for (com.editora.run.MainMethodScanner.MainMethod m : com.editora.run.MainMethodScanner.scan(text)) {
+                ml.put(m.line(), m);
+            }
+            nowMainLines = ml;
+        }
         boolean changed = nowRunnable != runnable;
         boolean httpLinesChanged = !nowHttpLines.equals(httpRequestLines);
         boolean makeTargetsChanged = !nowMakeTargets.equals(makeTargets);
         boolean testLinesChanged = !nowTestLines.equals(testLines);
+        boolean mainLinesChanged = !nowMainLines.equals(mainLines);
         int oldLine = runLine;
         runnable = nowRunnable;
         runLine = nowLine;
         httpRequestLines = nowHttpLines;
         makeTargets = nowMakeTargets;
         testLines = nowTestLines;
+        mainLines = nowMainLines;
         if (changed) {
             onRunnableChanged.run();
             refreshGutter(); // the Run slot appeared/disappeared on every row — rebuild the factory
-        } else if (httpLinesChanged || makeTargetsChanged || testLinesChanged) {
-            refreshGutter(); // requests/targets/test methods added/removed — relight the glyphs on the new lines
+        } else if (httpLinesChanged || makeTargetsChanged || testLinesChanged || mainLinesChanged) {
+            refreshGutter(); // requests/targets/test/main methods added/removed — relight the glyphs
         } else if (nowLine != oldLine) {
             // The entry line moved (edits above it) — repaint just the old and new gutter rows.
             if (oldLine >= 0) {

--- a/src/main/java/com/editora/editor/MenuIcons.java
+++ b/src/main/java/com/editora/editor/MenuIcons.java
@@ -208,6 +208,15 @@ final class MenuIcons {
         return FoldManager.runGlyph();
     }
 
+    /** Material "bug_report" — "Debug Main Class". */
+    static Node debug() {
+        return of(
+                "M20 8h-2.81c-.45-.78-1.07-1.45-1.82-1.96L17 4.41 15.59 3l-2.17 2.17C12.96 5.06 12.49 "
+                        + "5 12 5c-.49 0-.96.06-1.41.17L8.41 3 7 4.41l1.62 1.63C7.88 6.55 7.26 7.22 6.81 8H4v2h2.09c-.05"
+                        + ".33-.09.66-.09 1v1H4v2h2v1c0 .34.04.67.09 1H4v2h2.81c1.04 1.79 2.97 3 5.19 3s4.15-1.21 "
+                        + "5.19-3H20v-2h-2.09c.05-.33.09-.66.09-1v-1h2v-2h-2v-1c0-.34-.04-.67-.09-1H20V8zm-6 8h-4v-2h4v2zm0-4h-4v-2h4v2z");
+    }
+
     /** Material "comment" — "Add Personal Note". */
     static Node note() {
         return of("M20 2H4c-1.1 0-2 .9-2 2v18l4-4h14c1.1 0 2-.9 2-2V4c0-1.1-.9-2-2-2z");

--- a/src/main/java/com/editora/run/MainMethodScanner.java
+++ b/src/main/java/com/editora/run/MainMethodScanner.java
@@ -1,0 +1,157 @@
+package com.editora.run;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Finds {@code public static void main(String[])} entry points in Java source text, for the editor's gutter
+ * ▶ Run/Debug markers and the jdtls-free fallback (a build-tool run needs a main class to launch). A
+ * lightweight, length-preserving blank-comments-and-literals pass + brace-depth walk — no real parser (the
+ * {@code test/JavaTestScanner} / {@code editor/CompactSource} heuristic style; the blanker is duplicated
+ * because the pure {@code run} package must not depend on {@code editor}).
+ *
+ * <p>Detects a {@code static void main} method whose single parameter is a {@code String[]} / {@code
+ * String...} / {@code String args[]}, declared directly in a top-level class (brace depth 1). The class of a
+ * match is the nearest top-level type; a {@code main} inside a nested class (depth ≥2) or with a multi-line
+ * signature is not reported (jdtls's real enumeration covers those). Pure — no toolkit.
+ */
+public final class MainMethodScanner {
+
+    private MainMethodScanner() {}
+
+    /** A runnable entry point on {@code line} (0-based) in class {@code fqn} (fully qualified). */
+    public record MainMethod(int line, String fqn) {}
+
+    private static final Pattern PACKAGE = Pattern.compile("^\\s*package\\s+([\\w.]+)\\s*;");
+    private static final Pattern TYPE_DECL = Pattern.compile("\\b(?:class|enum|record)\\s+(\\w+)");
+    // `… static … void main(String[] / String... / String args[] …)` on one (blanked) line.
+    private static final Pattern MAIN = Pattern.compile("\\bstatic\\b[^;{}()]*\\bvoid\\s+main\\s*\\(\\s*"
+            + "(?:final\\s+)?String\\s*(?:\\.\\.\\.|\\[\\s*\\]|\\w+\\s*\\[\\s*\\])[^)]*\\)");
+
+    public static List<MainMethod> scan(String source) {
+        if (source == null || source.isBlank()) {
+            return List.of();
+        }
+        String[] lines = blank(source).split("\n", -1);
+
+        String pkg = "";
+        String topClass = null; // nearest top-level type name (depth-0 declaration)
+        int depth = 0;
+        List<MainMethod> out = new ArrayList<>();
+
+        for (int li = 0; li < lines.length; li++) {
+            String line = lines[li];
+
+            if (pkg.isEmpty()) {
+                Matcher pm = PACKAGE.matcher(line);
+                if (pm.find()) {
+                    pkg = pm.group(1);
+                }
+            }
+            if (depth == 0) {
+                Matcher tm = TYPE_DECL.matcher(line);
+                if (tm.find()) {
+                    topClass = tm.group(1);
+                }
+            }
+            // A main method sits directly in the top-level class body (depth 1).
+            if (depth == 1 && topClass != null && MAIN.matcher(line).find()) {
+                out.add(new MainMethod(li, fqcn(pkg, topClass)));
+            }
+
+            depth += braceDelta(line);
+            if (depth < 0) {
+                depth = 0;
+            }
+        }
+        return out;
+    }
+
+    private static String fqcn(String pkg, String cls) {
+        return pkg.isEmpty() ? cls : pkg + "." + cls;
+    }
+
+    private static int braceDelta(String line) {
+        int d = 0;
+        for (int i = 0; i < line.length(); i++) {
+            char c = line.charAt(i);
+            if (c == '{') {
+                d++;
+            } else if (c == '}') {
+                d--;
+            }
+        }
+        return d;
+    }
+
+    /**
+     * Replaces comment + string/char/text-block content with spaces, preserving length + newline positions.
+     * Duplicated from {@code test/JavaTestScanner} / {@code editor/CompactSource}.
+     */
+    static String blank(String s) {
+        int n = s.length();
+        StringBuilder out = new StringBuilder(n);
+        int i = 0;
+        while (i < n) {
+            char c = s.charAt(i);
+            if (c == '/' && i + 1 < n && s.charAt(i + 1) == '/') {
+                while (i < n && s.charAt(i) != '\n') {
+                    out.append(' ');
+                    i++;
+                }
+            } else if (c == '/' && i + 1 < n && s.charAt(i + 1) == '*') {
+                out.append("  ");
+                i += 2;
+                while (i < n && !(s.charAt(i) == '*' && i + 1 < n && s.charAt(i + 1) == '/')) {
+                    out.append(s.charAt(i) == '\n' ? '\n' : ' ');
+                    i++;
+                }
+                if (i < n) {
+                    out.append("  ");
+                    i += 2;
+                }
+            } else if (c == '"' && i + 2 < n && s.charAt(i + 1) == '"' && s.charAt(i + 2) == '"') {
+                out.append("   ");
+                i += 3;
+                while (i < n
+                        && !(s.charAt(i) == '"' && i + 2 < n && s.charAt(i + 1) == '"' && s.charAt(i + 2) == '"')) {
+                    out.append(s.charAt(i) == '\n' ? '\n' : ' ');
+                    i++;
+                }
+                if (i < n) {
+                    out.append("   ");
+                    i += 3;
+                }
+            } else if (c == '"') {
+                i = blankQuoted(s, n, '"', out, i);
+            } else if (c == '\'') {
+                i = blankQuoted(s, n, '\'', out, i);
+            } else {
+                out.append(c);
+                i++;
+            }
+        }
+        return out.toString();
+    }
+
+    private static int blankQuoted(String s, int n, char quote, StringBuilder out, int i) {
+        out.append(' ');
+        i++; // opening quote
+        while (i < n && s.charAt(i) != quote) {
+            if (s.charAt(i) == '\\' && i + 1 < n) {
+                out.append("  ");
+                i += 2;
+            } else {
+                out.append(s.charAt(i) == '\n' ? '\n' : ' ');
+                i++;
+            }
+        }
+        if (i < n) {
+            out.append(' ');
+            i++; // closing quote
+        }
+        return i;
+    }
+}

--- a/src/main/java/com/editora/ui/DebugCoordinator.java
+++ b/src/main/java/com/editora/ui/DebugCoordinator.java
@@ -735,6 +735,15 @@ final class DebugCoordinator {
      * root as the working directory.
      */
     void debugMainClass() {
+        startMainClassDebug(null);
+    }
+
+    /** Debugs a specific main class by fully-qualified name (the gutter ▶ / editor menu on a {@code main}). */
+    void debugMainClassNamed(String fqn) {
+        startMainClassDebug(fqn);
+    }
+
+    private void startMainClassDebug(String targetFqn) {
         if (!debugEffectiveFor("java")) {
             host.setStatus(tr("status.debug.unavailable"));
             return;
@@ -767,7 +776,17 @@ final class DebugCoordinator {
                 dapManager.setProgramArgs(ProgramArgs.tokenize(programArgsForMain(opt)));
                 withClosedBreakpoints(() -> dapManager.startLaunchMainClass(routing, opt, root));
             };
-            if (options.size() == 1) {
+            if (targetFqn != null) {
+                DapManager.MainClassOption match = options.stream()
+                        .filter(o -> targetFqn.equals(o.mainClass()))
+                        .findFirst()
+                        .orElse(null);
+                if (match == null) {
+                    host.setStatus(tr("status.debug.noMainClass"));
+                    return;
+                }
+                launch.accept(match);
+            } else if (options.size() == 1) {
                 launch.accept(options.get(0));
             } else {
                 pickMainClass(options, launch);

--- a/src/main/java/com/editora/ui/MainController.java
+++ b/src/main/java/com/editora/ui/MainController.java
@@ -3262,10 +3262,12 @@ public class MainController implements com.editora.mcp.McpBridge {
                             if (buildOutputToolWindow != null) {
                                 toolWindows.setAvailable(buildOutputToolWindow, anyBuildDetected());
                             }
-                            // A JVM marker (pom/build.gradle) appearing/vanishing flips the JUnit test gutter —
-                            // re-gate every open buffer (setTestGutterEnabled no-ops on an unchanged flag).
+                            // A JVM marker (pom/build.gradle) appearing/vanishing flips the JUnit test gutter and
+                            // the project main-method gutter — re-gate every open buffer (both no-op on an
+                            // unchanged flag).
                             if (tool == BuildTool.MAVEN || tool == BuildTool.GRADLE) {
                                 coordinatorHost.forEachBuffer(MainController.this::applyTestGutter);
+                                coordinatorHost.forEachBuffer(MainController.this::applyMainGutter);
                             }
                         }
 
@@ -4695,6 +4697,15 @@ public class MainController implements com.editora.mcp.McpBridge {
                 .anyMatch(c -> (c.tool() == BuildTool.MAVEN || c.tool() == BuildTool.GRADLE)
                         && c.isEnabled()
                         && c.isDetected());
+    }
+
+    /** Pushes the project main-method gutter gate to a buffer (not Simple mode + local + a JVM project + Java
+     *  run/debug available — resolution rides jdtls's java-debug bundle). */
+    private void applyMainGutter(EditorBuffer buffer) {
+        buffer.setMainGutterEnabled(!simpleModeActive()
+                && isLocalBuffer(buffer)
+                && jvmBuildDetected()
+                && debugCoordinator.debugEffectiveFor("java"));
     }
 
     /** Pushes the JUnit test-gutter gate to a buffer (Test Runner on + not Simple mode + local + JVM project). */
@@ -6202,6 +6213,9 @@ public class MainController implements com.editora.mcp.McpBridge {
         // Makefile-run rides the same Run-feature gate as Java/Python/shell (setRunEnabled above).
         buffer.setTestRunHandler(this::runSingleTest); // JUnit class/method gutter ▶ → the build tool
         applyTestGutter(buffer); // gated by the Test Runner feature + a detected JVM (Maven/Gradle) project
+        buffer.setMainRunHandler(m -> runCoordinator.runMainClassNamed(m.fqn())); // project main() ▶ → run
+        buffer.setMainDebugHandler(m -> debugCoordinator.debugMainClassNamed(m.fqn())); // editor menu → debug
+        applyMainGutter(buffer); // gated by not-Simple + local + JVM project + Java run/debug available
         // Debugging: the breakpoint gutter gate + change/hover hooks (debuggable languages only).
         debugCoordinator.wireBuffer(buffer);
         buffer.setAddNoteHandler(notesCoordinator::addNoteFromContext);
@@ -11435,6 +11449,7 @@ public class MainController implements com.editora.mcp.McpBridge {
         applyMultiCaret();
         lspCoordinator.applySupport(); // (re)configure LSP: command/enabled change re-detects + re-gates buffers
         debugCoordinator.applySupport(); // (re)configure DAP after LSP (it layers on jdtls)
+        coordinatorHost.forEachBuffer(this::applyMainGutter); // re-gate the project main-method ▶ (needs jdtls+debug)
         applyMarkdownPreviewTheme(); // re-resolve "follow app" previews + the toggle glyph after a theme change
         // Match the console fonts + per-buffer view to the editor font/zoom (shared with the text-zoom path).
         applyFontsAndPerBufferView(settings);

--- a/src/main/java/com/editora/ui/RunCoordinator.java
+++ b/src/main/java/com/editora/ui/RunCoordinator.java
@@ -111,6 +111,15 @@ final class RunCoordinator {
      * working directory.
      */
     void runMainClass() {
+        startMainClassRun(null);
+    }
+
+    /** Runs a specific main class by fully-qualified name (the gutter ▶ on a {@code main} method). */
+    void runMainClassNamed(String fqn) {
+        startMainClassRun(fqn);
+    }
+
+    private void startMainClassRun(String targetFqn) {
         if (!ops.javaLaunchAvailable()) {
             host.setStatus(tr("status.run.javaUnavailable"));
             return;
@@ -138,11 +147,20 @@ final class RunCoordinator {
                 host.setStatus(tr("status.run.noMainClass"));
                 return;
             }
-            Consumer<JavaMainClass> go = mc -> runResolvedMainClass(routing, root, mc);
-            if (list.size() == 1) {
-                go.accept(list.get(0));
+            if (targetFqn != null) {
+                JavaMainClass match = list.stream()
+                        .filter(mc -> targetFqn.equals(mc.fqn()))
+                        .findFirst()
+                        .orElse(null);
+                if (match == null) {
+                    host.setStatus(tr("status.run.noMainClass"));
+                    return;
+                }
+                runResolvedMainClass(routing, root, match);
+            } else if (list.size() == 1) {
+                runResolvedMainClass(routing, root, list.get(0));
             } else {
-                pickMainClass(list, go);
+                pickMainClass(list, mc -> runResolvedMainClass(routing, root, mc));
             }
         });
     }

--- a/src/main/resources/com/editora/i18n/messages.properties
+++ b/src/main/resources/com/editora/i18n/messages.properties
@@ -3617,6 +3617,9 @@ testrunner.detail.runHeader=Run: {0}
 testrunner.detail.elapsed=Elapsed: {0}
 # --- Test Results: gutter tooltip + run-tests menu ---
 editmenu.runTests=Run Tests
+editmenu.runMainClass=Run ''{0}.main()''
+editmenu.debugMainClass=Debug ''{0}.main()''
+editmenu.runMainTooltip=Run ''{0}.main()''
 testrunner.gutter.runClass=Run test class {0}
 testrunner.gutter.runMethod=Run test method {0}
 testrunner.followRunning=Track the running test (scroll to the newest result)

--- a/src/main/resources/com/editora/i18n/messages_de.properties
+++ b/src/main/resources/com/editora/i18n/messages_de.properties
@@ -3608,6 +3608,9 @@ testrunner.detail.runHeader=Ausführung: {0}
 testrunner.detail.elapsed=Dauer: {0}
 # --- Test Results: gutter tooltip + run-tests menu ---
 editmenu.runTests=Tests ausführen
+editmenu.runMainClass=''{0}.main()'' ausführen
+editmenu.debugMainClass=''{0}.main()'' debuggen
+editmenu.runMainTooltip=''{0}.main()'' ausführen
 testrunner.gutter.runClass=Testklasse {0} ausführen
 testrunner.gutter.runMethod=Testmethode {0} ausführen
 testrunner.followRunning=Laufendem Test folgen (zum neuesten Ergebnis scrollen)

--- a/src/main/resources/com/editora/i18n/messages_es.properties
+++ b/src/main/resources/com/editora/i18n/messages_es.properties
@@ -3608,6 +3608,9 @@ testrunner.detail.runHeader=Ejecución: {0}
 testrunner.detail.elapsed=Tiempo: {0}
 # --- Test Results: gutter tooltip + run-tests menu ---
 editmenu.runTests=Ejecutar pruebas
+editmenu.runMainClass=Ejecutar ''{0}.main()''
+editmenu.debugMainClass=Depurar ''{0}.main()''
+editmenu.runMainTooltip=Ejecutar ''{0}.main()''
 testrunner.gutter.runClass=Ejecutar la clase de prueba {0}
 testrunner.gutter.runMethod=Ejecutar el método de prueba {0}
 testrunner.followRunning=Seguir la prueba en ejecución (desplazar al resultado más reciente)

--- a/src/main/resources/com/editora/i18n/messages_fr.properties
+++ b/src/main/resources/com/editora/i18n/messages_fr.properties
@@ -3608,6 +3608,9 @@ testrunner.detail.runHeader=Exécution : {0}
 testrunner.detail.elapsed=Durée : {0}
 # --- Test Results: gutter tooltip + run-tests menu ---
 editmenu.runTests=Lancer les tests
+editmenu.runMainClass=Exécuter ''{0}.main()''
+editmenu.debugMainClass=Déboguer ''{0}.main()''
+editmenu.runMainTooltip=Exécuter ''{0}.main()''
 testrunner.gutter.runClass=Lancer la classe de test {0}
 testrunner.gutter.runMethod=Lancer la méthode de test {0}
 testrunner.followRunning=Suivre le test en cours (défiler jusqu'au résultat le plus récent)

--- a/src/main/resources/com/editora/i18n/messages_it.properties
+++ b/src/main/resources/com/editora/i18n/messages_it.properties
@@ -3608,6 +3608,9 @@ testrunner.detail.runHeader=Esecuzione: {0}
 testrunner.detail.elapsed=Tempo: {0}
 # --- Test Results: gutter tooltip + run-tests menu ---
 editmenu.runTests=Esegui i test
+editmenu.runMainClass=Esegui ''{0}.main()''
+editmenu.debugMainClass=Debug di ''{0}.main()''
+editmenu.runMainTooltip=Esegui ''{0}.main()''
 testrunner.gutter.runClass=Esegui la classe di test {0}
 testrunner.gutter.runMethod=Esegui il metodo di test {0}
 testrunner.followRunning=Segui il test in esecuzione (scorri fino al risultato più recente)

--- a/src/main/resources/com/editora/i18n/messages_pt.properties
+++ b/src/main/resources/com/editora/i18n/messages_pt.properties
@@ -3608,6 +3608,9 @@ testrunner.detail.runHeader=Execução: {0}
 testrunner.detail.elapsed=Tempo: {0}
 # --- Test Results: gutter tooltip + run-tests menu ---
 editmenu.runTests=Executar testes
+editmenu.runMainClass=Executar ''{0}.main()''
+editmenu.debugMainClass=Depurar ''{0}.main()''
+editmenu.runMainTooltip=Executar ''{0}.main()''
 testrunner.gutter.runClass=Executar a classe de teste {0}
 testrunner.gutter.runMethod=Executar o método de teste {0}
 testrunner.followRunning=Acompanhar o teste em execução (rolar até o resultado mais recente)

--- a/src/test/java/com/editora/run/MainMethodScannerTest.java
+++ b/src/test/java/com/editora/run/MainMethodScannerTest.java
@@ -1,0 +1,102 @@
+package com.editora.run;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class MainMethodScannerTest {
+
+    @Test
+    void findsMainWithPackage() {
+        String src = """
+                package com.app;
+                public class Main {
+                    public static void main(String[] args) {
+                        System.out.println("hi");
+                    }
+                }
+                """;
+        List<MainMethodScanner.MainMethod> found = MainMethodScanner.scan(src);
+        assertEquals(1, found.size());
+        assertEquals("com.app.Main", found.get(0).fqn());
+        assertEquals(2, found.get(0).line());
+    }
+
+    @Test
+    void noPackage() {
+        String src = "class App {\n  static public void main(String... a) {}\n}\n";
+        List<MainMethodScanner.MainMethod> found = MainMethodScanner.scan(src);
+        assertEquals(1, found.size());
+        assertEquals("App", found.get(0).fqn());
+        assertEquals(1, found.get(0).line());
+    }
+
+    @Test
+    void cStyleArrayParam() {
+        String src = "class A {\n  public static void main(String args[]) {}\n}\n";
+        assertEquals(List.of(new MainMethodScanner.MainMethod(1, "A")), MainMethodScanner.scan(src));
+    }
+
+    @Test
+    void ignoresNonStaticOrWrongSignature() {
+        String src = """
+                class A {
+                    public void main(String[] a) {}
+                    static void main() {}
+                    static void mainish(String[] a) {}
+                    void run(String[] a) {}
+                }
+                """;
+        assertTrue(MainMethodScanner.scan(src).isEmpty());
+    }
+
+    @Test
+    void ignoresMainInStringOrComment() {
+        String src = """
+                class A {
+                    // public static void main(String[] a) {}
+                    String s = "public static void main(String[] a)";
+                }
+                """;
+        assertTrue(MainMethodScanner.scan(src).isEmpty());
+    }
+
+    @Test
+    void ignoresNestedClassMain() {
+        String src = """
+                class Outer {
+                    static class Inner {
+                        public static void main(String[] a) {}
+                    }
+                }
+                """;
+        // main is at depth 2 (inside Inner) — not reported.
+        assertTrue(MainMethodScanner.scan(src).isEmpty());
+    }
+
+    @Test
+    void twoTopLevelClassesEachWithMain() {
+        String src = """
+                package p;
+                class A {
+                    public static void main(String[] a) {}
+                }
+                class B {
+                    public static void main(String[] a) {}
+                }
+                """;
+        List<MainMethodScanner.MainMethod> found = MainMethodScanner.scan(src);
+        assertEquals(2, found.size());
+        assertEquals("p.A", found.get(0).fqn());
+        assertEquals("p.B", found.get(1).fqn());
+    }
+
+    @Test
+    void emptyAndNull() {
+        assertTrue(MainMethodScanner.scan(null).isEmpty());
+        assertTrue(MainMethodScanner.scan("   ").isEmpty());
+    }
+}


### PR DESCRIPTION
Third slice of #700 (stacked on #703). Adds the discoverable gutter/menu UX for running/debugging a project `main`.

## Changes
- Pure, unit-tested `run/MainMethodScanner.scan(src)` → each `public static void main(String[])` at class-body depth (mirrors `JavaTestScanner`; length-preserving blank pass + brace walk). Also feeds the PR 4 build-tool fallback.
- **Gutter ▶** on every project `main()` line. Drawn independently of the single-file `runnable` flag, so the generic *Run File* / `file.run` never mis-launches a project class as one source file. Additive line→target map in `recomputeRun` alongside the test glyphs — **no cost off the Java+project path** (the scan only runs when the main gutter is gated on).
- **Editor right-click menu**: *Run 'Class.main()'* (green ▶) / *Debug 'Class.main()'* (bug icon) when the caret is on/near a `main`. `MenuIcons.debug()` added.
- `RunCoordinator.runMainClassNamed(fqn)` / `DebugCoordinator.debugMainClassNamed(fqn)` run a specific class (no picker). `applyMainGutter` gates on not-Simple + local + JVM project + Java run/debug available, re-applied on build detection + settings apply.
- i18n ×6.

## Verification
- `mvn test` — 2960 pass (new `MainMethodScannerTest`, 8 cases).
- compile + `spotless:check` clean.

Part of #700 (PR 3 of 6). Base rebases to master once #703 merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)