### PR TITLE
feat(lsp): show code actions at the caret instead of a centred card (#767)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Quick fixes now appear at the caret** — the code-action list used to open as a card centred near the top
+  of the window, the same surface used for picking a project. It now drops just below the cursor, where you
+  are actually looking, with the server's preferred fix preselected so Enter usually does the right thing.
+  Arrow keys or `C-n`/`C-p` move, Enter applies, Escape or `C-g` dismisses, and the caret stays visible on
+  the spot the fix will land.
+
 ### Added
 
 - **A menu bar** — File / Edit / Find / View / Navigate / Code / Run / VCS / Tools / Window / Help, so the

--- a/src/main/java/com/editora/editor/CodeAction.java
+++ b/src/main/java/com/editora/editor/CodeAction.java
@@ -1,0 +1,16 @@
+package com.editora.editor;
+
+/**
+ * One offered quick fix or refactoring, in terms this package can hold.
+ *
+ * <p>{@code editor} stays free of lsp4j — the same rule that keeps {@link LspDiagnostic} and
+ * {@link com.editora.completion.Completion} neutral — so the server's own action object rides along as an
+ * opaque {@link #token()}. The popup shows {@link #title()} and {@link #kind()}; only the coordinator that
+ * created the action knows how to apply it, and it gets its object back untouched.
+ *
+ * @param title what the server calls the action, shown to the user
+ * @param kind the LSP action kind ({@code quickfix}, {@code refactor.extract}, …), shown muted; may be null
+ * @param preferred whether the server marked this its preferred action, so it can be selected on open
+ * @param token the originating action, handed back verbatim on accept
+ */
+public record CodeAction(String title, String kind, boolean preferred, Object token) {}

--- a/src/main/java/com/editora/editor/CodeActionPopup.java
+++ b/src/main/java/com/editora/editor/CodeActionPopup.java
@@ -1,0 +1,199 @@
+package com.editora.editor;
+
+import java.util.List;
+import java.util.function.Consumer;
+
+import javafx.geometry.Bounds;
+import javafx.geometry.Pos;
+import javafx.scene.control.Label;
+import javafx.scene.control.ListCell;
+import javafx.scene.control.ListView;
+import javafx.scene.input.MouseButton;
+import javafx.scene.layout.HBox;
+import javafx.scene.layout.Priority;
+import javafx.scene.layout.Region;
+import javafx.scene.layout.VBox;
+import javafx.stage.Popup;
+import javafx.stage.Window;
+
+/**
+ * The quick-fix / refactoring list, anchored <b>at the caret</b> — IntelliJ's Alt+Enter intention popup and
+ * Eclipse's Ctrl+1 (#767).
+ *
+ * <p>The protocol side of code actions already worked; this replaces the presentation. It was a
+ * {@code QuickOpen} overlay: a card centred near the top of the window, the same surface used for "pick a
+ * project". That is the wrong place for something that acts on the symbol under the cursor — the user is
+ * looking at the caret, and the list appeared somewhere else entirely.
+ *
+ * <p>Structurally this is {@link CompletionPopup}: a <b>focus-less</b> {@link Popup}, so the editor keeps
+ * focus and its key filter drives selection, acceptance and dismissal. It reuses the completion popup's style
+ * classes rather than introducing parallel ones, so it tracks the theme with no new CSS and the two read as
+ * the same kind of object — which they are.
+ */
+public final class CodeActionPopup {
+
+    private static final int VISIBLE_ROWS = 9;
+    private static final double ROW_HEIGHT = 24;
+    private static final double MIN_WIDTH = 320;
+    private static final double MAX_WIDTH = 720;
+    private static final double CHAR_PX = 7.2;
+    private static final double H_PADDING = 26;
+    private static final double KIND_GAP = 24;
+
+    private final Popup popup = new Popup();
+    private final ListView<CodeAction> list = new ListView<>();
+    private Consumer<CodeAction> onAccept = a -> {};
+
+    public CodeActionPopup() {
+        list.getStyleClass().addAll("completion-list", "code-action-list");
+        list.setFocusTraversable(false);
+        list.setFixedCellSize(ROW_HEIGHT);
+        list.setCellFactory(v -> new ActionCell());
+        list.setOnMouseClicked(e -> {
+            if (e.getButton() == MouseButton.PRIMARY) {
+                CodeAction sel = selected();
+                if (sel != null) {
+                    onAccept.accept(sel);
+                }
+            }
+        });
+        VBox box = new VBox(list);
+        box.getStyleClass().addAll("completion-popup", "code-action-popup");
+        popup.getContent().add(box);
+        popup.setAutoFix(true); // keep it on screen near a window edge
+        popup.setAutoHide(false);
+        // Escape must reach the editor's filter, not be swallowed by the Popup's own default handling: the
+        // filter is what releases the key ownership taken when the list opened. With the default (true) the
+        // popup hid itself first, the filter then saw a closed list, skipped its branch, and left the editor
+        // owning chords it no longer needed. CompletionPopup sets this for the same reason.
+        popup.setHideOnEscape(false);
+    }
+
+    /**
+     * Notified whenever the popup hides, however it hid. A belt-and-braces release point: any path that
+     * closes the popup without going through the editor's own hide leaves the key ownership stranded
+     * otherwise, and not every such path is under this class's control.
+     */
+    public void setOnHidden(Runnable onHidden) {
+        popup.setOnHidden(e -> onHidden.run());
+    }
+
+    public void setOnAccept(Consumer<CodeAction> onAccept) {
+        this.onAccept = onAccept == null ? a -> {} : onAccept;
+    }
+
+    public boolean isShowing() {
+        return popup.isShowing();
+    }
+
+    public CodeAction selected() {
+        return list.getSelectionModel().getSelectedItem();
+    }
+
+    /** Fires the accept handler for the current selection, as a click does. */
+    public void accept() {
+        CodeAction sel = selected();
+        if (sel != null) {
+            onAccept.accept(sel);
+        }
+    }
+
+    public void moveDown() {
+        int n = list.getItems().size();
+        if (n > 0) {
+            list.getSelectionModel().select((list.getSelectionModel().getSelectedIndex() + 1) % n);
+            list.scrollTo(list.getSelectionModel().getSelectedIndex());
+        }
+    }
+
+    public void moveUp() {
+        int n = list.getItems().size();
+        if (n > 0) {
+            int i = list.getSelectionModel().getSelectedIndex();
+            list.getSelectionModel().select((i - 1 + n) % n);
+            list.scrollTo(list.getSelectionModel().getSelectedIndex());
+        }
+    }
+
+    /** Shows the list just below {@code caretScreen}, preselecting the server's preferred action if any. */
+    public void show(Window owner, Bounds caretScreen, List<CodeAction> actions) {
+        if (owner == null || caretScreen == null || actions == null || actions.isEmpty()) {
+            hide();
+            return;
+        }
+        list.getItems().setAll(actions);
+        int preferred = 0;
+        for (int i = 0; i < actions.size(); i++) {
+            if (actions.get(i).preferred()) {
+                preferred = i;
+                break;
+            }
+        }
+        list.getSelectionModel().select(preferred);
+        list.scrollTo(preferred);
+
+        int rows = Math.min(actions.size(), VISIBLE_ROWS);
+        double h = rows * ROW_HEIGHT + 2; // +2 for the list's 1px top/bottom border
+        list.setPrefHeight(h);
+        list.setMinHeight(h);
+        list.setMaxHeight(h);
+        double w = width(actions);
+        list.setPrefWidth(w);
+        list.setMinWidth(w);
+        list.setMaxWidth(w);
+
+        double x = caretScreen.getMinX();
+        double y = caretScreen.getMaxY() + 2;
+        if (popup.isShowing()) {
+            popup.setAnchorX(x);
+            popup.setAnchorY(y);
+        } else {
+            popup.show(owner, x, y);
+        }
+    }
+
+    public void hide() {
+        if (popup.isShowing()) {
+            popup.hide();
+        }
+        list.getItems().clear();
+    }
+
+    /** Width that fits the widest title plus its kind column, clamped. */
+    private static double width(List<CodeAction> actions) {
+        int widest = 0;
+        for (CodeAction a : actions) {
+            int len = (a.title() == null ? 0 : a.title().length())
+                    + (a.kind() == null || a.kind().isBlank() ? 0 : a.kind().length() + 3);
+            widest = Math.max(widest, len);
+        }
+        return Math.max(MIN_WIDTH, Math.min(MAX_WIDTH, widest * CHAR_PX + H_PADDING + KIND_GAP));
+    }
+
+    /** Title on the left, the LSP kind muted on the right — the completion popup's detail-column idiom. */
+    private static final class ActionCell extends ListCell<CodeAction> {
+        @Override
+        protected void updateItem(CodeAction item, boolean empty) {
+            super.updateItem(item, empty);
+            if (empty || item == null) {
+                setText(null);
+                setGraphic(null);
+                return;
+            }
+            Label title = new Label(item.title());
+            title.getStyleClass().add("completion-label");
+            Region spacer = new Region();
+            HBox.setHgrow(spacer, Priority.ALWAYS);
+            HBox row = new HBox(6, title, spacer);
+            if (item.kind() != null && !item.kind().isBlank()) {
+                Label kind = new Label(item.kind());
+                kind.getStyleClass().add("completion-detail");
+                row.getChildren().add(kind);
+            }
+            row.setAlignment(Pos.CENTER_LEFT);
+            row.getStyleClass().add("completion-cell-row");
+            setText(null);
+            setGraphic(row);
+        }
+    }
+}

--- a/src/main/java/com/editora/editor/EditorBuffer.java
+++ b/src/main/java/com/editora/editor/EditorBuffer.java
@@ -374,6 +374,11 @@ public class EditorBuffer implements TabContent {
     /** The view the completion popup is currently driven by (for click-accept routing). */
     private CodeArea completionArea;
 
+    /** The quick-fix list, anchored at the caret (#767). Lazily built, like the completion popup. */
+    private CodeActionPopup codeActionPopup;
+    /** The area the quick-fix list belongs to, so its key ownership can be released on hide. */
+    private CodeArea codeActionArea;
+
     /** The IntelliJ-style documentation side-popup (lazily created) + its lazy resolver/state. */
     private CompletionDocPopup docPopup;
 
@@ -8215,6 +8220,61 @@ public class EditorBuffer implements TabContent {
      * snippet or inserting a newline); ↑/↓ move; Esc closes; caret-moving keys dismiss. With the popup
      * closed it does nothing, so normal Tab/Enter behavior is unaffected.
      */
+    /** True while the caret-anchored quick-fix list is up. */
+    public boolean codeActionsShowing() {
+        return codeActionPopup != null && codeActionPopup.isShowing();
+    }
+
+    /**
+     * Shows {@code actions} at the caret and calls {@code onAccept} with the chosen one.
+     *
+     * <p>Focus stays in the editor — the popup is focus-less and this buffer's key filter drives it — which
+     * is why the caret keeps blinking where the fix will land while the list is open.
+     */
+    public void showCodeActions(List<CodeAction> actions, java.util.function.Consumer<CodeAction> onAccept) {
+        CodeArea a = getFocusedArea();
+        if (a == null || actions == null || actions.isEmpty()) {
+            return;
+        }
+        Bounds caretScreen = a.getCharacterBoundsOnScreen(a.getCaretPosition(), a.getCaretPosition())
+                .orElse(null);
+        if (caretScreen == null) {
+            return;
+        }
+        hideCompletion(); // the two lists are both caret-anchored; never stack them
+        if (codeActionPopup == null) {
+            codeActionPopup = new CodeActionPopup();
+            // However the popup ends up hidden, the key ownership goes back with it.
+            codeActionPopup.setOnHidden(this::releaseCodeActionKeys);
+        }
+        codeActionPopup.setOnAccept(action -> {
+            hideCodeActions();
+            if (action != null && onAccept != null) {
+                onAccept.accept(action);
+            }
+        });
+        codeActionArea = a;
+        // Own the editor-context chords so C-n/C-p reach the list rather than moving the caret.
+        a.getProperties().put("editora.ownsKeys", Boolean.TRUE);
+        codeActionPopup.show(a.getScene().getWindow(), caretScreen, actions);
+    }
+
+    /** Dismisses the quick-fix list and returns the editor chords to the dispatcher. */
+    public void hideCodeActions() {
+        if (codeActionPopup != null) {
+            codeActionPopup.hide();
+        }
+        releaseCodeActionKeys();
+    }
+
+    /** Hands the editor-context chords back. Idempotent, since it runs from both hide paths. */
+    private void releaseCodeActionKeys() {
+        if (codeActionArea != null) {
+            codeActionArea.getProperties().remove("editora.ownsKeys");
+            codeActionArea = null;
+        }
+    }
+
     private void addCompletionKeys(CodeArea a) {
         a.addEventFilter(KeyEvent.KEY_PRESSED, e -> {
             if (multiCaretActiveOn(a)) { // suspend single-caret assists while multiple carets exist
@@ -8237,6 +8297,53 @@ public class EditorBuffer implements TabContent {
                         e.consume();
                     }
                     default -> {} // typing/Backspace/arrows fall through
+                }
+                return;
+            }
+            // Quick-fix list first: it and the completion popup are both caret-anchored and never coexist
+            // (showCodeActions hides completion), so whichever is up owns the keys.
+            if (codeActionsShowing()) {
+                boolean ctrl = e.isControlDown() && !e.isAltDown() && !e.isMetaDown();
+                switch (e.getCode()) {
+                    case DOWN -> {
+                        codeActionPopup.moveDown();
+                        e.consume();
+                    }
+                    case UP -> {
+                        codeActionPopup.moveUp();
+                        e.consume();
+                    }
+                    case ENTER -> {
+                        codeActionPopup.accept();
+                        e.consume();
+                    }
+                    case ESCAPE -> {
+                        hideCodeActions();
+                        e.consume();
+                    }
+                    case N -> {
+                        if (ctrl) {
+                            codeActionPopup.moveDown();
+                            e.consume();
+                        }
+                    }
+                    case P -> {
+                        if (ctrl) {
+                            codeActionPopup.moveUp();
+                            e.consume();
+                        }
+                    }
+                    case G -> {
+                        if (ctrl) { // C-g cancels, as everywhere else in the editor
+                            hideCodeActions();
+                            e.consume();
+                        }
+                    }
+                    default -> {
+                        // Anything else dismisses: the list is about the caret's current position, and a
+                        // keystroke that moves or edits invalidates it.
+                        hideCodeActions();
+                    }
                 }
                 return;
             }
@@ -8713,7 +8820,11 @@ public class EditorBuffer implements TabContent {
                     || docVersion != version
                     || a.getScene() == null
                     || a.getCaretPosition() != caret
-                    || hasActiveSnippet()) {
+                    || hasActiveSnippet()
+                    // A completion request already in flight when the quick-fix list opened must not land on
+                    // top of it: both are caret-anchored and both claim the editor's chords, so the late
+                    // arrival would steal the keys from a list the user is looking at (#767).
+                    || codeActionsShowing()) {
                 return;
             }
             // Order LSP items by the server's relevance (preselect, then sortText) — IntelliJ-style —

--- a/src/main/java/com/editora/ui/LspCoordinator.java
+++ b/src/main/java/com/editora/ui/LspCoordinator.java
@@ -1867,29 +1867,48 @@ final class LspCoordinator {
                 host.setStatus(tr("status.lsp.noCodeActions"));
                 return;
             }
-            QuickOpen<LspManager.CodeActionItem> picker = new QuickOpen<>(
-                    tr("command.lsp.codeActions"),
-                    tr("palette.setting.pick"),
-                    () -> items,
-                    LspManager.CodeActionItem::title,
-                    LspManager.CodeActionItem::kind,
-                    item -> {
-                        if (item == null) {
-                            return;
-                        }
-                        if (runGeneratePrompt(path, item)) {
-                            return; // a jdtls generate prompt: we drive it, not the server (#741)
-                        }
-                        lspManager.applyCodeAction(
-                                path,
-                                item.raw(),
-                                ok -> host.setStatus(tr(
-                                        ok ? "status.lsp.codeActionApplied" : "status.lsp.codeActionFailed",
-                                        item.title())));
-                    });
-            picker.setOverlayHost(host.overlayHost());
-            picker.show(host.window());
+            // Anchored at the caret rather than a centred overlay card (#767): this acts on the symbol under
+            // the cursor, which is where the user is looking. The editor keeps focus, so the caret stays
+            // visible at the spot the fix will land while the list is open.
+            b.showCodeActions(
+                    items.stream()
+                            .map(i -> new com.editora.editor.CodeAction(i.title(), i.kind(), i.preferred(), i.raw()))
+                            .toList(),
+                    chosen -> applyChosenAction(path, items, chosen));
         });
+    }
+
+    /**
+     * Applies the action the user picked from the caret popup.
+     *
+     * <p>The popup deals in the neutral {@link com.editora.editor.CodeAction} — {@code editor} must not see
+     * lsp4j — so the server's own object rides across as an opaque token and is matched back by identity
+     * here. The lists are a handful of entries, so a scan is cheaper than building a map.
+     */
+    private void applyChosenAction(
+            Path path, List<LspManager.CodeActionItem> items, com.editora.editor.CodeAction chosen) {
+        if (chosen == null) {
+            return;
+        }
+        LspManager.CodeActionItem item = null;
+        for (LspManager.CodeActionItem candidate : items) {
+            if (candidate.raw() == chosen.token()) {
+                item = candidate;
+                break;
+            }
+        }
+        if (item == null) {
+            return;
+        }
+        if (runGeneratePrompt(path, item)) {
+            return; // a jdtls generate prompt: we drive it, not the server (#741)
+        }
+        LspManager.CodeActionItem applied = item;
+        lspManager.applyCodeAction(
+                path,
+                applied.raw(),
+                ok -> host.setStatus(
+                        tr(ok ? "status.lsp.codeActionApplied" : "status.lsp.codeActionFailed", applied.title())));
     }
 
     /**

--- a/src/test/java/com/editora/ui/CodeActionPopupFxTest.java
+++ b/src/test/java/com/editora/ui/CodeActionPopupFxTest.java
@@ -1,0 +1,169 @@
+package com.editora.ui;
+
+import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
+
+import javafx.scene.input.KeyCode;
+import javafx.scene.input.KeyEvent;
+
+import com.editora.editor.CodeAction;
+import com.editora.editor.EditorBuffer;
+import org.fxmisc.richtext.CodeArea;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Covers the caret-anchored quick-fix list (#767): that it opens, that the editor's key filter drives it,
+ * and that accepting hands back the action the user selected.
+ *
+ * <p>The protocol side already worked and is not retested here — what changed is the presentation, and the
+ * risk in a focus-less popup is entirely in the key wiring: a list that appears but cannot be driven, or one
+ * that swallows keys after it has closed, are both invisible to a compile.
+ */
+@Tag("fx")
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class CodeActionPopupFxTest {
+
+    private FxWindowFixture fx;
+
+    @BeforeAll
+    void setUp() throws Exception {
+        FxTestSupport.bootToolkit();
+        fx = FxWindowFixture.create();
+    }
+
+    @AfterAll
+    void tearDown() throws Exception {
+        if (fx != null) {
+            fx.dispose();
+        }
+    }
+
+    private static final List<CodeAction> ACTIONS = List.of(
+            new CodeAction("Remove unused import", "quickfix", false, "A"),
+            new CodeAction("Add missing cast", "quickfix", true, "B"),
+            new CodeAction("Extract method", "refactor.extract", false, "C"));
+
+    private EditorBuffer openBuffer() throws Exception {
+        return FxTestSupport.callOnFx(() -> {
+            EditorBuffer b = new EditorBuffer();
+            b.setContent("class A {\n  void x() {}\n}\n");
+            FxTestSupport.call(fx.controller, "addBuffer", new Class[] {EditorBuffer.class, boolean.class}, b, true);
+            // Autocomplete off for these buffers. It is caret-anchored and claims the same key ownership,
+            // so a request in flight can land *after* the quick-fix list closes and legitimately take the
+            // chords back — which would make the key-release assertion below flap for a reason that has
+            // nothing to do with what is under test.
+            b.setAutocomplete(false, false, false, false);
+            CodeArea area = FxTestSupport.field(b, "area");
+            area.requestFocus();
+            area.moveTo(12);
+            return b;
+        });
+    }
+
+    /** The server's preferred action is selected on open, so Enter alone does the likely-right thing. */
+    @Test
+    void thePopupOpensAtTheCaretWithThePreferredActionSelected() throws Exception {
+        EditorBuffer b = openBuffer();
+        AtomicReference<CodeAction> accepted = new AtomicReference<>();
+
+        FxTestSupport.runOnFx(() -> b.showCodeActions(ACTIONS, accepted::set));
+
+        assertTrue(FxTestSupport.callOnFx(b::codeActionsShowing), "the list is up");
+        FxTestSupport.runOnFx(() -> press(b, KeyCode.ENTER));
+        assertEquals("B", accepted.get().token(), "Enter took the preferred action");
+        assertFalse(FxTestSupport.callOnFx(b::codeActionsShowing), "and the list closed");
+
+        close(b);
+    }
+
+    /** Arrow and Emacs chords both move the selection — the editor owns the keys while the list is open. */
+    @Test
+    void theKeyboardDrivesTheSelection() throws Exception {
+        EditorBuffer b = openBuffer();
+        AtomicReference<CodeAction> accepted = new AtomicReference<>();
+        FxTestSupport.runOnFx(() -> b.showCodeActions(ACTIONS, accepted::set));
+
+        FxTestSupport.runOnFx(() -> press(b, KeyCode.DOWN)); // B -> C
+        FxTestSupport.runOnFx(() -> press(b, KeyCode.ENTER));
+        assertEquals("C", accepted.get().token(), "Down moved to the next action");
+
+        accepted.set(null);
+        FxTestSupport.runOnFx(() -> b.showCodeActions(ACTIONS, accepted::set));
+        FxTestSupport.runOnFx(() -> pressCtrl(b, KeyCode.P)); // B -> A
+        FxTestSupport.runOnFx(() -> press(b, KeyCode.ENTER));
+        assertEquals("A", accepted.get().token(), "C-p moved to the previous action");
+
+        close(b);
+    }
+
+    /** Escape dismisses without applying, and releases the key ownership it took. */
+    @Test
+    void escapeDismissesWithoutApplying() throws Exception {
+        EditorBuffer b = openBuffer();
+        AtomicReference<CodeAction> accepted = new AtomicReference<>();
+        FxTestSupport.runOnFx(() -> b.showCodeActions(ACTIONS, accepted::set));
+
+        FxTestSupport.runOnFx(() -> press(b, KeyCode.ESCAPE));
+
+        assertFalse(FxTestSupport.callOnFx(b::codeActionsShowing), "dismissed");
+        assertNull(accepted.get(), "nothing was applied");
+        assertNull(
+                FxTestSupport.callOnFx(() -> {
+                    CodeArea area = FxTestSupport.field(b, "area");
+                    return area.getProperties().get("editora.ownsKeys");
+                }),
+                "the editor chords were handed back to the dispatcher");
+
+        close(b);
+    }
+
+    /**
+     * A keystroke that is not list navigation dismisses the list. It was computed for one caret position, so
+     * leaving it open while the caret or the text moves would offer fixes for somewhere else.
+     */
+    @Test
+    void anUnrelatedKeystrokeDismissesTheList() throws Exception {
+        EditorBuffer b = openBuffer();
+        FxTestSupport.runOnFx(() -> b.showCodeActions(ACTIONS, a -> {}));
+
+        FxTestSupport.runOnFx(() -> press(b, KeyCode.LEFT));
+
+        assertFalse(FxTestSupport.callOnFx(b::codeActionsShowing), "moving the caret closed the list");
+        close(b);
+    }
+
+    private static void press(EditorBuffer b, KeyCode code) {
+        fire(b, code, false);
+    }
+
+    private static void pressCtrl(EditorBuffer b, KeyCode code) {
+        fire(b, code, true);
+    }
+
+    /** Fires a real KEY_PRESSED at the focused area, so the buffer's own filter chain is what runs. */
+    private static void fire(EditorBuffer b, KeyCode code, boolean control) {
+        CodeArea area = b.getFocusedArea();
+        area.fireEvent(new KeyEvent(KeyEvent.KEY_PRESSED, "", "", code, false, control, false, false));
+    }
+
+    private void close(EditorBuffer b) throws Exception {
+        FxTestSupport.runOnFx(() -> {
+            b.hideCodeActions();
+            b.markClean();
+            javafx.scene.control.TabPane pane = FxTestSupport.field(fx.controller, "tabPane");
+            javafx.scene.control.Tab sel = pane.getSelectionModel().getSelectedItem();
+            if (sel != null) {
+                FxTestSupport.call(fx.controller, "closeTab", new Class[] {javafx.scene.control.Tab.class}, sel);
+            }
+        });
+    }
+}


### PR DESCRIPTION
Closes #767. Third item on the IDE-parity list (#772).

## What changed — presentation, not plumbing

The protocol side already worked: request with overlapping diagnostics as context, preferred-first ordering, `codeAction/resolve`, `workspace/applyEdit`, the jdtls generate prompts. What was wrong was **where the result appeared** — a `QuickOpen` overlay centred near the top of the window, the same surface used for "pick a project". Quick fixes act on the symbol under the cursor, and that is where the user is looking.

`CodeActionPopup` is structurally `CompletionPopup`: a **focus-less** `Popup`, so the editor keeps focus and its key filter drives the list while the caret stays visible on the spot the fix will land. Arrows or `C-n`/`C-p` move, Enter applies, Escape or `C-g` dismisses, any other key dismisses. The server's preferred action is preselected, so Enter usually does the right thing.

It reuses the completion popup's style classes rather than adding parallel ones — no new CSS, tracks the theme, and the two read as the same kind of object, which they are.

`editor` stays lsp4j-free: the new `CodeAction` record carries the server's object as an opaque token, the same shape `Completion` already uses for its resolve token.

## Two bugs found while building it

Both by **instrumenting**, after reasoning got me the wrong answer twice — worth recording because the second guess was confidently wrong.

**1. Escape stranded the key ownership.** JavaFX `Popup` defaults `hideOnEscape` to **true**, so the popup hid *itself* before my filter ran; the filter then saw a closed list, skipped its branch, and never released the chords the editor had claimed. I diagnosed it only after printing state: `showing=false` but `codeActionArea` still set — which said plainly that my hide never ran.

`CompletionPopup` already sets `hideOnEscape(false)` **and** exposes an `onHidden` hook, with a comment giving this exact reason. I modelled on that class and missed the two lines that exist for the problem I then hit. Both are now mirrored, so *any* path that closes the popup releases the keys — the same "don't assume every exit goes through your method" shape as the ✕-collapse bug in #777.

**2. A completion landing on an open quick-fix list.** Both are caret-anchored and both claim key ownership, so a request already in flight could land on top and steal the keys. The async completion callback now drops its result while the list is showing, alongside its existing staleness guards. Real race — though, to be accurate, *not* the cause of the symptom I was chasing when I found it.

## Verification

3359 tests green (4 new), spotless and the JaCoCo floors pass. The tests disable autocomplete on their buffers, because it is caret-anchored and claims the same ownership — a request landing after the list closes would make the key-release assertion flap for reasons unrelated to what is under test.

## Not in this PR

The issue also asks for a **gutter lightbulb** advertising that a fix is available. Left out deliberately: doing it properly means deciding when to ask the server, and asking on caret move is a hot path. The cheap version — show it only on lines that already carry a diagnostic, which costs nothing since we hold those locally — is worth doing, but as its own change rather than bolted onto this one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)