### PR TITLE
fix(lsp): format mangling, signature help, class-rename file move

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -205,6 +205,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Format Document no longer mangles the file.** A multi-edit format was applied top-to-bottom using
+  offsets computed against the *original* text, so the first edit that changed a line's length shifted
+  every later edit onto the wrong place — which is exactly what re-indenting does. Edits now apply
+  bottom-to-top, as the LSP spec prescribes. The same path backs quick fixes and multi-file rename, so
+  those were affected too. (#667)
+- **Signature help works with Java.** jdtls advertises the capability but ships the feature disabled;
+  Editora now enables it (`java.signatureHelp.enabled`), so typing `(` or `,` in a Java call shows the
+  overloads. Typing `(` with bracket auto-close on also triggers it correctly now — the trigger check
+  only accepted a single character, and auto-close inserts `()` as one edit. (#674)
+- **Renaming a Java class moves its file again.** jdtls only emits the file-rename operation when the
+  client declares create, rename *and* delete resource operations; Editora declared only rename, so the
+  symbol was renamed but `OldName.java` stayed behind. (#676)
+
 - **Go to Definition now reaches JDK and dependency classes.** A Java definition inside a library — jdtls
   reports it under a `jdt://` URI, not a file — was silently dropped, so `M-.` on `String`, `List`, or any
   dependency symbol claimed "no definition". The class's source is now fetched from the server

--- a/TODO.md
+++ b/TODO.md
@@ -3,6 +3,31 @@
 A backlog of planned features and improvements. Unordered within each section.
 
 ## Recently shipped
+- [x] **LSP device-test fixes** (#667/#674/#676 follow-ups; #681 still open as #715) — five device-reported
+      failures, **four with root causes unreachable by reading our own code**; a standalone probe driving a
+      real jdtls (`JdtlsProbeTest`, opt-in `-Dlsp.probe=true`, self-skipping) settled them.
+      **(a) Format Document mangled the file:** the fork's `MultiChangeBuilder` applies replacements
+      *sequentially against the progressively-edited document* (already documented in CLAUDE.md), but
+      `applyLspEdits` fed it **ascending** absolute offsets computed against the ORIGINAL text — so the first
+      length-changing edit shifted every later one. Now applied **descending** (the LSP spec's own rule).
+      The pre-existing test passed only because it used same-length replacements, where order is invisible;
+      two regression tests now cover growing and shrinking edits. Shared by quick fixes + multi-file rename.
+      **(b) Signature help returned nothing:** jdtls *advertises* `signatureHelpProvider` (trigger chars
+      `(` `,`) but its handler returns empty unless `java.signatureHelp.enabled` is pushed — it ships OFF
+      (VS Code's Java extension sets it in its own defaults). Proven on a live server: same position, 0
+      signatures before the flag, both overloads after. Same class as #468's `provideFormatter`. Also fixed
+      the trigger itself: with auto-close on, `(` arrives as a 2-char `()` insert and the `length()==1`
+      guard rejected it. **And a self-inflicted one:** an attempt to add context support used
+      `SignatureHelpCapabilities(sigInfo, true)`, whose second arg is **dynamicRegistration** — that made
+      jdtls stop advertising the capability entirely (the probe caught it instantly); context support is a
+      separate setter. **(c) Class rename didn't move the file:** jdtls's `isResourceOperationSupported()`
+      is all-or-nothing — it emits a `RenameFile` only when the client declares Create AND Rename AND
+      Delete. We declared only Rename, so jdtls silently stripped the move. Verified: the probe now shows
+      `RESOURCE-OP RenameFile OldName.java → NewName.java`. We still only *apply* renames (create/delete
+      refuse the whole edit safely). **Verified-clean by the same round:** #678 incremental sync — a shadow
+      comparison reported byte-identical server/buffer documents, killing the theory that it was corrupting
+      the file; it was one step from being needlessly reverted.
+      *Deferred → #715: inlay hints still don't render although jdtls demonstrably returns them.*
 - [x] **Doctor — external-tool health screen** — `view.doctor` opens a Welcome-style tab reporting the
       health of every external CLI (git/gh/rg/mmdc/maid/dot/plantuml/typst, the enabled LSP servers, the
       3 debug adapters, run interpreters, build tools, agent CLI, installer prereqs) with fresh

--- a/src/main/java/com/editora/editor/EditorBuffer.java
+++ b/src/main/java/com/editora/editor/EditorBuffer.java
@@ -803,15 +803,15 @@ public class EditorBuffer implements TabContent {
             if (lspActive && lspDiagnosticsRequester != null) {
                 lspDiagnosticsRequester.run();
             }
-            if (semanticActive && semanticTokensRequester != null) {
-                semanticTokensRequester.run();
+            if ((semanticActive || inlayHintsActive) && semanticTokensRequester != null) {
+                semanticTokensRequester.run(); // drives semantic tokens AND inlay hints (#681)
             }
         });
         // After scrolling settles, re-request semantic tokens for the now-visible region (debounced so a
         // drag-scroll doesn't fire a request per frame). Inert unless semantic highlighting is active.
         semanticScrollDebounce.setOnFinished(e -> {
-            if (semanticActive && semanticTokensRequester != null) {
-                semanticTokensRequester.run();
+            if ((semanticActive || inlayHintsActive) && semanticTokensRequester != null) {
+                semanticTokensRequester.run(); // drives semantic tokens AND inlay hints (#681)
             }
         });
         // HTML live preview: debounced reload pulse for HTML buffers (only while a browser preview is open).
@@ -3426,10 +3426,19 @@ public class EditorBuffer implements TabContent {
         diagnosticStripe.setDiagnostics(java.util.List.of());
     }
 
-    /** The debounced semantic-tokens request (fired on the 300 ms didChange pulse while active); null = none. */
+    /** The debounced semantic-tokens request (fired on the 300 ms didChange pulse while active); null = none.
+     *  Also drives inlay hints (#681) — fired when {@link #inlayHintsActive} even if semantic is off. */
     public void setSemanticTokensRequester(Runnable requester) {
         this.semanticTokensRequester = requester;
     }
+
+    /** Whether inlay hints should re-request on the edit/scroll pulse — independent of semantic highlighting
+     *  (#681, which was silently coupled to {@code semanticActive} so hints never fired with it off). */
+    public void setInlayHintsActive(boolean active) {
+        this.inlayHintsActive = active;
+    }
+
+    private boolean inlayHintsActive;
 
     /** Turns LSP semantic highlighting on/off for this buffer (server supports it + feature enabled). Off in
      *  large-file mode, like the diagnostics overlay. Re-applies the highlight so the overlay appears/clears. */
@@ -8005,12 +8014,31 @@ public class EditorBuffer implements TabContent {
             return;
         }
         org.fxmisc.richtext.model.PlainTextChange c = changes.get(0);
-        String inserted = c.getInserted();
-        if (inserted.length() == 1
-                && (c.getRemoved() == null || c.getRemoved().isEmpty())
-                && lspSignatureTriggerChars.contains(inserted.charAt(0))) {
+        if (signatureTriggerTyped(c.getInserted(), c.getRemoved())) {
             Platform.runLater(signatureHelpRequester);
         }
+    }
+
+    /**
+     * Whether {@code inserted}/{@code removed} is a single typed signature-help trigger character. The
+     * subtlety: with bracket auto-close on (the default), typing {@code (} inserts {@code ()} as one 2-char
+     * change — so a bare {@code length()==1} check silently never fired for {@code (}, the primary trigger
+     * (#674, caught in device-testing). We also accept a trigger char that auto-close expanded to a pair:
+     * length 1 (auto-close off, or {@code ,}), or length 2 whose second char closes the first. A paste
+     * (longer, or a non-empty removal) never triggers.
+     */
+    private boolean signatureTriggerTyped(String inserted, String removed) {
+        if (inserted.isEmpty() || (removed != null && !removed.isEmpty())) {
+            return false;
+        }
+        if (!lspSignatureTriggerChars.contains(inserted.charAt(0))) {
+            return false;
+        }
+        return inserted.length() == 1 || (inserted.length() == 2 && isCloserChar(inserted.charAt(1)));
+    }
+
+    private static boolean isCloserChar(char ch) {
+        return ch == ')' || ch == ']' || ch == '}' || ch == '>';
     }
 
     /**
@@ -8599,8 +8627,15 @@ public class EditorBuffer implements TabContent {
             a.replaceText(ranges.get(0)[0], ranges.get(0)[1], texts.get(0));
             return;
         }
+        // Apply BOTTOM-TO-TOP. The fork's MultiChangeBuilder applies its replacements *sequentially against
+        // the progressively-edited document* (documented in CLAUDE.md), so absolute offsets computed against
+        // the ORIGINAL text are only valid while nothing before them has changed length. Feeding ascending
+        // order silently corrupted every edit after the first length-changing one — which is exactly what
+        // Format Document does (re-indent = grow/shrink), so it mangled the file. Descending order keeps
+        // every offset valid because each edit lies before the region already rewritten. (The LSP spec gives
+        // the same rule for applying a TextEdit[].) Same-length edits hid this in the original test.
         org.fxmisc.richtext.MultiChangeBuilder<?, ?, ?> builder = a.createMultiChange(ranges.size());
-        for (int i = 0; i < ranges.size(); i++) {
+        for (int i = ranges.size() - 1; i >= 0; i--) {
             builder.replaceTextAbsolutely(ranges.get(i)[0], ranges.get(i)[1], texts.get(i));
         }
         builder.commit(); // one undo unit for the whole edit set

--- a/src/main/java/com/editora/lsp/LanguageServerSession.java
+++ b/src/main/java/com/editora/lsp/LanguageServerSession.java
@@ -361,7 +361,13 @@ final class LanguageServerSession implements LanguageClient {
                 new org.eclipse.lsp4j.SignatureInformationCapabilities(java.util.List.of("markdown", "plaintext"));
         sigInfo.setParameterInformation(new org.eclipse.lsp4j.ParameterInformationCapabilities(true));
         sigInfo.setActiveParameterSupport(true);
-        td.setSignatureHelp(new org.eclipse.lsp4j.SignatureHelpCapabilities(sigInfo, false));
+        // NOTE: the 2-arg ctor's second parameter is dynamicRegistration, NOT contextSupport — passing
+        // true there made jdtls stop advertising signatureHelpProvider statically (it registers dynamically
+        // instead, which we don't handle), so signature help died outright. Context support is its own
+        // setter (#674).
+        var sigCaps = new org.eclipse.lsp4j.SignatureHelpCapabilities(sigInfo, false);
+        sigCaps.setContextSupport(true);
+        td.setSignatureHelp(sigCaps);
         // Code actions (#670): literal support is what makes servers return CodeAction objects (kind,
         // isPreferred, an inline edit) instead of bare Commands; resolveSupport("edit") lets a server defer
         // the expensive edit to codeAction/resolve; dataSupport lets its opaque data ride the round-trip
@@ -419,9 +425,18 @@ final class LanguageServerSession implements LanguageClient {
         ws.setApplyEdit(true);
         var wsEdit = new org.eclipse.lsp4j.WorkspaceEditCapabilities();
         wsEdit.setDocumentChanges(true);
-        // Renaming a public Java class makes jdtls move the .java file too — declared so it sends the
-        // RenameFile op (create/delete stay undeclared and refused by the mapper) (#676).
-        wsEdit.setResourceOperations(java.util.List.of(org.eclipse.lsp4j.ResourceOperationKind.Rename));
+        // Renaming a public Java class makes jdtls move the .java file too — but jdtls's
+        // isResourceOperationSupported() gate is ALL-OR-NOTHING: it emits a resource operation (the
+        // RenameFile) only when the client declares Create AND Rename AND Delete. Declaring just Rename
+        // made jdtls strip the file move, so a class rename renamed the symbols but left OldName.java on
+        // disk (#676). We still only *apply* renames — a Create/Delete op refuses the whole edit in
+        // WorkspaceEditMapper (safe: nothing half-applied), which is why the far-less-common create/delete
+        // refactorings degrade to a "failed" status rather than corrupting the workspace. (jdtls's own
+        // gate mirrors VS Code / eglot, which likewise declare all three.)
+        wsEdit.setResourceOperations(java.util.List.of(
+                org.eclipse.lsp4j.ResourceOperationKind.Create,
+                org.eclipse.lsp4j.ResourceOperationKind.Rename,
+                org.eclipse.lsp4j.ResourceOperationKind.Delete));
         ws.setWorkspaceEdit(wsEdit);
         cc.setWorkspace(ws);
         return cc;
@@ -434,8 +449,19 @@ final class LanguageServerSession implements LanguageClient {
             analysis.put("autoImportCompletions", true);
             java.util.Map<String, Object> python = new java.util.HashMap<>();
             python.put("analysis", analysis);
+            // jdtls ADVERTISES signatureHelpProvider but its handler returns an empty result unless
+            // `java.signatureHelp.enabled` is set — it ships OFF (VS Code's Java extension sets it in its
+            // own defaults, which is why it "just works" there). Verified by driving a real jdtls: same
+            // position, same params — 0 signatures before this flag, both overloads after (#674). Same
+            // class of bug as #468's provideFormatter. Harmless to non-java servers (unknown section).
+            java.util.Map<String, Object> signatureHelp = new java.util.HashMap<>();
+            signatureHelp.put("enabled", true);
+            signatureHelp.put("description", true); // include the javadoc in the signature popup
+            java.util.Map<String, Object> java_ = new java.util.HashMap<>();
+            java_.put("signatureHelp", signatureHelp);
             java.util.Map<String, Object> settings = new java.util.HashMap<>();
             settings.put("python", python);
+            settings.put("java", java_);
             server.getWorkspaceService()
                     .didChangeConfiguration(new org.eclipse.lsp4j.DidChangeConfigurationParams(settings));
         } catch (RuntimeException e) {
@@ -772,11 +798,20 @@ final class LanguageServerSession implements LanguageClient {
 
     /** Signature help ({@code textDocument/signatureHelp}) at a position → the overloads + active
      *  parameter, or null when unavailable/failed (#674). */
-    CompletableFuture<org.eclipse.lsp4j.SignatureHelp> signatureHelp(String uri, Position pos) {
+    CompletableFuture<org.eclipse.lsp4j.SignatureHelp> signatureHelp(String uri, Position pos, String triggerChar) {
         if (!ready()) {
             return CompletableFuture.completedFuture(null);
         }
         var params = new org.eclipse.lsp4j.SignatureHelpParams(new TextDocumentIdentifier(uri), pos);
+        var context = new org.eclipse.lsp4j.SignatureHelpContext();
+        if (triggerChar == null) {
+            context.setTriggerKind(org.eclipse.lsp4j.SignatureHelpTriggerKind.Invoked);
+        } else {
+            context.setTriggerKind(org.eclipse.lsp4j.SignatureHelpTriggerKind.TriggerCharacter);
+            context.setTriggerCharacter(triggerChar);
+        }
+        context.setIsRetrigger(false);
+        params.setContext(context);
         return server.getTextDocumentService().signatureHelp(params).exceptionally(t -> null);
     }
 

--- a/src/main/java/com/editora/lsp/LspManager.java
+++ b/src/main/java/com/editora/lsp/LspManager.java
@@ -643,13 +643,14 @@ public final class LspManager {
 
     /** Requests signature help at a 0-based position; the raw lsp4j result (or null) arrives on the FX
      *  thread — resolved for display via {@link SignatureFormat#resolve}. */
-    public void signatureHelp(Path file, int line, int character, Consumer<org.eclipse.lsp4j.SignatureHelp> cb) {
+    public void signatureHelp(
+            Path file, int line, int character, String triggerChar, Consumer<org.eclipse.lsp4j.SignatureHelp> cb) {
         LanguageServerSession s = sessionFor(file);
         if (s == null) {
             Platform.runLater(() -> cb.accept(null));
             return;
         }
-        s.signatureHelp(uri(file), new Position(line, character))
+        s.signatureHelp(uri(file), new Position(line, character), triggerChar)
                 .whenComplete((r, e) -> Platform.runLater(() -> cb.accept(e == null ? r : null)));
     }
 

--- a/src/main/java/com/editora/ui/LspCoordinator.java
+++ b/src/main/java/com/editora/ui/LspCoordinator.java
@@ -739,7 +739,11 @@ final class LspCoordinator {
 
     /** Re-applies the inlay-hints gate to every open buffer (the palette/Settings toggle's apply). */
     void applyInlayHints() {
-        host.forEachBuffer(this::requestInlayHints); // the gate inside clears buffers when toggled off
+        boolean on = host.settings().isInlayHints();
+        host.forEachBuffer(b -> {
+            b.setInlayHintsActive(on && b.getPath() != null && lspManager.isManaged(b.getPath()));
+            requestInlayHints(b); // the gate inside clears buffers when toggled off
+        });
     }
 
     void requestSemanticTokens(EditorBuffer buffer) {
@@ -843,6 +847,7 @@ final class LspCoordinator {
             if (semantic) {
                 requestSemanticTokens(buffer);
             }
+            buffer.setInlayHintsActive(host.settings().isInlayHints()); // decoupled from semantic (#681)
             requestInlayHints(buffer); // gated internally on the setting + capability (#681)
         } else {
             buffer.setLspActive(false);
@@ -853,6 +858,7 @@ final class LspCoordinator {
             buffer.setLspRenameAvailable(false);
             buffer.setLspSignatureTriggerChars(java.util.Set.of());
             buffer.clearOccurrenceSpans();
+            buffer.setInlayHintsActive(false);
             buffer.setInlayHints(null);
             buffer.setSemanticActive(false);
             if (path != null && lspManager.isManaged(path)) {
@@ -1019,6 +1025,7 @@ final class LspCoordinator {
                         if (sem) {
                             requestSemanticTokens(b);
                         }
+                        b.setInlayHintsActive(host.settings().isInlayHints()); // re-fire on edits (#681)
                         requestInlayHints(b); // capabilities known now (#681)
                     }
                 });
@@ -1699,7 +1706,7 @@ final class LspCoordinator {
         Path path = b.getPath();
         CodeArea area = b.getFocusedArea();
         lspManager.changeDocument(path, b.text()); // sync latest text before the request
-        lspManager.signatureHelp(path, area.getCurrentParagraph(), area.getCaretColumn(), help -> {
+        lspManager.signatureHelp(path, area.getCurrentParagraph(), area.getCaretColumn(), null, help -> {
             if (b != host.activeBuffer()) {
                 return;
             }

--- a/src/test/java/com/editora/lsp/JdtlsProbeTest.java
+++ b/src/test/java/com/editora/lsp/JdtlsProbeTest.java
@@ -1,0 +1,198 @@
+package com.editora.lsp;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import org.eclipse.lsp4j.*;
+import org.eclipse.lsp4j.jsonrpc.Launcher;
+import org.eclipse.lsp4j.launch.LSPLauncher;
+import org.eclipse.lsp4j.services.LanguageClient;
+import org.eclipse.lsp4j.services.LanguageServer;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+/**
+ * MANUAL PROBE (not part of the suite — @Tag("probe"), run explicitly). Drives a REAL jdtls with the
+ * exact capabilities Editora declares and asks it the three questions device-testing left open:
+ * signature help, inlay hints, and rename-with-file-move. Prints the raw answers so we can tell a
+ * client bug from server behavior.
+ */
+@Tag("probe")
+class JdtlsProbeTest {
+
+    /** Opt-in: {@code ./mvnw test -Dtest=JdtlsProbeTest -Dgroups=probe -Dlsp.probe=true}. Without the flag
+     *  (and without a local jdtls + fixture) it self-skips, so CI and a normal {@code verify} never run it. */
+    private static final Path PROJECT = Path.of(System.getProperty("user.home"), "src/adl/lsp-test-fixture");
+
+    private static final String JDTLS = "/opt/homebrew/bin/jdtls";
+
+    @Test
+    void probe() throws Exception {
+        org.junit.jupiter.api.Assumptions.assumeTrue(Boolean.getBoolean("lsp.probe"), "opt-in: pass -Dlsp.probe=true");
+        org.junit.jupiter.api.Assumptions.assumeTrue(Files.isExecutable(Path.of(JDTLS)), "needs a local jdtls");
+        org.junit.jupiter.api.Assumptions.assumeTrue(Files.isDirectory(PROJECT), "needs the local fixture project");
+        Path file = PROJECT.resolve("src/main/java/demo/App.java");
+        String text = Files.readString(file);
+        String uri = file.toUri().toString();
+
+        Path data = Files.createTempDirectory("jdtls-probe");
+        ProcessBuilder pb = new ProcessBuilder(JDTLS, "-data", data.toString());
+        pb.redirectError(ProcessBuilder.Redirect.DISCARD);
+        Process proc = pb.start();
+
+        LanguageClient client = new ProbeClient();
+        Launcher<LanguageServer> launcher =
+                LSPLauncher.createClientLauncher(client, proc.getInputStream(), proc.getOutputStream());
+        LanguageServer server = launcher.getRemoteProxy();
+        launcher.startListening();
+
+        InitializeParams ip = new InitializeParams();
+        ip.setProcessId((int) ProcessHandle.current().pid());
+        ip.setRootUri(PROJECT.toUri().toString());
+        ip.setWorkspaceFolders(List.of(new WorkspaceFolder(PROJECT.toUri().toString(), "fixture")));
+        ip.setCapabilities(editoraCapabilities());
+        InitializeResult init = server.initialize(ip).get(120, TimeUnit.SECONDS);
+        server.initialized(new InitializedParams());
+
+        var caps = init.getCapabilities();
+        System.out.println("=== CAPABILITIES ===");
+        System.out.println("signatureHelpProvider = " + caps.getSignatureHelpProvider());
+        System.out.println("inlayHintProvider     = " + caps.getInlayHintProvider());
+        System.out.println("renameProvider        = " + caps.getRenameProvider());
+
+        server.getTextDocumentService()
+                .didOpen(new DidOpenTextDocumentParams(new TextDocumentItem(uri, "java", 1, text)));
+
+        System.out.println("\n=== waiting 45s for the project import ===");
+        Thread.sleep(45_000);
+
+        // Line 15 (0-based) = "        System.out.println(greeter.greet(\"prefix\", 2));"; col 41 = after greet(
+        int line = 15;
+        int col = 41;
+        System.out.println("probing line[" + line + "] = <" + text.split("\n")[line] + ">");
+        System.out.println("char at col " + col + " onwards: <"
+                + text.split("\n")[line].substring(Math.min(col, text.split("\n")[line].length())) + ">");
+
+        System.out.println("\n=== SIGNATURE HELP (no context) ===");
+        var p1 = new SignatureHelpParams(new TextDocumentIdentifier(uri), new Position(line, col));
+        System.out.println(server.getTextDocumentService().signatureHelp(p1).get(30, TimeUnit.SECONDS));
+
+        System.out.println("\n=== enabling java.signatureHelp.enabled via didChangeConfiguration ===");
+        java.util.Map<String, Object> sig = new java.util.HashMap<>();
+        sig.put("enabled", true);
+        sig.put("description", true);
+        java.util.Map<String, Object> java_ = new java.util.HashMap<>();
+        java_.put("signatureHelp", sig);
+        java.util.Map<String, Object> settings = new java.util.HashMap<>();
+        settings.put("java", java_);
+        server.getWorkspaceService().didChangeConfiguration(new DidChangeConfigurationParams(settings));
+        Thread.sleep(3000);
+
+        System.out.println("\n=== SIGNATURE HELP (after enabling the preference) ===");
+        var p2 = new SignatureHelpParams(new TextDocumentIdentifier(uri), new Position(line, col));
+        var ctx = new SignatureHelpContext();
+        ctx.setTriggerKind(SignatureHelpTriggerKind.Invoked);
+        ctx.setIsRetrigger(false);
+        p2.setContext(ctx);
+        System.out.println(server.getTextDocumentService().signatureHelp(p2).get(30, TimeUnit.SECONDS));
+
+        System.out.println("\n=== INLAY HINTS (whole file) ===");
+        var ih = new InlayHintParams(
+                new TextDocumentIdentifier(uri),
+                new Range(new Position(0, 0), new Position(text.split("\n").length, 0)));
+        System.out.println(server.getTextDocumentService().inlayHint(ih).get(30, TimeUnit.SECONDS));
+
+        // OldName is declared in OldName.java; rename it there.
+        Path oldFile = PROJECT.resolve("src/main/java/demo/OldName.java");
+        String oldText = Files.readString(oldFile);
+        String oldUri = oldFile.toUri().toString();
+        server.getTextDocumentService()
+                .didOpen(new DidOpenTextDocumentParams(new TextDocumentItem(oldUri, "java", 1, oldText)));
+        Thread.sleep(3000);
+        int classLine = -1;
+        String[] oldLines = oldText.split("\n");
+        for (int i = 0; i < oldLines.length; i++) {
+            if (oldLines[i].startsWith("public class OldName")) {
+                classLine = i;
+            }
+        }
+        int nameCol = oldLines[classLine].indexOf("OldName") + 2;
+        System.out.println("\n=== RENAME at OldName.java " + classLine + ":" + nameCol + " ===");
+        var rp = new RenameParams(new TextDocumentIdentifier(oldUri), new Position(classLine, nameCol), "NewName");
+        WorkspaceEdit we = server.getTextDocumentService().rename(rp).get(60, TimeUnit.SECONDS);
+        System.out.println("documentChanges = "
+                + (we == null
+                        ? "null"
+                        : (we.getDocumentChanges() == null
+                                ? "NULL"
+                                : we.getDocumentChanges().size())));
+        if (we != null && we.getDocumentChanges() != null) {
+            for (var c : we.getDocumentChanges()) {
+                System.out.println("  "
+                        + (c.isLeft()
+                                ? ("TextDocumentEdit "
+                                        + c.getLeft().getTextDocument().getUri())
+                                : ("RESOURCE-OP " + c.getRight().getClass().getSimpleName() + " " + c.getRight())));
+            }
+        }
+        proc.destroyForcibly();
+    }
+
+    /** Exactly what Editora declares (mirrors LanguageServerSession.clientCapabilities). */
+    private static ClientCapabilities editoraCapabilities() {
+        TextDocumentClientCapabilities td = new TextDocumentClientCapabilities();
+        td.setSynchronization(new SynchronizationCapabilities(false, false, true));
+        td.setPublishDiagnostics(new PublishDiagnosticsCapabilities(true));
+        var sigInfo = new SignatureInformationCapabilities(List.of("markdown", "plaintext"));
+        sigInfo.setParameterInformation(new ParameterInformationCapabilities(true));
+        sigInfo.setActiveParameterSupport(true);
+        var sigCaps = new SignatureHelpCapabilities(sigInfo, false); // 2nd arg = dynamicRegistration!
+        sigCaps.setContextSupport(true);
+        td.setSignatureHelp(sigCaps);
+        td.setInlayHint(new InlayHintCapabilities());
+        var rename = new RenameCapabilities();
+        rename.setPrepareSupport(true);
+        td.setRename(rename);
+        ClientCapabilities cc = new ClientCapabilities();
+        cc.setTextDocument(td);
+        WorkspaceClientCapabilities ws = new WorkspaceClientCapabilities();
+        ws.setApplyEdit(true);
+        var wsEdit = new WorkspaceEditCapabilities();
+        wsEdit.setDocumentChanges(true);
+        wsEdit.setResourceOperations(
+                List.of(ResourceOperationKind.Create, ResourceOperationKind.Rename, ResourceOperationKind.Delete));
+        ws.setWorkspaceEdit(wsEdit);
+        cc.setWorkspace(ws);
+        return cc;
+    }
+
+    private static final class ProbeClient implements LanguageClient {
+        @Override
+        public void telemetryEvent(Object o) {}
+
+        @Override
+        public void publishDiagnostics(PublishDiagnosticsParams p) {}
+
+        @Override
+        public void showMessage(MessageParams p) {}
+
+        @Override
+        public java.util.concurrent.CompletableFuture<MessageActionItem> showMessageRequest(
+                ShowMessageRequestParams p) {
+            return java.util.concurrent.CompletableFuture.completedFuture(null);
+        }
+
+        @Override
+        public void logMessage(MessageParams p) {}
+
+        @Override
+        public java.util.concurrent.CompletableFuture<Void> createProgress(WorkDoneProgressCreateParams p) {
+            return java.util.concurrent.CompletableFuture.completedFuture(null);
+        }
+
+        @Override
+        public void notifyProgress(ProgressParams p) {}
+    }
+}

--- a/src/test/java/com/editora/ui/LspEditsOrderFxTest.java
+++ b/src/test/java/com/editora/ui/LspEditsOrderFxTest.java
@@ -1,0 +1,65 @@
+package com.editora.ui;
+
+import java.util.List;
+
+import com.editora.editor.EditorBuffer;
+import com.editora.editor.LspTextEdit;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Format Document applies a multi-edit set whose replacements CHANGE LENGTH (real formatting: re-indent,
+ * collapse whitespace). The existing multi-edit test only used same-length swaps, where a wrong apply
+ * order is invisible — this reproduces the device-reported file mangling.
+ */
+@Tag("fx")
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class LspEditsOrderFxTest {
+
+    @BeforeAll
+    void setUp() throws Exception {
+        FxTestSupport.bootToolkit();
+    }
+
+    @Test
+    void lengthChangingEditsApplyAtTheRightPlaces() throws Exception {
+        String result = FxTestSupport.callOnFx(() -> {
+            EditorBuffer b = new EditorBuffer();
+            b.setLanguageOverride("java");
+            //            0123456789...
+            b.setContent("a();\nbb();\nccc();\n");
+            b.getNode();
+            // Three GROWING replacements, as a formatter re-indenting lines would produce:
+            //   line 0: "a"   -> "AAAA"  (+3)
+            //   line 1: "bb"  -> "BBBB"  (+2)
+            //   line 2: "ccc" -> "CCCC"  (+1)
+            b.applyLspEdits(List.of(
+                    new LspTextEdit(0, 0, 0, 1, "AAAA"),
+                    new LspTextEdit(1, 0, 1, 2, "BBBB"),
+                    new LspTextEdit(2, 0, 2, 3, "CCCC")));
+            return b.getContent();
+        });
+        assertEquals("AAAA();\nBBBB();\nCCCC();\n", result, "each edit must land on ITS OWN line");
+    }
+
+    @Test
+    void lengthShrinkingEditsApplyAtTheRightPlaces() throws Exception {
+        String result = FxTestSupport.callOnFx(() -> {
+            EditorBuffer b = new EditorBuffer();
+            b.setLanguageOverride("java");
+            b.setContent("    x();\n        y();\n            z();\n");
+            b.getNode();
+            // Dedent each line (shrinking replacements) — the classic Format Document shape.
+            b.applyLspEdits(List.of(
+                    new LspTextEdit(0, 0, 0, 4, ""),
+                    new LspTextEdit(1, 0, 1, 8, "  "),
+                    new LspTextEdit(2, 0, 2, 12, "    ")));
+            return b.getContent();
+        });
+        assertEquals("x();\n  y();\n    z();\n", result, "dedents must not shift into each other");
+    }
+}


### PR DESCRIPTION
Device-testing the LSP work found five failures. Four had root causes that **could not be found by reading our own code** — two were server-side defaults, one was fork-specific edit ordering, one was an lsp4j parameter I misread. A standalone probe driving a **real jdtls 1.60** settled each one.

## Fixed

**Format Document mangled the file (#667)** — the highest-severity of the three. The RichTextFX fork's `MultiChangeBuilder` applies replacements *sequentially against the progressively-edited document* (already documented in CLAUDE.md), but `applyLspEdits` fed it **ascending** absolute offsets computed against the *original* text. The first length-changing edit therefore shifted every later edit onto the wrong place — and re-indenting is exactly that. Now applied **descending**, which is also the LSP spec's rule for a `TextEdit[]`.
*Why the tests missed it:* the existing multi-edit test used **same-length** replacements (`"a"→"A"`), where wrong ordering is invisible. Two new regression tests cover growing and shrinking edits and fail against the old code. Quick fixes and multi-file rename share this path, so they were affected too.

**Signature help returned nothing (#674)** — jdtls *advertises* `signatureHelpProvider` with `(`/`,` but its handler returns an empty result unless `java.signatureHelp.enabled` is pushed; it ships **off** (VS Code's Java extension sets it in its own defaults). Proven on a live server: identical position and params, **0 signatures before the flag, both overloads after** (`activeSignature=1, activeParameter=0`). Same class of bug as #468's `provideFormatter`. Two further defects on the same feature:
- with bracket auto-close on (the default), typing `(` arrives as a **2-char `()` insert**, which the `length()==1` trigger guard rejected — so the primary trigger never fired;
- **self-inflicted:** an attempt to add context support used `SignatureHelpCapabilities(sigInfo, true)`, whose second argument is **`dynamicRegistration`**, not `contextSupport`. That made jdtls stop advertising the capability entirely (`signatureHelpProvider = null` — the probe caught it in one run). Context support is a separate setter; both are now correct.

**Renaming a Java class didn't move its file (#676)** — jdtls's `isResourceOperationSupported()` is all-or-nothing: it emits a `RenameFile` only when the client declares **Create AND Rename AND Delete**. We declared only `Rename`, so jdtls silently stripped the move and the symbol renamed while `OldName.java` stayed behind. The probe now shows `RESOURCE-OP RenameFile OldName.java → NewName.java`. We still only *apply* renames — create/delete refuse the whole edit, unchanged.

## Verified clean (a theory disproved)

**#678 incremental sync is correct.** All three symptoms fit "the server's document diverged from ours", so I instrumented a shadow-vs-buffer comparison — it reported **byte-identical** documents. That feature was one step from being needlessly reverted; the real cause was the edit ordering above.

## Not fixed — tracked as #715

**Inlay hints still don't render.** The probe proves jdtls returns them (`line 9 → "times:"`). One real defect was found and fixed here (the refresh was coupled to `semanticActive`, so it never re-requested with semantic highlighting off), but device-retest shows it wasn't sufficient. The feature is **off by default**, so no user impact. #715 records the evidence and the three places left to look.

## Testing
- 2 new regression tests for the edit ordering; full `mvn verify` green (**2944 tests**).
- `JdtlsProbeTest` — a manual harness that drives a real jdtls with Editora's exact capabilities. **Opt-in** (`-Dlsp.probe=true`) and self-skipping without a local jdtls/fixture, so CI and normal `verify` never run it. It's what made four of these diagnosable; worth keeping.
- All temporary diagnostics stripped before merge.

Closes #667, closes #674, closes #676.

🤖 Generated with [Claude Code](https://claude.com/claude-code)