### PR TITLE
Recognise a jdtls that already bundles java-debug (#711)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Java debugging no longer stays off when your language server already includes it** — some jdtls
+  distributions (Homebrew's, for one) ship and load the java-debug plugin themselves. Editora only looked for
+  its own copy of that plugin on disk, so it reported debugging as unavailable — which also pushed *Run Main
+  Class* onto the slower build-tool fallback. It now recognises a language server that provides the debug
+  commands, so Java Run/Debug work with no second copy to install.
+
 - **Multi-module Maven Run without the language server** — running a project main class via the Maven
   classpath fallback now resolves sibling-module dependencies in a reactor build (it runs from the reactor
   root with `-pl <module> -am` instead of only the module), so a submodule that depends on an uninstalled

--- a/src/main/java/com/editora/dap/DapManager.java
+++ b/src/main/java/com/editora/dap/DapManager.java
@@ -173,8 +173,25 @@ public final class DapManager implements DapClient.Host {
         return bundlePaths;
     }
 
+    /**
+     * Set when the running jdtls already advertises the java-debug commands — some distributions (e.g.
+     * Homebrew's jdtls) ship and auto-load the plugin, so there is no jar for {@link #locate()} to find and
+     * nothing to inject, yet debugging works. Pushed by the controller from the LSP capabilities (#711).
+     */
+    private volatile boolean serverProvidesJavaDebug;
+
+    /** Records whether the running Java server itself provides the debug commands (see the field doc). */
+    public void setServerProvidesJavaDebug(boolean provided) {
+        this.serverProvidesJavaDebug = provided;
+    }
+
+    /** Whether Java debugging can run: we located a bundle to inject, <b>or</b> jdtls already provides it. */
     public boolean isAdapterAvailable() {
-        return !bundlePaths.isEmpty();
+        return javaDebugUsable();
+    }
+
+    private boolean javaDebugUsable() {
+        return enabled && (!bundlePaths.isEmpty() || serverProvidesJavaDebug);
     }
 
     /** Whether a usable debug adapter is available for {@code language} (after detection). */
@@ -183,7 +200,7 @@ public final class DapManager implements DapClient.Host {
             return false;
         }
         return switch (language) {
-            case "java" -> !bundlePaths.isEmpty();
+            case "java" -> javaDebugUsable();
             case "python" -> pythonAvailable;
             case "javascript" -> jsAvailable;
             default -> false;
@@ -411,7 +428,7 @@ public final class DapManager implements DapClient.Host {
     }
 
     private boolean ready(Path file) {
-        if (!enabled || bundlePaths.isEmpty()) {
+        if (!javaDebugUsable()) {
             listener.onError("Java debugging is not available (enable it and install the java-debug plugin).");
             return false;
         }
@@ -497,7 +514,7 @@ public final class DapManager implements DapClient.Host {
      * any error / when debugging isn't available. Callback runs on the FX thread.
      */
     public void resolveMainClasses(Path routingFile, Consumer<List<MainClassOption>> cb) {
-        if (!enabled || bundlePaths.isEmpty() || routingFile == null) {
+        if (!javaDebugUsable() || routingFile == null) {
             cb.accept(List.of());
             return;
         }

--- a/src/main/java/com/editora/lsp/LspManager.java
+++ b/src/main/java/com/editora/lsp/LspManager.java
@@ -613,6 +613,33 @@ public final class LspManager {
         return caps != null && caps.getSignatureHelpProvider() != null;
     }
 
+    /**
+     * Whether <b>any</b> running Java server advertises the java-debug commands — true when jdtls already has
+     * the plugin (some distributions, e.g. Homebrew's jdtls, ship and auto-load it), so debugging works
+     * without Editora injecting a bundle jar of its own. See {@link #providesJavaDebug}.
+     */
+    public boolean javaDebugCommandsAvailable() {
+        String prefix = sessionKeyPrefix("java");
+        for (Map.Entry<String, LanguageServerSession> e : sessionsByRoot.entrySet()) {
+            if (e.getKey().startsWith(prefix) && providesJavaDebug(e.getValue().capabilities())) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /** The jdtls command that starts a debug session; its presence means the java-debug plugin is loaded. */
+    public static final String JAVA_DEBUG_COMMAND = "vscode.java.startDebugSession";
+
+    /** Pure: whether {@code caps} advertises the java-debug {@code startDebugSession} command (null-safe). */
+    static boolean providesJavaDebug(org.eclipse.lsp4j.ServerCapabilities caps) {
+        if (caps == null || caps.getExecuteCommandProvider() == null) {
+            return false;
+        }
+        java.util.List<String> commands = caps.getExecuteCommandProvider().getCommands();
+        return commands != null && commands.contains(JAVA_DEBUG_COMMAND);
+    }
+
     /** The signature-help trigger characters {@code file}'s server advertised (usually {@code (} and
      *  {@code ,}), retrigger characters included; empty when not ready / none. */
     public java.util.Set<Character> signatureTriggerCharacters(Path file) {

--- a/src/main/java/com/editora/ui/DebugCoordinator.java
+++ b/src/main/java/com/editora/ui/DebugCoordinator.java
@@ -249,6 +249,20 @@ final class DebugCoordinator {
         }
     }
 
+    /**
+     * Re-reads whether the running jdtls itself advertises the java-debug commands and re-gates. Some
+     * distributions (e.g. Homebrew's jdtls) ship and auto-load the plugin, so {@code locate()} finds no jar to
+     * inject yet debugging works — capabilities are only known once a server finishes {@code initialize}, so
+     * the controller calls this from the server-ready event (#711). Light: no bundle push, no restart.
+     */
+    void refreshJavaDebugAvailability() {
+        boolean before = dapManager.isLanguageAvailable("java");
+        dapManager.setServerProvidesJavaDebug(lspManager.javaDebugCommandsAvailable());
+        if (dapManager.isLanguageAvailable("java") != before) {
+            applyGating(); // the breakpoint gutter + Debug window just became (un)available
+        }
+    }
+
     /** Per-buffer breakpoint-gutter gate (only for debuggable languages) + Debug tool-window availability. */
     void applyGating() {
         boolean on = debugSupportEnabled();

--- a/src/main/java/com/editora/ui/LspCoordinator.java
+++ b/src/main/java/com/editora/ui/LspCoordinator.java
@@ -109,6 +109,10 @@ final class LspCoordinator {
         /** Detection finished updating — re-evaluate the active buffer's install banner. */
         void onDetectionSettled();
 
+        /** A server finished {@code initialize}: its capabilities are known, so re-check whether jdtls itself
+         *  provides the java-debug commands (some distributions bundle the plugin — #711). */
+        void onServerCapabilitiesReady();
+
         /**
          * The canonical (symlink-resolved) form of {@code file}, so every consumer of the diagnostics map keys
          * agrees. A server reports diagnostics under whatever URI it chose (some canonicalize, some echo the
@@ -1023,6 +1027,9 @@ final class LspCoordinator {
                     }
                 });
                 requestStructureSymbols(host.activeBuffer()); // the outline can now be populated from the server
+                // Capabilities are known now — a jdtls that bundles java-debug advertises its commands here,
+                // which is the only way to tell without a locally-located plugin jar (#711).
+                ops.onServerCapabilitiesReady();
             }
         }
     }

--- a/src/main/java/com/editora/ui/MainController.java
+++ b/src/main/java/com/editora/ui/MainController.java
@@ -3850,6 +3850,14 @@ public class MainController implements com.editora.mcp.McpBridge {
                 }
 
                 @Override
+                public void onServerCapabilitiesReady() {
+                    // A jdtls that ships java-debug (e.g. Homebrew's) advertises the debug commands here —
+                    // there is no local plugin jar to locate, so this is what un-gates debugging (#711).
+                    debugCoordinator.refreshJavaDebugAvailability();
+                    maybeOfferInstall(activeBuffer()); // the install banner may no longer be warranted
+                }
+
+                @Override
                 public Path canonicalize(Path file) {
                     return canonicalPath(file);
                 }

--- a/src/test/java/com/editora/lsp/LspManagerTest.java
+++ b/src/test/java/com/editora/lsp/LspManagerTest.java
@@ -419,4 +419,33 @@ class LspManagerTest {
             LspManager.releaseJdtlsWorkspaceName(again);
         }
     }
+
+    // --- java-debug capability (#711) ------------------------------------------------------------
+
+    @Test
+    void providesJavaDebugWhenTheServerAdvertisesTheStartDebugSessionCommand() {
+        // A jdtls that ships the java-debug plugin (e.g. Homebrew's) lists its commands here — that's the
+        // only signal available when there is no locally-located plugin jar to inject.
+        ServerCapabilities caps = new ServerCapabilities();
+        caps.setExecuteCommandProvider(new org.eclipse.lsp4j.ExecuteCommandOptions(List.of(
+                "java.project.refreshDiagnostics", LspManager.JAVA_DEBUG_COMMAND, "java.edit.organizeImports")));
+        assertTrue(LspManager.providesJavaDebug(caps));
+    }
+
+    @Test
+    void doesNotProvideJavaDebugWithoutThatCommand() {
+        ServerCapabilities caps = new ServerCapabilities();
+        caps.setExecuteCommandProvider(
+                new org.eclipse.lsp4j.ExecuteCommandOptions(List.of("java.edit.organizeImports")));
+        assertFalse(LspManager.providesJavaDebug(caps));
+    }
+
+    @Test
+    void providesJavaDebugIsNullSafe() {
+        assertFalse(LspManager.providesJavaDebug(null)); // no capabilities yet (server still initializing)
+        assertFalse(LspManager.providesJavaDebug(new ServerCapabilities())); // no executeCommandProvider
+        ServerCapabilities nullCommands = new ServerCapabilities();
+        nullCommands.setExecuteCommandProvider(new org.eclipse.lsp4j.ExecuteCommandOptions());
+        assertFalse(LspManager.providesJavaDebug(nullCommands)); // provider present, command list null
+    }
 }


### PR DESCRIPTION
Fixes #711 — found while device-testing the #700 run/debug work.

## The bug
Some jdtls distributions ship **and auto-load** the java-debug plugin. Homebrew's does:

```
$ brew list jdtls | grep java.debug
…/libexec/configuration/org.eclipse.osgi/109/0/.cp/lib/com.microsoft.java.debug.core-0.53.2.jar
```
```
[jdtls stderr] com.microsoft.java.debug.plugin.internal.JavaDebuggerServerPlugin start
[jdtls stderr] INFO: Starting com.microsoft.java.debug.plugin
```

`DebugAdapterLocator` only searches Editora's own install dir, VS Code and mason, so `bundlePaths` was empty → `isAdapterAvailable()` false → **Java debugging gated off entirely**, despite the plugin being live in the server. And since `RunCoordinator.Ops.javaLaunchAvailable()` is `debugEffectiveFor("java")`, it also silently pushed **Run Main Class** onto the slower build-tool fallback.

## The fix
Ask the **server**, not the filesystem: a jdtls with the plugin advertises `vscode.java.startDebugSession` in its `executeCommandProvider`.

- `LspManager.providesJavaDebug(caps)` — pure, null-safe, unit-tested — plus `javaDebugCommandsAvailable()` scoped to Java sessions.
- `DapManager` gains `serverProvidesJavaDebug`; the three gates (`isAdapterAvailable`, `ready`, `resolveMainClasses`) now share `javaDebugUsable()` = `enabled && (a located bundle || the server provides it)`.
- **Nothing extra is injected.** The plugin is already loaded, so `bundlePaths` keeps its single meaning: the list to inject. Re-passing it would risk a duplicate bundle.
- Capabilities are only known after `initialize`, so the server-ready branch calls a new `Ops.onServerCapabilitiesReady()` → `DebugCoordinator.refreshJavaDebugAvailability()`, which re-gates **only when availability actually flipped** — no bundle push, no jdtls restart.

Users who install java-debug separately are unaffected (the located-bundle path is unchanged).

## Verification
- `mvn test` — **3000** pass (3 new capability tests in `LspManagerTest`).
- compile + `spotless:check` clean.
- Environment evidence above is from a real Homebrew jdtls 1.60.0 session.

**Device-test worth doing:** with Homebrew jdtls + Debugging enabled in Settings, *Debug Main Class* should now start a session where it previously reported "unavailable".

Closes #711

🤖 Generated with [Claude Code](https://claude.com/claude-code)