### PR TITLE
fix(editor): fan out Emacs movement chords to all carets (#635)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Multi-caret movement chords** — with multiple cursors, the Emacs movement chords (`C-f`, `C-b`, `C-n`,
+  `C-p`, `C-a`, `C-e`, `M-f`, `M-b`) now move **every** caret, not just the primary one — matching how the
+  arrow keys already behaved. (Document/paragraph/sentence/page motions stay primary-only.)
+
 ### Added
 
 - **Deeper code folding** — fold by nesting level (Fold Level 1–7, like VS Code's `Ctrl+K Ctrl+1..7`), fold or

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -527,12 +527,21 @@ add-on (a layered wellbehaved `InputMap`, gated on `MultiCaretManager.hasExtras(
 one caret). **`EditorBuffer`** installs it on `area`/`area2` via `setMultiCaretEnabled(...)` (gated by
 `Settings.multiCaret`, default on; pushed by `MainController.applyMultiCaret`), exposes
 `hasMultipleCarets()` + delegating `addCaretNextOccurrence`/`addCaretAbove`/`addCaretBelow`/`collapseCarets`
-(palette commands `edit.addCaret*`/`edit.collapseCarets`, `view.toggleMultiCaret` — **no keymap bindings**:
-gestures are mouse + Esc, native to the fork). **Select all occurrences** (`edit.selectAllOccurrences`, VS Code `selectHighlights` Ctrl+Shift+L in the vscode/sublime keymaps) places a caret at every literal, case-sensitive occurrence of the selection — or, with none, the word under the caret (pure/unit-tested `editops/SelectOccurrences.wordAt`) — via `EditorBuffer.placeOccurrenceCarets(ranges, anchorStart)`: `collapseToPrimary` then one `MultiCaretManager.addCaretWithSelection(start,end)` per match, the match containing the anchor kept primary (pure `SelectOccurrences.primaryIndex`), capped at `MAX_OCCURRENCE_CARETS`=10k. **`find.selectAllMatches`** (Alt+Enter in the find field, handled in the field’s key handler + palette) reuses the same placement over the find bar’s live `currentMatches()` (query + case/regex/whole-word toggles), then closes the bar. Both gated by `withMultiCaret` (off in Simple mode); the resulting carets inherit the movement-chord fan-out limitation above. Because Editora's area-level KEY filters (auto-indent/close,
+(palette commands `edit.addCaret*`/`edit.collapseCarets`, `view.toggleMultiCaret` — **no Emacs keymap bindings** (gestures are mouse + Esc,
+native to the fork; the `vscode` keymap does bind `C-d`/`C-M-up`/`C-M-down`)). **Select all occurrences** (`edit.selectAllOccurrences`, VS Code `selectHighlights` Ctrl+Shift+L in the vscode/sublime keymaps) places a caret at every literal, case-sensitive occurrence of the selection — or, with none, the word under the caret (pure/unit-tested `editops/SelectOccurrences.wordAt`) — via `EditorBuffer.placeOccurrenceCarets(ranges, anchorStart)`: `collapseToPrimary` then one `MultiCaretManager.addCaretWithSelection(start,end)` per match, the match containing the anchor kept primary (pure `SelectOccurrences.primaryIndex`), capped at `MAX_OCCURRENCE_CARETS`=10k. **`find.selectAllMatches`** (Alt+Enter in the find field, handled in the field’s key handler + palette) reuses the same placement over the find bar’s live `currentMatches()` (query + case/regex/whole-word toggles), then closes the bar. Both gated by `withMultiCaret` (off in Simple mode); the resulting carets inherit the movement-chord fan-out limitation above. Because Editora's area-level KEY filters (auto-indent/close,
 snippets, completion, view paging) are capture-phase *filters* that run before the fork's node InputMap,
 each one early-returns (no consume) via `multiCaretActiveOn(a)` when that area has extra carets, so editing
-fans out to all carets. *Known limitation:* Emacs movement chords (`C-f`/`C-n`/…) are resolved by the
-scene-level `KeyDispatcher` on the primary caret and don't fan out — use arrows for multi-caret movement.
+fans out to all carets. **Movement chords fan out too (#635):** the Emacs movement commands are resolved by
+the scene-level `KeyDispatcher` on the primary caret, so the fork's node-level movement InputMap never sees
+them — instead the `nav.*` command handlers branch through `MainController.multiCaretMove(op)` when the
+active buffer `hasMultipleCarets()`, calling `EditorBuffer.multiMoveHorizontal`/`multiMoveVertical`/
+`multiMoveLineBoundary` (thin wrappers over the fork's `MultiCaretManager.moveHorizontal(amount, byWord,
+select)`/`moveVertical(down, select)`/`moveLineBoundary(toEnd, select)`, each returning false when there are
+no extras so the caller falls through to its single-caret motion; `select` = `markActive`, mirroring
+`selPolicy()`). This covers `nav.charForward`/`charBackward` (`±1` char), `wordForward`/`wordBackward` (`±1`
+word), `lineUp`/`lineDown` (via `moveLine`), and `lineStart`/`lineEnd`. *Still primary-only* (the fork has no
+multi-caret API for them): `docStart`/`docEnd`, paragraph/sentence motion, page up/down, `backToIndentation`,
+and subword nav; and the fork's `moveVertical` is best-effort about scrolling out-of-view carets into view.
 To update the fork: rebuild it, copy the new `richtextfx-<version>.{jar,pom}` into `m2-repo/`, bump
 `<richtextfx.version>`. RichTextFX and its transitive deps (`reactfx`, `flowless`, `undofx`, `wellbehavedfx`)
 are **automatic modules**, which `jlink` cannot link. The `moditect-maven-plugin` in

--- a/src/main/java/com/editora/editor/EditorBuffer.java
+++ b/src/main/java/com/editora/editor/EditorBuffer.java
@@ -4797,6 +4797,43 @@ public class EditorBuffer implements TabContent {
         }
     }
 
+    // --- Multi-caret movement fan-out (#635) ------------------------------------------------------
+    // The fork's multi-caret movement lives in its node-level InputMap, which the scene-level
+    // KeyDispatcher preempts for the Emacs chords. These expose that movement so MainController's
+    // nav.* commands can fan out to every caret when extras exist; each returns whether it handled the
+    // move (false → no extra carets, so the caller runs the normal single-caret motion). {@code select}
+    // extends the selection (= Emacs mark active), mirroring {@code selPolicy()}.
+
+    /** Moves every caret horizontally by {@code amount} chars (or words); see {@link #addCaretBelow}. */
+    public boolean multiMoveHorizontal(int amount, boolean byWord, boolean select) {
+        var m = activeManager();
+        if (m != null && m.hasExtras()) {
+            m.moveHorizontal(amount, byWord, select);
+            return true;
+        }
+        return false;
+    }
+
+    /** Moves every caret one line up ({@code down=false}) or down. */
+    public boolean multiMoveVertical(boolean down, boolean select) {
+        var m = activeManager();
+        if (m != null && m.hasExtras()) {
+            m.moveVertical(down, select);
+            return true;
+        }
+        return false;
+    }
+
+    /** Moves every caret to its line start ({@code toEnd=false}) or line end. */
+    public boolean multiMoveLineBoundary(boolean toEnd, boolean select) {
+        var m = activeManager();
+        if (m != null && m.hasExtras()) {
+            m.moveLineBoundary(toEnd, select);
+            return true;
+        }
+        return false;
+    }
+
     /** True when {@code a} currently has extra carets, so this buffer's single-caret KEY filters
      *  (auto-indent/close, snippets, completion, view paging) should stand down and let the fork's
      *  multi-caret input map handle the key for every caret. */

--- a/src/main/java/com/editora/ui/MainController.java
+++ b/src/main/java/com/editora/ui/MainController.java
@@ -13421,10 +13421,32 @@ public class MainController implements com.editora.mcp.McpBridge {
 
     /** Emacs-style vertical caret move (C-n/C-p) preserving the goal column; see {@link EditorBuffer#moveLine}. */
     private void moveLine(int delta) {
+        if (multiCaretMove(b -> b.multiMoveVertical(delta > 0, markActive))) {
+            return;
+        }
         EditorBuffer buffer = activeBuffer();
         if (buffer != null) {
             buffer.moveLine(delta, selPolicy());
         }
+    }
+
+    /**
+     * When the active buffer has multiple carets, runs {@code op} (a fork multi-caret movement that fans
+     * out to every caret) and follows the primary caret; returns whether it handled the move. The Emacs
+     * movement chords are resolved by the scene-level {@code KeyDispatcher} on the primary caret only, so
+     * the nav.* commands branch here to reach the fork's fan-out (#635). Each {@code op} returns false when
+     * no extra carets exist, so the caller falls through to its normal single-caret motion.
+     */
+    private boolean multiCaretMove(java.util.function.Predicate<EditorBuffer> op) {
+        EditorBuffer buffer = activeBuffer();
+        if (buffer == null || !op.test(buffer)) {
+            return false;
+        }
+        CodeArea area = activeArea();
+        if (area != null) {
+            area.requestFollowCaret(); // fork moves all carets; keep the primary in view (best-effort)
+        }
+        return true;
     }
 
     /** Run a navigation action and scroll the viewport to follow the caret. */
@@ -14560,27 +14582,46 @@ public class MainController implements com.editora.mcp.McpBridge {
         registry.register(Command.of("edit.occur", this::occur));
         // C-a: smart line start — first press to the beginning of the line's text (first non-whitespace),
         // a second press toggles to the true line start (column 0).
-        registry.register(Command.of(
-                "nav.lineStart",
-                () -> moveAndFollow(
-                        a -> a.moveTo(TextNav.smartLineStart(a.getText(), a.getCaretPosition()), selPolicy()))));
-        registry.register(Command.of("nav.lineEnd", () -> moveAndFollow(a -> a.lineEnd(selPolicy()))));
+        registry.register(Command.of("nav.lineStart", () -> {
+            if (multiCaretMove(b -> b.multiMoveLineBoundary(false, markActive))) {
+                return;
+            }
+            moveAndFollow(a -> a.moveTo(TextNav.smartLineStart(a.getText(), a.getCaretPosition()), selPolicy()));
+        }));
+        registry.register(Command.of("nav.lineEnd", () -> {
+            if (multiCaretMove(b -> b.multiMoveLineBoundary(true, markActive))) {
+                return;
+            }
+            moveAndFollow(a -> a.lineEnd(selPolicy()));
+        }));
         registry.register(Command.of("nav.docStart", () -> moveAndFollow(a -> a.start(selPolicy()))));
         registry.register(Command.of("nav.docEnd", () -> moveAndFollow(a -> a.end(selPolicy()))));
-        registry.register(Command.of(
-                "nav.charForward",
-                () -> moveAndFollow(a -> a.moveTo(Math.min(a.getLength(), a.getCaretPosition() + 1), selPolicy()))));
-        registry.register(Command.of(
-                "nav.charBackward",
-                () -> moveAndFollow(a -> a.moveTo(Math.max(0, a.getCaretPosition() - 1), selPolicy()))));
+        registry.register(Command.of("nav.charForward", () -> {
+            if (multiCaretMove(b -> b.multiMoveHorizontal(1, false, markActive))) {
+                return;
+            }
+            moveAndFollow(a -> a.moveTo(Math.min(a.getLength(), a.getCaretPosition() + 1), selPolicy()));
+        }));
+        registry.register(Command.of("nav.charBackward", () -> {
+            if (multiCaretMove(b -> b.multiMoveHorizontal(-1, false, markActive))) {
+                return;
+            }
+            moveAndFollow(a -> a.moveTo(Math.max(0, a.getCaretPosition() - 1), selPolicy()));
+        }));
         registry.register(Command.of("nav.lineDown", () -> moveLine(1)));
         registry.register(Command.of("nav.lineUp", () -> moveLine(-1)));
-        registry.register(Command.of(
-                "nav.wordForward",
-                () -> moveAndFollow(a -> a.moveTo(nextWordBoundary(a.getText(), a.getCaretPosition()), selPolicy()))));
-        registry.register(Command.of(
-                "nav.wordBackward",
-                () -> moveAndFollow(a -> a.moveTo(prevWordBoundary(a.getText(), a.getCaretPosition()), selPolicy()))));
+        registry.register(Command.of("nav.wordForward", () -> {
+            if (multiCaretMove(b -> b.multiMoveHorizontal(1, true, markActive))) {
+                return;
+            }
+            moveAndFollow(a -> a.moveTo(nextWordBoundary(a.getText(), a.getCaretPosition()), selPolicy()));
+        }));
+        registry.register(Command.of("nav.wordBackward", () -> {
+            if (multiCaretMove(b -> b.multiMoveHorizontal(-1, true, markActive))) {
+                return;
+            }
+            moveAndFollow(a -> a.moveTo(prevWordBoundary(a.getText(), a.getCaretPosition()), selPolicy()));
+        }));
         registry.register(Command.of(
                 "nav.subwordForward",
                 () -> moveAndFollow(

--- a/src/test/java/com/editora/ui/MultiCaretMovementFxTest.java
+++ b/src/test/java/com/editora/ui/MultiCaretMovementFxTest.java
@@ -1,0 +1,139 @@
+package com.editora.ui;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import com.editora.command.CommandRegistry;
+import com.editora.editor.EditorBuffer;
+import org.fxmisc.richtext.CodeArea;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Proves the Emacs movement chords fan out to every caret when extras exist (#635). Movement chords are
+ * resolved by the scene-level {@code KeyDispatcher} on the primary caret; the {@code nav.*} commands now
+ * branch to the fork's multi-caret movement, so running one through the real {@link CommandRegistry} must
+ * move <em>all</em> carets. Extra-caret positions are read via reflection into the vendored fork (the only
+ * way to observe them) — {@code MultiCaretManager.extras[].caret.getPosition()}.
+ */
+@Tag("fx")
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class MultiCaretMovementFxTest {
+
+    // line 0 "aaaa" [0..4], line 1 "bbbb" [5..9], line 2 "cccc" [10..14]
+    private static final String SRC = "aaaa\nbbbb\ncccc\n";
+
+    private FxWindowFixture fx;
+    private CommandRegistry registry;
+
+    @BeforeAll
+    void setUp() throws Exception {
+        FxTestSupport.bootToolkit();
+        fx = FxWindowFixture.create();
+        registry = FxTestSupport.field(fx.controller, "registry");
+    }
+
+    @AfterAll
+    void tearDown() throws Exception {
+        if (fx != null) {
+            fx.dispose();
+        }
+    }
+
+    private void run(String id) throws Exception {
+        FxTestSupport.runOnFx(() -> registry.run(id));
+    }
+
+    /** Two carets, one on line 0 and one on line 1, both at column 0. */
+    private EditorBuffer twoCaretBuffer() throws Exception {
+        return FxTestSupport.callOnFx(() -> {
+            EditorBuffer b = new EditorBuffer();
+            b.setContent(SRC);
+            FxTestSupport.call(fx.controller, "addBuffer", new Class[] {EditorBuffer.class, boolean.class}, b, true);
+            b.setMultiCaretEnabled(true);
+            CodeArea area = FxTestSupport.field(b, "area");
+            area.requestFocus();
+            area.moveTo(0);
+            // addCaretBelow is geometry-based (no layout headless); add the extra by absolute offset instead.
+            Object controller = FxTestSupport.field(b, "multiCaret");
+            Object manager = FxTestSupport.call(controller, "getManager", new Class[] {});
+            FxTestSupport.call(manager, "addCaretAt", new Class[] {int.class}, 5); // line 1, column 0
+            return b;
+        });
+    }
+
+    /** Sorted absolute offsets of every caret (primary + extras), read out of the fork. */
+    private List<Integer> carets(EditorBuffer b) throws Exception {
+        return FxTestSupport.callOnFx(() -> {
+            CodeArea area = FxTestSupport.field(b, "area");
+            Object controller = FxTestSupport.field(b, "multiCaret"); // MultiCaretController
+            Object manager = FxTestSupport.call(controller, "getManager", new Class[] {});
+            List<?> extras = FxTestSupport.field(manager, "extras");
+            List<Integer> out = new ArrayList<>();
+            out.add(area.getCaretPosition());
+            for (Object cws : extras) {
+                Object caret = FxTestSupport.field(cws, "caret"); // CaretNode
+                out.add((Integer) FxTestSupport.call(caret, "getPosition", new Class[] {}));
+            }
+            Collections.sort(out);
+            return out;
+        });
+    }
+
+    @Test
+    void charForwardMovesEveryCaret() throws Exception {
+        EditorBuffer b = twoCaretBuffer();
+        assertEquals(List.of(0, 5), carets(b), "carets start at both line beginnings");
+
+        run("nav.charForward");
+        assertEquals(List.of(1, 6), carets(b), "both carets step right one char");
+        run("nav.charForward");
+        assertEquals(List.of(2, 7), carets(b), "and again");
+
+        closeActiveTab(b);
+    }
+
+    @Test
+    void wordAndLineBoundaryMoveEveryCaret() throws Exception {
+        EditorBuffer b = twoCaretBuffer();
+
+        run("nav.wordForward");
+        assertEquals(List.of(4, 9), carets(b), "both carets jump to the end of their word");
+
+        run("nav.lineStart");
+        assertEquals(List.of(0, 5), carets(b), "both carets return to line start");
+
+        run("nav.lineEnd");
+        assertEquals(List.of(4, 9), carets(b), "both carets go to line end");
+
+        closeActiveTab(b);
+    }
+
+    @Test
+    void lineDownMovesEveryCaret() throws Exception {
+        EditorBuffer b = twoCaretBuffer(); // carets on lines 0 and 1
+
+        run("nav.lineDown");
+        assertEquals(List.of(5, 10), carets(b), "both carets move down a line, keeping column 0");
+
+        closeActiveTab(b);
+    }
+
+    private void closeActiveTab(EditorBuffer b) throws Exception {
+        FxTestSupport.runOnFx(() -> {
+            b.collapseCarets();
+            b.markClean();
+            javafx.scene.control.TabPane tabPane = FxTestSupport.field(fx.controller, "tabPane");
+            javafx.scene.control.Tab sel = tabPane.getSelectionModel().getSelectedItem();
+            if (sel != null) {
+                FxTestSupport.call(fx.controller, "closeTab", new Class[] {javafx.scene.control.Tab.class}, sel);
+            }
+        });
+    }
+}


### PR DESCRIPTION
Closes #635.

With multiple carets, the arrow keys already moved every caret but the **Emacs movement chords** (`C-f` / `C-b` / `C-n` / `C-p` / `C-a` / `C-e` / `M-f` / `M-b`) moved only the **primary** one — surprising mid-edit, and it made multi-caret much less useful under the default Emacs keymap.

## Cause
Movement chords are resolved by the scene-level `KeyDispatcher`, which acts on the focused area's primary caret. The fork's fan-out lives in its node-level `InputMap`, which never sees the keystroke because the dispatcher consumes it first.

## Fix
- **`EditorBuffer.multiMoveHorizontal` / `multiMoveVertical` / `multiMoveLineBoundary`** — thin wrappers over the fork's `MultiCaretManager.moveHorizontal(amount, byWord, select)` / `moveVertical(down, select)` / `moveLineBoundary(toEnd, select)`, each returning `false` when the buffer has no extra carets.
- **`MainController.multiCaretMove(op)`** — the `nav.*` command handlers branch here when the active buffer `hasMultipleCarets()`, running the fork fan-out and following the primary caret; otherwise they fall through to the existing single-caret motion. `select` = `markActive`, mirroring `selPolicy()`.

Covers char / word forward+backward, line up/down (via `moveLine`), and line start/end. **Still primary-only** (the fork has no multi-caret API for them): document start/end, paragraph/sentence motion, page up/down, back-to-indentation, and subword nav.

## Tests
`MultiCaretMovementFxTest` places two carets and drives `nav.charForward` / `wordForward` / `lineStart` / `lineEnd` / `lineDown` through the real command registry, asserting **all** carets move (extra-caret offsets read out of the vendored fork — the only way to observe them).

## Docs
Corrected the two `CLAUDE.md` notes the issue flagged: the "movement chords don't fan out" known-limitation, and "multi-caret has no keymap bindings" (now Emacs-only — the `vscode` keymap binds `C-d` / `C-M-up` / `C-M-down`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)