### PR TITLE
Run/Debug projects (6/6): VM args in debug + Spring Boot bootRun

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,9 +16,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   void main`, and the editor right-click menu offers *Run '…​.main()'* / *Debug '…​.main()'*. Debugging (and
   the fastest, project-wide Run) uses the Java language server; when it isn't set up, plain **Run** falls back
   to the build tool — Maven resolves the classpath (`mvn compile dependency:build-classpath`) and runs the
-  file's `main`, and Gradle delegates to its `run` task. **Save run configurations** (main class + program /
-  VM args + working directory) per project and re-run or debug them from the palette (*Run Configuration…* /
-  *Save Run Configuration…* / *Delete Run Configuration…*).
+  file's `main`, and Gradle delegates to its `run` task (or `bootRun` for a Spring Boot project). **Save run
+  configurations** (main class + program / VM args + working directory) per project and re-run or debug them
+  from the palette (*Run Configuration…* / *Save Run Configuration…* / *Delete Run Configuration…*); VM args
+  apply to both Run and Debug.
 
 - **Right-click Select All / Copy in the Build Output and Test Runner consoles** — copies the selection, or
   all the output when nothing is selected. Both read-only consoles share one helper.

--- a/src/main/java/com/editora/build/SpringBoot.java
+++ b/src/main/java/com/editora/build/SpringBoot.java
@@ -1,0 +1,30 @@
+package com.editora.build;
+
+/**
+ * Detects a Spring Boot Gradle project from its build script, so the no-jdtls Gradle Run fallback can run
+ * {@code bootRun} (the Spring Boot plugin's task) instead of {@code run} (the {@code application} plugin's,
+ * which a Spring Boot project often doesn't apply). Pure and unit-tested — a lightweight text sniff of the
+ * Spring Boot plugin id, not a real Gradle parse.
+ *
+ * <p>Maven needs no equivalent: the Maven fallback launches {@code java -cp <full classpath> <mainClass>},
+ * and a Spring Boot {@code @SpringBootApplication} {@code main} runs fine that way.
+ */
+public final class SpringBoot {
+
+    private SpringBoot() {}
+
+    /** The Gradle task to run for a project whose build script is {@code buildFileText}: {@code bootRun}
+     *  when the Spring Boot plugin is applied, else {@code run}. */
+    public static String gradleRunTask(String buildFileText) {
+        return isSpringBootGradle(buildFileText) ? "bootRun" : "run";
+    }
+
+    /** Whether {@code buildFileText} applies the Spring Boot Gradle plugin. */
+    public static boolean isSpringBootGradle(String buildFileText) {
+        if (buildFileText == null) {
+            return false;
+        }
+        return buildFileText.contains("org.springframework.boot")
+                || buildFileText.contains("spring-boot-gradle-plugin");
+    }
+}

--- a/src/main/java/com/editora/dap/DapManager.java
+++ b/src/main/java/com/editora/dap/DapManager.java
@@ -327,10 +327,18 @@ public final class DapManager implements DapClient.Host {
     /** Program arguments for the next launch (shared with the Run feature's per-file args). */
     private volatile List<String> programArgs = List.of();
 
+    /** JVM arguments for the next launch (from a saved run configuration; "" otherwise). */
+    private volatile String vmArgs = "";
+
     /** Sets the debuggee's program arguments; call before {@link #startLaunch}. Sticky across
      *  {@link #restart()} (the restart re-runs the same launch). */
     public void setProgramArgs(List<String> args) {
         this.programArgs = args == null ? List.of() : List.copyOf(args);
+    }
+
+    /** Sets the debuggee's JVM arguments; call before {@link #startLaunchMainClass}. "" clears them. */
+    public void setVmArgs(String vmArgs) {
+        this.vmArgs = vmArgs == null ? "" : vmArgs;
     }
 
     /**
@@ -437,6 +445,7 @@ public final class DapManager implements DapClient.Host {
                             r.javaExec(),
                             cwd,
                             programArgs,
+                            vmArgs,
                             false),
                     false);
         });
@@ -534,7 +543,15 @@ public final class DapManager implements DapClient.Host {
                 Platform.runLater(() -> startDebugSessionAndConnect(
                         file,
                         LaunchConfig.launch(
-                                fqn, null, List.of(out.toString()), List.of(), javaExec, cwd, programArgs, false),
+                                fqn,
+                                null,
+                                List.of(out.toString()),
+                                List.of(),
+                                javaExec,
+                                cwd,
+                                programArgs,
+                                vmArgs,
+                                false),
                         false));
             } catch (Exception e) {
                 fail("Could not compile/launch " + fqn + ": " + msg(e));

--- a/src/main/java/com/editora/dap/LaunchConfig.java
+++ b/src/main/java/com/editora/dap/LaunchConfig.java
@@ -27,12 +27,17 @@ public final class LaunchConfig {
             String javaExec,
             String cwd,
             List<String> args,
+            String vmArgs,
             boolean stopOnEntry) {
         Map<String, Object> m = new LinkedHashMap<>();
         m.put("type", "java");
         m.put("name", "Editora (Launch)");
         m.put("request", "launch");
         m.put("mainClass", mainClass == null ? "" : mainClass);
+        if (notBlank(vmArgs)) {
+            // java-debug's vmArgs is a single string of JVM options (kept verbatim, so a quoted value survives).
+            m.put("vmArgs", vmArgs);
+        }
         if (notBlank(projectName)) {
             m.put("projectName", projectName);
         }

--- a/src/main/java/com/editora/ui/DebugCoordinator.java
+++ b/src/main/java/com/editora/ui/DebugCoordinator.java
@@ -725,6 +725,7 @@ final class DebugCoordinator {
         debugPanel.setSessionFile(b.getPath().getFileName().toString());
         // The debuggee gets the same per-file program arguments the Run feature uses.
         dapManager.setProgramArgs(ProgramArgs.tokenize(ops.programArgs(b.getPath())));
+        dapManager.setVmArgs(""); // no VM args on a plain debug (only saved run configs carry them)
         // Re-anchor closed files' breakpoints first (off-thread) so the initial setBreakpoints arms them too.
         withClosedBreakpoints(() -> dapManager.startLaunch(b.getPath(), language, this::pickMainClass));
     }
@@ -778,6 +779,7 @@ final class DebugCoordinator {
             ops.openToolWindow();
             debugPanel.setSessionFile(shortName(match.mainClass()));
             dapManager.setProgramArgs(ProgramArgs.tokenize(cfg.args()));
+            dapManager.setVmArgs(cfg.vmArgs());
             withClosedBreakpoints(() -> dapManager.startLaunchMainClass(routing, match, cwd));
         });
     }
@@ -813,6 +815,7 @@ final class DebugCoordinator {
                 ops.openToolWindow();
                 debugPanel.setSessionFile(shortName(opt.mainClass()));
                 dapManager.setProgramArgs(ProgramArgs.tokenize(programArgsForMain(opt)));
+                dapManager.setVmArgs(""); // the gutter/command debug carries no VM args
                 withClosedBreakpoints(() -> dapManager.startLaunchMainClass(routing, opt, root));
             };
             if (targetFqn != null) {

--- a/src/main/java/com/editora/ui/MainController.java
+++ b/src/main/java/com/editora/ui/MainController.java
@@ -3626,15 +3626,36 @@ public class MainController implements com.editora.mcp.McpBridge {
         }
 
         @Override
-        public void runGradleRunTask() {
+        public void runGradleRunTask(java.nio.file.Path root) {
+            String task =
+                    com.editora.build.SpringBoot.gradleRunTask(readGradleBuildFile(root)); // bootRun for Spring Boot
             for (BuildCoordinator c : buildCoordinators) {
                 if (c.tool() == BuildTool.GRADLE && c.isEnabled() && c.isDetected()) {
-                    c.runTask(List.of("run"), List.of());
+                    c.runTask(List.of(task), List.of());
                     return;
                 }
             }
         }
     });
+
+    /** Reads the Gradle build script at {@code root} ({@code build.gradle} or {@code .kts}) for the Spring
+     *  Boot sniff, or "" when neither is readable. */
+    private static String readGradleBuildFile(java.nio.file.Path root) {
+        if (root == null) {
+            return "";
+        }
+        for (String name : List.of("build.gradle", "build.gradle.kts")) {
+            java.nio.file.Path f = root.resolve(name);
+            if (java.nio.file.Files.isRegularFile(f)) {
+                try {
+                    return java.nio.file.Files.readString(f);
+                } catch (java.io.IOException e) {
+                    return "";
+                }
+            }
+        }
+        return "";
+    }
 
     /** The IntelliJ-style Test Results feature: it hooks each build coordinator (see the injection where the
      *  tool windows are built) and builds the results tree from a recognized {@code test} run. See

--- a/src/main/java/com/editora/ui/RunCoordinator.java
+++ b/src/main/java/com/editora/ui/RunCoordinator.java
@@ -64,9 +64,10 @@ final class RunCoordinator {
          *  dependency:build-classpath} + {@code target/classes}); delivers null/empty on failure. FX thread. */
         void resolveMavenClasspath(Path root, Consumer<List<String>> cb);
 
-        /** Runs the Gradle {@code run} task via the build tool (streams to Build Output) — the no-jdtls Gradle
-         *  fallback, which runs the project's configured main class. */
-        void runGradleRunTask();
+        /** Runs the Gradle Run task via the build tool (streams to Build Output) — the no-jdtls Gradle
+         *  fallback. Runs {@code bootRun} for a Spring Boot project, else {@code run}; {@code root} locates the
+         *  build script. */
+        void runGradleRunTask(Path root);
     }
 
     private final CoordinatorHost host;
@@ -209,7 +210,7 @@ final class RunCoordinator {
         } else if (ops.mavenProjectAt(root)) {
             runViaMaven(b, root, targetFqn); // fallback: resolve the classpath with mvn, run `java -cp`
         } else if (ops.gradleProjectAt(root)) {
-            ops.runGradleRunTask(); // Gradle has no clean classpath dump — delegate to the `run` task
+            ops.runGradleRunTask(root); // Gradle has no clean classpath dump — delegate to run/bootRun
             host.setStatus(tr("status.run.gradleFallback"));
         } else {
             host.setStatus(tr("status.run.javaUnavailable"));

--- a/src/test/java/com/editora/build/SpringBootTest.java
+++ b/src/test/java/com/editora/build/SpringBootTest.java
@@ -1,0 +1,36 @@
+package com.editora.build;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class SpringBootTest {
+
+    @Test
+    void detectsPluginsDslId() {
+        String g = "plugins {\n  id 'org.springframework.boot' version '3.2.0'\n  id 'java'\n}\n";
+        assertTrue(SpringBoot.isSpringBootGradle(g));
+        assertEquals("bootRun", SpringBoot.gradleRunTask(g));
+    }
+
+    @Test
+    void detectsLegacyPluginArtifact() {
+        assertTrue(
+                SpringBoot.isSpringBootGradle("classpath 'org.springframework.boot:spring-boot-gradle-plugin:2.7.0'"));
+    }
+
+    @Test
+    void plainApplicationProjectRunsRun() {
+        String g = "plugins {\n  id 'application'\n}\napplication {\n  mainClass = 'com.app.Main'\n}\n";
+        assertFalse(SpringBoot.isSpringBootGradle(g));
+        assertEquals("run", SpringBoot.gradleRunTask(g));
+    }
+
+    @Test
+    void nullSafe() {
+        assertFalse(SpringBoot.isSpringBootGradle(null));
+        assertEquals("run", SpringBoot.gradleRunTask(null));
+    }
+}

--- a/src/test/java/com/editora/dap/LaunchConfigTest.java
+++ b/src/test/java/com/editora/dap/LaunchConfigTest.java
@@ -14,7 +14,7 @@ class LaunchConfigTest {
     @Test
     void launchEmitsRequiredFieldsAndOmitsBlankOptionals() {
         Map<String, Object> m =
-                LaunchConfig.launch("com.example.Main", "", List.of(), List.of(), "", "", List.of(), false);
+                LaunchConfig.launch("com.example.Main", "", List.of(), List.of(), "", "", List.of(), "", false);
         assertEquals("java", m.get("type"));
         assertEquals("launch", m.get("request"));
         assertEquals("com.example.Main", m.get("mainClass"));
@@ -27,6 +27,14 @@ class LaunchConfigTest {
         assertFalse(m.containsKey("javaExec"));
         assertFalse(m.containsKey("cwd"));
         assertFalse(m.containsKey("args"));
+        assertFalse(m.containsKey("vmArgs"));
+    }
+
+    @Test
+    void launchEmitsVmArgsWhenProvided() {
+        Map<String, Object> m =
+                LaunchConfig.launch("M", "", List.of(), List.of(), "", "", List.of(), "-Xmx512m -Dk=v", false);
+        assertEquals("-Xmx512m -Dk=v", m.get("vmArgs")); // verbatim string, not tokenized
     }
 
     @Test
@@ -39,6 +47,7 @@ class LaunchConfigTest {
                 "/usr/bin/java",
                 "/work",
                 List.of("--flag", "x"),
+                "",
                 true);
         assertEquals("proj", m.get("projectName"));
         assertEquals(List.of("/cp/a.jar", "/cp/b.jar"), m.get("classPaths"));
@@ -55,7 +64,7 @@ class LaunchConfigTest {
         // Run passes exactly those. Joining them back on a space is lossy: main() would receive 3. The
         // collision is the proof — [hello world, second] and [hello, world, second] join to one same string.
         List<String> argv = List.of("hello world", "second");
-        Map<String, Object> m = LaunchConfig.launch("A", "", List.of(), List.of(), "", "", argv, false);
+        Map<String, Object> m = LaunchConfig.launch("A", "", List.of(), List.of(), "", "", argv, "", false);
         assertEquals(argv, m.get("args"), "the debuggee must get the same argv the Run feature passes");
 
         // The same argv reaches debugpy/node the same way (this sibling was always correct).


### PR DESCRIPTION
Final slice of #700 (stacked on #706).

## Changes
- **VM args reach the debugger.** `LaunchConfig.launch` now emits `vmArgs` (verbatim string); `DapManager` carries a per-launch `vmArgs` set at each debug entry (`""` for plain/gutter debug, `cfg.vmArgs()` for a saved config). So a run configuration's VM args now apply to **both** Run and Debug — completing PR 5's deferred item.
- **Spring Boot awareness.** Pure, unit-tested `build/SpringBoot`: the no-jdtls Gradle Run fallback runs `bootRun` for a Spring Boot project (a plugin sniff of the build script) instead of `run`. Maven Spring Boot needs no special-casing — its `java -cp` + full classpath runs a `@SpringBootApplication` `main` directly.

## Verification
- `mvn test` — 2973 pass (new `SpringBootTest`; `LaunchConfigTest` extended for `vmArgs`).
- compile + `spotless:check` clean.

## #700 deferred (documented)
A Settings run-config **form editor** (rename/edit in place), multi-module sibling-module classpaths, JavaFX/`application`-plugin niceties, and a no-jdtls **debug** attach (`mvnDebug` / Gradle `--debug-jvm`).

Completes #700 (PR 6 of 6). Base rebases to master once #706 merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)