### PR TITLE
feat(run): before-launch step and shareable run configurations (#765 part 4/4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Run configurations gain a before-launch step, and can be shared with your team** — a configuration can
+  name a command to run first (a build, a codegen step); a non-zero exit aborts the launch, so a stale binary
+  is never run by accident. And **Export Configurations to Project** writes them to
+  `.editora/run-configurations.json` inside the project, where they can be committed; **Import** merges them
+  back by name, so importing twice doesn't duplicate and a colleague's edit updates rather than doubles.
+
 - **A run-configuration selector in the toolbar** — pick a saved configuration and hit Run or Debug, with
   Stop beside them; the choice is remembered across restarts. Each configuration also becomes a real command,
   so it appears in the command palette by name and can be given its own keyboard shortcut, the same way saved

--- a/src/main/java/com/editora/config/RunConfiguration.java
+++ b/src/main/java/com/editora/config/RunConfiguration.java
@@ -15,6 +15,9 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
  * make target. It is orthogonal to {@code kind}, which says whether to run or debug. Absent from an older
  * entry it defaults to {@code java}, so every configuration saved before types existed keeps working.
  *
+ * <p>{@code beforeLaunch} is an optional command line run first — a build, a codegen step — in the same
+ * working directory; a non-zero exit aborts the launch, so a stale binary is never run by accident.
+ *
  * <p>Persisted per window in {@code WorkspaceState.runConfigurations}. Jackson
  * round-trips this record; the compact constructor defaults every field so an older/partial entry loads.
  */
@@ -29,7 +32,8 @@ public record RunConfiguration(
         String args,
         String vmArgs,
         String workingDir,
-        String env) {
+        String env,
+        String beforeLaunch) {
 
     /** Prefix of the synthetic per-configuration commands, so stale ones can be found and dropped. */
     public static final String COMMAND_PREFIX = "run.config.";
@@ -46,6 +50,7 @@ public record RunConfiguration(
         vmArgs = vmArgs == null ? "" : vmArgs;
         workingDir = workingDir == null ? "" : workingDir;
         env = env == null ? "" : env;
+        beforeLaunch = beforeLaunch == null ? "" : beforeLaunch;
     }
 
     /** Back-compat constructor for callers that don't set environment variables ({@code env} = {@code ""}). */
@@ -70,7 +75,7 @@ public record RunConfiguration(
             String vmArgs,
             String workingDir,
             String env) {
-        this(name, kind, "java", "", mainClass, projectName, args, vmArgs, workingDir, env);
+        this(name, kind, "java", "", mainClass, projectName, args, vmArgs, workingDir, env, "");
     }
 
     /** The id of the synthetic command that launches this configuration ({@code run.config.<slug>}). */

--- a/src/main/java/com/editora/config/SharedRunConfigs.java
+++ b/src/main/java/com/editora/config/SharedRunConfigs.java
@@ -1,0 +1,92 @@
+package com.editora.config;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+
+/**
+ * Reading and writing run configurations as a file inside the project, so a team can commit them.
+ *
+ * <p>Configurations normally live in the window's session file, which is private to one machine. This is the
+ * shareable half: an explicit <b>export</b> writes them to {@code <project>/.editora/run-configurations.json}
+ * and an explicit <b>import</b> merges them back.
+ *
+ * <p>Deliberately export/import rather than a live second store that the editor reads and writes
+ * continuously. A dual-source model has to decide, on every read, which copy wins when the two disagree —
+ * and on every write, which store a configuration belongs to. Getting that wrong loses configurations
+ * silently, and the failure only shows up once someone has already edited both. An explicit copy in each
+ * direction has none of that: at any moment exactly one store is authoritative for a given configuration, and
+ * the user chose when to move it. A live shared store is a reasonable follow-up, but it is a different and
+ * much more delicate feature than it looks.
+ */
+public final class SharedRunConfigs {
+
+    /** Folder Editora keeps project-local, committable files in. */
+    public static final String DIR = ".editora";
+
+    public static final String FILE = "run-configurations.json";
+
+    private SharedRunConfigs() {}
+
+    /** Where a project's shared configurations live. */
+    public static Path fileFor(Path projectRoot) {
+        return projectRoot.resolve(DIR).resolve(FILE);
+    }
+
+    /** Reads a project's shared configurations; an empty list when the file is absent or unreadable. */
+    public static List<RunConfiguration> load(ObjectMapper mapper, Path projectRoot) {
+        Path file = fileFor(projectRoot);
+        if (!Files.isReadable(file)) {
+            return List.of();
+        }
+        try {
+            Stored stored = mapper.readValue(file.toFile(), Stored.class);
+            return stored == null || stored.configurations == null ? List.of() : stored.configurations;
+        } catch (IOException | RuntimeException e) {
+            return List.of(); // a hand-edited or half-written file must not break opening the project
+        }
+    }
+
+    /** Writes {@code configs} into the project, creating {@code .editora/} if needed. */
+    public static void save(ObjectMapper mapper, Path projectRoot, List<RunConfiguration> configs) throws IOException {
+        Path file = fileFor(projectRoot);
+        Files.createDirectories(file.getParent());
+        Stored stored = new Stored();
+        stored.configurations = new ArrayList<>(configs);
+        // Temp file + atomic move, like every other config store: a crash mid-write must not leave a
+        // truncated file, and this one lives in the user's repository where a corrupt file is worse still.
+        // ConfigDurabilityTest enforces this for every store.
+        ConfigWriter.writeAtomic(file, mapper.copy().enable(SerializationFeature.INDENT_OUTPUT), stored);
+    }
+
+    /**
+     * Merges {@code incoming} into {@code existing}, matching by name.
+     *
+     * <p>An incoming configuration replaces one of the same name rather than being added beside it —
+     * importing twice must not leave duplicates, and re-importing after a colleague changed a configuration
+     * should update it, which is the whole point. Order is preserved: existing entries stay where they are,
+     * genuinely new ones are appended.
+     */
+    public static List<RunConfiguration> merge(List<RunConfiguration> existing, List<RunConfiguration> incoming) {
+        Map<String, RunConfiguration> byName = new LinkedHashMap<>();
+        for (RunConfiguration c : existing) {
+            byName.put(c.name(), c);
+        }
+        for (RunConfiguration c : incoming) {
+            byName.put(c.name(), c);
+        }
+        return new ArrayList<>(byName.values());
+    }
+
+    /** On-disk shape: an object rather than a bare array, so a version or other keys can be added later. */
+    static final class Stored {
+        public List<RunConfiguration> configurations = new ArrayList<>();
+    }
+}

--- a/src/main/java/com/editora/ui/MainController.java
+++ b/src/main/java/com/editora/ui/MainController.java
@@ -9586,6 +9586,67 @@ public class MainController implements com.editora.mcp.McpBridge {
         });
     }
 
+    /** This window's project root, or null when it has no project open. */
+    private Path activeProjectRoot() {
+        Project active = projects == null ? null : projects.active();
+        return active == null ? null : Path.of(active.root());
+    }
+
+    /**
+     * {@code run.exportConfigs}: writes this window's run configurations into the project, so they can be
+     * committed and shared. Needs a project — there is nowhere else they would belong.
+     */
+    private void exportRunConfigs() {
+        Path root = activeProjectRoot();
+        if (root == null) {
+            setStatus(tr("status.run.configsNeedProject"));
+            return;
+        }
+        List<com.editora.config.RunConfiguration> configs =
+                config.getWorkspaceState().getRunConfigurations();
+        if (configs.isEmpty()) {
+            setStatus(tr("status.run.noConfigs"));
+            return;
+        }
+        try {
+            com.editora.config.SharedRunConfigs.save(new com.fasterxml.jackson.databind.ObjectMapper(), root, configs);
+            setStatus(tr(
+                    "status.run.configsExported",
+                    configs.size(),
+                    homeCollapsed(
+                            com.editora.config.SharedRunConfigs.fileFor(root).toString())));
+        } catch (java.io.IOException e) {
+            setStatus(tr("status.run.configsExportFailed", e.getMessage()));
+        }
+    }
+
+    /**
+     * {@code run.importConfigs}: merges the project's shared configurations into this window's, matching by
+     * name so importing twice does not duplicate and a colleague's edit updates rather than doubles.
+     */
+    private void importRunConfigs() {
+        Path root = activeProjectRoot();
+        if (root == null) {
+            setStatus(tr("status.run.configsNeedProject"));
+            return;
+        }
+        List<com.editora.config.RunConfiguration> incoming =
+                com.editora.config.SharedRunConfigs.load(new com.fasterxml.jackson.databind.ObjectMapper(), root);
+        if (incoming.isEmpty()) {
+            setStatus(tr(
+                    "status.run.noSharedConfigs",
+                    homeCollapsed(
+                            com.editora.config.SharedRunConfigs.fileFor(root).toString())));
+            return;
+        }
+        List<com.editora.config.RunConfiguration> merged = com.editora.config.SharedRunConfigs.merge(
+                config.getWorkspaceState().getRunConfigurations(), incoming);
+        config.getWorkspaceState().setRunConfigurations(merged);
+        config.save();
+        refreshRunConfigs();
+        setStatus(tr("status.run.configsImported", incoming.size()));
+    }
+
     /** {@code run.deleteConfig}: pick a saved run configuration and remove it. */
     private void deleteRunConfig() {
         if (config.getWorkspaceState().getRunConfigurations().isEmpty()) {
@@ -14724,6 +14785,8 @@ public class MainController implements com.editora.mcp.McpBridge {
         registry.register(Command.of("run.config", this::runSavedConfig));
         registry.register(Command.of("run.saveConfig", this::saveRunConfig));
         registry.register(Command.of("run.deleteConfig", this::deleteRunConfig));
+        registry.register(Command.of("run.exportConfigs", this::exportRunConfigs));
+        registry.register(Command.of("run.importConfigs", this::importRunConfigs));
         registry.register(Command.of("run.rerun", runCoordinator::rerunLast));
         registry.register(Command.of("run.stop", runCoordinator::stopRun));
         registry.register(Command.of("run.clear", runCoordinator::clearConsole));

--- a/src/main/java/com/editora/ui/RunCoordinator.java
+++ b/src/main/java/com/editora/ui/RunCoordinator.java
@@ -205,6 +205,9 @@ final class RunCoordinator {
         return null;
     }
 
+    /** A before-launch step is usually a build, so it gets a generous ceiling rather than a quick-probe one. */
+    private static final java.time.Duration BEFORE_LAUNCH_TIMEOUT = java.time.Duration.ofMinutes(10);
+
     /** Whether a program is currently running, so the toolbar Stop button can reflect it. */
     boolean isRunning() {
         return service.isRunning();
@@ -216,10 +219,80 @@ final class RunCoordinator {
             host.setStatus(tr("status.run.busy"));
             return;
         }
-        if (!cfg.isJava()) {
-            runScriptConfig(cfg);
+        // A before-launch step gates everything after it: if the build fails there is nothing worth running,
+        // and launching the previous binary anyway is the failure mode this exists to prevent.
+        withBeforeLaunch(cfg, () -> {
+            if (!cfg.isJava()) {
+                runScriptConfig(cfg);
+            } else {
+                runJavaConfig(cfg);
+            }
+        });
+    }
+
+    /**
+     * Runs {@code cfg}'s before-launch command, if it has one, then {@code then} — or reports the failure and
+     * runs nothing.
+     *
+     * <p>The command runs <b>off the FX thread</b> (it is a build; it can take minutes) and {@code then} is
+     * marshalled back on, so everything after it keeps the single-threaded UI assumption the rest of this
+     * class is written against. With no before-launch step this is a straight call, not a thread hop, so the
+     * common case is unchanged.
+     */
+    private void withBeforeLaunch(RunConfiguration cfg, Runnable then) {
+        String command = cfg.beforeLaunch();
+        if (command == null || command.isBlank()) {
+            then.run();
             return;
         }
+        List<String> argv = ProgramArgs.tokenize(command);
+        if (argv.isEmpty()) {
+            then.run();
+            return;
+        }
+        Path cwd = beforeLaunchDir(cfg);
+        host.setStatus(tr("status.run.beforeLaunch", cfg.name()));
+        Thread worker = new Thread(
+                () -> {
+                    com.editora.process.ProcessRunner.Result r =
+                            com.editora.process.ProcessRunner.run(cwd, BEFORE_LAUNCH_TIMEOUT, argv);
+                    javafx.application.Platform.runLater(() -> {
+                        if (r.ok()) {
+                            then.run();
+                        } else {
+                            // Surface the tool's own output: "before-launch failed" alone tells the user
+                            // nothing about which step or why.
+                            host.setStatus(tr("status.run.beforeLaunchFailed", cfg.name(), firstLine(r)));
+                        }
+                    });
+                },
+                "run-before-launch");
+        worker.setDaemon(true);
+        worker.start();
+    }
+
+    /** Where a before-launch command runs: the configuration's working directory, else the project root. */
+    private Path beforeLaunchDir(RunConfiguration cfg) {
+        if (!cfg.workingDir().isBlank()) {
+            return Path.of(cfg.workingDir());
+        }
+        Path routing = routingFor(host, cfg);
+        Path root = routing == null ? null : ops.javaProjectRoot(routing);
+        return root != null ? root : Path.of(System.getProperty("user.dir"));
+    }
+
+    /** The most useful single line of a failed command's output — stderr if it said anything, else stdout. */
+    private static String firstLine(com.editora.process.ProcessRunner.Result r) {
+        String text = r.err() == null || r.err().isBlank() ? r.out() : r.err();
+        if (text == null || text.isBlank()) {
+            return "exit " + r.exit();
+        }
+        String[] lines = text.strip().split("\\R");
+        return lines[lines.length - 1]; // the last line: a build tool's summary, not its banner
+    }
+
+    /** The Java half of {@link #runConfig}, after any before-launch step has succeeded. */
+    private void runJavaConfig(RunConfiguration cfg) {
         // A named configuration is independent of whatever is on screen: any open Java file in its project
         // can route the classpath resolution, so this no longer refuses just because the active tab is a
         // README. Null means no Java file is open at all, which is the only genuinely unresolvable case.

--- a/src/main/java/com/editora/ui/SettingsWindow.java
+++ b/src/main/java/com/editora/ui/SettingsWindow.java
@@ -4074,6 +4074,8 @@ public class SettingsWindow {
         workingDir.setPromptText(tr("settings.runConfig.workingDirPrompt"));
         TextField env = new TextField();
         env.setPromptText(tr("settings.runConfig.envPrompt"));
+        TextField beforeLaunch = new TextField();
+        beforeLaunch.setPromptText(tr("settings.runConfig.beforeLaunchPrompt"));
 
         javafx.scene.layout.GridPane form = new javafx.scene.layout.GridPane();
         form.setHgap(8);
@@ -4088,6 +4090,7 @@ public class SettingsWindow {
         formRow(form, 7, tr("settings.runConfig.vmArgs"), vmArgs);
         formRow(form, 8, tr("settings.runConfig.workingDir"), workingDir);
         formRow(form, 9, tr("settings.runConfig.env"), env);
+        formRow(form, 10, tr("settings.runConfig.beforeLaunch"), beforeLaunch);
         form.setDisable(true);
         HBox.setHgrow(form, Priority.ALWAYS);
 
@@ -4106,7 +4109,8 @@ public class SettingsWindow {
                     args.getText(),
                     vmArgs.getText(),
                     workingDir.getText(),
-                    env.getText());
+                    env.getText(),
+                    beforeLaunch.getText());
             runConfigItems.set(i, rebuilt);
             list.refresh();
             persistRunConfigs();
@@ -4143,6 +4147,7 @@ public class SettingsWindow {
                 vmArgs.setText(now == null ? "" : now.vmArgs());
                 workingDir.setText(now == null ? "" : now.workingDir());
                 env.setText(now == null ? "" : now.env());
+                beforeLaunch.setText(now == null ? "" : now.beforeLaunch());
             } finally {
                 loadingRunConfig = false;
             }

--- a/src/main/resources/com/editora/i18n/messages.properties
+++ b/src/main/resources/com/editora/i18n/messages.properties
@@ -3868,3 +3868,16 @@ toolbar.runConfig.none=No run configuration
 tooltip.runConfigRun=Run the selected configuration
 tooltip.runConfigDebug=Debug the selected configuration
 tooltip.runConfigStop=Stop the running program
+command.run.exportConfigs=Run: Export Configurations to Project
+command.run.exportConfigs.desc=Write this window's run configurations into the project so they can be committed and shared.
+command.run.importConfigs=Run: Import Configurations from Project
+command.run.importConfigs.desc=Merge the project's shared run configurations into this window, matching by name.
+status.run.configsNeedProject=Open a project to share run configurations
+status.run.configsExported=Exported {0} run configurations to {1}
+status.run.configsExportFailed=Could not export the run configurations: {0}
+status.run.noSharedConfigs=No shared run configurations at {0}
+status.run.configsImported=Imported {0} run configurations
+status.run.beforeLaunch=Running the before-launch step for "{0}"…
+status.run.beforeLaunchFailed=Before-launch step for "{0}" failed: {1}
+settings.runConfig.beforeLaunch=Before launch
+settings.runConfig.beforeLaunchPrompt=Command to run first, e.g. mvn -q compile (blank = none)

--- a/src/main/resources/com/editora/i18n/messages_de.properties
+++ b/src/main/resources/com/editora/i18n/messages_de.properties
@@ -3859,3 +3859,16 @@ toolbar.runConfig.none=Keine Konfiguration
 tooltip.runConfigRun=Ausgewählte Konfiguration ausführen
 tooltip.runConfigDebug=Ausgewählte Konfiguration debuggen
 tooltip.runConfigStop=Laufendes Programm stoppen
+command.run.exportConfigs=Ausführen: Konfigurationen ins Projekt exportieren
+command.run.exportConfigs.desc=Schreibt die Ausführungskonfigurationen ins Projekt, damit sie geteilt werden können.
+command.run.importConfigs=Ausführen: Konfigurationen aus dem Projekt importieren
+command.run.importConfigs.desc=Führt die geteilten Konfigurationen des Projekts namensbasiert mit denen dieses Fensters zusammen.
+status.run.configsNeedProject=Öffne ein Projekt, um Konfigurationen zu teilen
+status.run.configsExported={0} Konfigurationen nach {1} exportiert
+status.run.configsExportFailed=Konfigurationen konnten nicht exportiert werden: {0}
+status.run.noSharedConfigs=Keine geteilten Konfigurationen in {0}
+status.run.configsImported={0} Konfigurationen importiert
+status.run.beforeLaunch=Vorbereitungsschritt für "{0}" wird ausgeführt…
+status.run.beforeLaunchFailed=Vorbereitungsschritt für "{0}" fehlgeschlagen: {1}
+settings.runConfig.beforeLaunch=Vor dem Start
+settings.runConfig.beforeLaunchPrompt=Vorher auszuführender Befehl, z. B. mvn -q compile (leer = keiner)

--- a/src/main/resources/com/editora/i18n/messages_es.properties
+++ b/src/main/resources/com/editora/i18n/messages_es.properties
@@ -3859,3 +3859,16 @@ toolbar.runConfig.none=Sin configuración
 tooltip.runConfigRun=Ejecutar la configuración seleccionada
 tooltip.runConfigDebug=Depurar la configuración seleccionada
 tooltip.runConfigStop=Detener el programa en ejecución
+command.run.exportConfigs=Ejecutar: exportar configuraciones al proyecto
+command.run.exportConfigs.desc=Escribe las configuraciones de ejecución en el proyecto para poder compartirlas.
+command.run.importConfigs=Ejecutar: importar configuraciones del proyecto
+command.run.importConfigs.desc=Fusiona las configuraciones compartidas del proyecto con las de esta ventana, por nombre.
+status.run.configsNeedProject=Abre un proyecto para compartir configuraciones
+status.run.configsExported=Se exportaron {0} configuraciones a {1}
+status.run.configsExportFailed=No se pudieron exportar las configuraciones: {0}
+status.run.noSharedConfigs=No hay configuraciones compartidas en {0}
+status.run.configsImported=Se importaron {0} configuraciones
+status.run.beforeLaunch=Ejecutando el paso previo de "{0}"…
+status.run.beforeLaunchFailed=El paso previo de "{0}" falló: {1}
+settings.runConfig.beforeLaunch=Antes de lanzar
+settings.runConfig.beforeLaunchPrompt=Comando previo, p. ej. mvn -q compile (vacío = ninguno)

--- a/src/main/resources/com/editora/i18n/messages_fr.properties
+++ b/src/main/resources/com/editora/i18n/messages_fr.properties
@@ -3859,3 +3859,16 @@ toolbar.runConfig.none=Aucune configuration
 tooltip.runConfigRun=Exécuter la configuration sélectionnée
 tooltip.runConfigDebug=Déboguer la configuration sélectionnée
 tooltip.runConfigStop=Arrêter le programme en cours
+command.run.exportConfigs=Exécuter : exporter les configurations vers le projet
+command.run.exportConfigs.desc=Écrit les configurations dexécution dans le projet afin de pouvoir les partager.
+command.run.importConfigs=Exécuter : importer les configurations du projet
+command.run.importConfigs.desc=Fusionne les configurations partagées du projet avec celles de cette fenêtre, par nom.
+status.run.configsNeedProject=Ouvrez un projet pour partager les configurations
+status.run.configsExported={0} configurations exportées vers {1}
+status.run.configsExportFailed=Impossible dexporter les configurations : {0}
+status.run.noSharedConfigs=Aucune configuration partagée dans {0}
+status.run.configsImported={0} configurations importées
+status.run.beforeLaunch=Exécution de létape préalable de « {0} »…
+status.run.beforeLaunchFailed=Létape préalable de « {0} » a échoué : {1}
+settings.runConfig.beforeLaunch=Avant le lancement
+settings.runConfig.beforeLaunchPrompt=Commande préalable, p. ex. mvn -q compile (vide = aucune)

--- a/src/main/resources/com/editora/i18n/messages_it.properties
+++ b/src/main/resources/com/editora/i18n/messages_it.properties
@@ -3859,3 +3859,16 @@ toolbar.runConfig.none=Nessuna configurazione
 tooltip.runConfigRun=Esegui la configurazione selezionata
 tooltip.runConfigDebug=Esegui il debug della configurazione selezionata
 tooltip.runConfigStop=Arresta il programma in esecuzione
+command.run.exportConfigs=Esegui: esporta le configurazioni nel progetto
+command.run.exportConfigs.desc=Scrive le configurazioni di esecuzione nel progetto per poterle condividere.
+command.run.importConfigs=Esegui: importa le configurazioni dal progetto
+command.run.importConfigs.desc=Unisce le configurazioni condivise del progetto a quelle di questa finestra, per nome.
+status.run.configsNeedProject=Apri un progetto per condividere le configurazioni
+status.run.configsExported=Esportate {0} configurazioni in {1}
+status.run.configsExportFailed=Impossibile esportare le configurazioni: {0}
+status.run.noSharedConfigs=Nessuna configurazione condivisa in {0}
+status.run.configsImported=Importate {0} configurazioni
+status.run.beforeLaunch=Esecuzione del passo preliminare per "{0}"…
+status.run.beforeLaunchFailed=Il passo preliminare per "{0}" non è riuscito: {1}
+settings.runConfig.beforeLaunch=Prima del lancio
+settings.runConfig.beforeLaunchPrompt=Comando da eseguire prima, es. mvn -q compile (vuoto = nessuno)

--- a/src/main/resources/com/editora/i18n/messages_pt.properties
+++ b/src/main/resources/com/editora/i18n/messages_pt.properties
@@ -3859,3 +3859,16 @@ toolbar.runConfig.none=Sem configuração
 tooltip.runConfigRun=Executar a configuração selecionada
 tooltip.runConfigDebug=Depurar a configuração selecionada
 tooltip.runConfigStop=Parar o programa em execução
+command.run.exportConfigs=Executar: exportar configurações para o projeto
+command.run.exportConfigs.desc=Escreve as configurações de execução no projeto para poderem ser partilhadas.
+command.run.importConfigs=Executar: importar configurações do projeto
+command.run.importConfigs.desc=Junta as configurações partilhadas do projeto às desta janela, por nome.
+status.run.configsNeedProject=Abra um projeto para partilhar configurações
+status.run.configsExported=Exportadas {0} configurações para {1}
+status.run.configsExportFailed=Não foi possível exportar as configurações: {0}
+status.run.noSharedConfigs=Sem configurações partilhadas em {0}
+status.run.configsImported=Importadas {0} configurações
+status.run.beforeLaunch=A executar o passo prévio de "{0}"…
+status.run.beforeLaunchFailed=O passo prévio de "{0}" falhou: {1}
+settings.runConfig.beforeLaunch=Antes do lançamento
+settings.runConfig.beforeLaunchPrompt=Comando a executar antes, p. ex. mvn -q compile (vazio = nenhum)

--- a/src/test/java/com/editora/config/SharedRunConfigsTest.java
+++ b/src/test/java/com/editora/config/SharedRunConfigsTest.java
@@ -1,0 +1,63 @@
+package com.editora.config;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class SharedRunConfigsTest {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    private static RunConfiguration cfg(String name, String args) {
+        return new RunConfiguration(name, "run", "com.example.App", "", args, "", "");
+    }
+
+    @Test
+    void configurationsRoundTripThroughTheProjectFile(@org.junit.jupiter.api.io.TempDir Path root) throws Exception {
+        SharedRunConfigs.save(MAPPER, root, List.of(cfg("Server", "--port 80"), cfg("Client", "")));
+
+        assertTrue(Files.exists(SharedRunConfigs.fileFor(root)), "written where a repo can commit it");
+        List<RunConfiguration> back = SharedRunConfigs.load(MAPPER, root);
+        assertEquals(2, back.size());
+        assertEquals("Server", back.get(0).name());
+        assertEquals("--port 80", back.get(0).args(), "fields survive the trip");
+    }
+
+    /** A hand-edited or half-written file must not stop a project opening. */
+    @Test
+    void anUnreadableFileYieldsNothingRatherThanThrowing(@org.junit.jupiter.api.io.TempDir Path root) throws Exception {
+        assertEquals(List.of(), SharedRunConfigs.load(MAPPER, root), "absent file");
+
+        Path file = SharedRunConfigs.fileFor(root);
+        Files.createDirectories(file.getParent());
+        Files.writeString(file, "{ this is not json");
+        assertEquals(List.of(), SharedRunConfigs.load(MAPPER, root), "malformed file");
+    }
+
+    /** Importing twice must not duplicate; re-importing after a colleague's edit must update. */
+    @Test
+    void mergeReplacesByNameRatherThanAppending() {
+        List<RunConfiguration> existing = List.of(cfg("Server", "old"), cfg("Local only", ""));
+        List<RunConfiguration> incoming = List.of(cfg("Server", "new"), cfg("Fresh", ""));
+
+        List<RunConfiguration> merged = SharedRunConfigs.merge(existing, incoming);
+
+        assertEquals(3, merged.size(), "no duplicate Server");
+        assertEquals("Server", merged.get(0).name(), "existing order preserved");
+        assertEquals("new", merged.get(0).args(), "and it was updated, not kept");
+        assertEquals("Local only", merged.get(1).name(), "a local-only configuration survives an import");
+        assertEquals("Fresh", merged.get(2).name(), "genuinely new ones are appended");
+    }
+
+    @Test
+    void mergingIntoNothingIsJustTheIncomingSet() {
+        assertEquals(1, SharedRunConfigs.merge(List.of(), List.of(cfg("A", ""))).size());
+        assertEquals(1, SharedRunConfigs.merge(List.of(cfg("A", "")), List.of()).size());
+    }
+}


### PR DESCRIPTION
Last of four parts on #765. Closes it.

## Before launch

A configuration can name a command to run first — a build, a codegen step. **A non-zero exit aborts the launch**, which is the entire point: running the previous binary after a failed build is the mistake this prevents.

It runs **off the FX thread** (it is a build; it can take minutes) with the continuation marshalled back on. With no before-launch step there is no thread hop at all, so the common path is unchanged.

The reported error is the tool's **own last output line** — "before-launch failed" alone says nothing about which step or why.

## Sharing

**Export Configurations to Project** writes them to `.editora/run-configurations.json` inside the project, where a team can commit them. **Import** merges them back, matching by name so importing twice doesn't duplicate and a colleague's edit updates rather than doubles.

**This is deliberately export/import, not a live second store**, and that's the decision worth reviewing.

A dual-source model has to decide, on every read, which copy wins when the two disagree — and on every write, which store a configuration belongs to. Getting that wrong loses configurations silently, and the failure only surfaces once someone has already edited both. An explicit copy in each direction has neither problem: at any moment exactly one store is authoritative, and the user chose when to move it.

IntelliJ's live shared/local split is nicer to use, and it's a reasonable follow-up — but it is a more delicate feature than it looks, and I'd rather ship the honest version than a subtly lossy one. Say the word if you'd prefer the live model instead.

## Caught by an existing invariant

`ConfigDurabilityTest` failed my new store for writing non-atomically:

```
these truncate the file before writing — use ConfigWriter.writeAtomic instead:
  [SharedRunConfigs.java: mapper.writerWithDefaultPrettyPrinter().writeValue(...)]
```

Exactly right, and doubly so here: this file lives in the **user's repository**, where a truncated file is worse than in the config dir. Now goes through `ConfigWriter.writeAtomic` like every other store.

## Verification

3381 tests green (4 new, all pure), spotless and the JaCoCo floors pass.

**Not covered:** that a before-launch command actually gates a real launch end-to-end. The sequencing is a few lines and the failure path is a status message, but it spawns a real process — worth one manual check.

## #765 complete

1. ✅ Decouple from the active buffer (#781)
2. ✅ Generalise beyond `mainClass` (#782)
3. ✅ Toolbar selector + bindable commands (#783)
4. ✅ Before-launch + sharing (this)

🤖 Generated with [Claude Code](https://claude.com/claude-code)