### PR TITLE
feat(run): run configurations for scripts and make targets, not just Java (#765 part 2/4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   are actually looking, with the server's preferred fix preselected so Enter usually does the right thing.
   Arrow keys or `C-n`/`C-p` move, Enter applies, Escape or `C-g` dismisses, and the caret stays visible on
   the spot the fix will land.
+- **Run configurations are no longer Java-only, and no longer care which tab is in front** — a saved
+  configuration can now launch a **Python script, a shell script or a make target** as well as a Java main
+  class, chosen with a Type field in Settings → Run Configurations. Script configurations need no project and
+  no language server at all. Separately, running a saved configuration used to refuse unless a Java file
+  happened to be the active tab — so saving one for your app and then opening a README broke it. Any open
+  Java file in the project now serves, and it only complains when there genuinely isn't one. Debugging
+  remains Java-only, and now says so instead of reporting a confusing Java error.
 
 ### Added
 

--- a/src/main/java/com/editora/config/RunConfiguration.java
+++ b/src/main/java/com/editora/config/RunConfiguration.java
@@ -4,17 +4,26 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 
 /**
- * A saved run/debug configuration for a Java project main class: a {@code name}, whether it runs or debugs
+ * A saved run/debug configuration: a {@code name}, whether it runs or debugs
  * ({@code kind} = {@code "run"}/{@code "debug"}), the {@code mainClass} (fully-qualified) + its {@code
  * projectName} (multi-module), program {@code args}, JVM {@code vmArgs}, an optional {@code workingDir}
  * (blank ⇒ the project root), and {@code env} — environment variables as quote-aware {@code KEY=VALUE} pairs
- * (see {@code run/EnvVars}). Persisted per window in {@code WorkspaceState.runConfigurations}. Jackson
+ * (see {@code run/EnvVars}).
+ *
+ * <p>{@code type} says <em>what</em> is launched — {@code java} (the {@code mainClass}, resolved through
+ * jdtls) or a script type handled by {@code run/ScriptRunCommand}, whose {@code target} is the script path or
+ * make target. It is orthogonal to {@code kind}, which says whether to run or debug. Absent from an older
+ * entry it defaults to {@code java}, so every configuration saved before types existed keeps working.
+ *
+ * <p>Persisted per window in {@code WorkspaceState.runConfigurations}. Jackson
  * round-trips this record; the compact constructor defaults every field so an older/partial entry loads.
  */
 @JsonIgnoreProperties(ignoreUnknown = true)
 public record RunConfiguration(
         String name,
         String kind,
+        String type,
+        String target,
         String mainClass,
         String projectName,
         String args,
@@ -25,6 +34,9 @@ public record RunConfiguration(
     public RunConfiguration {
         name = name == null ? "" : name;
         kind = kind == null ? "run" : kind;
+        // Defaults to java so every configuration saved before types existed keeps working untouched.
+        type = type == null || type.isBlank() ? "java" : type;
+        target = target == null ? "" : target;
         mainClass = mainClass == null ? "" : mainClass;
         projectName = projectName == null ? "" : projectName;
         args = args == null ? "" : args;
@@ -43,6 +55,25 @@ public record RunConfiguration(
             String vmArgs,
             String workingDir) {
         this(name, kind, mainClass, projectName, args, vmArgs, workingDir, "");
+    }
+
+    /** Back-compat constructor for the pre-type shape: a Java main-class configuration. */
+    public RunConfiguration(
+            String name,
+            String kind,
+            String mainClass,
+            String projectName,
+            String args,
+            String vmArgs,
+            String workingDir,
+            String env) {
+        this(name, kind, "java", "", mainClass, projectName, args, vmArgs, workingDir, env);
+    }
+
+    /** Whether this launches a Java main class (the jdtls path) rather than a script or make target. */
+    @JsonIgnore
+    public boolean isJava() {
+        return "java".equals(type);
     }
 
     @JsonIgnore

--- a/src/main/java/com/editora/config/WorkspaceState.java
+++ b/src/main/java/com/editora/config/WorkspaceState.java
@@ -20,8 +20,11 @@ public class WorkspaceState {
      *
      * <p>v1 → v2 added the editor-group layout ({@link #getEditorLayout()} plus {@code OpenFile.group}). Both
      * are additive with defaults that reproduce the old single-group behaviour, so the migration is identity.
+     *
+     * <p>v2 → v3 added {@code type}/{@code target} to {@link RunConfiguration}; {@code type} defaults to
+     * {@code java}, which is what every pre-existing configuration was, so this is identity too.
      */
-    public static final int SCHEMA_VERSION = 2;
+    public static final int SCHEMA_VERSION = 3;
 
     private int schemaVersion = SCHEMA_VERSION;
 

--- a/src/main/java/com/editora/config/migration/ConfigSchema.java
+++ b/src/main/java/com/editora/config/migration/ConfigSchema.java
@@ -151,7 +151,7 @@ public enum ConfigSchema {
                     Map.entry(87, (Migration) ConfigMigrations::identity))), // v87→88: + showMenuBar (additive)
     // v1 → v2 added the editor-group layout + OpenFile.group. Both default to the old single-group
     // behaviour, so the step is identity.
-    WORKSPACE(WorkspaceState.SCHEMA_VERSION, 1, Map.of(1, ConfigMigrations::identity)),
+    WORKSPACE(WorkspaceState.SCHEMA_VERSION, 1, Map.of(1, ConfigMigrations::identity, 2, ConfigMigrations::identity)),
     BOOKMARKS(BookmarkStore.SCHEMA_VERSION, 1, Map.of()),
     BREAKPOINTS(BreakpointStore.SCHEMA_VERSION, 1, Map.of()),
     // v1 → v2 added openProjectIds (the multi-window open-set), seeded from the old activeProjectId.

--- a/src/main/java/com/editora/run/ScriptRunCommand.java
+++ b/src/main/java/com/editora/run/ScriptRunCommand.java
@@ -1,0 +1,86 @@
+package com.editora.run;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * The launch argv for a run configuration that is <b>not</b> a Java main class.
+ *
+ * <p>Java configurations go through jdtls to resolve a classpath, which is why they need a project and a
+ * language server. Everything else Editora can already run — a Python script, a shell script, a make target —
+ * needs none of that: an interpreter and a path is the whole story. Keeping those in a pure builder means the
+ * argv is unit-testable, and that a script configuration launches with no project, no language server and no
+ * open Java file anywhere.
+ *
+ * <p>Mirrors what {@code RunCoordinator.buildRunCommand} does for the active file, but takes its target from
+ * the configuration rather than from whatever is on screen.
+ */
+public final class ScriptRunCommand {
+
+    /** Configuration types this builder handles. Java is deliberately absent — it takes the jdtls path. */
+    public static final String PYTHON = "python";
+
+    public static final String SHELL = "shell";
+    public static final String MAKE = "make";
+    public static final String JAVA = "java";
+
+    private ScriptRunCommand() {}
+
+    /** Whether {@code type} is a script type this builder can launch (i.e. anything but {@code java}). */
+    public static boolean isScript(String type) {
+        return PYTHON.equals(type) || SHELL.equals(type) || MAKE.equals(type);
+    }
+
+    /**
+     * Whether {@code type} needs a target to be launchable.
+     *
+     * <p>Make is the exception: a blank target means the default goal, which is exactly what a bare
+     * {@code make} does, so it is a valid configuration rather than an incomplete one.
+     */
+    public static boolean needsTarget(String type) {
+        return PYTHON.equals(type) || SHELL.equals(type);
+    }
+
+    /**
+     * Builds the argv.
+     *
+     * @param type one of {@link #PYTHON}, {@link #SHELL}, {@link #MAKE}
+     * @param target the script path, or the make target ({@code ""} = make's default goal)
+     * @param args already-tokenized program arguments
+     * @return the argv, or an empty list when the type is unknown or a required target is missing — the
+     *     caller reports that rather than launching something arbitrary
+     */
+    public static List<String> build(String type, String target, List<String> args) {
+        String t = target == null ? "" : target.strip();
+        List<String> argv = new ArrayList<>();
+        switch (type == null ? "" : type) {
+            case PYTHON -> {
+                if (t.isEmpty()) {
+                    return List.of();
+                }
+                argv.add("python3");
+                argv.add(t);
+            }
+            case SHELL -> {
+                if (t.isEmpty()) {
+                    return List.of();
+                }
+                argv.add("bash");
+                argv.add(t);
+            }
+            case MAKE -> {
+                argv.add("make");
+                if (!t.isEmpty()) {
+                    argv.add(t);
+                }
+            }
+            default -> {
+                return List.of();
+            }
+        }
+        if (args != null) {
+            argv.addAll(args);
+        }
+        return argv;
+    }
+}

--- a/src/main/java/com/editora/ui/DebugCoordinator.java
+++ b/src/main/java/com/editora/ui/DebugCoordinator.java
@@ -763,6 +763,12 @@ final class DebugCoordinator {
     /** Debugs a saved {@link RunConfiguration} (its main class + program args; its working dir when set). VM
      *  args aren't yet forwarded to the debug launch. */
     void debugConfig(RunConfiguration cfg) {
+        if (!cfg.isJava()) {
+            // Script types run but do not debug yet. Say so plainly: falling through would resolve a Java
+            // main class that a Python configuration does not have and report a confusing Java error.
+            host.setStatus(tr("status.debug.configTypeUnsupported", cfg.type()));
+            return;
+        }
         if (!debugEffectiveFor("java")) {
             host.setStatus(tr("status.debug.unavailable"));
             return;

--- a/src/main/java/com/editora/ui/RunCoordinator.java
+++ b/src/main/java/com/editora/ui/RunCoordinator.java
@@ -13,6 +13,7 @@ import com.editora.run.JavaRunCommand;
 import com.editora.run.ProgramArgs;
 import com.editora.run.RunConfigRouting;
 import com.editora.run.RunService;
+import com.editora.run.ScriptRunCommand;
 import com.editora.run.StackTraceLinks;
 
 import static com.editora.i18n.Messages.tr;
@@ -162,10 +163,56 @@ final class RunCoordinator {
         return RunConfigRouting.pick(open, activeJava, cfg.workingDir());
     }
 
+    /**
+     * Runs a non-Java configuration — a Python or shell script, or a make target.
+     *
+     * <p>Needs no project, no language server and no open Java file: the whole launch is an interpreter and a
+     * path (see {@link ScriptRunCommand}). The working directory is the configuration's own when set, else the
+     * script's folder, which is what makes a script's relative paths resolve the way they do from a terminal.
+     */
+    private void runScriptConfig(RunConfiguration cfg) {
+        List<String> argv = ScriptRunCommand.build(cfg.type(), cfg.target(), ProgramArgs.tokenize(cfg.args()));
+        if (argv.isEmpty()) {
+            host.setStatus(tr(
+                    ScriptRunCommand.needsTarget(cfg.type())
+                            ? "status.run.configNeedsTarget"
+                            : "status.run.configBadType",
+                    cfg.name()));
+            return;
+        }
+        Path cwd = workingDirFor(cfg);
+        if (cwd == null) {
+            host.setStatus(tr("status.run.configNeedsWorkingDir", cfg.name()));
+            return;
+        }
+        streamRun(cfg.name(), cwd, argv, com.editora.run.EnvVars.parse(cfg.env()));
+    }
+
+    /**
+     * Where a script configuration runs: its own working directory when set, else the target script's folder.
+     * Null when neither is known — a make target with no working directory, which has nothing to run against.
+     */
+    private static Path workingDirFor(RunConfiguration cfg) {
+        if (!cfg.workingDir().isBlank()) {
+            return Path.of(cfg.workingDir());
+        }
+        if (!cfg.target().isBlank()) {
+            Path parent = Path.of(cfg.target()).toAbsolutePath().getParent();
+            if (parent != null) {
+                return parent;
+            }
+        }
+        return null;
+    }
+
     /** Runs a saved {@link RunConfiguration}: its main class with its own program/VM args + working dir. */
     void runConfig(RunConfiguration cfg) {
         if (service.isRunning()) {
             host.setStatus(tr("status.run.busy"));
+            return;
+        }
+        if (!cfg.isJava()) {
+            runScriptConfig(cfg);
             return;
         }
         // A named configuration is independent of whatever is on screen: any open Java file in its project

--- a/src/main/java/com/editora/ui/SettingsWindow.java
+++ b/src/main/java/com/editora/ui/SettingsWindow.java
@@ -4060,6 +4060,11 @@ public class SettingsWindow {
         TextField name = new TextField();
         ComboBox<String> kind = new ComboBox<>(javafx.collections.FXCollections.observableArrayList("run", "debug"));
         kind.setConverter(enumConverter(k -> "debug".equals(k) ? tr("run.config.debugTag") : tr("run.config.runTag")));
+        ComboBox<String> type =
+                new ComboBox<>(javafx.collections.FXCollections.observableArrayList("java", "python", "shell", "make"));
+        type.setConverter(enumConverter(t -> tr("settings.runConfig.type." + t)));
+        TextField target = new TextField();
+        target.setPromptText(tr("settings.runConfig.targetPrompt"));
         TextField mainClass = new TextField();
         TextField projectName = new TextField();
         projectName.setPromptText(tr("settings.runConfig.projectNamePrompt"));
@@ -4075,12 +4080,14 @@ public class SettingsWindow {
         form.setVgap(6);
         formRow(form, 0, tr("settings.runConfig.name"), name);
         formRow(form, 1, tr("settings.runConfig.kind"), kind);
-        formRow(form, 2, tr("settings.runConfig.mainClass"), mainClass);
-        formRow(form, 3, tr("settings.runConfig.projectName"), projectName);
-        formRow(form, 4, tr("settings.runConfig.args"), args);
-        formRow(form, 5, tr("settings.runConfig.vmArgs"), vmArgs);
-        formRow(form, 6, tr("settings.runConfig.workingDir"), workingDir);
-        formRow(form, 7, tr("settings.runConfig.env"), env);
+        formRow(form, 2, tr("settings.runConfig.type"), type);
+        formRow(form, 3, tr("settings.runConfig.target"), target);
+        formRow(form, 4, tr("settings.runConfig.mainClass"), mainClass);
+        formRow(form, 5, tr("settings.runConfig.projectName"), projectName);
+        formRow(form, 6, tr("settings.runConfig.args"), args);
+        formRow(form, 7, tr("settings.runConfig.vmArgs"), vmArgs);
+        formRow(form, 8, tr("settings.runConfig.workingDir"), workingDir);
+        formRow(form, 9, tr("settings.runConfig.env"), env);
         form.setDisable(true);
         HBox.setHgrow(form, Priority.ALWAYS);
 
@@ -4092,6 +4099,8 @@ public class SettingsWindow {
             com.editora.config.RunConfiguration rebuilt = new com.editora.config.RunConfiguration(
                     name.getText(),
                     kind.getValue() == null ? "run" : kind.getValue(),
+                    type.getValue() == null ? "java" : type.getValue(),
+                    target.getText(),
                     mainClass.getText(),
                     projectName.getText(),
                     args.getText(),
@@ -4103,6 +4112,7 @@ public class SettingsWindow {
             persistRunConfigs();
         };
         kind.valueProperty().addListener((o, a, b) -> commit.run());
+        type.valueProperty().addListener((o, a, b) -> commit.run());
         java.util.function.Consumer<TextField> wire = tf -> {
             tf.setOnAction(e -> commit.run());
             tf.focusedProperty().addListener((o, was, now) -> {
@@ -4125,6 +4135,8 @@ public class SettingsWindow {
                 form.setDisable(now == null);
                 name.setText(now == null ? "" : now.name());
                 kind.setValue(now == null ? "run" : (now.isDebug() ? "debug" : "run"));
+                type.setValue(now == null ? "java" : now.type());
+                target.setText(now == null ? "" : now.target());
                 mainClass.setText(now == null ? "" : now.mainClass());
                 projectName.setText(now == null ? "" : now.projectName());
                 args.setText(now == null ? "" : now.args());

--- a/src/main/resources/com/editora/i18n/messages.properties
+++ b/src/main/resources/com/editora/i18n/messages.properties
@@ -3853,3 +3853,14 @@ command.view.toggleMenuBar=View: Toggle Menu Bar
 command.view.toggleMenuBar.desc=Show or hide the menu bar.
 settings.showMenuBar=Show menu bar
 status.run.configNeedsJavaFile=Open a Java file from the project to run this configuration
+status.run.configNeedsTarget=Run configuration "{0}" has no script to run
+status.run.configBadType=Run configuration "{0}" has an unknown type
+status.run.configNeedsWorkingDir=Run configuration "{0}" needs a working directory
+status.debug.configTypeUnsupported=Debugging a {0} configuration is not supported yet
+settings.runConfig.type=Type
+settings.runConfig.target=Script / target
+settings.runConfig.targetPrompt=Script path, or make target (blank = default goal)
+settings.runConfig.type.java=Java main class
+settings.runConfig.type.python=Python script
+settings.runConfig.type.shell=Shell script
+settings.runConfig.type.make=Make target

--- a/src/main/resources/com/editora/i18n/messages_de.properties
+++ b/src/main/resources/com/editora/i18n/messages_de.properties
@@ -3844,3 +3844,14 @@ command.view.toggleMenuBar=Ansicht: Menüleiste ein-/ausblenden
 command.view.toggleMenuBar.desc=Blendet die Menüleiste ein oder aus.
 settings.showMenuBar=Menüleiste anzeigen
 status.run.configNeedsJavaFile=Öffne eine Java-Datei des Projekts, um diese Konfiguration auszuführen
+status.run.configNeedsTarget=Die Konfiguration "{0}" hat kein auszuführendes Skript
+status.run.configBadType=Die Konfiguration "{0}" hat einen unbekannten Typ
+status.run.configNeedsWorkingDir=Die Konfiguration "{0}" benötigt ein Arbeitsverzeichnis
+status.debug.configTypeUnsupported=Das Debuggen einer {0}-Konfiguration wird noch nicht unterstützt
+settings.runConfig.type=Typ
+settings.runConfig.target=Skript / Ziel
+settings.runConfig.targetPrompt=Skriptpfad oder Make-Ziel (leer = Standardziel)
+settings.runConfig.type.java=Java-Hauptklasse
+settings.runConfig.type.python=Python-Skript
+settings.runConfig.type.shell=Shell-Skript
+settings.runConfig.type.make=Make-Ziel

--- a/src/main/resources/com/editora/i18n/messages_es.properties
+++ b/src/main/resources/com/editora/i18n/messages_es.properties
@@ -3844,3 +3844,14 @@ command.view.toggleMenuBar=Vista: mostrar u ocultar la barra de menús
 command.view.toggleMenuBar.desc=Muestra u oculta la barra de menús.
 settings.showMenuBar=Mostrar la barra de menús
 status.run.configNeedsJavaFile=Abre un archivo Java del proyecto para ejecutar esta configuración
+status.run.configNeedsTarget=La configuración "{0}" no tiene ningún script que ejecutar
+status.run.configBadType=La configuración "{0}" tiene un tipo desconocido
+status.run.configNeedsWorkingDir=La configuración "{0}" necesita un directorio de trabajo
+status.debug.configTypeUnsupported=Depurar una configuración {0} aún no está soportado
+settings.runConfig.type=Tipo
+settings.runConfig.target=Script / objetivo
+settings.runConfig.targetPrompt=Ruta del script, u objetivo de make (vacío = objetivo predeterminado)
+settings.runConfig.type.java=Clase main de Java
+settings.runConfig.type.python=Script de Python
+settings.runConfig.type.shell=Script de shell
+settings.runConfig.type.make=Objetivo de make

--- a/src/main/resources/com/editora/i18n/messages_fr.properties
+++ b/src/main/resources/com/editora/i18n/messages_fr.properties
@@ -3844,3 +3844,14 @@ command.view.toggleMenuBar=Affichage : afficher ou masquer la barre de menus
 command.view.toggleMenuBar.desc=Affiche ou masque la barre de menus.
 settings.showMenuBar=Afficher la barre de menus
 status.run.configNeedsJavaFile=Ouvrez un fichier Java du projet pour exécuter cette configuration
+status.run.configNeedsTarget=La configuration "{0}" na aucun script à exécuter
+status.run.configBadType=La configuration "{0}" a un type inconnu
+status.run.configNeedsWorkingDir=La configuration "{0}" nécessite un répertoire de travail
+status.debug.configTypeUnsupported=Le débogage dune configuration {0} nest pas encore pris en charge
+settings.runConfig.type=Type
+settings.runConfig.target=Script / cible
+settings.runConfig.targetPrompt=Chemin du script, ou cible make (vide = cible par défaut)
+settings.runConfig.type.java=Classe main Java
+settings.runConfig.type.python=Script Python
+settings.runConfig.type.shell=Script shell
+settings.runConfig.type.make=Cible make

--- a/src/main/resources/com/editora/i18n/messages_it.properties
+++ b/src/main/resources/com/editora/i18n/messages_it.properties
@@ -3844,3 +3844,14 @@ command.view.toggleMenuBar=Vista: mostra/nascondi la barra dei menu
 command.view.toggleMenuBar.desc=Mostra o nasconde la barra dei menu.
 settings.showMenuBar=Mostra la barra dei menu
 status.run.configNeedsJavaFile=Apri un file Java del progetto per eseguire questa configurazione
+status.run.configNeedsTarget=La configurazione "{0}" non ha uno script da eseguire
+status.run.configBadType=La configurazione "{0}" ha un tipo sconosciuto
+status.run.configNeedsWorkingDir=La configurazione "{0}" richiede una directory di lavoro
+status.debug.configTypeUnsupported=Il debug di una configurazione {0} non è ancora supportato
+settings.runConfig.type=Tipo
+settings.runConfig.target=Script / destinazione
+settings.runConfig.targetPrompt=Percorso dello script, o destinazione make (vuoto = obiettivo predefinito)
+settings.runConfig.type.java=Classe main Java
+settings.runConfig.type.python=Script Python
+settings.runConfig.type.shell=Script di shell
+settings.runConfig.type.make=Destinazione make

--- a/src/main/resources/com/editora/i18n/messages_pt.properties
+++ b/src/main/resources/com/editora/i18n/messages_pt.properties
@@ -3844,3 +3844,14 @@ command.view.toggleMenuBar=Ver: mostrar ou ocultar a barra de menus
 command.view.toggleMenuBar.desc=Mostra ou oculta a barra de menus.
 settings.showMenuBar=Mostrar a barra de menus
 status.run.configNeedsJavaFile=Abra um ficheiro Java do projeto para executar esta configuração
+status.run.configNeedsTarget=A configuração "{0}" não tem nenhum script para executar
+status.run.configBadType=A configuração "{0}" tem um tipo desconhecido
+status.run.configNeedsWorkingDir=A configuração "{0}" precisa de um diretório de trabalho
+status.debug.configTypeUnsupported=Depurar uma configuração {0} ainda não é suportado
+settings.runConfig.type=Tipo
+settings.runConfig.target=Script / alvo
+settings.runConfig.targetPrompt=Caminho do script, ou alvo make (vazio = alvo predefinido)
+settings.runConfig.type.java=Classe main Java
+settings.runConfig.type.python=Script Python
+settings.runConfig.type.shell=Script de shell
+settings.runConfig.type.make=Alvo make

--- a/src/test/java/com/editora/run/ScriptRunCommandTest.java
+++ b/src/test/java/com/editora/run/ScriptRunCommandTest.java
@@ -1,0 +1,70 @@
+package com.editora.run;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ScriptRunCommandTest {
+
+    @Test
+    void aPythonScriptRunsUnderPython3() {
+        assertEquals(
+                List.of("python3", "/w/app/main.py", "--verbose"),
+                ScriptRunCommand.build("python", "/w/app/main.py", List.of("--verbose")));
+    }
+
+    @Test
+    void aShellScriptRunsUnderBash() {
+        assertEquals(List.of("bash", "/w/deploy.sh"), ScriptRunCommand.build("shell", "/w/deploy.sh", List.of()));
+    }
+
+    @Test
+    void aMakeTargetRunsUnderMake() {
+        assertEquals(List.of("make", "test"), ScriptRunCommand.build("make", "test", List.of()));
+    }
+
+    /**
+     * A blank make target is not an incomplete configuration — a bare {@code make} runs the default goal,
+     * which is a perfectly ordinary thing to want.
+     */
+    @Test
+    void aBlankMakeTargetMeansTheDefaultGoal() {
+        assertEquals(List.of("make"), ScriptRunCommand.build("make", "", List.of()));
+        assertEquals(List.of("make"), ScriptRunCommand.build("make", "   ", List.of()));
+        assertFalse(ScriptRunCommand.needsTarget("make"), "make is launchable without one");
+    }
+
+    /** A script type with no target has nothing to run; an empty argv tells the caller to say so. */
+    @Test
+    void aMissingScriptPathYieldsNothingToLaunch() {
+        assertTrue(ScriptRunCommand.build("python", "", List.of()).isEmpty());
+        assertTrue(ScriptRunCommand.build("shell", null, List.of()).isEmpty());
+        assertTrue(ScriptRunCommand.needsTarget("python"));
+        assertTrue(ScriptRunCommand.needsTarget("shell"));
+    }
+
+    /** Java takes the jdtls path, so this builder must decline it rather than invent an argv. */
+    @Test
+    void javaIsNotAScriptType() {
+        assertFalse(ScriptRunCommand.isScript("java"));
+        assertTrue(ScriptRunCommand.build("java", "com.example.App", List.of()).isEmpty());
+    }
+
+    @Test
+    void anUnknownTypeLaunchesNothing() {
+        assertTrue(ScriptRunCommand.build("perl", "/w/x.pl", List.of()).isEmpty());
+        assertTrue(ScriptRunCommand.build(null, "/w/x", List.of()).isEmpty());
+        assertFalse(ScriptRunCommand.isScript(null));
+    }
+
+    @Test
+    void argumentsAreAppendedAfterTheTarget() {
+        assertEquals(List.of("make", "build", "-j4"), ScriptRunCommand.build("make", "build", List.of("-j4")));
+        assertEquals(
+                List.of("bash", "/w/x.sh", "a", "b"), ScriptRunCommand.build("shell", "/w/x.sh", List.of("a", "b")));
+    }
+}


### PR DESCRIPTION
Second of four parts on #765. **Stacked on #781** (part 1) — review that first; this branch contains its commits until it merges.

## The gap

The model was `mainClass`-shaped, so a saved configuration could only ever be a Java main class — even though `RunCoordinator` already knew how to launch Python, shell and make files ad hoc. You could run a script, you just couldn't *save* one.

## The change

`RunConfiguration` gains a **`type`** saying *what* is launched — orthogonal to the existing `kind` (run vs debug) — plus a **`target`** for the script path or make target.

`type` defaults to `"java"`, which is what every pre-existing configuration was, so the `WorkspaceState` step (2 → 3) is identity and nothing already saved changes shape or behaviour.

The argv for the non-Java types is the pure **`ScriptRunCommand`**. Keeping it pure is what makes a script configuration need **no project, no language server and no open Java file** — an interpreter and a path is the whole story, the opposite of the Java path's jdtls classpath resolution.

Three decisions worth a look:

- **A blank make target is the default goal**, not an incomplete configuration — that is exactly what a bare `make` does, so refusing it would be wrong.
- **A missing script path yields an empty argv** so the caller reports it, rather than the builder inventing something to launch.
- **Working directory falls back to the script's own folder**, so a script's relative paths resolve the way they would from a terminal.

**Debugging stays Java-only and now says so plainly.** Falling through would have resolved a Java main class that a Python configuration does not have, and reported a confusing Java error instead of "not supported yet".

Settings → Run Configurations gains the Type and Script/target fields.

## Verification

3369 tests green (8 new, all pure), spotless and the JaCoCo floors pass.

**Not covered by tests:** that a script configuration actually launches end-to-end. The argv construction is unit-tested and the dispatch is a few lines, but the launch itself goes through `ProcessRunner` to a real interpreter — worth one manual run of a Python config before this ships.

## Still to come on #765

3. Toolbar selector + bindable `run.config.<slug>` commands
4. Before-launch step and shareable storage

🤖 Generated with [Claude Code](https://claude.com/claude-code)