### PR TITLE
Run configs: environment variables + Gradle application main class (#700 deferred)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Environment variables in run configurations** — a saved run/debug configuration can now set environment
+  variables (`KEY=value`, quote values containing spaces). They apply to both Run and Debug, and are edited in
+  Settings → Run Configurations.
+- **Gradle `application` main class** — saving a run configuration in a Gradle project now pre-fills the main
+  class the build declares (`mainClass = '…'`, `mainClass.set("…")`, or the legacy `mainClassName`), so the
+  config matches what `gradle run` would launch instead of whichever file is open.
+
 ### Fixed
 
 - **Multi-module Maven Run without the language server** — running a project main class via the Maven

--- a/src/main/java/com/editora/build/GradleApplication.java
+++ b/src/main/java/com/editora/build/GradleApplication.java
@@ -1,0 +1,43 @@
+package com.editora.build;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Reads the main class a Gradle build script declares via the {@code application} plugin, so Run/Debug can
+ * name what it will launch (and pre-fill a saved run configuration) without scanning sources or asking the
+ * language server. A lightweight regex sniff of the common spellings — not a Gradle evaluation:
+ *
+ * <ul>
+ *   <li>{@code mainClass = 'com.app.Main'} (Groovy / Kotlin DSL assignment)</li>
+ *   <li>{@code mainClass.set("com.app.Main")} (Kotlin DSL property)</li>
+ *   <li>{@code mainClassName = 'com.app.Main'} (legacy, pre-Gradle 6.4)</li>
+ * </ul>
+ *
+ * <p>A value built from a variable or a computed expression yields {@code null} — the caller falls back to a
+ * source scan / the language server. Pure and unit-tested.
+ */
+public final class GradleApplication {
+
+    private GradleApplication() {}
+
+    /** {@code mainClass = "x"} / {@code mainClassName = "x"} — quoted literal, single or double quotes. */
+    private static final Pattern ASSIGN = Pattern.compile("\\bmainClass(?:Name)?\\s*=\\s*[\"']([\\w.$]+)[\"']");
+
+    /** {@code mainClass.set("x")} — the Kotlin-DSL Property form. */
+    private static final Pattern SET =
+            Pattern.compile("\\bmainClass(?:Name)?\\s*\\.\\s*set\\s*\\(\\s*[\"']([\\w.$]+)[\"']\\s*\\)");
+
+    /** The declared main class, or {@code null} when the script doesn't declare a literal one. */
+    public static String mainClass(String buildScript) {
+        if (buildScript == null || buildScript.isBlank()) {
+            return null;
+        }
+        Matcher m = ASSIGN.matcher(buildScript);
+        if (m.find()) {
+            return m.group(1);
+        }
+        Matcher s = SET.matcher(buildScript);
+        return s.find() ? s.group(1) : null;
+    }
+}

--- a/src/main/java/com/editora/config/RunConfiguration.java
+++ b/src/main/java/com/editora/config/RunConfiguration.java
@@ -6,13 +6,21 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 /**
  * A saved run/debug configuration for a Java project main class: a {@code name}, whether it runs or debugs
  * ({@code kind} = {@code "run"}/{@code "debug"}), the {@code mainClass} (fully-qualified) + its {@code
- * projectName} (multi-module), program {@code args}, JVM {@code vmArgs}, and an optional {@code workingDir}
- * (blank ⇒ the project root). Persisted per window in {@code WorkspaceState.runConfigurations}. Jackson
+ * projectName} (multi-module), program {@code args}, JVM {@code vmArgs}, an optional {@code workingDir}
+ * (blank ⇒ the project root), and {@code env} — environment variables as quote-aware {@code KEY=VALUE} pairs
+ * (see {@code run/EnvVars}). Persisted per window in {@code WorkspaceState.runConfigurations}. Jackson
  * round-trips this record; the compact constructor defaults every field so an older/partial entry loads.
  */
 @JsonIgnoreProperties(ignoreUnknown = true)
 public record RunConfiguration(
-        String name, String kind, String mainClass, String projectName, String args, String vmArgs, String workingDir) {
+        String name,
+        String kind,
+        String mainClass,
+        String projectName,
+        String args,
+        String vmArgs,
+        String workingDir,
+        String env) {
 
     public RunConfiguration {
         name = name == null ? "" : name;
@@ -22,6 +30,19 @@ public record RunConfiguration(
         args = args == null ? "" : args;
         vmArgs = vmArgs == null ? "" : vmArgs;
         workingDir = workingDir == null ? "" : workingDir;
+        env = env == null ? "" : env;
+    }
+
+    /** Back-compat constructor for callers that don't set environment variables ({@code env} = {@code ""}). */
+    public RunConfiguration(
+            String name,
+            String kind,
+            String mainClass,
+            String projectName,
+            String args,
+            String vmArgs,
+            String workingDir) {
+        this(name, kind, mainClass, projectName, args, vmArgs, workingDir, "");
     }
 
     @JsonIgnore

--- a/src/main/java/com/editora/dap/DapManager.java
+++ b/src/main/java/com/editora/dap/DapManager.java
@@ -341,6 +341,14 @@ public final class DapManager implements DapClient.Host {
         this.vmArgs = vmArgs == null ? "" : vmArgs;
     }
 
+    /** Environment variables for the next launch (from a saved run configuration; empty otherwise). */
+    private volatile java.util.Map<String, String> env = java.util.Map.of();
+
+    /** Sets the debuggee's environment variables; call before {@link #startLaunchMainClass}. Empty clears them. */
+    public void setEnv(java.util.Map<String, String> env) {
+        this.env = env == null ? java.util.Map.of() : java.util.Map.copyOf(env);
+    }
+
     /**
      * Launches a Java debug session for {@code file}: resolves the main class (asking {@code picker} if
      * several are found), its classpath + java executable, starts the adapter, and connects. No-op (with an
@@ -446,6 +454,7 @@ public final class DapManager implements DapClient.Host {
                             cwd,
                             programArgs,
                             vmArgs,
+                            env,
                             false),
                     false);
         });

--- a/src/main/java/com/editora/dap/LaunchConfig.java
+++ b/src/main/java/com/editora/dap/LaunchConfig.java
@@ -29,11 +29,30 @@ public final class LaunchConfig {
             List<String> args,
             String vmArgs,
             boolean stopOnEntry) {
+        return launch(
+                mainClass, projectName, classPaths, modulePaths, javaExec, cwd, args, vmArgs, Map.of(), stopOnEntry);
+    }
+
+    /** As above, plus {@code env} — extra environment variables for the debuggee (java-debug's {@code env} map). */
+    public static Map<String, Object> launch(
+            String mainClass,
+            String projectName,
+            List<String> classPaths,
+            List<String> modulePaths,
+            String javaExec,
+            String cwd,
+            List<String> args,
+            String vmArgs,
+            Map<String, String> env,
+            boolean stopOnEntry) {
         Map<String, Object> m = new LinkedHashMap<>();
         m.put("type", "java");
         m.put("name", "Editora (Launch)");
         m.put("request", "launch");
         m.put("mainClass", mainClass == null ? "" : mainClass);
+        if (env != null && !env.isEmpty()) {
+            m.put("env", env);
+        }
         if (notBlank(vmArgs)) {
             // java-debug's vmArgs is a single string of JVM options (kept verbatim, so a quoted value survives).
             m.put("vmArgs", vmArgs);

--- a/src/main/java/com/editora/run/EnvVars.java
+++ b/src/main/java/com/editora/run/EnvVars.java
@@ -1,0 +1,34 @@
+package com.editora.run;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * Parses a run configuration's environment-variable string into a name→value map. The text is tokenized with
+ * the same quote-aware splitter as program arguments ({@link ProgramArgs#tokenize}), so a value containing
+ * spaces works when quoted: {@code FOO=bar GREETING="hello world"}. Each token splits on its <b>first</b>
+ * {@code =}, so a value may itself contain {@code =} (e.g. a base64 or connection string).
+ *
+ * <p>Tokens without an {@code =}, or with an empty name, are skipped rather than failing — a half-typed entry
+ * shouldn't stop the launch. Insertion order is preserved. Pure and unit-tested.
+ */
+public final class EnvVars {
+
+    private EnvVars() {}
+
+    /** Name→value pairs from {@code text} ({@code ""}/null ⇒ an empty map). */
+    public static Map<String, String> parse(String text) {
+        Map<String, String> out = new LinkedHashMap<>();
+        if (text == null || text.isBlank()) {
+            return out;
+        }
+        for (String token : ProgramArgs.tokenize(text)) {
+            int eq = token.indexOf('=');
+            if (eq <= 0) {
+                continue; // no '=' at all, or an empty name like "=value"
+            }
+            out.put(token.substring(0, eq), token.substring(eq + 1));
+        }
+        return out;
+    }
+}

--- a/src/main/java/com/editora/run/RunService.java
+++ b/src/main/java/com/editora/run/RunService.java
@@ -141,6 +141,14 @@ public final class RunService {
      * All listener callbacks run on the FX thread.
      */
     public void runInDir(Path workingDir, List<String> argv, Listener listener) {
+        runInDir(workingDir, argv, java.util.Map.of(), listener);
+    }
+
+    /**
+     * As {@link #runInDir(Path, List, Listener)}, plus {@code env} — extra environment variables for the
+     * child (a saved run configuration's {@code KEY=VALUE} pairs), applied over the inherited environment.
+     */
+    public void runInDir(Path workingDir, List<String> argv, java.util.Map<String, String> env, Listener listener) {
         if (argv == null || argv.isEmpty() || listener == null || isRunning()) {
             return;
         }
@@ -152,6 +160,9 @@ public final class RunService {
             pb.directory(dir.toFile());
         }
         ProcessRunner.applyStandardEnv(pb);
+        if (env != null && !env.isEmpty()) {
+            pb.environment().putAll(env); // after applyStandardEnv so a config can override PATH etc.
+        }
         Process process;
         try {
             process = pb.start();

--- a/src/main/java/com/editora/ui/DebugCoordinator.java
+++ b/src/main/java/com/editora/ui/DebugCoordinator.java
@@ -725,7 +725,8 @@ final class DebugCoordinator {
         debugPanel.setSessionFile(b.getPath().getFileName().toString());
         // The debuggee gets the same per-file program arguments the Run feature uses.
         dapManager.setProgramArgs(ProgramArgs.tokenize(ops.programArgs(b.getPath())));
-        dapManager.setVmArgs(""); // no VM args on a plain debug (only saved run configs carry them)
+        dapManager.setVmArgs(""); // no VM args/env on a plain debug (only saved run configs carry them)
+        dapManager.setEnv(java.util.Map.of());
         // Re-anchor closed files' breakpoints first (off-thread) so the initial setBreakpoints arms them too.
         withClosedBreakpoints(() -> dapManager.startLaunch(b.getPath(), language, this::pickMainClass));
     }
@@ -780,6 +781,7 @@ final class DebugCoordinator {
             debugPanel.setSessionFile(shortName(match.mainClass()));
             dapManager.setProgramArgs(ProgramArgs.tokenize(cfg.args()));
             dapManager.setVmArgs(cfg.vmArgs());
+            dapManager.setEnv(com.editora.run.EnvVars.parse(cfg.env()));
             withClosedBreakpoints(() -> dapManager.startLaunchMainClass(routing, match, cwd));
         });
     }
@@ -815,7 +817,8 @@ final class DebugCoordinator {
                 ops.openToolWindow();
                 debugPanel.setSessionFile(shortName(opt.mainClass()));
                 dapManager.setProgramArgs(ProgramArgs.tokenize(programArgsForMain(opt)));
-                dapManager.setVmArgs(""); // the gutter/command debug carries no VM args
+                dapManager.setVmArgs(""); // the gutter/command debug carries no VM args/env
+                dapManager.setEnv(java.util.Map.of());
                 withClosedBreakpoints(() -> dapManager.startLaunchMainClass(routing, opt, root));
             };
             if (targetFqn != null) {

--- a/src/main/java/com/editora/ui/MainController.java
+++ b/src/main/java/com/editora/ui/MainController.java
@@ -9071,13 +9071,17 @@ public class MainController implements com.editora.mcp.McpBridge {
             setStatus(tr("status.run.needJavaFile"));
             return;
         }
+        // Prefer the main class a Gradle `application` block declares — that's what `gradle run` would launch,
+        // so a config saved in such a project matches the build rather than whichever file happens to be open.
+        String declared =
+                com.editora.build.GradleApplication.mainClass(readGradleBuildFile(JavaProjectRoot.find(b.getPath())));
         List<com.editora.run.MainMethodScanner.MainMethod> mains =
                 com.editora.run.MainMethodScanner.scan(b.getContent());
-        if (mains.isEmpty()) {
+        if (declared == null && mains.isEmpty()) {
             setStatus(tr("status.run.noMainInFile"));
             return;
         }
-        String fqn = mains.get(0).fqn();
+        String fqn = declared != null ? declared : mains.get(0).fqn();
         String simple = com.editora.test.TestSourceLocator.simpleName(fqn);
         String args = programArgsFor(b.getPath());
         promptText(tr("run.config.saveTitle"), tr("run.config.saveName"), simple, name -> {

--- a/src/main/java/com/editora/ui/RunCoordinator.java
+++ b/src/main/java/com/editora/ui/RunCoordinator.java
@@ -78,6 +78,7 @@ final class RunCoordinator {
     /** The most recent launch, for {@code run.rerun} and the shared stack-trace link resolver. */
     private Path lastRunDir;
 
+    private java.util.Map<String, String> lastRunEnv = java.util.Map.of();
     private String lastRunLabel;
     private List<String> lastRunCommand;
 
@@ -117,7 +118,7 @@ final class RunCoordinator {
             host.setStatus(tr("status.run.busy"));
             return;
         }
-        streamRun(lastRunLabel, lastRunDir, lastRunCommand);
+        streamRun(lastRunLabel, lastRunDir, lastRunCommand, lastRunEnv);
     }
 
     /**
@@ -158,6 +159,7 @@ final class RunCoordinator {
         Path cwd = cfg.workingDir().isBlank() ? root : Path.of(cfg.workingDir());
         List<String> vm = ProgramArgs.tokenize(cfg.vmArgs());
         List<String> args = ProgramArgs.tokenize(cfg.args());
+        java.util.Map<String, String> env = com.editora.run.EnvVars.parse(cfg.env());
         String label = shortName(cfg.mainClass());
         if (ops.javaLaunchAvailable()) {
             JavaMainClass mc = new JavaMainClass(cfg.mainClass(), cfg.projectName(), routing.toString());
@@ -170,7 +172,8 @@ final class RunCoordinator {
                         label,
                         cwd,
                         JavaRunCommand.build(
-                                info.javaExec(), info.modulePaths(), info.classPaths(), cfg.mainClass(), vm, args));
+                                info.javaExec(), info.modulePaths(), info.classPaths(), cfg.mainClass(), vm, args),
+                        env);
             });
         } else if (ops.mavenProjectAt(root)) {
             host.setStatus(tr("status.run.resolvingClasspath"));
@@ -179,7 +182,7 @@ final class RunCoordinator {
                     host.setStatus(tr("status.run.resolveFailed"));
                     return;
                 }
-                streamRun(label, cwd, JavaRunCommand.build("", List.of(), cp, cfg.mainClass(), vm, args));
+                streamRun(label, cwd, JavaRunCommand.build("", List.of(), cp, cfg.mainClass(), vm, args), env);
             });
         } else {
             host.setStatus(tr("status.run.javaUnavailable"));
@@ -453,13 +456,19 @@ final class RunCoordinator {
     /** Runs {@code command} in {@code workingDir} (the project root for a main class, else a file's folder),
      *  streaming into the Run console and remembering it for {@code run.rerun}. */
     private void streamRun(String label, Path workingDir, List<String> command) {
+        streamRun(label, workingDir, command, java.util.Map.of());
+    }
+
+    /** As above, plus {@code env} — a saved run configuration's environment variables. */
+    private void streamRun(String label, Path workingDir, List<String> command, java.util.Map<String, String> env) {
         lastRunDir = workingDir;
         lastRunLabel = label;
         lastRunCommand = command;
+        lastRunEnv = env;
         ops.openToolWindow();
         panel.started(label);
         host.setStatus(tr("status.run.started", label));
-        service.runInDir(workingDir, command, new RunService.Listener() {
+        service.runInDir(workingDir, command, env, new RunService.Listener() {
             @Override
             public void onStart(String commandLine) {
                 panel.started(commandLine);

--- a/src/main/java/com/editora/ui/SettingsWindow.java
+++ b/src/main/java/com/editora/ui/SettingsWindow.java
@@ -4046,6 +4046,8 @@ public class SettingsWindow {
         TextField vmArgs = new TextField();
         TextField workingDir = new TextField();
         workingDir.setPromptText(tr("settings.runConfig.workingDirPrompt"));
+        TextField env = new TextField();
+        env.setPromptText(tr("settings.runConfig.envPrompt"));
 
         javafx.scene.layout.GridPane form = new javafx.scene.layout.GridPane();
         form.setHgap(8);
@@ -4057,6 +4059,7 @@ public class SettingsWindow {
         formRow(form, 4, tr("settings.runConfig.args"), args);
         formRow(form, 5, tr("settings.runConfig.vmArgs"), vmArgs);
         formRow(form, 6, tr("settings.runConfig.workingDir"), workingDir);
+        formRow(form, 7, tr("settings.runConfig.env"), env);
         form.setDisable(true);
         HBox.setHgrow(form, Priority.ALWAYS);
 
@@ -4072,7 +4075,8 @@ public class SettingsWindow {
                     projectName.getText(),
                     args.getText(),
                     vmArgs.getText(),
-                    workingDir.getText());
+                    workingDir.getText(),
+                    env.getText());
             runConfigItems.set(i, rebuilt);
             list.refresh();
             persistRunConfigs();
@@ -4092,6 +4096,7 @@ public class SettingsWindow {
         wire.accept(args);
         wire.accept(vmArgs);
         wire.accept(workingDir);
+        wire.accept(env);
 
         list.getSelectionModel().selectedItemProperty().addListener((o, was, now) -> {
             loadingRunConfig = true;
@@ -4104,6 +4109,7 @@ public class SettingsWindow {
                 args.setText(now == null ? "" : now.args());
                 vmArgs.setText(now == null ? "" : now.vmArgs());
                 workingDir.setText(now == null ? "" : now.workingDir());
+                env.setText(now == null ? "" : now.env());
             } finally {
                 loadingRunConfig = false;
             }

--- a/src/main/resources/com/editora/i18n/messages.properties
+++ b/src/main/resources/com/editora/i18n/messages.properties
@@ -2458,6 +2458,8 @@ settings.runConfig.args=Program arguments
 settings.runConfig.vmArgs=VM arguments
 settings.runConfig.workingDir=Working directory
 settings.runConfig.workingDirPrompt=blank ⇒ project root
+settings.runConfig.env=Environment
+settings.runConfig.envPrompt=KEY=value, quote values with spaces
 settings.runConfig.add=Add
 settings.runConfig.remove=Remove
 settings.runConfig.newName=New Configuration

--- a/src/main/resources/com/editora/i18n/messages_de.properties
+++ b/src/main/resources/com/editora/i18n/messages_de.properties
@@ -2450,6 +2450,8 @@ settings.runConfig.args=Programmargumente
 settings.runConfig.vmArgs=VM-Argumente
 settings.runConfig.workingDir=Arbeitsverzeichnis
 settings.runConfig.workingDirPrompt=leer ⇒ Projektstamm
+settings.runConfig.env=Umgebung
+settings.runConfig.envPrompt=KEY=Wert; Werte mit Leerzeichen in Anführungszeichen
 settings.runConfig.add=Hinzufügen
 settings.runConfig.remove=Entfernen
 settings.runConfig.newName=Neue Konfiguration

--- a/src/main/resources/com/editora/i18n/messages_es.properties
+++ b/src/main/resources/com/editora/i18n/messages_es.properties
@@ -2450,6 +2450,8 @@ settings.runConfig.args=Argumentos del programa
 settings.runConfig.vmArgs=Argumentos de la JVM
 settings.runConfig.workingDir=Directorio de trabajo
 settings.runConfig.workingDirPrompt=vacío ⇒ raíz del proyecto
+settings.runConfig.env=Entorno
+settings.runConfig.envPrompt=CLAVE=valor; entrecomilla los valores con espacios
 settings.runConfig.add=Añadir
 settings.runConfig.remove=Quitar
 settings.runConfig.newName=Nueva configuración

--- a/src/main/resources/com/editora/i18n/messages_fr.properties
+++ b/src/main/resources/com/editora/i18n/messages_fr.properties
@@ -2450,6 +2450,8 @@ settings.runConfig.args=Arguments du programme
 settings.runConfig.vmArgs=Arguments de la JVM
 settings.runConfig.workingDir=Répertoire de travail
 settings.runConfig.workingDirPrompt=vide ⇒ racine du projet
+settings.runConfig.env=Environnement
+settings.runConfig.envPrompt=CLE=valeur ; guillemets si la valeur contient des espaces
 settings.runConfig.add=Ajouter
 settings.runConfig.remove=Supprimer
 settings.runConfig.newName=Nouvelle configuration

--- a/src/main/resources/com/editora/i18n/messages_it.properties
+++ b/src/main/resources/com/editora/i18n/messages_it.properties
@@ -2450,6 +2450,8 @@ settings.runConfig.args=Argomenti del programma
 settings.runConfig.vmArgs=Argomenti della JVM
 settings.runConfig.workingDir=Directory di lavoro
 settings.runConfig.workingDirPrompt=vuoto ⇒ radice del progetto
+settings.runConfig.env=Ambiente
+settings.runConfig.envPrompt=CHIAVE=valore; usa le virgolette per valori con spazi
 settings.runConfig.add=Aggiungi
 settings.runConfig.remove=Rimuovi
 settings.runConfig.newName=Nuova configurazione

--- a/src/main/resources/com/editora/i18n/messages_pt.properties
+++ b/src/main/resources/com/editora/i18n/messages_pt.properties
@@ -2450,6 +2450,8 @@ settings.runConfig.args=Argumentos do programa
 settings.runConfig.vmArgs=Argumentos da JVM
 settings.runConfig.workingDir=Diretório de trabalho
 settings.runConfig.workingDirPrompt=vazio ⇒ raiz do projeto
+settings.runConfig.env=Ambiente
+settings.runConfig.envPrompt=CHAVE=valor; use aspas em valores com espaços
 settings.runConfig.add=Adicionar
 settings.runConfig.remove=Remover
 settings.runConfig.newName=Nova configuração

--- a/src/test/java/com/editora/build/GradleApplicationTest.java
+++ b/src/test/java/com/editora/build/GradleApplicationTest.java
@@ -1,0 +1,51 @@
+package com.editora.build;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+class GradleApplicationTest {
+
+    @Test
+    void groovyAssignmentSingleQuotes() {
+        String g = "plugins { id 'application' }\napplication {\n    mainClass = 'com.app.Main'\n}\n";
+        assertEquals("com.app.Main", GradleApplication.mainClass(g));
+    }
+
+    @Test
+    void kotlinDslAssignmentDoubleQuotes() {
+        String g = "application {\n    mainClass = \"demo.App\"\n}\n";
+        assertEquals("demo.App", GradleApplication.mainClass(g));
+    }
+
+    @Test
+    void kotlinDslPropertySetForm() {
+        String g = "application {\n    mainClass.set(\"com.example.Boot\")\n}\n";
+        assertEquals("com.example.Boot", GradleApplication.mainClass(g));
+    }
+
+    @Test
+    void legacyMainClassName() {
+        assertEquals("legacy.Main", GradleApplication.mainClass("mainClassName = 'legacy.Main'"));
+    }
+
+    @Test
+    void nestedClassNameWithDollar() {
+        assertEquals("a.Outer$Inner", GradleApplication.mainClass("mainClass = 'a.Outer$Inner'"));
+    }
+
+    @Test
+    void computedValueYieldsNullSoCallerFallsBack() {
+        // Built from a variable — we don't evaluate Gradle, so the caller must fall back to a scan.
+        assertNull(GradleApplication.mainClass("mainClass = mainClassProperty"));
+        assertNull(GradleApplication.mainClass("mainClass = \"$group.Main\"".replace("$group", "\" + g + \"")));
+    }
+
+    @Test
+    void noApplicationBlock() {
+        assertNull(GradleApplication.mainClass("plugins { id 'java' }"));
+        assertNull(GradleApplication.mainClass(""));
+        assertNull(GradleApplication.mainClass(null));
+    }
+}

--- a/src/test/java/com/editora/config/RunConfigurationTest.java
+++ b/src/test/java/com/editora/config/RunConfigurationTest.java
@@ -28,9 +28,21 @@ class RunConfigurationTest {
     @Test
     void jacksonRoundTrip() throws Exception {
         ObjectMapper m = new ObjectMapper();
-        RunConfiguration c = new RunConfiguration("App", "debug", "com.app.Main", "core", "--x", "-Xmx1g", "/tmp");
+        RunConfiguration c =
+                new RunConfiguration("App", "debug", "com.app.Main", "core", "--x", "-Xmx1g", "/tmp", "FOO=bar");
         RunConfiguration back = m.readValue(m.writeValueAsString(c), RunConfiguration.class);
         assertEquals(c, back);
+        assertEquals("FOO=bar", back.env());
+    }
+
+    @Test
+    void backCompatConstructorAndOlderJsonDefaultEnvToEmpty() throws Exception {
+        // A config saved before `env` existed must still load (and the 7-arg ctor keeps old call sites working).
+        assertEquals("", new RunConfiguration("A", "run", "M", "", "", "", "").env());
+        ObjectMapper m = new ObjectMapper();
+        RunConfiguration old = m.readValue(
+                "{\"name\":\"A\",\"kind\":\"run\",\"mainClass\":\"M\",\"workingDir\":\"\"}", RunConfiguration.class);
+        assertEquals("", old.env());
     }
 
     @Test

--- a/src/test/java/com/editora/run/EnvVarsTest.java
+++ b/src/test/java/com/editora/run/EnvVarsTest.java
@@ -1,0 +1,52 @@
+package com.editora.run;
+
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class EnvVarsTest {
+
+    @Test
+    void parsesSimplePairs() {
+        assertEquals(Map.of("FOO", "bar", "BAZ", "qux"), EnvVars.parse("FOO=bar BAZ=qux"));
+    }
+
+    @Test
+    void quotedValueKeepsItsSpaces() {
+        assertEquals(Map.of("GREETING", "hello world"), EnvVars.parse("GREETING=\"hello world\""));
+    }
+
+    @Test
+    void valueMayContainEquals() {
+        // Splitting on the FIRST '=' only — a base64/connection-string value survives.
+        assertEquals(Map.of("TOKEN", "ab=cd=="), EnvVars.parse("TOKEN=ab=cd=="));
+    }
+
+    @Test
+    void emptyValueIsAllowed() {
+        assertEquals(Map.of("EMPTY", ""), EnvVars.parse("EMPTY="));
+    }
+
+    @Test
+    void malformedTokensAreSkippedNotFatal() {
+        // "novalue" has no '='; "=orphan" has an empty name. Neither should break the launch.
+        assertEquals(Map.of("OK", "1"), EnvVars.parse("novalue =orphan OK=1"));
+    }
+
+    @Test
+    void blankAndNullYieldEmptyMap() {
+        assertTrue(EnvVars.parse("").isEmpty());
+        assertTrue(EnvVars.parse("   ").isEmpty());
+        assertTrue(EnvVars.parse(null).isEmpty());
+    }
+
+    @Test
+    void insertionOrderIsPreserved() {
+        assertEquals(
+                List.of("A", "B", "C"), List.copyOf(EnvVars.parse("A=1 B=2 C=3").keySet()));
+    }
+}


### PR DESCRIPTION
The last two small #700 deferrals.

## 1. Environment variables per run configuration
`RunConfiguration` gains an `env` field — quote-aware `KEY=VALUE` pairs parsed by the pure, unit-tested `run/EnvVars`, which **reuses `ProgramArgs.tokenize`**, so `GREETING="hello world"` works and a value may itself contain `=` (base64 / connection strings split on the *first* `=` only). Malformed tokens are skipped rather than failing a launch.

Applied to **both** paths: Run (new `RunService.runInDir(dir, argv, env, listener)` overload, layered over the inherited environment) and Debug (`LaunchConfig`'s `env` map + `DapManager.setEnv`). `run.rerun` preserves it. Edited in Settings → Run Configurations.

**Back-compat:** a 7-arg constructor plus the record's field defaults mean configs saved before this field still load — pinned by a test that deserializes older JSON.

## 2. Gradle `application` main class
Pure, unit-tested `build/GradleApplication` reads the declared main class — `mainClass = '…'`, `mainClass.set("…")`, and the legacy `mainClassName`. `run.saveConfig` now prefers it, so a config saved in a Gradle project matches what `gradle run` would actually launch instead of whichever file happens to be open; it falls back to the source scan when the value is computed from a variable (we don't evaluate Gradle).

## Verification
- `mvn test` — **2997** pass (new `EnvVarsTest`, `GradleApplicationTest`, extended `RunConfigurationTest`).
- compile + `spotless:check` clean.
- Checked against **real** fixture input, not just synthetic: `gdemo.GApp` extracted from an actual `build.gradle`, and `APP_ENV=prod GREETING="hello world" TOKEN=a=b` → `{APP_ENV=prod, GREETING=hello world, TOKEN=a=b}`.

Closes the #700 follow-up list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)