### PR TITLE
fix(ui): disable the split buttons on tabs that can't be split

### DIFF
--- a/src/main/java/com/editora/ui/MainController.java
+++ b/src/main/java/com/editora/ui/MainController.java
@@ -5794,10 +5794,16 @@ public class MainController implements com.editora.mcp.McpBridge {
         }
     }
 
-    /** Reflects the active buffer's split state in the toolbar toggle buttons. */
+    /**
+     * Reflects the active buffer's split state in the toolbar toggle buttons, and disables them on a tab
+     * that can't be split at all — the Welcome/Doctor pages and the image/hex/PDF/diff viewers, none of
+     * which is an {@link EditorBuffer}, so {@link #toggleSplit} would silently do nothing there.
+     */
     private void refreshSplitButtons() {
         EditorBuffer buffer = activeBuffer();
         EditorBuffer.Split split = buffer == null ? EditorBuffer.Split.NONE : buffer.getSplit();
+        splitVerticalButton.setDisable(buffer == null);
+        splitHorizontalButton.setDisable(buffer == null);
         splitVerticalButton.pseudoClassStateChanged(OPEN, split == EditorBuffer.Split.SIDE_BY_SIDE);
         splitHorizontalButton.pseudoClassStateChanged(OPEN, split == EditorBuffer.Split.STACKED);
     }


### PR DESCRIPTION
The Welcome and Doctor pages — and the image/hex/PDF/diff viewers — are non-`EditorBuffer` `TabContent`s, so `activeBuffer()` is null and `toggleSplit()` silently does nothing. The toolbar's **Split Vertical** / **Split Horizontal** buttons stayed lit anyway, advertising an action that no-ops.

`refreshSplitButtons()` now disables both when there's no active buffer:

```java
splitVerticalButton.setDisable(buffer == null);
splitHorizontalButton.setDisable(buffer == null);
```

It already runs on every tab switch, at toolbar build time (so a startup on the Welcome page is correct from the first frame), and after each toggle — no new call sites, no new per-pulse work.

Any `EditorBuffer` can split (`setSplit` has no guards), so "no buffer" is exactly the unsplittable condition.

**Not included:** the palette commands `view.splitVertical`/`view.splitHorizontal` are still lit on those tabs. `Chrome.contextReason` already has a `hasBuffer` rule (`edit.`/`nav.`/`markwhen.`) that would gray them with the existing `palette.disabled.needsBuffer` tooltip — left out as a separate surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)