### PR TITLE
feat(lsp): preview a rename before applying it (#768)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Rename now shows you what it will change** — a rename that reaches beyond the current file lists every
+  affected file first, with its change count and where it moves to, and you can untick any file before
+  applying. A rename confined to the file you're looking at applies straight away as before: it's on screen
+  and one undo away, so there'd be nothing to confirm.
+
 - **Run configurations gain a before-launch step, and can be shared with your team** — a configuration can
   name a command to run first (a build, a codegen step); a non-zero exit aborts the launch, so a stale binary
   is never run by accident. And **Export Configurations to Project** writes them to

--- a/src/main/java/com/editora/lsp/LspManager.java
+++ b/src/main/java/com/editora/lsp/LspManager.java
@@ -1167,6 +1167,24 @@ public final class LspManager {
 
     /** Renames the symbol at a 0-based position to {@code newName}; the workspace edit applies through the
      *  registered handler and {@code cb} gets overall success on the FX thread (#676). */
+    /**
+     * Asks the server what a rename would change, <b>without applying it</b>, so the caller can preview and
+     * filter first (#768). Delivers null when the server refuses or the edit contains an operation the mapper
+     * will not perform.
+     */
+    public void previewRename(
+            Path file, int line, int character, String newName, Consumer<WorkspaceEditMapper.Mapped> cb) {
+        LanguageServerSession s = sessionFor(file);
+        if (s == null) {
+            Platform.runLater(() -> cb.accept(null));
+            return;
+        }
+        s.rename(uri(file), new Position(line, character), newName).whenComplete((edit, e) -> {
+            WorkspaceEditMapper.Mapped mapped = e != null || edit == null ? null : WorkspaceEditMapper.map(edit);
+            Platform.runLater(() -> cb.accept(mapped));
+        });
+    }
+
     public void rename(Path file, int line, int character, String newName, Consumer<Boolean> cb) {
         LanguageServerSession s = sessionFor(file);
         if (s == null) {

--- a/src/main/java/com/editora/lsp/RenamePreview.java
+++ b/src/main/java/com/editora/lsp/RenamePreview.java
@@ -1,0 +1,120 @@
+package com.editora.lsp;
+
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Summarising and filtering a rename's {@link WorkspaceEditMapper.Mapped} so it can be previewed before it is
+ * applied (#768).
+ *
+ * <p>A rename edits files the user cannot see. Every desktop IDE treats "show me what you are about to do" as
+ * the thing that makes refactoring usable at all — Eclipse's preview page, IntelliJ's refactoring preview.
+ * Editora applied the server's edit immediately: safe, in that the whole thing is one undoable batch, but
+ * safety after the fact is not the same as consent before it.
+ *
+ * <p>Pure, so the counting and the filtering are testable without a language server: the interesting bugs are
+ * a file dropped from the summary, or a deselected file still being written.
+ */
+public final class RenamePreview {
+
+    private RenamePreview() {}
+
+    /**
+     * One affected file, for a preview row.
+     *
+     * @param file the file
+     * @param edits how many text edits it receives
+     * @param renamedTo where the file itself moves to, or null when it stays put
+     */
+    public record FileChange(Path file, int edits, Path renamedTo) {}
+
+    /**
+     * Every file a rename touches, in the order the edit lists them, with any file rename folded into the
+     * same row.
+     *
+     * <p>A file can be renamed without receiving text edits (jdtls moves a {@code .java} file whose public
+     * class was renamed), so renames contribute rows of their own rather than only annotating existing ones —
+     * otherwise the preview would understate what is about to happen.
+     */
+    public static List<FileChange> summarise(WorkspaceEditMapper.Mapped mapped) {
+        if (mapped == null) {
+            return List.of();
+        }
+        List<FileChange> rows = new ArrayList<>();
+        Set<Path> seen = new LinkedHashSet<>();
+        for (WorkspaceEditMapper.FileEdit edit : mapped.edits()) {
+            rows.add(new FileChange(edit.file(), edit.edits().size(), renameTargetOf(mapped, edit.file())));
+            seen.add(edit.file());
+        }
+        for (WorkspaceEditMapper.FileRename rename : mapped.renames()) {
+            if (!seen.contains(rename.from())) {
+                rows.add(new FileChange(rename.from(), 0, rename.to()));
+                seen.add(rename.from());
+            }
+        }
+        return rows;
+    }
+
+    private static Path renameTargetOf(WorkspaceEditMapper.Mapped mapped, Path file) {
+        for (WorkspaceEditMapper.FileRename rename : mapped.renames()) {
+            if (rename.from().equals(file)) {
+                return rename.to();
+            }
+        }
+        return null;
+    }
+
+    /**
+     * The subset of {@code mapped} that touches only {@code keep}.
+     *
+     * <p>A file rename is kept only when its source file is kept: moving a file whose edits the user just
+     * excluded would leave the rename half-applied, which is worse than doing nothing to it.
+     */
+    public static WorkspaceEditMapper.Mapped filter(WorkspaceEditMapper.Mapped mapped, Set<Path> keep) {
+        if (mapped == null) {
+            return null;
+        }
+        List<WorkspaceEditMapper.FileEdit> edits = new ArrayList<>();
+        for (WorkspaceEditMapper.FileEdit edit : mapped.edits()) {
+            if (keep.contains(edit.file())) {
+                edits.add(edit);
+            }
+        }
+        List<WorkspaceEditMapper.FileRename> renames = new ArrayList<>();
+        for (WorkspaceEditMapper.FileRename rename : mapped.renames()) {
+            if (keep.contains(rename.from())) {
+                renames.add(rename);
+            }
+        }
+        return new WorkspaceEditMapper.Mapped(edits, renames);
+    }
+
+    /**
+     * Whether a rename is worth previewing.
+     *
+     * <p>True once it reaches beyond the current file — several files, or a file rename. A single-file rename
+     * is already visible in the editor and is one undo away, so interposing a confirmation there would be
+     * friction with nothing to confirm; the case the preview exists for is the edit you cannot see.
+     */
+    public static boolean worthPreviewing(WorkspaceEditMapper.Mapped mapped) {
+        if (mapped == null) {
+            return false;
+        }
+        return mapped.edits().size() > 1 || !mapped.renames().isEmpty();
+    }
+
+    /** Total text edits across every file, for a one-line summary. */
+    public static int totalEdits(WorkspaceEditMapper.Mapped mapped) {
+        if (mapped == null) {
+            return 0;
+        }
+        int n = 0;
+        for (WorkspaceEditMapper.FileEdit edit : mapped.edits()) {
+            n += edit.edits().size();
+        }
+        return n;
+    }
+}

--- a/src/main/java/com/editora/ui/LspCoordinator.java
+++ b/src/main/java/com/editora/ui/LspCoordinator.java
@@ -57,6 +57,9 @@ final class LspCoordinator {
         /** Opens {@code file} (if needed) and moves the caret to a 0-based LSP line/column. */
         void openAndGoto(Path file, int line0, int col0);
 
+        /** A path with the home directory shown as {@code ~}, for preview labels. */
+        String homeCollapsed(String absolutePath);
+
         /** Opens (selected) a read-only in-memory buffer — no path, {@code language} highlighting — used for
          *  a {@code jdt://} class-file's fetched source (#665). Returns the buffer (null if refused). */
         EditorBuffer openReadOnlyDoc(String title, String content, String language);
@@ -1961,13 +1964,54 @@ final class LspCoordinator {
                 return; // nothing to do
             }
             host.setStatus(tr("status.lsp.renaming"));
-            lspManager.rename(
-                    path,
-                    line,
-                    col,
-                    name,
-                    ok -> host.setStatus(tr(ok ? "status.lsp.renamed" : "status.lsp.renameFailed", name)));
+            lspManager.previewRename(path, line, col, name, mapped -> {
+                if (mapped == null) {
+                    host.setStatus(tr("status.lsp.renameFailed", name));
+                    return;
+                }
+                if (!com.editora.lsp.RenamePreview.worthPreviewing(mapped)) {
+                    // Confined to this file: visible on screen and one undo away, so a confirmation step here
+                    // would be friction with nothing to confirm.
+                    applyRename(mapped, name);
+                    return;
+                }
+                previewThenApply(mapped, name);
+            });
         });
+    }
+
+    /**
+     * Shows which files a rename would change and applies only the ones left ticked.
+     *
+     * <p>A rename edits files the user cannot see, and every desktop IDE treats showing them first as what
+     * makes refactoring trustworthy. Reuses {@link MultiSelectPicker} — the same checkbox card the jdtls
+     * generators use — rather than a bespoke preview pane; a per-file choice is what the filtering can
+     * honour safely, and a per-hunk one would need the diff viewer and a much larger change.
+     */
+    private void previewThenApply(com.editora.lsp.WorkspaceEditMapper.Mapped mapped, String name) {
+        java.util.List<MultiSelectPicker.Item<java.nio.file.Path>> rows = new java.util.ArrayList<>();
+        for (com.editora.lsp.RenamePreview.FileChange change : com.editora.lsp.RenamePreview.summarise(mapped)) {
+            String label = ops.homeCollapsed(change.file().toString());
+            if (change.edits() > 0) {
+                label += "  ·  " + tr("lsp.rename.editCount", change.edits());
+            }
+            if (change.renamedTo() != null) {
+                label += "  ·  " + tr("lsp.rename.movesTo", change.renamedTo().getFileName());
+            }
+            rows.add(new MultiSelectPicker.Item<>(label, true, change.file()));
+        }
+        MultiSelectPicker.show(
+                host.overlayHost(),
+                tr("lsp.rename.previewTitle", name, com.editora.lsp.RenamePreview.totalEdits(mapped), rows.size()),
+                rows,
+                keep -> applyRename(
+                        com.editora.lsp.RenamePreview.filter(mapped, new java.util.LinkedHashSet<>(keep)), name));
+    }
+
+    /** Applies a (possibly filtered) rename edit and reports the outcome. */
+    private void applyRename(com.editora.lsp.WorkspaceEditMapper.Mapped mapped, String name) {
+        boolean ok = applyWorkspaceEdits(mapped);
+        host.setStatus(tr(ok ? "status.lsp.renamed" : "status.lsp.renameFailed", name));
     }
 
     /** The document text inside a 0-based LSP range (single-line expected), or "" when out of bounds. */

--- a/src/main/java/com/editora/ui/MainController.java
+++ b/src/main/java/com/editora/ui/MainController.java
@@ -3835,6 +3835,11 @@ public class MainController implements com.editora.mcp.McpBridge {
     private final LspCoordinator lspCoordinator =
             new LspCoordinator(coordinatorHost, lspManager, new LspCoordinator.Ops() {
                 @Override
+                public String homeCollapsed(String absolutePath) {
+                    return MainController.homeCollapsed(absolutePath);
+                }
+
+                @Override
                 public void openAndGoto(Path file, int line0, int col0) {
                     MainController.this.openAndGoto(file, line0, col0);
                 }

--- a/src/main/resources/com/editora/i18n/messages.properties
+++ b/src/main/resources/com/editora/i18n/messages.properties
@@ -3881,3 +3881,6 @@ status.run.beforeLaunch=Running the before-launch step for "{0}"…
 status.run.beforeLaunchFailed=Before-launch step for "{0}" failed: {1}
 settings.runConfig.beforeLaunch=Before launch
 settings.runConfig.beforeLaunchPrompt=Command to run first, e.g. mvn -q compile (blank = none)
+lsp.rename.previewTitle=Rename to "{0}" — {1} changes in {2} files
+lsp.rename.editCount={0} changes
+lsp.rename.movesTo=moves to {0}

--- a/src/main/resources/com/editora/i18n/messages_de.properties
+++ b/src/main/resources/com/editora/i18n/messages_de.properties
@@ -3872,3 +3872,6 @@ status.run.beforeLaunch=Vorbereitungsschritt für "{0}" wird ausgeführt…
 status.run.beforeLaunchFailed=Vorbereitungsschritt für "{0}" fehlgeschlagen: {1}
 settings.runConfig.beforeLaunch=Vor dem Start
 settings.runConfig.beforeLaunchPrompt=Vorher auszuführender Befehl, z. B. mvn -q compile (leer = keiner)
+lsp.rename.previewTitle=Umbenennen in "{0}" — {1} Änderungen in {2} Dateien
+lsp.rename.editCount={0} Änderungen
+lsp.rename.movesTo=wird zu {0}

--- a/src/main/resources/com/editora/i18n/messages_es.properties
+++ b/src/main/resources/com/editora/i18n/messages_es.properties
@@ -3872,3 +3872,6 @@ status.run.beforeLaunch=Ejecutando el paso previo de "{0}"…
 status.run.beforeLaunchFailed=El paso previo de "{0}" falló: {1}
 settings.runConfig.beforeLaunch=Antes de lanzar
 settings.runConfig.beforeLaunchPrompt=Comando previo, p. ej. mvn -q compile (vacío = ninguno)
+lsp.rename.previewTitle=Renombrar a "{0}" — {1} cambios en {2} archivos
+lsp.rename.editCount={0} cambios
+lsp.rename.movesTo=pasa a {0}

--- a/src/main/resources/com/editora/i18n/messages_fr.properties
+++ b/src/main/resources/com/editora/i18n/messages_fr.properties
@@ -3872,3 +3872,6 @@ status.run.beforeLaunch=Exécution de létape préalable de « {0} »…
 status.run.beforeLaunchFailed=Létape préalable de « {0} » a échoué : {1}
 settings.runConfig.beforeLaunch=Avant le lancement
 settings.runConfig.beforeLaunchPrompt=Commande préalable, p. ex. mvn -q compile (vide = aucune)
+lsp.rename.previewTitle=Renommer en « {0} » — {1} modifications dans {2} fichiers
+lsp.rename.editCount={0} modifications
+lsp.rename.movesTo=devient {0}

--- a/src/main/resources/com/editora/i18n/messages_it.properties
+++ b/src/main/resources/com/editora/i18n/messages_it.properties
@@ -3872,3 +3872,6 @@ status.run.beforeLaunch=Esecuzione del passo preliminare per "{0}"…
 status.run.beforeLaunchFailed=Il passo preliminare per "{0}" non è riuscito: {1}
 settings.runConfig.beforeLaunch=Prima del lancio
 settings.runConfig.beforeLaunchPrompt=Comando da eseguire prima, es. mvn -q compile (vuoto = nessuno)
+lsp.rename.previewTitle=Rinomina in "{0}" — {1} modifiche in {2} file
+lsp.rename.editCount={0} modifiche
+lsp.rename.movesTo=diventa {0}

--- a/src/main/resources/com/editora/i18n/messages_pt.properties
+++ b/src/main/resources/com/editora/i18n/messages_pt.properties
@@ -3872,3 +3872,6 @@ status.run.beforeLaunch=A executar o passo prévio de "{0}"…
 status.run.beforeLaunchFailed=O passo prévio de "{0}" falhou: {1}
 settings.runConfig.beforeLaunch=Antes do lançamento
 settings.runConfig.beforeLaunchPrompt=Comando a executar antes, p. ex. mvn -q compile (vazio = nenhum)
+lsp.rename.previewTitle=Mudar o nome para "{0}" — {1} alterações em {2} ficheiros
+lsp.rename.editCount={0} alterações
+lsp.rename.movesTo=passa a {0}

--- a/src/test/java/com/editora/lsp/RenamePreviewTest.java
+++ b/src/test/java/com/editora/lsp/RenamePreviewTest.java
@@ -1,0 +1,120 @@
+package com.editora.lsp;
+
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Set;
+
+import com.editora.editor.LspTextEdit;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class RenamePreviewTest {
+
+    private static final Path A = Path.of("/w/A.java");
+    private static final Path B = Path.of("/w/B.java");
+    private static final Path C = Path.of("/w/C.java");
+
+    private static LspTextEdit edit() {
+        return new LspTextEdit(0, 0, 0, 1, "x");
+    }
+
+    private static WorkspaceEditMapper.FileEdit fileEdit(Path p, int n) {
+        return new WorkspaceEditMapper.FileEdit(p, java.util.Collections.nCopies(n, edit()));
+    }
+
+    private static WorkspaceEditMapper.Mapped mapped(
+            List<WorkspaceEditMapper.FileEdit> edits, List<WorkspaceEditMapper.FileRename> renames) {
+        return new WorkspaceEditMapper.Mapped(edits, renames);
+    }
+
+    @Test
+    void everyEditedFileBecomesARowWithItsCount() {
+        var m = mapped(List.of(fileEdit(A, 3), fileEdit(B, 1)), List.of());
+
+        List<RenamePreview.FileChange> rows = RenamePreview.summarise(m);
+
+        assertEquals(2, rows.size());
+        assertEquals(A, rows.get(0).file());
+        assertEquals(3, rows.get(0).edits());
+        assertEquals(1, rows.get(1).edits());
+        assertEquals(4, RenamePreview.totalEdits(m));
+    }
+
+    /**
+     * jdtls moves a .java file whose public class was renamed, and that file may receive no text edits of its
+     * own. Folding renames only into existing rows would understate what the rename is about to do.
+     */
+    @Test
+    void aFileRenamedWithoutEditsStillAppears() {
+        var m = mapped(List.of(fileEdit(A, 2)), List.of(new WorkspaceEditMapper.FileRename(B, C, false)));
+
+        List<RenamePreview.FileChange> rows = RenamePreview.summarise(m);
+
+        assertEquals(2, rows.size(), "the moved file has its own row");
+        assertEquals(B, rows.get(1).file());
+        assertEquals(0, rows.get(1).edits());
+        assertEquals(C, rows.get(1).renamedTo(), "and shows where it goes");
+    }
+
+    /** A file both edited and renamed is one row, not two. */
+    @Test
+    void anEditedAndRenamedFileIsASingleRow() {
+        var m = mapped(List.of(fileEdit(A, 2)), List.of(new WorkspaceEditMapper.FileRename(A, C, false)));
+
+        List<RenamePreview.FileChange> rows = RenamePreview.summarise(m);
+
+        assertEquals(1, rows.size());
+        assertEquals(2, rows.get(0).edits());
+        assertEquals(C, rows.get(0).renamedTo());
+    }
+
+    @Test
+    void filteringKeepsOnlyTheChosenFiles() {
+        var m = mapped(List.of(fileEdit(A, 2), fileEdit(B, 1)), List.of());
+
+        var kept = RenamePreview.filter(m, Set.of(A));
+
+        assertEquals(1, kept.edits().size());
+        assertEquals(A, kept.edits().get(0).file());
+    }
+
+    /**
+     * The important filtering rule: moving a file whose edits were excluded would leave the rename
+     * half-applied — a file moved but not updated — which is worse than leaving it alone entirely.
+     */
+    @Test
+    void deselectingAFileAlsoDropsItsRename() {
+        var m = mapped(
+                List.of(fileEdit(A, 1), fileEdit(B, 1)), List.of(new WorkspaceEditMapper.FileRename(B, C, false)));
+
+        var kept = RenamePreview.filter(m, Set.of(A));
+
+        assertEquals(1, kept.edits().size());
+        assertTrue(kept.renames().isEmpty(), "B's rename went with B's edits");
+    }
+
+    /**
+     * A single-file rename is visible in the editor and one undo away, so interposing a confirmation adds
+     * friction with nothing to confirm. The preview is for the edit you cannot see.
+     */
+    @Test
+    void onlyRenamesReachingBeyondOneFileAreWorthPreviewing() {
+        assertFalse(RenamePreview.worthPreviewing(mapped(List.of(fileEdit(A, 5)), List.of())), "one file");
+        assertTrue(RenamePreview.worthPreviewing(mapped(List.of(fileEdit(A, 1), fileEdit(B, 1)), List.of())));
+        assertTrue(
+                RenamePreview.worthPreviewing(
+                        mapped(List.of(fileEdit(A, 1)), List.of(new WorkspaceEditMapper.FileRename(A, C, false)))),
+                "a file move is never invisible-safe");
+    }
+
+    @Test
+    void nullAndEmptyAreHandled() {
+        assertEquals(List.of(), RenamePreview.summarise(null));
+        assertFalse(RenamePreview.worthPreviewing(null));
+        assertEquals(0, RenamePreview.totalEdits(null));
+        assertEquals(List.of(), RenamePreview.summarise(mapped(List.of(), List.of())));
+    }
+}

--- a/src/test/java/com/editora/ui/LspOpsStub.java
+++ b/src/test/java/com/editora/ui/LspOpsStub.java
@@ -17,6 +17,11 @@ import com.editora.lsp.SymbolNode;
 class LspOpsStub implements LspCoordinator.Ops {
 
     @Override
+    public String homeCollapsed(String absolutePath) {
+        return absolutePath;
+    }
+
+    @Override
     public void openAndGoto(Path file, int line0, int col0) {}
 
     @Override


### PR DESCRIPTION
First slice of #768 (refactoring UI). **I checked what already existed before writing this** — after getting #765's premise wrong by not doing so — and the issue's claim was accurate here: rename works, with `prepareRename` validation and one undoable all-or-nothing apply, but it applies **immediately**.

## Why a preview

A rename edits files the user cannot see. Every desktop IDE treats "show me what you're about to do" as the thing that makes refactoring trustworthy — Eclipse's preview page, IntelliJ's refactoring preview. Editora's apply was *safe* (one undoable batch), but safety after the fact isn't the same as consent before it.

## What's here

`LspManager.previewRename` asks the server what would change **without applying**, and the pure `RenamePreview` summarises and filters it: a row per affected file with its change count and any move, and a filter keeping only the ticked files.

**The rule worth reviewing:** a file rename is kept only when its source file is kept. Moving a file whose edits were just excluded would leave it renamed but not updated — worse than leaving it alone. That's the case its test exists for.

**A single-file rename skips the preview** and applies directly. It's on screen and one undo away, so a confirmation there is friction with nothing to confirm; the preview is for the edit you *can't* see. That's a deliberate reading of the issue's "shows a preview of every affected file" — say if you'd rather it always prompt.

The UI reuses **`MultiSelectPicker`**, the checkbox card the jdtls generators already use, rather than a bespoke pane. A per-file choice is what the filtering can honour safely; per-hunk would need the diff viewer and a much larger change.

`LspCoordinator.Ops` gains `homeCollapsed` rather than this class growing a **fourth** private copy of it (`MainController`, `AgentCoordinator` and `SearchCoordinator` each already have one — worth consolidating some day).

## Verification

3388 tests green (7 new, all pure), spotless and the JaCoCo floors pass.

**Not covered:** the preview against a real multi-file rename. The summarise/filter logic is unit-tested and the picker is existing UI, but the round trip needs a live language server — worth a manual check on a Java project.

## Still open on #768

- **In-place rename** in the editor (type over the identifier, occurrences update live). Likely reuses either the `SnippetSession` mirroring or the multi-caret occurrence placement.
- **Extract Method / Variable** — these arrive as code actions already, so what's missing is the naming prompt and preview, not the analysis.
- **Change Signature** — no standard LSP request; likely jdtls-specific like the `java.action.*Prompt` family, or out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)