### PR TITLE
fix(doctor): scale the Doctor tab with text zoom, like the Welcome page

### DIFF
--- a/src/main/java/com/editora/ui/MainController.java
+++ b/src/main/java/com/editora/ui/MainController.java
@@ -11742,6 +11742,9 @@ public class MainController implements com.editora.mcp.McpBridge {
         if (welcomeTab != null) {
             welcomePane.setFontScale(settings.getFontZoom()); // scale Welcome text to the current zoom (#540)
         }
+        if (doctorTab != null) {
+            doctorCoordinator.pane().setFontScale(settings.getFontZoom()); // scale the Doctor tab like Welcome
+        }
         for (Tab t : tabPane.getTabs()) {
             if (t.getUserData() instanceof PrReviewPane pr) {
                 pr.setFontScale(settings.getFontZoom()); // scale the PR review tab like Welcome

--- a/src/test/java/com/editora/ui/DoctorTabFxTest.java
+++ b/src/test/java/com/editora/ui/DoctorTabFxTest.java
@@ -60,4 +60,29 @@ class DoctorTabFxTest {
             fx.dispose();
         }
     }
+
+    @Test
+    void textZoomRescalesTheOpenDoctorTabLikeWelcome() throws Exception {
+        FxWindowFixture fx = FxWindowFixture.create();
+        try {
+            DoctorCoordinator doctor = FxTestSupport.field(fx.controller, "doctorCoordinator");
+            doctor.probeOverrideForTest = spec -> spec.placeholder().ok("stubbed");
+            CommandRegistry registry = FxTestSupport.field(fx.controller, "registry");
+            DoctorPane pane = doctor.pane();
+
+            FxTestSupport.runOnFx(() -> registry.run("view.textZoomReset"));
+            FxTestSupport.runOnFx(() -> registry.run("view.doctor"));
+            // Opening scales to the current 100% zoom.
+            assertEquals("-fx-font-size: 1.0em;", FxTestSupport.callOnFx(pane::getStyle));
+
+            // Zooming while the tab is open must re-scale it live (the gap this fix closes).
+            FxTestSupport.runOnFx(() -> registry.run("view.textZoomIn"));
+            assertEquals("-fx-font-size: 1.1em;", FxTestSupport.callOnFx(pane::getStyle));
+
+            FxTestSupport.runOnFx(() -> registry.run("view.textZoomReset"));
+            assertEquals("-fx-font-size: 1.0em;", FxTestSupport.callOnFx(pane::getStyle));
+        } finally {
+            fx.dispose();
+        }
+    }
 }


### PR DESCRIPTION
## Summary

The Doctor screen scaled its text to the current zoom only when it was **opened** — zooming (`C-=`/`C--`/`C-0`, Ctrl+wheel) while the Doctor tab was already open left it unchanged, unlike the Welcome page.

`applyFontsAndPerBufferView` — the shared text-zoom path (`textZoom` and the full settings apply both call it) — already re-scaled the Welcome tab and PR-review tabs on every zoom notch but had no branch for the Doctor tab. This adds the one-line re-scale right after the existing `welcomeTab` block, mirroring it exactly (guarded on the `doctorTab` field; the content is `doctorCoordinator.pane()`, whose `setFontScale` sets an `em`-relative root font size).

## Test

New `DoctorTabFxTest` case opens the Doctor tab, then drives `view.textZoomIn` / `view.textZoomReset` and asserts the open pane's `-fx-font-size` style tracks the zoom (`1.0em` → `1.1em` → `1.0em`) — the live re-scale this fixes.

Full suite green locally: **3001 tests, 0 failures**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)