### PR TITLE
Multi-module Maven classpath in the Run fallback (#700 deferred)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Multi-module Maven Run without the language server** — running a project main class via the Maven
+  classpath fallback now resolves sibling-module dependencies in a reactor build (it runs from the reactor
+  root with `-pl <module> -am` instead of only the module), so a submodule that depends on an uninstalled
+  sibling runs correctly.
+
 ### Added
 
 - **Settings → Run Configurations** — a master-detail editor for the saved run/debug configurations

--- a/src/main/java/com/editora/maven/MavenClasspath.java
+++ b/src/main/java/com/editora/maven/MavenClasspath.java
@@ -35,6 +35,25 @@ public final class MavenClasspath {
     }
 
     /**
+     * Like {@link #argv} but for a submodule in a multi-module build, run from the reactor root:
+     * {@code -pl <moduleSelector> -am} ("also make") builds the sibling modules the target depends on, so
+     * their compiled output lands in {@code outputFile}'s classpath. {@code outputFile} must be an absolute
+     * path (the working directory is the reactor root, not the module).
+     */
+    public static List<String> reactorArgv(Path outputFile, String moduleSelector) {
+        return List.of(
+                "mvn",
+                "-q",
+                "-pl",
+                moduleSelector,
+                "-am",
+                "compile",
+                "dependency:build-classpath",
+                "-Dmdep.outputFile=" + outputFile,
+                "-Dmdep.pathSeparator=" + File.pathSeparator);
+    }
+
+    /**
      * Full launch classpath = the module's compiled output (when present) followed by the dependency
      * classpath from {@code dependencyClasspath} (a {@code File.pathSeparator}-joined string). Blank/empty
      * entries are dropped. {@code root} is the Maven module root ({@code root/target/classes}).

--- a/src/main/java/com/editora/maven/MavenReactor.java
+++ b/src/main/java/com/editora/maven/MavenReactor.java
@@ -1,0 +1,41 @@
+package com.editora.maven;
+
+import java.io.File;
+import java.nio.file.Path;
+import java.util.function.Predicate;
+
+/**
+ * Locates the Maven <b>reactor root</b> for a module so the Run classpath fallback resolves sibling-module
+ * dependencies in a multi-module build. {@code mvn dependency:build-classpath} run in a submodule misses
+ * sibling modules that aren't installed in the local repo; running it from the reactor root with
+ * {@code -pl <module> -am} ("also make") builds the upstream modules and includes their output.
+ *
+ * <p>Heuristic (no pom parse): the reactor root is the topmost ancestor in a contiguous chain of directories
+ * that each hold a {@code pom.xml} — the standard multi-module layout. Pure: the {@code pom.xml} presence
+ * check is injected, so it's unit-tested without a filesystem.
+ */
+public final class MavenReactor {
+
+    private MavenReactor() {}
+
+    /** The topmost ancestor of {@code moduleDir} in a contiguous chain of pom-bearing dirs, or {@code moduleDir}
+     *  itself when its parent has no {@code pom.xml}. {@code hasPom} tests whether a directory holds a pom. */
+    public static Path reactorRoot(Path moduleDir, Predicate<Path> hasPom) {
+        if (moduleDir == null) {
+            return null;
+        }
+        Path root = moduleDir;
+        Path parent = moduleDir.getParent();
+        while (parent != null && hasPom.test(parent)) {
+            root = parent;
+            parent = parent.getParent();
+        }
+        return root;
+    }
+
+    /** The {@code -pl} project selector: {@code moduleDir} relative to {@code reactorRoot}, forward-slashed. */
+    public static String moduleSelector(Path reactorRoot, Path moduleDir) {
+        String rel = reactorRoot.relativize(moduleDir).toString();
+        return rel.replace(File.separatorChar, '/');
+    }
+}

--- a/src/main/java/com/editora/ui/MainController.java
+++ b/src/main/java/com/editora/ui/MainController.java
@@ -3602,10 +3602,18 @@ public class MainController implements com.editora.mcp.McpBridge {
                         try {
                             java.nio.file.Path tmp = java.nio.file.Files.createTempFile("editora-cp", ".txt");
                             try {
+                                // Multi-module: run from the reactor root with -pl <module> -am so the sibling
+                                // modules the target depends on are built and included; else run in the module.
+                                java.nio.file.Path reactor = com.editora.maven.MavenReactor.reactorRoot(
+                                        root, d -> java.nio.file.Files.isRegularFile(d.resolve("pom.xml")));
+                                boolean multi = reactor != null && !reactor.equals(root);
+                                java.nio.file.Path cwd = multi ? reactor : root;
+                                List<String> argv = multi
+                                        ? com.editora.maven.MavenClasspath.reactorArgv(
+                                                tmp, com.editora.maven.MavenReactor.moduleSelector(reactor, root))
+                                        : com.editora.maven.MavenClasspath.argv(tmp);
                                 com.editora.process.ProcessRunner.Result r = com.editora.process.ProcessRunner.run(
-                                        root,
-                                        java.time.Duration.ofMinutes(3),
-                                        com.editora.maven.MavenClasspath.argv(tmp));
+                                        cwd, java.time.Duration.ofMinutes(3), argv);
                                 if (r.exit() == 0) {
                                     String content =
                                             java.nio.file.Files.exists(tmp) ? java.nio.file.Files.readString(tmp) : "";

--- a/src/test/java/com/editora/maven/MavenClasspathTest.java
+++ b/src/test/java/com/editora/maven/MavenClasspathTest.java
@@ -25,6 +25,17 @@ class MavenClasspathTest {
     }
 
     @Test
+    void reactorArgvSelectsModuleAndAlsoMakes() {
+        List<String> argv = MavenClasspath.reactorArgv(Path.of("/tmp/cp.txt"), "services/api");
+        assertEquals("mvn", argv.get(0));
+        assertTrue(argv.contains("-pl"));
+        assertTrue(argv.contains("services/api"));
+        assertTrue(argv.contains("-am"));
+        assertTrue(argv.contains("dependency:build-classpath"));
+        assertTrue(argv.contains("-Dmdep.outputFile=/tmp/cp.txt"));
+    }
+
+    @Test
     void assemblePrependsTargetClasses() {
         List<String> cp = MavenClasspath.assemble("/m2/a.jar" + S + "/m2/b.jar", Path.of("/proj"));
         assertEquals(List.of(Path.of("/proj/target/classes").toString(), "/m2/a.jar", "/m2/b.jar"), cp);

--- a/src/test/java/com/editora/maven/MavenReactorTest.java
+++ b/src/test/java/com/editora/maven/MavenReactorTest.java
@@ -1,0 +1,41 @@
+package com.editora.maven;
+
+import java.nio.file.Path;
+import java.util.Set;
+import java.util.function.Predicate;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class MavenReactorTest {
+
+    @Test
+    void singleModuleIsItsOwnRoot() {
+        Path project = Path.of("/repo/app");
+        Predicate<Path> hasPom = Set.of(project)::contains; // only /repo/app has a pom
+        assertEquals(project, MavenReactor.reactorRoot(project, hasPom));
+    }
+
+    @Test
+    void walksUpContiguousPomChain() {
+        Path reactor = Path.of("/repo");
+        Path module = Path.of("/repo/services/api");
+        Predicate<Path> hasPom = Set.of(reactor, Path.of("/repo/services"), module)::contains;
+        assertEquals(reactor, MavenReactor.reactorRoot(module, hasPom));
+    }
+
+    @Test
+    void stopsAtAGapInThePomChain() {
+        // /repo has a pom but /repo/detached does NOT — so /repo/detached/mod's root is itself.
+        Path module = Path.of("/repo/detached/mod");
+        Predicate<Path> hasPom = Set.of(Path.of("/repo"), module)::contains; // gap at /repo/detached
+        assertEquals(module, MavenReactor.reactorRoot(module, hasPom));
+    }
+
+    @Test
+    void moduleSelectorIsForwardSlashRelativePath() {
+        assertEquals("services/api", MavenReactor.moduleSelector(Path.of("/repo"), Path.of("/repo/services/api")));
+        assertEquals("mod", MavenReactor.moduleSelector(Path.of("/repo"), Path.of("/repo/mod")));
+    }
+}


### PR DESCRIPTION
Third and final #700 deferred item.

## What
The Maven **Run fallback** (no language server) missed sibling-module dependencies in a reactor build: `mvn dependency:build-classpath` run in a submodule only sees deps installed in the local repo. Now, for a submodule, it resolves from the **reactor root** with `-pl <module> -am` ("also make"), so the upstream sibling modules are built and their output is on the classpath.

## How
- Pure, unit-tested `maven/MavenReactor`: `reactorRoot(moduleDir, hasPom)` walks the contiguous pom-chain up to the reactor root (pom-presence check injected, so it's tested with no filesystem); `moduleSelector` builds the `-pl` value.
- `MavenClasspath.reactorArgv(outputFile, moduleSelector)` — the `-pl … -am` form.
- `resolveMavenClasspath` picks the reactor cwd/argv for a submodule; **single-module behaviour is unchanged**.

## Verification
- `mvn test` — 2978 pass (new `MavenReactorTest` + extended `MavenClasspathTest`).
- compile + `spotless:check` clean.

Completes the #700 follow-ups (deferred item 3 of 3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)