### PR TITLE
fix(ui): count only persisted tabs in the saved editor-group selection

### DIFF
--- a/src/main/java/com/editora/ui/EditorArea.java
+++ b/src/main/java/com/editora/ui/EditorArea.java
@@ -3,6 +3,7 @@ package com.editora.ui;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.function.Predicate;
 import java.util.function.Supplier;
 
 import javafx.application.Platform;
@@ -639,20 +640,51 @@ final class EditorArea {
      * nothing and an older reader is unaffected. Leaves carry only their selected-tab index; which files sit
      * in which group is recorded per file, so the two halves cannot disagree (see {@link EditorGroupLayout}).
      */
-    EditorGroupLayout snapshotLayout() {
-        return isSplit() ? describe(tree) : null;
+    EditorGroupLayout snapshotLayout(Predicate<Tab> persisted) {
+        return isSplit() ? describe(tree, persisted) : null;
     }
 
-    private static EditorGroupLayout describe(Node node) {
+    private static EditorGroupLayout describe(Node node, Predicate<Tab> persisted) {
         if (node instanceof TabPane leaf) {
-            return EditorGroupLayout.leaf(leaf.getSelectionModel().getSelectedIndex());
+            return EditorGroupLayout.leaf(persistedIndexOfSelection(leaf, persisted));
         }
         SplitPane branch = (SplitPane) node;
         List<EditorGroupLayout> children = new ArrayList<>();
         for (Node child : branch.getItems()) {
-            children.add(describe(child));
+            children.add(describe(child, persisted));
         }
         return EditorGroupLayout.branch(branch.getOrientation().name(), children);
+    }
+
+    /**
+     * The selected tab's index <em>among the tabs that will actually be written to the session</em>, which is
+     * not the same as its index in the group.
+     *
+     * <p>Not every open tab is persisted — the Welcome tab and an unsaved buffer have no path, so the session
+     * skips them — but they still occupy a slot in the group. Recording the live index would therefore save a
+     * number in one coordinate system and restore it in another: a group of {@code [Welcome, a.c, b.c]} with
+     * {@code b.c} selected would save index 2 and, on restore into a two-tab group, select {@code a.c}. The
+     * clamp hides it whenever the number lands out of range, which is why the symptom is intermittent and
+     * looks like "sometimes the wrong file is focused" rather than an obvious break.
+     *
+     * <p>Counting only persisted tabs puts the index in the same space restore fills the group in. A selected
+     * tab that is not itself persisted lands on the next one that is, which is the closest thing to right.
+     */
+    private static int persistedIndexOfSelection(TabPane leaf, Predicate<Tab> persisted) {
+        Tab selected = leaf.getSelectionModel().getSelectedItem();
+        if (selected == null) {
+            return 0;
+        }
+        int index = 0;
+        for (Tab tab : leaf.getTabs()) {
+            if (tab == selected) {
+                break;
+            }
+            if (persisted.test(tab)) {
+                index++;
+            }
+        }
+        return index;
     }
 
     /**

--- a/src/main/java/com/editora/ui/MainController.java
+++ b/src/main/java/com/editora/ui/MainController.java
@@ -8414,7 +8414,8 @@ public class MainController implements com.editora.mcp.McpBridge {
         }
         WorkspaceState state = config.getWorkspaceState();
         state.setOpenFiles(files);
-        state.setEditorLayout(editorArea.snapshotLayout()); // null while unsplit, so an unsplit window writes none
+        // Same predicate the loop above filters on, so the saved selection index counts the same tabs.
+        state.setEditorLayout(editorArea.snapshotLayout(t -> tabPath(t) != null));
         Path activePath = tabPath(editorArea.selectedTab());
         state.setActiveFile(activePath != null ? com.editora.vfs.Vfs.toStorableString(activePath) : "");
         persistWindowBounds(state);

--- a/src/test/java/com/editora/ui/EditorGroupsFxTest.java
+++ b/src/test/java/com/editora/ui/EditorGroupsFxTest.java
@@ -230,13 +230,75 @@ class EditorGroupsFxTest {
         cleanUp();
     }
 
+    /**
+     * The saved selection index must count only the tabs the session will actually write, not every tab in
+     * the group.
+     *
+     * <p>Editora does not persist a tab with no path — the Welcome tab, an unsaved buffer — but such a tab
+     * still occupies a slot. Recording the live index saved a number in one coordinate system and restored it
+     * in another: a group of {@code [unsaved, a, b]} with {@code b} selected saved index 2 and, restoring into
+     * a two-tab group, selected {@code a}. Found in a real session file, where a one-file group had recorded
+     * {@code selected: 1}; the restore clamp masked it that time, which is why the symptom would have surfaced
+     * as "sometimes focuses the wrong file" rather than an obvious break.
+     */
+    @Test
+    void theSavedSelectionCountsOnlyPersistedTabs() throws Exception {
+        Tab unsaved = addBuffer(); // no path — exactly what persistSession skips
+        Tab first = addBuffer();
+        Tab second = addBuffer();
+        FxTestSupport.runOnFx(() -> {
+            // Force all three into one group beside another, so the layout is split and gets recorded.
+            area.splitActive(Orientation.HORIZONTAL);
+            area.unsplit();
+        });
+        addBuffer();
+        FxTestSupport.runOnFx(() -> area.splitActive(Orientation.HORIZONTAL));
+        FxTestSupport.runOnFx(() -> {
+            area.select(second); // the last of the three in group 0
+        });
+
+        // Persist as the session does: skip the path-less tab.
+        EditorGroupLayout saved = FxTestSupport.callOnFx(() -> area.snapshotLayout(t -> t != unsaved));
+        List<EditorGroupLayout> leaves = new ArrayList<>();
+        collectLeaves(saved, leaves);
+
+        int groupOfSecond = FxTestSupport.callOnFx(() -> area.groupIndexOf(second));
+        int liveIndex = FxTestSupport.callOnFx(() -> {
+            for (Tab t : area.tabs()) {
+                if (t == second) {
+                    return area.indexOf(t);
+                }
+            }
+            return -1;
+        });
+        int savedIndex = leaves.get(groupOfSecond).getSelected();
+
+        assertTrue(
+                liveIndex > savedIndex,
+                "the live index counts the unsaved tab, the saved one must not" + " (live=" + liveIndex + ", saved="
+                        + savedIndex + ")");
+        assertEquals(liveIndex - 1, savedIndex, "exactly one skipped tab sits before the selection");
+
+        cleanUp();
+    }
+
+    private static void collectLeaves(EditorGroupLayout node, List<EditorGroupLayout> out) {
+        if (node.isLeaf()) {
+            out.add(node);
+            return;
+        }
+        for (EditorGroupLayout child : node.getChildren()) {
+            collectLeaves(child, out);
+        }
+    }
+
     /** An unsplit area writes no layout at all, so an unsplit session file is byte-identical to before. */
     @Test
     void anUnsplitAreaSavesNoLayout() throws Exception {
         addBuffer();
         addBuffer();
 
-        assertNull(FxTestSupport.callOnFx(() -> area.snapshotLayout()), "nothing to record while unsplit");
+        assertNull(FxTestSupport.callOnFx(() -> area.snapshotLayout(t -> true)), "nothing to record while unsplit");
 
         cleanUp();
     }
@@ -254,7 +316,7 @@ class EditorGroupsFxTest {
         addBuffer();
         FxTestSupport.runOnFx(() -> area.splitActive(Orientation.VERTICAL));
 
-        EditorGroupLayout saved = FxTestSupport.callOnFx(() -> area.snapshotLayout());
+        EditorGroupLayout saved = FxTestSupport.callOnFx(() -> area.snapshotLayout(t -> true));
         assertEquals(3, saved.leafCount(), "three groups recorded");
         // Which group each file was in, exactly as persistSession records it on OpenFile.group.
         List<Integer> savedGroups = new ArrayList<>();
@@ -296,7 +358,7 @@ class EditorGroupsFxTest {
         addBuffer();
         addBuffer();
         FxTestSupport.runOnFx(() -> area.splitActive(Orientation.HORIZONTAL));
-        EditorGroupLayout saved = FxTestSupport.callOnFx(() -> area.snapshotLayout());
+        EditorGroupLayout saved = FxTestSupport.callOnFx(() -> area.snapshotLayout(t -> true));
         List<Tab> savedTabs = FxTestSupport.callOnFx(() -> new ArrayList<>(area.tabs()));
 
         FxTestSupport.runOnFx(() -> {


### PR DESCRIPTION
Bug in merged code (#777). Found by diffing a real session file across a restart, not by a test.

## What was wrong

The per-group selected-tab index was recorded as the tab's index in the **live** group — but the session doesn't write every tab. One with no path (the Welcome tab, an unsaved buffer) is skipped. So the number was saved in one coordinate system and restored in another.

A group of `[Welcome, a.c, b.c]` with `b.c` selected saved index **2** and, restoring into a two-tab group, selected **`a.c`**.

The restore clamp masks it whenever the value lands out of range, so the symptom is "sometimes focuses the wrong file after a restart" rather than an obvious break — the kind of thing that gets written off as imagination.

## How it surfaced

Diffing the layout across a restart:

```
before: group 0 → selected: 1
after:  group 0 → selected: 0
```

Group 0 held exactly **one** file. `selected: 1` was already out of range when written; the run I looked at clamped to the right answer by luck, so nothing looked wrong from the outside. The shapes and file placement matched perfectly — only the equality check caught it.

## Fix

`snapshotLayout` now takes the same predicate `persistSession` filters on and counts only tabs that will actually be written, putting the index in the space restore fills the group in. A selected tab that isn't itself persisted lands on the next one that is.

## Test

Reproduces the real shape — a path-less tab sitting before the selection — and I checked it against the old behaviour to confirm it fails without the fix (`live=2, saved=2` instead of `saved=1`). A test that passed either way would have been worthless.

3346 green.

## Worth noting

This is the second bug in this feature found by reading the artifact the app writes rather than by testing it, after the ✕-collapse one. Both were invisible to a green suite and both were obvious in the output. It may be worth a standing habit of diffing session files across a restart when touching persistence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)