### PR TITLE
feat(run): toolbar run-configuration selector and bindable per-config commands (#765 part 3/4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **A run-configuration selector in the toolbar** — pick a saved configuration and hit Run or Debug, with
+  Stop beside them; the choice is remembered across restarts. Each configuration also becomes a real command,
+  so it appears in the command palette by name and can be given its own keyboard shortcut, the same way saved
+  macros and external tools already work.
+
 ### Changed
 
 - **Quick fixes now appear at the caret** — the code-action list used to open as a card centred near the top

--- a/src/main/java/com/editora/config/RunConfiguration.java
+++ b/src/main/java/com/editora/config/RunConfiguration.java
@@ -31,6 +31,9 @@ public record RunConfiguration(
         String workingDir,
         String env) {
 
+    /** Prefix of the synthetic per-configuration commands, so stale ones can be found and dropped. */
+    public static final String COMMAND_PREFIX = "run.config.";
+
     public RunConfiguration {
         name = name == null ? "" : name;
         kind = kind == null ? "run" : kind;
@@ -68,6 +71,28 @@ public record RunConfiguration(
             String workingDir,
             String env) {
         this(name, kind, "java", "", mainClass, projectName, args, vmArgs, workingDir, env);
+    }
+
+    /** The id of the synthetic command that launches this configuration ({@code run.config.<slug>}). */
+    public static String commandIdFor(String name) {
+        return COMMAND_PREFIX + slug(name);
+    }
+
+    /**
+     * A command-id-safe slug of a configuration name.
+     *
+     * <p>Its own rather than shared with {@code MacroService.slug}, whose empty-name fallback is the literal
+     * {@code "macro"} — reusing it would give a configuration named only of punctuation the id
+     * {@code run.config.macro}. Same shape as {@code ExternalTool.commandIdFor}, which carries its own for the
+     * same reason.
+     */
+    public static String slug(String name) {
+        String s = (name == null ? "" : name)
+                .trim()
+                .toLowerCase(java.util.Locale.ROOT)
+                .replaceAll("[^a-z0-9]+", "-")
+                .replaceAll("(^-|-$)", "");
+        return s.isEmpty() ? "unnamed" : s;
     }
 
     /** Whether this launches a Java main class (the jdtls path) rather than a script or make target. */

--- a/src/main/java/com/editora/config/WorkspaceState.java
+++ b/src/main/java/com/editora/config/WorkspaceState.java
@@ -23,8 +23,10 @@ public class WorkspaceState {
      *
      * <p>v2 → v3 added {@code type}/{@code target} to {@link RunConfiguration}; {@code type} defaults to
      * {@code java}, which is what every pre-existing configuration was, so this is identity too.
+     *
+     * <p>v3 → v4 added {@code selectedRunConfig} (the toolbar selection); blank by default, identity.
      */
-    public static final int SCHEMA_VERSION = 3;
+    public static final int SCHEMA_VERSION = 4;
 
     private int schemaVersion = SCHEMA_VERSION;
 
@@ -65,6 +67,9 @@ public class WorkspaceState {
     private Map<String, String> programArgs = new LinkedHashMap<>();
     /** Saved run/debug configurations for project main classes (this window's project). */
     private List<RunConfiguration> runConfigurations = new ArrayList<>();
+
+    /** Name of the configuration selected in the toolbar, so the choice survives a restart. */
+    private String selectedRunConfig = "";
     /** The active HTTP Client environment name (for {@code .http} {@code {{var}}} resolution), or "". */
     private String httpEnvironment = "";
 
@@ -280,6 +285,14 @@ public class WorkspaceState {
 
     public void setRunConfigurations(List<RunConfiguration> runConfigurations) {
         this.runConfigurations = runConfigurations == null ? new ArrayList<>() : runConfigurations;
+    }
+
+    public String getSelectedRunConfig() {
+        return selectedRunConfig;
+    }
+
+    public void setSelectedRunConfig(String selectedRunConfig) {
+        this.selectedRunConfig = selectedRunConfig == null ? "" : selectedRunConfig;
     }
 
     public Map<String, String> getProgramArgs() {

--- a/src/main/java/com/editora/config/migration/ConfigSchema.java
+++ b/src/main/java/com/editora/config/migration/ConfigSchema.java
@@ -151,7 +151,15 @@ public enum ConfigSchema {
                     Map.entry(87, (Migration) ConfigMigrations::identity))), // v87→88: + showMenuBar (additive)
     // v1 → v2 added the editor-group layout + OpenFile.group. Both default to the old single-group
     // behaviour, so the step is identity.
-    WORKSPACE(WorkspaceState.SCHEMA_VERSION, 1, Map.of(1, ConfigMigrations::identity, 2, ConfigMigrations::identity)),
+    // v1→v2 editor-group layout, v2→v3 RunConfiguration type/target, v3→v4 selectedRunConfig — all additive
+    // with defaults reproducing the previous behaviour, so every step is identity.
+    WORKSPACE(
+            WorkspaceState.SCHEMA_VERSION,
+            1,
+            Map.of(
+                    1, ConfigMigrations::identity,
+                    2, ConfigMigrations::identity,
+                    3, ConfigMigrations::identity)),
     BOOKMARKS(BookmarkStore.SCHEMA_VERSION, 1, Map.of()),
     BREAKPOINTS(BreakpointStore.SCHEMA_VERSION, 1, Map.of()),
     // v1 → v2 added openProjectIds (the multi-window open-set), seeded from the old activeProjectId.

--- a/src/main/java/com/editora/ui/MainController.java
+++ b/src/main/java/com/editora/ui/MainController.java
@@ -111,6 +111,30 @@ public class MainController implements com.editora.mcp.McpBridge {
     /** The window's menu bar — a browsable map over the command registry (#763). */
     private MainMenuBar menuBar;
 
+    /**
+     * True while {@link #refreshRunConfigs()} is repopulating the selector, so its value listener can tell a
+     * programmatic reset from a user's choice.
+     *
+     * <p>Without this the listener persisted on every repopulation — including the one during {@code init},
+     * which runs <em>before</em> {@code setWindowContext} points the config at this window's session file. It
+     * therefore wrote the default, empty workspace state over the saved one and wiped the open-file list.
+     * Caught by {@code NoSessionStartupFxTest}, which exists for exactly that class of clobber.
+     */
+    private boolean populatingRunConfigs;
+
+    /** Toolbar run-configuration selector + its Run/Debug/Stop buttons (#765). */
+    @FXML
+    private javafx.scene.control.ComboBox<com.editora.config.RunConfiguration> runConfigCombo;
+
+    @FXML
+    private Button runConfigRunButton;
+
+    @FXML
+    private Button runConfigDebugButton;
+
+    @FXML
+    private Button runConfigStopButton;
+
     @FXML
     private VBox topBox;
 
@@ -771,6 +795,7 @@ public class MainController implements com.editora.mcp.McpBridge {
         setupMruTracking();
         registerCommands();
         setupToolbar();
+        refreshRunConfigs(); // populate the selector + register run.config.<slug> for the saved set
         setupRecentFiles();
         setupJumpPickers();
         setupProjects();
@@ -1066,13 +1091,22 @@ public class MainController implements com.editora.mcp.McpBridge {
         // applyProjectSupport so its later pass doesn't re-show them). The Open icon is deliberately
         // KEPT so opening a file stays one click away in Simple mode.
         for (Button b : new Button[] {
-            newFromTemplateButton, clearRecentButton, findInFilesButton, splitVerticalButton, splitHorizontalButton
+            newFromTemplateButton,
+            clearRecentButton,
+            findInFilesButton,
+            splitVerticalButton,
+            splitHorizontalButton,
+            runConfigRunButton,
+            runConfigDebugButton,
+            runConfigStopButton
         }) {
             b.setVisible(!simple);
             b.setManaged(!simple);
         }
         recentButton.setVisible(!simple);
         recentButton.setManaged(!simple);
+        runConfigCombo.setVisible(!simple);
+        runConfigCombo.setManaged(!simple);
         // Each build-tool button's visibility otherwise follows marker-file detection (BuildCoordinator), not
         // this unconditional show/hide — re-derive it from the cached detection now that isEnabled() (which
         // folds in !simpleModeActive()) may have changed, rather than forcing it shown.
@@ -1392,6 +1426,7 @@ public class MainController implements com.editora.mcp.McpBridge {
         }
         maybeOfferInstall(activeBuffer()); // the install-prompts toggle / a feature gate may have changed
         applyAdminSaveSupport(); // the admin-save toggle may have flipped
+        refreshRunConfigs(); // the Settings page edits the same list this selector shows
     }
 
     /**
@@ -5660,6 +5695,10 @@ public class MainController implements com.editora.mcp.McpBridge {
         setupButton(splitVerticalButton, Icons.splitVertical(), tr("tooltip.splitVertical"), "view.splitVertical");
         setupButton(
                 splitHorizontalButton, Icons.splitHorizontal(), tr("tooltip.splitHorizontal"), "view.splitHorizontal");
+        setupButton(runConfigRunButton, Icons.run(), tr("tooltip.runConfigRun"), null);
+        setupButton(runConfigDebugButton, Icons.debug(), tr("tooltip.runConfigDebug"), null);
+        setupButton(runConfigStopButton, Icons.stopSquare(), tr("tooltip.runConfigStop"), null);
+        setupRunConfigCombo();
         setupButton(paletteButton, Icons.palette(), tr("tooltip.palette"), "palette.show");
         setupButton(closeTabButton, Icons.closeTab(), tr("tooltip.closeTab"), "buffer.close");
         setupButton(simpleModeButton, Icons.simpleMode(), tr("tooltip.simpleMode"), "view.toggleSimpleMode");
@@ -9382,6 +9421,137 @@ public class MainController implements com.editora.mcp.McpBridge {
         picker.show(stage);
     }
 
+    /** Renders the selector's rows by name (with a run/debug tag) and remembers the choice across restarts. */
+    private void setupRunConfigCombo() {
+        runConfigCombo.getStyleClass().add("run-config-combo");
+        runConfigCombo.setPromptText(tr("toolbar.runConfig.none"));
+        runConfigCombo.setConverter(new javafx.util.StringConverter<>() {
+            @Override
+            public String toString(com.editora.config.RunConfiguration cfg) {
+                if (cfg == null) {
+                    return "";
+                }
+                String tag = cfg.isDebug() ? tr("run.config.debugTag") : tr("run.config.runTag");
+                return cfg.name() + "  ·  " + tag;
+            }
+
+            @Override
+            public com.editora.config.RunConfiguration fromString(String s) {
+                return null; // not editable
+            }
+        });
+        runConfigCombo.valueProperty().addListener((o, was, now) -> {
+            if (populatingRunConfigs) {
+                updateRunConfigButtons(); // a rebuild, not a choice: reflect it but persist nothing
+                return;
+            }
+            config.getWorkspaceState().setSelectedRunConfig(now == null ? "" : now.name());
+            requestSave();
+            updateRunConfigButtons();
+        });
+    }
+
+    /**
+     * Rebuilds the toolbar selector from the saved configurations and re-registers one synthetic
+     * {@code run.config.<slug>} command per configuration, so each is palette-visible and can be given a
+     * keybinding — the same shape macros ({@code macro.run.*}) and external tools already use.
+     *
+     * <p>Called after any change to the list: the save/delete commands, and every settings apply (the
+     * Settings page edits the same list).
+     */
+    private void refreshRunConfigs() {
+        List<com.editora.config.RunConfiguration> configs =
+                List.copyOf(config.getWorkspaceState().getRunConfigurations());
+
+        // Drop stale synthetic commands before re-registering, or a renamed configuration would leave its old
+        // id behind in the palette pointing at something that no longer exists.
+        List<String> stale = new ArrayList<>();
+        for (Command c : registry.all()) {
+            if (c.id().startsWith(com.editora.config.RunConfiguration.COMMAND_PREFIX)) {
+                stale.add(c.id());
+            }
+        }
+        stale.forEach(registry::remove);
+        for (com.editora.config.RunConfiguration cfg : configs) {
+            registry.register(Command.of(
+                    com.editora.config.RunConfiguration.commandIdFor(cfg.name()),
+                    cfg.name(),
+                    () -> launchRunConfig(cfg)));
+        }
+
+        if (runConfigCombo == null) {
+            return;
+        }
+        com.editora.config.RunConfiguration previous = runConfigCombo.getValue();
+        populatingRunConfigs = true;
+        try {
+            repopulate(configs, previous);
+        } finally {
+            populatingRunConfigs = false;
+        }
+        updateRunConfigButtons();
+    }
+
+    /** Replaces the selector's items, re-selecting the previous choice by name. */
+    private void repopulate(
+            List<com.editora.config.RunConfiguration> configs, com.editora.config.RunConfiguration previous) {
+        runConfigCombo.getItems().setAll(configs);
+        // Re-select by name: the list is rebuilt from the store on every refresh, so the old instance is not
+        // the same object even when the configuration is unchanged.
+        com.editora.config.RunConfiguration reselect = null;
+        String wanted =
+                previous != null ? previous.name() : config.getWorkspaceState().getSelectedRunConfig();
+        for (com.editora.config.RunConfiguration cfg : configs) {
+            if (cfg.name().equals(wanted)) {
+                reselect = cfg;
+                break;
+            }
+        }
+        runConfigCombo.setValue(reselect != null ? reselect : (configs.isEmpty() ? null : configs.get(0)));
+    }
+
+    /** Enables the toolbar Run/Debug buttons only when a configuration is selected; Stop only while running. */
+    private void updateRunConfigButtons() {
+        boolean hasSelection = runConfigCombo != null && runConfigCombo.getValue() != null;
+        if (runConfigRunButton != null) {
+            runConfigRunButton.setDisable(!hasSelection);
+            runConfigDebugButton.setDisable(!hasSelection);
+            runConfigStopButton.setDisable(!runCoordinator.isRunning());
+        }
+    }
+
+    /** Launches {@code cfg} by its own kind — the selector's Run button honours a debug configuration. */
+    private void launchRunConfig(com.editora.config.RunConfiguration cfg) {
+        if (cfg == null) {
+            return;
+        }
+        if (cfg.isDebug()) {
+            debugCoordinator.debugConfig(cfg);
+        } else {
+            runCoordinator.runConfig(cfg);
+        }
+    }
+
+    @FXML
+    private void onRunSelectedConfig() {
+        launchRunConfig(runConfigCombo == null ? null : runConfigCombo.getValue());
+    }
+
+    /** Debug regardless of the configuration's own kind — the Debug button is an explicit override. */
+    @FXML
+    private void onDebugSelectedConfig() {
+        com.editora.config.RunConfiguration cfg = runConfigCombo == null ? null : runConfigCombo.getValue();
+        if (cfg != null) {
+            debugCoordinator.debugConfig(cfg);
+        }
+    }
+
+    @FXML
+    private void onStopRun() {
+        runCoordinator.stopRun();
+        updateRunConfigButtons();
+    }
+
     /** {@code run.saveConfig}: save the active Java file's main class as a run configuration. */
     private void saveRunConfig() {
         EditorBuffer b = activeBuffer();
@@ -9411,6 +9581,7 @@ public class MainController implements com.editora.mcp.McpBridge {
             list.add(new com.editora.config.RunConfiguration(name.strip(), "run", fqn, "", args, "", ""));
             config.getWorkspaceState().setRunConfigurations(list);
             config.save();
+            refreshRunConfigs();
             setStatus(tr("status.run.configSaved", name.strip()));
         });
     }
@@ -9437,6 +9608,7 @@ public class MainController implements com.editora.mcp.McpBridge {
                             c -> c.name().equals(cfg.name()) && c.mainClass().equals(cfg.mainClass()));
                     config.getWorkspaceState().setRunConfigurations(list);
                     config.save();
+                    refreshRunConfigs();
                     setStatus(tr("status.run.configDeleted", cfg.name()));
                 });
         picker.setOverlayHost(overlayHost);

--- a/src/main/java/com/editora/ui/RunCoordinator.java
+++ b/src/main/java/com/editora/ui/RunCoordinator.java
@@ -205,6 +205,11 @@ final class RunCoordinator {
         return null;
     }
 
+    /** Whether a program is currently running, so the toolbar Stop button can reflect it. */
+    boolean isRunning() {
+        return service.isRunning();
+    }
+
     /** Runs a saved {@link RunConfiguration}: its main class with its own program/VM args + working dir. */
     void runConfig(RunConfiguration cfg) {
         if (service.isRunning()) {

--- a/src/main/resources/com/editora/i18n/messages.properties
+++ b/src/main/resources/com/editora/i18n/messages.properties
@@ -3864,3 +3864,7 @@ settings.runConfig.type.java=Java main class
 settings.runConfig.type.python=Python script
 settings.runConfig.type.shell=Shell script
 settings.runConfig.type.make=Make target
+toolbar.runConfig.none=No run configuration
+tooltip.runConfigRun=Run the selected configuration
+tooltip.runConfigDebug=Debug the selected configuration
+tooltip.runConfigStop=Stop the running program

--- a/src/main/resources/com/editora/i18n/messages_de.properties
+++ b/src/main/resources/com/editora/i18n/messages_de.properties
@@ -3855,3 +3855,7 @@ settings.runConfig.type.java=Java-Hauptklasse
 settings.runConfig.type.python=Python-Skript
 settings.runConfig.type.shell=Shell-Skript
 settings.runConfig.type.make=Make-Ziel
+toolbar.runConfig.none=Keine Konfiguration
+tooltip.runConfigRun=Ausgewählte Konfiguration ausführen
+tooltip.runConfigDebug=Ausgewählte Konfiguration debuggen
+tooltip.runConfigStop=Laufendes Programm stoppen

--- a/src/main/resources/com/editora/i18n/messages_es.properties
+++ b/src/main/resources/com/editora/i18n/messages_es.properties
@@ -3855,3 +3855,7 @@ settings.runConfig.type.java=Clase main de Java
 settings.runConfig.type.python=Script de Python
 settings.runConfig.type.shell=Script de shell
 settings.runConfig.type.make=Objetivo de make
+toolbar.runConfig.none=Sin configuración
+tooltip.runConfigRun=Ejecutar la configuración seleccionada
+tooltip.runConfigDebug=Depurar la configuración seleccionada
+tooltip.runConfigStop=Detener el programa en ejecución

--- a/src/main/resources/com/editora/i18n/messages_fr.properties
+++ b/src/main/resources/com/editora/i18n/messages_fr.properties
@@ -3855,3 +3855,7 @@ settings.runConfig.type.java=Classe main Java
 settings.runConfig.type.python=Script Python
 settings.runConfig.type.shell=Script shell
 settings.runConfig.type.make=Cible make
+toolbar.runConfig.none=Aucune configuration
+tooltip.runConfigRun=Exécuter la configuration sélectionnée
+tooltip.runConfigDebug=Déboguer la configuration sélectionnée
+tooltip.runConfigStop=Arrêter le programme en cours

--- a/src/main/resources/com/editora/i18n/messages_it.properties
+++ b/src/main/resources/com/editora/i18n/messages_it.properties
@@ -3855,3 +3855,7 @@ settings.runConfig.type.java=Classe main Java
 settings.runConfig.type.python=Script Python
 settings.runConfig.type.shell=Script di shell
 settings.runConfig.type.make=Destinazione make
+toolbar.runConfig.none=Nessuna configurazione
+tooltip.runConfigRun=Esegui la configurazione selezionata
+tooltip.runConfigDebug=Esegui il debug della configurazione selezionata
+tooltip.runConfigStop=Arresta il programma in esecuzione

--- a/src/main/resources/com/editora/i18n/messages_pt.properties
+++ b/src/main/resources/com/editora/i18n/messages_pt.properties
@@ -3855,3 +3855,7 @@ settings.runConfig.type.java=Classe main Java
 settings.runConfig.type.python=Script Python
 settings.runConfig.type.shell=Script de shell
 settings.runConfig.type.make=Alvo make
+toolbar.runConfig.none=Sem configuração
+tooltip.runConfigRun=Executar a configuração selecionada
+tooltip.runConfigDebug=Depurar a configuração selecionada
+tooltip.runConfigStop=Parar o programa em execução

--- a/src/main/resources/com/editora/ui/main.fxml
+++ b/src/main/resources/com/editora/ui/main.fxml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <?import javafx.scene.control.Button?>
+<?import javafx.scene.control.ComboBox?>
 <?import javafx.scene.control.MenuButton?>
 <?import javafx.scene.control.Separator?>
 <?import javafx.scene.control.TabPane?>
@@ -38,6 +39,11 @@
                         <Separator orientation="VERTICAL"/>
                         <Button fx:id="splitVerticalButton" onAction="#onSplitVertical"/>
                         <Button fx:id="splitHorizontalButton" onAction="#onSplitHorizontal"/>
+                        <Separator orientation="VERTICAL"/>
+                        <ComboBox fx:id="runConfigCombo"/>
+                        <Button fx:id="runConfigRunButton" onAction="#onRunSelectedConfig"/>
+                        <Button fx:id="runConfigDebugButton" onAction="#onDebugSelectedConfig"/>
+                        <Button fx:id="runConfigStopButton" onAction="#onStopRun"/>
                         <Separator orientation="VERTICAL"/>
                         <Button fx:id="paletteButton" onAction="#onPalette"/>
                         <Separator orientation="VERTICAL"/>

--- a/src/test/java/com/editora/ui/RunConfigToolbarFxTest.java
+++ b/src/test/java/com/editora/ui/RunConfigToolbarFxTest.java
@@ -1,0 +1,136 @@
+package com.editora.ui;
+
+import java.util.List;
+
+import javafx.scene.control.ComboBox;
+
+import com.editora.command.CommandRegistry;
+import com.editora.config.RunConfiguration;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Covers the toolbar run-configuration selector and its synthetic commands (#765 part 3).
+ *
+ * <p>The interesting failure is the synthetic commands going stale: a renamed or deleted configuration that
+ * leaves its old {@code run.config.<slug>} behind gives the palette an entry pointing at something that no
+ * longer exists, which nothing else would catch.
+ */
+@Tag("fx")
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class RunConfigToolbarFxTest {
+
+    private FxWindowFixture fx;
+    private CommandRegistry registry;
+
+    @BeforeAll
+    void setUp() throws Exception {
+        FxTestSupport.bootToolkit();
+        fx = FxWindowFixture.create();
+        registry = FxTestSupport.field(fx.controller, "registry");
+    }
+
+    @AfterAll
+    void tearDown() throws Exception {
+        if (fx != null) {
+            fx.dispose();
+        }
+    }
+
+    private void setConfigs(List<RunConfiguration> configs) throws Exception {
+        FxTestSupport.runOnFx(() -> {
+            com.editora.config.ConfigManager cfg = FxTestSupport.field(fx.controller, "config");
+            cfg.getWorkspaceState().setRunConfigurations(new java.util.ArrayList<>(configs));
+            FxTestSupport.invoke(fx.controller, "refreshRunConfigs");
+        });
+    }
+
+    @SuppressWarnings("unchecked")
+    private ComboBox<RunConfiguration> combo() throws Exception {
+        return FxTestSupport.callOnFx(() -> FxTestSupport.field(fx.controller, "runConfigCombo"));
+    }
+
+    private static RunConfiguration java(String name) {
+        return new RunConfiguration(name, "run", "com.example.App", "", "", "", "");
+    }
+
+    @Test
+    void theSelectorListsTheSavedConfigurations() throws Exception {
+        setConfigs(List.of(java("Server"), java("Client")));
+
+        ComboBox<RunConfiguration> combo = combo();
+        assertEquals(2, FxTestSupport.callOnFx(() -> combo.getItems().size()), "both are listed");
+        assertEquals("Server", FxTestSupport.callOnFx(() -> combo.getValue().name()), "the first is selected");
+
+        setConfigs(List.of());
+    }
+
+    /** Each configuration becomes a real command, so it shows in the palette and can take a keybinding. */
+    @Test
+    void eachConfigurationBecomesABindableCommand() throws Exception {
+        setConfigs(List.of(java("Integration Tests")));
+
+        String id = RunConfiguration.commandIdFor("Integration Tests");
+        assertEquals("run.config.integration-tests", id, "slugged into a stable id");
+        assertTrue(FxTestSupport.callOnFx(() -> registry.get(id).isPresent()), "registered");
+        assertEquals(
+                "Integration Tests",
+                FxTestSupport.callOnFx(() -> registry.get(id).orElseThrow().title()),
+                "titled by the configuration's own name");
+
+        setConfigs(List.of());
+    }
+
+    /**
+     * The failure worth guarding: a renamed or removed configuration must not leave its command behind. A
+     * stale entry looks fine in the palette and does nothing when run.
+     */
+    @Test
+    void renamingAConfigurationDoesNotStrandItsOldCommand() throws Exception {
+        setConfigs(List.of(java("Old Name")));
+        String oldId = RunConfiguration.commandIdFor("Old Name");
+        assertTrue(FxTestSupport.callOnFx(() -> registry.get(oldId).isPresent()), "registered to begin with");
+
+        setConfigs(List.of(java("New Name")));
+
+        assertFalse(FxTestSupport.callOnFx(() -> registry.get(oldId).isPresent()), "the old command is gone");
+        assertTrue(
+                FxTestSupport.callOnFx(() ->
+                        registry.get(RunConfiguration.commandIdFor("New Name")).isPresent()),
+                "and the new one is there");
+
+        setConfigs(List.of());
+        assertFalse(
+                FxTestSupport.callOnFx(() ->
+                        registry.get(RunConfiguration.commandIdFor("New Name")).isPresent()),
+                "deleting them all leaves none behind");
+    }
+
+    /** Run/Debug are meaningless with nothing selected, so they are disabled rather than silently no-op. */
+    @Test
+    void theButtonsDisableWithNoSelection() throws Exception {
+        setConfigs(List.of());
+
+        assertTrue(
+                FxTestSupport.callOnFx(
+                        () -> ((javafx.scene.control.Button) FxTestSupport.field(fx.controller, "runConfigRunButton"))
+                                .isDisable()),
+                "Run is disabled with no configuration");
+
+        setConfigs(List.of(java("Server")));
+        assertFalse(
+                FxTestSupport.callOnFx(
+                        () -> ((javafx.scene.control.Button) FxTestSupport.field(fx.controller, "runConfigRunButton"))
+                                .isDisable()),
+                "and enabled once one is selected");
+
+        setConfigs(List.of());
+    }
+}


### PR DESCRIPTION
Third of four parts on #765.

## What you get

A **selector plus Run / Debug / Stop** in the toolbar, with the choice persisted across restarts. Run honours the configuration's own `kind` (a debug configuration debugs); the Debug button is an explicit override.

Each configuration also registers a synthetic **`run.config.<slug>`** command, so it appears in the palette by name and can take a keybinding — the shape macros (`macro.run.*`) and external tools already use.

Stale commands are dropped before re-registering. Otherwise a renamed configuration leaves a palette entry pointing at something that no longer exists — looks fine, does nothing. That is what the new test pins.

`RunConfiguration` carries its own slug rather than reusing `MacroService.slug`, whose empty-name fallback is the literal `"macro"`: sharing it would give a configuration named only of punctuation the id `run.config.macro`. `ExternalTool` carries its own for the same reason.

## Two bugs of my own, both caught by the existing suite

**1. The selector clobbered the saved session.** Its value listener persisted on every repopulation — including the one during `init`, which runs *before* `setWindowContext` points the config at this window's session file. So it wrote the default, empty workspace state over the saved one. A populating flag now distinguishes a rebuild from a user's choice.

**2. A silent no-op edit shipped a broken schema.** More instructive, and worth reading if you review nothing else here.

The `ConfigSchema` change adding the v3 → v4 step **never applied**: it targeted a multi-line form that spotless had already collapsed to one line. Unlike every other edit in this change it carried no assertion, so the failure was invisible. `SCHEMA_VERSION` advanced to 4 with no migration for it, `applySteps` threw exactly as it is designed to, `readVersioned` fell back to defaults, and the session's open-file list was wiped.

`NoSessionStartupFxTest` caught it — precisely the clobber that test exists for. Three things worked as intended here: the missing-step exception, the fallback, and the test. The only thing that failed was my edit not verifying itself.

I initially misdiagnosed it as my own new hooks and had to bisect by disabling them, then check against clean master, before looking at the actual file. Reading the file first would have been quicker.

## Verification

3377 tests green (4 new), spotless and the JaCoCo floors pass.

## Still to come on #765

4. Before-launch step and shareable storage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)