### PR TITLE
feat(run): launch a saved configuration regardless of the active tab (#765 part 1/4)

### DIFF
--- a/src/main/java/com/editora/run/RunConfigRouting.java
+++ b/src/main/java/com/editora/run/RunConfigRouting.java
@@ -1,0 +1,75 @@
+package com.editora.run;
+
+import java.nio.file.Path;
+import java.util.List;
+
+/**
+ * Picks the file a saved run configuration should be resolved against.
+ *
+ * <p>Launching a Java configuration goes through jdtls, and jdtls is keyed <b>per project root</b>: the file
+ * handed to {@code resolveClasspath} only selects which language-server session answers. It does not have to
+ * be the class being run, and it does not have to be the file on screen.
+ *
+ * <p>It used to be the active buffer, and the launch refused outright unless that buffer was a Java file — so
+ * saving a configuration for {@code MyApp}, opening {@code README.md} and running it reported "needs a Java
+ * file". That defeats the purpose of a <em>named</em> configuration, which should not care what you are
+ * currently looking at.
+ *
+ * <p>So any open Java file in the right project will do. Preference order:
+ *
+ * <ol>
+ *   <li>a Java file under the configuration's own working directory, when it sets one — with several projects
+ *       open this is the only signal that says which one the configuration belongs to;
+ *   <li>the active buffer, if it is a Java file — the common case, and keeps the previous behaviour exactly;
+ *   <li>any other open Java file.
+ * </ol>
+ *
+ * <p>Returns {@code null} only when no Java file is open at all, which is the one case the caller genuinely
+ * cannot resolve — and it can then say so precisely instead of blaming the current tab.
+ *
+ * <p>Deliberately does not search the disk for a candidate. That would be I/O on the FX thread to cover a
+ * case (a Java project open with no Java file anywhere in it) that barely occurs, and jdtls would not have
+ * indexed the project in that state anyway.
+ */
+public final class RunConfigRouting {
+
+    private RunConfigRouting() {}
+
+    /**
+     * @param openJavaFiles every open, local Java file, in tab order
+     * @param activeJavaFile the active buffer's path when it is a local Java file, else null
+     * @param workingDir the configuration's working directory, blank when it has none
+     * @return the file to resolve against, or null when no Java file is open
+     */
+    public static Path pick(List<Path> openJavaFiles, Path activeJavaFile, String workingDir) {
+        if (openJavaFiles == null || openJavaFiles.isEmpty()) {
+            return activeJavaFile;
+        }
+        if (workingDir != null && !workingDir.isBlank()) {
+            Path dir = normalize(Path.of(workingDir));
+            // The active file wins among equally-valid candidates inside the configuration's own project.
+            if (activeJavaFile != null && under(activeJavaFile, dir)) {
+                return activeJavaFile;
+            }
+            for (Path candidate : openJavaFiles) {
+                if (under(candidate, dir)) {
+                    return candidate;
+                }
+            }
+            // No open file under it: fall through rather than refuse. The working directory may simply be
+            // somewhere else (an output folder, a sandbox), which says nothing about where the sources are.
+        }
+        if (activeJavaFile != null) {
+            return activeJavaFile;
+        }
+        return openJavaFiles.get(0);
+    }
+
+    private static boolean under(Path file, Path dir) {
+        return normalize(file).startsWith(dir);
+    }
+
+    private static Path normalize(Path p) {
+        return p.toAbsolutePath().normalize();
+    }
+}

--- a/src/main/java/com/editora/ui/DebugCoordinator.java
+++ b/src/main/java/com/editora/ui/DebugCoordinator.java
@@ -767,19 +767,21 @@ final class DebugCoordinator {
             host.setStatus(tr("status.debug.unavailable"));
             return;
         }
-        EditorBuffer b = host.activeBuffer();
-        if (b == null || b.getPath() == null || !host.isLocalBuffer(b) || !"java".equals(b.getLanguage())) {
-            host.setStatus(tr("status.debug.needJavaFile"));
+        // Same reasoning as RunCoordinator.runConfig: a named configuration must not depend on which tab is
+        // in front, only on a Java file being open somewhere in its project.
+        Path routing = RunCoordinator.routingFor(host, cfg);
+        if (routing == null) {
+            host.setStatus(tr("status.run.configNeedsJavaFile"));
             return;
         }
-        Path routing = b.getPath();
         Path root = JavaProjectRoot.find(routing);
         if (root == null) {
             host.setStatus(tr("status.debug.noProject"));
             return;
         }
-        if (b.isDirty() && !ops.saveBuffer(b)) {
-            return;
+        EditorBuffer b = host.activeBuffer();
+        if (b != null && b.isDirty() && host.isLocalBuffer(b) && !ops.saveBuffer(b)) {
+            return; // save whatever the user was editing before launching, as before
         }
         Path cwd = cfg.workingDir().isBlank() ? root : Path.of(cfg.workingDir());
         dapManager.resolveMainClasses(routing, options -> {

--- a/src/main/java/com/editora/ui/RunCoordinator.java
+++ b/src/main/java/com/editora/ui/RunCoordinator.java
@@ -11,6 +11,7 @@ import com.editora.run.JavaLaunchInfo;
 import com.editora.run.JavaMainClass;
 import com.editora.run.JavaRunCommand;
 import com.editora.run.ProgramArgs;
+import com.editora.run.RunConfigRouting;
 import com.editora.run.RunService;
 import com.editora.run.StackTraceLinks;
 
@@ -136,25 +137,53 @@ final class RunCoordinator {
         startMainClassRun(fqn);
     }
 
+    /**
+     * The file a saved configuration should be resolved against — see {@link RunConfigRouting}.
+     *
+     * <p>Shared with {@link DebugCoordinator}, because a configuration's {@code kind} decides which of the two
+     * launches it, and both need to agree on which project it belongs to.
+     *
+     * @return null when no Java file is open anywhere, the one case neither can resolve
+     */
+    static Path routingFor(CoordinatorHost host, RunConfiguration cfg) {
+        List<Path> open = new java.util.ArrayList<>();
+        host.forEachBuffer(b -> {
+            if (b.getPath() != null && host.isLocalBuffer(b) && "java".equals(b.getLanguage())) {
+                open.add(b.getPath());
+            }
+        });
+        EditorBuffer active = host.activeBuffer();
+        Path activeJava = active != null
+                        && active.getPath() != null
+                        && host.isLocalBuffer(active)
+                        && "java".equals(active.getLanguage())
+                ? active.getPath()
+                : null;
+        return RunConfigRouting.pick(open, activeJava, cfg.workingDir());
+    }
+
     /** Runs a saved {@link RunConfiguration}: its main class with its own program/VM args + working dir. */
     void runConfig(RunConfiguration cfg) {
-        EditorBuffer b = host.activeBuffer();
-        if (b == null || b.getPath() == null || !host.isLocalBuffer(b) || !"java".equals(b.getLanguage())) {
-            host.setStatus(tr("status.run.needJavaFile"));
-            return;
-        }
         if (service.isRunning()) {
             host.setStatus(tr("status.run.busy"));
             return;
         }
-        Path routing = b.getPath();
+        // A named configuration is independent of whatever is on screen: any open Java file in its project
+        // can route the classpath resolution, so this no longer refuses just because the active tab is a
+        // README. Null means no Java file is open at all, which is the only genuinely unresolvable case.
+        Path routing = routingFor(host, cfg);
+        if (routing == null) {
+            host.setStatus(tr("status.run.configNeedsJavaFile"));
+            return;
+        }
         Path root = ops.javaProjectRoot(routing);
         if (root == null) {
             host.setStatus(tr("status.run.noProject"));
             return;
         }
-        if (b.isDirty() && !ops.saveBuffer(b)) {
-            return;
+        EditorBuffer b = host.activeBuffer();
+        if (b != null && b.isDirty() && host.isLocalBuffer(b) && !ops.saveBuffer(b)) {
+            return; // save whatever the user was editing before launching, as before
         }
         Path cwd = cfg.workingDir().isBlank() ? root : Path.of(cfg.workingDir());
         List<String> vm = ProgramArgs.tokenize(cfg.vmArgs());

--- a/src/main/resources/com/editora/i18n/messages.properties
+++ b/src/main/resources/com/editora/i18n/messages.properties
@@ -3852,3 +3852,4 @@ menubar.help=Help
 command.view.toggleMenuBar=View: Toggle Menu Bar
 command.view.toggleMenuBar.desc=Show or hide the menu bar.
 settings.showMenuBar=Show menu bar
+status.run.configNeedsJavaFile=Open a Java file from the project to run this configuration

--- a/src/main/resources/com/editora/i18n/messages_de.properties
+++ b/src/main/resources/com/editora/i18n/messages_de.properties
@@ -3843,3 +3843,4 @@ menubar.help=Hilfe
 command.view.toggleMenuBar=Ansicht: Menüleiste ein-/ausblenden
 command.view.toggleMenuBar.desc=Blendet die Menüleiste ein oder aus.
 settings.showMenuBar=Menüleiste anzeigen
+status.run.configNeedsJavaFile=Öffne eine Java-Datei des Projekts, um diese Konfiguration auszuführen

--- a/src/main/resources/com/editora/i18n/messages_es.properties
+++ b/src/main/resources/com/editora/i18n/messages_es.properties
@@ -3843,3 +3843,4 @@ menubar.help=Ayuda
 command.view.toggleMenuBar=Vista: mostrar u ocultar la barra de menús
 command.view.toggleMenuBar.desc=Muestra u oculta la barra de menús.
 settings.showMenuBar=Mostrar la barra de menús
+status.run.configNeedsJavaFile=Abre un archivo Java del proyecto para ejecutar esta configuración

--- a/src/main/resources/com/editora/i18n/messages_fr.properties
+++ b/src/main/resources/com/editora/i18n/messages_fr.properties
@@ -3843,3 +3843,4 @@ menubar.help=Aide
 command.view.toggleMenuBar=Affichage : afficher ou masquer la barre de menus
 command.view.toggleMenuBar.desc=Affiche ou masque la barre de menus.
 settings.showMenuBar=Afficher la barre de menus
+status.run.configNeedsJavaFile=Ouvrez un fichier Java du projet pour exécuter cette configuration

--- a/src/main/resources/com/editora/i18n/messages_it.properties
+++ b/src/main/resources/com/editora/i18n/messages_it.properties
@@ -3843,3 +3843,4 @@ menubar.help=Aiuto
 command.view.toggleMenuBar=Vista: mostra/nascondi la barra dei menu
 command.view.toggleMenuBar.desc=Mostra o nasconde la barra dei menu.
 settings.showMenuBar=Mostra la barra dei menu
+status.run.configNeedsJavaFile=Apri un file Java del progetto per eseguire questa configurazione

--- a/src/main/resources/com/editora/i18n/messages_pt.properties
+++ b/src/main/resources/com/editora/i18n/messages_pt.properties
@@ -3843,3 +3843,4 @@ menubar.help=Ajuda
 command.view.toggleMenuBar=Ver: mostrar ou ocultar a barra de menus
 command.view.toggleMenuBar.desc=Mostra ou oculta a barra de menus.
 settings.showMenuBar=Mostrar a barra de menus
+status.run.configNeedsJavaFile=Abra um ficheiro Java do projeto para executar esta configuração

--- a/src/test/java/com/editora/run/RunConfigRoutingTest.java
+++ b/src/test/java/com/editora/run/RunConfigRoutingTest.java
@@ -1,0 +1,61 @@
+package com.editora.run;
+
+import java.nio.file.Path;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+class RunConfigRoutingTest {
+
+    private static final Path APP = Path.of("/w/app/src/main/java/App.java");
+    private static final Path UTIL = Path.of("/w/app/src/main/java/Util.java");
+    private static final Path OTHER = Path.of("/w/other/src/main/java/Other.java");
+
+    /** The previous behaviour, preserved: with a Java file active, that is what gets used. */
+    @Test
+    void theActiveJavaFileIsPreferred() {
+        assertEquals(APP, RunConfigRouting.pick(List.of(UTIL, APP), APP, ""));
+    }
+
+    /**
+     * The point of the change. A configuration is named and independent of the current tab, so looking at a
+     * Markdown file must not stop it launching when a Java file is open elsewhere.
+     */
+    @Test
+    void anyOpenJavaFileWorksWhenTheActiveOneIsNot() {
+        assertEquals(UTIL, RunConfigRouting.pick(List.of(UTIL, APP), null, ""));
+    }
+
+    /** With several projects open, the configuration's working directory says which one it belongs to. */
+    @Test
+    void theWorkingDirectorySelectsTheProject() {
+        // Active file is in a different project than the configuration's working dir: the config wins.
+        assertEquals(OTHER, RunConfigRouting.pick(List.of(APP, OTHER), APP, "/w/other"));
+    }
+
+    /** Among candidates inside the right project, the active one is still preferred. */
+    @Test
+    void theActiveFileWinsAmongCandidatesInTheSameProject() {
+        assertEquals(APP, RunConfigRouting.pick(List.of(UTIL, APP), APP, "/w/app"));
+    }
+
+    /**
+     * A working directory with no open file under it says nothing about where the sources are — it may be an
+     * output folder or a sandbox — so it must not veto an otherwise usable candidate.
+     */
+    @Test
+    void anUnmatchedWorkingDirectoryFallsBackRatherThanRefusing() {
+        assertEquals(APP, RunConfigRouting.pick(List.of(APP), APP, "/tmp/sandbox"));
+        assertEquals(APP, RunConfigRouting.pick(List.of(APP), null, "/tmp/sandbox"));
+    }
+
+    /** The one genuinely unresolvable case, so the caller can say precisely that. */
+    @Test
+    void nothingOpenYieldsNull() {
+        assertNull(RunConfigRouting.pick(List.of(), null, ""));
+        assertNull(RunConfigRouting.pick(null, null, "/w/app"));
+    }
+}

--- a/src/test/java/com/editora/ui/MultiCaretMovementFxTest.java
+++ b/src/test/java/com/editora/ui/MultiCaretMovementFxTest.java
@@ -68,6 +68,31 @@ class MultiCaretMovementFxTest {
         });
     }
 
+    /**
+     * Forces a layout pass and reports whether the area actually has one.
+     *
+     * <p>Vertical caret movement is <b>geometry-based</b> — it has to know which offset sits on the next line
+     * at the same visual column — so it silently does nothing until the virtual flow has laid out. Under the
+     * headless platform that is not guaranteed to have happened by the time a test runs, which made
+     * {@link #lineDownMovesEveryCaret} fail intermittently (#773): the carets stayed at their starting
+     * offsets, indistinguishable from a broken implementation.
+     *
+     * <p>Height, not an exception, is the readiness test — a not-yet-laid-out area no-ops rather than
+     * throwing, the same property documented for {@code scrollRestoredCaretIntoView}.
+     */
+    private boolean layOut(EditorBuffer b) throws Exception {
+        return FxTestSupport.callOnFx(() -> {
+            CodeArea area = FxTestSupport.field(b, "area");
+            if (area.getScene() != null) {
+                area.getScene().getRoot().applyCss();
+                area.getScene().getRoot().layout();
+            }
+            area.requestLayout();
+            area.layout();
+            return area.getHeight() > 0;
+        });
+    }
+
     /** Sorted absolute offsets of every caret (primary + extras), read out of the fork. */
     private List<Integer> carets(EditorBuffer b) throws Exception {
         return FxTestSupport.callOnFx(() -> {
@@ -118,6 +143,12 @@ class MultiCaretMovementFxTest {
     @Test
     void lineDownMovesEveryCaret() throws Exception {
         EditorBuffer b = twoCaretBuffer(); // carets on lines 0 and 1
+
+        // Unlike the other tests here, this one moves *vertically*, which needs real geometry. Assert the
+        // area laid out rather than assume it: without this the failure looks like "the carets did not move",
+        // which reads as a product bug rather than a test that ran too early (#773).
+        org.junit.jupiter.api.Assumptions.assumeTrue(
+                layOut(b), "the editor never laid out, so vertical movement cannot be exercised");
 
         run("nav.lineDown");
         assertEquals(List.of(5, 10), carets(b), "both carets move down a line, keeping column 0");


### PR DESCRIPTION
First of four parts on #765 — **whose description I corrected first**, because it claimed run configurations did not exist. They do: model, per-project persistence, a full Settings editor page, and both launch paths were already there. What is actually missing is narrower, and this is the smallest piece of it.

Also closes #773 (separate commit — see below).

## The problem

Both `runConfig` and `debugConfig` read the **active buffer** for routing and refused unless it was a Java file. Save a configuration for `MyApp`, open `README.md`, run it → *"needs a Java file"*.

That defeats the point of a *named* configuration, which should be independent of what you happen to be looking at. It also fails when a Java file **is** open, just not in front.

## The fix

The file handed to jdtls only selects which language-server **session** resolves the classpath — jdtls is keyed per project root, so any open Java file in the right project works. It does not have to be the class being run, and it does not have to be on screen.

The new pure `RunConfigRouting` picks one:

1. a Java file under the configuration's own **working directory**, when it sets one — with several projects open that is the only signal saying which project the configuration belongs to;
2. else the active buffer, when it is Java — the common case, preserving the old behaviour exactly;
3. else any other open Java file.

Null now means what it should — no Java file open anywhere — so the message says that rather than blaming the current tab.

An unmatched working directory **falls back rather than refusing**: it may be an output folder or a sandbox, which says nothing about where the sources are.

**No disk search**, deliberately: that would be I/O on the FX thread to cover a Java project with no Java file open at all, and jdtls would have no session for it in that state anyway.

Run and debug share the routing, so a configuration's `kind` cannot change which project it resolves against.

## Also: #773, the flaky test

Fixed here rather than later because it **stopped being a nuisance**. It interrupted four separate branches, and on this one it failed **twice in a row**, so a green `verify` was no longer reachable by re-running.

Vertical caret movement is geometry-based and silently does nothing until the virtual flow has laid out, which the headless platform does not guarantee. The failure looked like the carets not moving — indistinguishable from a product bug. The test now forces a layout pass and assumes on the result; height, not an exception, is the readiness test, matching what is already documented for `scrollRestoredCaretIntoView`. The class's other three tests move only by offset, which is why they never flaked.

Two consecutive full runs are clean.

## Verification

3361 tests green (6 new, all pure), spotless and the JaCoCo floors pass. Kept as two commits since the concerns are unrelated.

## Still to come on #765

2. Generalise the model beyond `mainClass` (Python, shell, make, build tasks) — the substantial piece
3. Toolbar selector + bindable `run.config.<slug>` commands
4. Before-launch step and shareable storage

🤖 Generated with [Claude Code](https://claude.com/claude-code)