### PR TITLE
feat(ui): show running background work in the status bar (#770 part 2/2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Failures no longer slip past you** — the status bar shows one message at a time and the next one replaces
+  it, so an error that appeared while you were typing used to vanish without trace. Errors are now shown in
+  red, recorded as errors in the message log, and leave a small count beside the status line that stays until
+  you open the log. Warnings are marked too, without the count.
+
 - **Rename now shows you what it will change** — a rename that reaches beyond the current file lists every
   affected file first, with its change count and where it moves to, and you can untick any file before
   applying. A rename confined to the file you're looking at applies straight away as before: it's on screen

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Long-running work now says it's running** — a find-in-files sweep over a big tree used to announce itself
+  once and then go quiet, which looks identical to a hang. The status bar now shows what's in progress with a
+  spinner, and a count when several things run at once; it disappears entirely when nothing is happening.
+
 - **Failures no longer slip past you** — the status bar shows one message at a time and the next one replaces
   it, so an error that appeared while you were typing used to vanish without trace. Errors are now shown in
   red, recorded as errors in the message log, and leave a small count beside the status line that stays until

--- a/src/main/java/com/editora/ui/BackgroundTasks.java
+++ b/src/main/java/com/editora/ui/BackgroundTasks.java
@@ -1,0 +1,109 @@
+package com.editora.ui;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * The window's register of long-running background work, so the status bar can say what is happening (#770).
+ *
+ * <p>Editora starts plenty of work the user cannot see: a find-in-files sweep, a build, a language-server
+ * install, a Gradle task enumeration that takes a minute and a half. Each reported itself with a transient
+ * status message and then went quiet, which is indistinguishable from having hung — and the only visible
+ * progress anywhere was two indeterminate bars hard-wired to LSP startup and debugging.
+ *
+ * <p>Plain Java, no JavaFX: a registry of what is running plus a change callback. That keeps it unit-testable
+ * — the interesting behaviour is bookkeeping (a task ending while two others run, the same task ended twice)
+ * rather than anything visual. FX-thread-confined by convention, like the rest of the UI layer.
+ */
+final class BackgroundTasks {
+
+    /** One running operation. {@code cancel} is null when the work cannot be stopped. */
+    record Task(long id, String label, Runnable cancel) {
+        boolean cancellable() {
+            return cancel != null;
+        }
+    }
+
+    /**
+     * A started task. Callers hold one and call {@link #done()} when the work finishes — including when it
+     * fails, which is why it is a handle rather than a "remove by label": two searches can be in flight, and
+     * a failed one that never removed itself would leave the indicator claiming work that stopped long ago.
+     */
+    interface Handle {
+        void done();
+    }
+
+    /** Insertion-ordered, so the indicator shows the oldest running task rather than flickering between them. */
+    private final Map<Long, Task> running = new LinkedHashMap<>();
+
+    private final List<Runnable> listeners = new ArrayList<>();
+    private long nextId = 1;
+
+    /** Registers a change observer, called after every start and finish. */
+    void addListener(Runnable listener) {
+        listeners.add(listener);
+    }
+
+    /** Starts an uncancellable task. */
+    Handle start(String label) {
+        return start(label, null);
+    }
+
+    /**
+     * Starts a task shown until its handle is closed.
+     *
+     * @param label what to show the user, e.g. "Searching…"
+     * @param cancel how to stop it, or null when it cannot be stopped
+     */
+    Handle start(String label, Runnable cancel) {
+        long id = nextId++;
+        running.put(id, new Task(id, label == null ? "" : label, cancel));
+        notifyListeners();
+        return () -> {
+            // Idempotent: a service that both completes and errors, or retries its own cleanup, must not
+            // remove some *other* task by reusing a stale id — ids are never reused, so a second call is a
+            // no-op rather than a mix-up.
+            if (running.remove(id) != null) {
+                notifyListeners();
+            }
+        };
+    }
+
+    /** Everything currently running, oldest first. */
+    List<Task> running() {
+        return List.copyOf(running.values());
+    }
+
+    int count() {
+        return running.size();
+    }
+
+    boolean isIdle() {
+        return running.isEmpty();
+    }
+
+    /** The oldest running task, or null when idle — what the status bar names. */
+    Task current() {
+        for (Task t : running.values()) {
+            return t;
+        }
+        return null;
+    }
+
+    /** Cancels every cancellable task. The rest keep running and stay listed. */
+    void cancelAll() {
+        for (Task t : List.copyOf(running.values())) {
+            if (t.cancellable()) {
+                t.cancel().run();
+            }
+        }
+    }
+
+    private void notifyListeners() {
+        for (Runnable l : List.copyOf(listeners)) {
+            l.run();
+        }
+    }
+}

--- a/src/main/java/com/editora/ui/CoordinatorHost.java
+++ b/src/main/java/com/editora/ui/CoordinatorHost.java
@@ -40,6 +40,14 @@ interface CoordinatorHost {
     /** Reports a failure: coloured in the echo line and flagged unread until the message log is opened. */
     void setError(String message);
 
+    /**
+     * Registers long-running work so the status bar can show it; close the handle when the work ends.
+     *
+     * <p>Close it on <em>every</em> exit including failure — an operation that errors without closing leaves
+     * the indicator claiming work that stopped long ago, which is worse than showing nothing at all.
+     */
+    AutoCloseable startBackgroundTask(String label);
+
     long fileSize(Path file);
 
     String bufferBaseName(EditorBuffer buffer);

--- a/src/main/java/com/editora/ui/CoordinatorHost.java
+++ b/src/main/java/com/editora/ui/CoordinatorHost.java
@@ -37,6 +37,9 @@ interface CoordinatorHost {
 
     void setStatus(String message);
 
+    /** Reports a failure: coloured in the echo line and flagged unread until the message log is opened. */
+    void setError(String message);
+
     long fileSize(Path file);
 
     String bufferBaseName(EditorBuffer buffer);

--- a/src/main/java/com/editora/ui/MainController.java
+++ b/src/main/java/com/editora/ui/MainController.java
@@ -2942,6 +2942,11 @@ public class MainController implements com.editora.mcp.McpBridge {
         }
 
         @Override
+        public void setError(String message) {
+            MainController.this.setError(message);
+        }
+
+        @Override
         public long fileSize(Path file) {
             return MainController.this.fileSize(file);
         }
@@ -6484,6 +6489,18 @@ public class MainController implements com.editora.mcp.McpBridge {
         statusBar.setMessage(message);
     }
 
+    /**
+     * Reports a failure: the echo shows it in the danger colour and it stays flagged as unread until the user
+     * opens the message log.
+     *
+     * <p>Ordinary {@link #setStatus} messages replace one another and are then gone, which is right for
+     * "Saved" and wrong for "could not save" — a background failure landing while someone is typing is
+     * overwritten a moment later with nothing left to notice.
+     */
+    public void setError(String message) {
+        statusBar.setMessage(message, MessageLog.Severity.ERROR);
+    }
+
     private EditorBuffer activeBuffer() {
         return bufferOf(editorArea.selectedTab());
     }
@@ -9621,7 +9638,7 @@ public class MainController implements com.editora.mcp.McpBridge {
                     homeCollapsed(
                             com.editora.config.SharedRunConfigs.fileFor(root).toString())));
         } catch (java.io.IOException e) {
-            setStatus(tr("status.run.configsExportFailed", e.getMessage()));
+            setError(tr("status.run.configsExportFailed", e.getMessage()));
         }
     }
 

--- a/src/main/java/com/editora/ui/MainController.java
+++ b/src/main/java/com/editora/ui/MainController.java
@@ -105,6 +105,9 @@ public class MainController implements com.editora.mcp.McpBridge {
     @FXML
     private TabPane tabPane;
 
+    /** Long-running background work, surfaced in the status bar so a slow operation isn't mistaken for a hang. */
+    private final BackgroundTasks backgroundTasks = new BackgroundTasks();
+
     /** The editor area — the single entry point for reading and mutating open tabs. See {@link EditorArea}. */
     private EditorArea editorArea;
 
@@ -792,6 +795,10 @@ public class MainController implements com.editora.mcp.McpBridge {
                 () -> editorArea.selectedTab(),
                 this::activateAndFocusTab,
                 this::closeTabFromSwitcher);
+        backgroundTasks.addListener(() -> {
+            BackgroundTasks.Task t = backgroundTasks.current();
+            statusBar.setBackgroundTasks(t == null ? null : t.label(), backgroundTasks.count());
+        });
         setupMruTracking();
         registerCommands();
         setupToolbar();
@@ -2944,6 +2951,12 @@ public class MainController implements com.editora.mcp.McpBridge {
         @Override
         public void setError(String message) {
             MainController.this.setError(message);
+        }
+
+        @Override
+        public AutoCloseable startBackgroundTask(String label) {
+            BackgroundTasks.Handle h = backgroundTasks.start(label);
+            return h::done;
         }
 
         @Override

--- a/src/main/java/com/editora/ui/MessageLog.java
+++ b/src/main/java/com/editora/ui/MessageLog.java
@@ -21,19 +21,51 @@ public final class MessageLog {
     /** Maximum retained messages; older ones are evicted. */
     public static final int MAX_ENTRIES = 200;
 
-    /** One logged message: its wall-clock time (epoch millis) and text. */
-    public record Entry(long epochMillis, String text) {}
+    /** How much the message matters. Drives its styling and whether it counts as unread. */
+    public enum Severity {
+        INFO,
+        WARN,
+        ERROR
+    }
+
+    /** One logged message: its wall-clock time (epoch millis), text and severity. */
+    public record Entry(long epochMillis, String text, Severity severity) {
+        public Entry {
+            severity = severity == null ? Severity.INFO : severity;
+        }
+    }
 
     // Insertion order (oldest first); we evict from the head and append at the tail.
     private final Deque<Entry> entries = new ArrayDeque<>();
 
+    /**
+     * Errors recorded since the log was last read.
+     *
+     * <p>The status bar shows one message at a time and never clears it — it is <em>replaced</em> by the next
+     * one. So a failure that lands while the user is typing is overwritten a moment later by something
+     * routine and is gone with no trace they would notice. Counting unread errors is what lets the status bar
+     * keep a marker up until someone has actually looked, without hijacking the echo line to do it.
+     */
+    private int unreadErrors;
+
     /** Records {@code message} at {@code epochMillis}; no-ops for null/blank. Evicts the oldest past the cap. */
     public void add(String message, long epochMillis) {
+        add(message, Severity.INFO, epochMillis);
+    }
+
+    /** Records {@code message} with an explicit severity. */
+    public void add(String message, Severity severity, long epochMillis) {
         if (message == null || message.isBlank()) {
             return;
         }
-        entries.addLast(new Entry(epochMillis, message));
+        entries.addLast(new Entry(epochMillis, message, severity));
+        if (severity == Severity.ERROR) {
+            unreadErrors++;
+        }
         while (entries.size() > MAX_ENTRIES) {
+            // Evicting an unread error would lose the marker for a failure nobody has seen, so the count
+            // deliberately survives eviction: it tracks "something went wrong that you have not looked at",
+            // not "this specific entry is still retained".
             entries.removeFirst();
         }
     }
@@ -41,6 +73,16 @@ public final class MessageLog {
     /** Records {@code message} at the current wall-clock time. */
     public void add(String message) {
         add(message, System.currentTimeMillis());
+    }
+
+    /** Errors recorded since {@link #markRead()}. */
+    public int unreadErrors() {
+        return unreadErrors;
+    }
+
+    /** Clears the unread-error count — called when the user opens the log, i.e. has had a chance to see. */
+    public void markRead() {
+        unreadErrors = 0;
     }
 
     /** A snapshot of the messages, newest first. */
@@ -60,5 +102,6 @@ public final class MessageLog {
 
     public void clear() {
         entries.clear();
+        unreadErrors = 0; // clearing the log is an explicit "I have seen these"
     }
 }

--- a/src/main/java/com/editora/ui/MessageLogPopup.java
+++ b/src/main/java/com/editora/ui/MessageLogPopup.java
@@ -88,6 +88,14 @@ public final class MessageLogPopup {
                 time.setText(
                         TIME_FMT.format(Instant.ofEpochMilli(item.epochMillis()).atZone(ZoneId.systemDefault())));
                 msg.setText(item.text());
+                // Severity on the message, not the row: the time indicator stays muted so the colour marks
+                // what went wrong rather than washing the whole line.
+                msg.getStyleClass().removeAll("message-log-warn", "message-log-error");
+                if (item.severity() == MessageLog.Severity.ERROR) {
+                    msg.getStyleClass().add("message-log-error");
+                } else if (item.severity() == MessageLog.Severity.WARN) {
+                    msg.getStyleClass().add("message-log-warn");
+                }
                 setGraphic(box);
             }
         });

--- a/src/main/java/com/editora/ui/SearchCoordinator.java
+++ b/src/main/java/com/editora/ui/SearchCoordinator.java
@@ -176,13 +176,25 @@ final class SearchCoordinator {
         host.setStatus(tr("search.searching"));
         List<String> include = Globs.split(includeGlobs);
         List<String> exclude = Globs.split(excludeGlobs);
+        // Registered so a sweep over a large tree reads as running work rather than going quiet (#770).
+        AutoCloseable task = host.startBackgroundTask(tr("search.searching"));
         service.search(query, root, open, include, exclude, outcome -> {
+            closeQuietly(task);
             panel.setResults(outcome);
             host.setStatus(
                     outcome.totalMatches() == 0
                             ? tr("search.none")
                             : tr("search.summary", outcome.totalMatches(), outcome.fileCount()));
         });
+    }
+
+    /** Closes a background-task handle; a bookkeeping slip must never break the callback around it. */
+    private static void closeQuietly(AutoCloseable task) {
+        try {
+            task.close();
+        } catch (Exception ignored) {
+            // The handle only removes a map entry — nothing here is worth failing a search over.
+        }
     }
 
     /**

--- a/src/main/java/com/editora/ui/StatusBar.java
+++ b/src/main/java/com/editora/ui/StatusBar.java
@@ -46,6 +46,14 @@ public final class StatusBar extends HBox {
      */
     private final Label unreadErrors = new Label();
 
+    /**
+     * What background work is running, so an operation that takes a minute is distinguishable from a hang.
+     * Hidden entirely when idle — a permanently-present empty segment would be chrome that earns nothing.
+     */
+    private final Label backgroundTasks = new Label();
+
+    private final ProgressBar backgroundProgress = new ProgressBar(0);
+
     private final MessageLogPopup messageLogPopup = new MessageLogPopup();
     /** Git branch + ahead/behind; clickable to switch branches. Hidden outside a Git repo. */
     private final Label git = segment("git.switchBranch", tr("statusbar.tip.gitSwitch"));
@@ -131,6 +139,9 @@ public final class StatusBar extends HBox {
         unreadErrors.setOnMouseClicked(e -> registry.run("view.messageLog"));
         unreadErrors.setVisible(false);
         unreadErrors.setManaged(false);
+        backgroundTasks.getStyleClass().add("status-segment");
+        backgroundProgress.setPrefWidth(60);
+        setBackgroundTasks(null, 0);
         size.getStyleClass().add("status-segment");
         size.setTooltip(new Tooltip(tr("statusbar.tip.fileSize")));
         encoding.getStyleClass().add("status-segment");
@@ -202,6 +213,8 @@ public final class StatusBar extends HBox {
                         echo,
                         unreadErrors,
                         spacer,
+                        backgroundProgress,
+                        backgroundTasks,
                         update,
                         macroRec,
                         remote,
@@ -301,6 +314,24 @@ public final class StatusBar extends HBox {
         unreadErrors.setText(unread == 0 ? "" : String.valueOf(unread));
         unreadErrors.setVisible(unread > 0);
         unreadErrors.setManaged(unread > 0);
+    }
+
+    /**
+     * Shows the running background work: the oldest task's label, plus a count when others queue behind it.
+     * Null or zero hides both the label and its bar.
+     *
+     * <p>The bar is indeterminate only while something runs. An indeterminate {@code ProgressBar} drives an
+     * animation timeline that keeps pulsing the scene, so leaving one spinning when idle would burn repaints
+     * for nothing — the same reason the LSP bar sits at a fixed value when it has nothing to say.
+     */
+    public void setBackgroundTasks(String label, int count) {
+        boolean busy = count > 0 && label != null && !label.isBlank();
+        backgroundTasks.setText(busy ? (count > 1 ? label + "  (" + count + ")" : label) : "");
+        backgroundTasks.setVisible(busy);
+        backgroundTasks.setManaged(busy);
+        backgroundProgress.setProgress(busy ? ProgressBar.INDETERMINATE_PROGRESS : 0);
+        backgroundProgress.setVisible(busy);
+        backgroundProgress.setManaged(busy);
     }
 
     /** Clears the unread-error marker — the user has opened the log and had a chance to see them. */

--- a/src/main/java/com/editora/ui/StatusBar.java
+++ b/src/main/java/com/editora/ui/StatusBar.java
@@ -40,6 +40,12 @@ public final class StatusBar extends HBox {
     /** In-memory, session-only history of echo messages, shown by clicking the echo area. */
     private final MessageLog messageLog = new MessageLog();
 
+    /**
+     * Count of errors recorded since the log was last opened. Stays up after the echo has moved on, so a
+     * failure the user was not looking at leaves something behind that says so.
+     */
+    private final Label unreadErrors = new Label();
+
     private final MessageLogPopup messageLogPopup = new MessageLogPopup();
     /** Git branch + ahead/behind; clickable to switch branches. Hidden outside a Git repo. */
     private final Label git = segment("git.switchBranch", tr("statusbar.tip.gitSwitch"));
@@ -120,6 +126,11 @@ public final class StatusBar extends HBox {
         echo.getStyleClass().addAll("status-message", "status-segment-clickable");
         echo.setTooltip(new Tooltip(tr("statusbar.tip.messageLog")));
         echo.setOnMouseClicked(e -> registry.run("view.messageLog"));
+        unreadErrors.getStyleClass().addAll("status-unread-errors", "status-segment-clickable");
+        unreadErrors.setTooltip(new Tooltip(tr("statusbar.tip.unreadErrors")));
+        unreadErrors.setOnMouseClicked(e -> registry.run("view.messageLog"));
+        unreadErrors.setVisible(false);
+        unreadErrors.setManaged(false);
         size.getStyleClass().add("status-segment");
         size.setTooltip(new Tooltip(tr("statusbar.tip.fileSize")));
         encoding.getStyleClass().add("status-segment");
@@ -189,6 +200,7 @@ public final class StatusBar extends HBox {
         getChildren()
                 .addAll(
                         echo,
+                        unreadErrors,
                         spacer,
                         update,
                         macroRec,
@@ -260,8 +272,41 @@ public final class StatusBar extends HBox {
      *  message — e.g. a compiler error dump — would grow the whole status bar); the full text goes to the
      *  message log, whose rows wrap and are copyable. */
     public void setMessage(String message) {
+        setMessage(message, MessageLog.Severity.INFO);
+    }
+
+    /**
+     * Shows {@code message} in the echo line and records it with {@code severity}.
+     *
+     * <p>The echo shows one message and is replaced by the next, so an error that lands while the user is
+     * mid-keystroke is overwritten moments later. Colouring it is half the answer; the other half is
+     * {@link #refreshUnreadErrors()}, which keeps a marker up until someone opens the log — so a failure can
+     * never disappear entirely unnoticed without the echo line being hijacked to hold it.
+     */
+    public void setMessage(String message, MessageLog.Severity severity) {
         echo.setText(echoLine(message));
-        messageLog.add(message); // full text; no-ops for null/blank (a blank clears the echo)
+        echo.getStyleClass().removeAll("status-echo-warn", "status-echo-error");
+        if (severity == MessageLog.Severity.ERROR) {
+            echo.getStyleClass().add("status-echo-error");
+        } else if (severity == MessageLog.Severity.WARN) {
+            echo.getStyleClass().add("status-echo-warn");
+        }
+        messageLog.add(message, severity, System.currentTimeMillis()); // no-ops for null/blank
+        refreshUnreadErrors();
+    }
+
+    /** Shows or hides the unread-error marker beside the echo line. */
+    private void refreshUnreadErrors() {
+        int unread = messageLog.unreadErrors();
+        unreadErrors.setText(unread == 0 ? "" : String.valueOf(unread));
+        unreadErrors.setVisible(unread > 0);
+        unreadErrors.setManaged(unread > 0);
+    }
+
+    /** Clears the unread-error marker — the user has opened the log and had a chance to see them. */
+    public void markMessagesRead() {
+        messageLog.markRead();
+        refreshUnreadErrors();
     }
 
     /** Maximum characters shown in the echo line; longer messages are truncated with an ellipsis. */
@@ -295,6 +340,7 @@ public final class StatusBar extends HBox {
         Window owner = getScene() == null ? null : getScene().getWindow();
         if (owner != null) {
             messageLogPopup.toggle(owner, echo, messageLog);
+            markMessagesRead(); // opening the log is the user having had a chance to see them
         }
     }
 

--- a/src/main/java/com/editora/ui/WindowManager.java
+++ b/src/main/java/com/editora/ui/WindowManager.java
@@ -91,8 +91,10 @@ public class WindowManager {
     private void notifyConfigWriteError(Path file) {
         Holder h = focusedHolder();
         if (h != null && h.controller() != null) {
+            // A lost config write is exactly the failure that used to vanish: it happens in the background,
+            // and the next routine status message replaced it a moment later (#418, #770).
             h.controller()
-                    .setStatus(com.editora.i18n.Messages.tr(
+                    .setError(com.editora.i18n.Messages.tr(
                             "status.config.saveFailed", file.getFileName().toString()));
         }
     }

--- a/src/main/resources/com/editora/i18n/messages.properties
+++ b/src/main/resources/com/editora/i18n/messages.properties
@@ -3884,3 +3884,4 @@ settings.runConfig.beforeLaunchPrompt=Command to run first, e.g. mvn -q compile 
 lsp.rename.previewTitle=Rename to "{0}" — {1} changes in {2} files
 lsp.rename.editCount={0} changes
 lsp.rename.movesTo=moves to {0}
+statusbar.tip.unreadErrors=Errors you have not looked at — click to open the message log

--- a/src/main/resources/com/editora/i18n/messages_de.properties
+++ b/src/main/resources/com/editora/i18n/messages_de.properties
@@ -3875,3 +3875,4 @@ settings.runConfig.beforeLaunchPrompt=Vorher auszuführender Befehl, z. B. mvn -
 lsp.rename.previewTitle=Umbenennen in "{0}" — {1} Änderungen in {2} Dateien
 lsp.rename.editCount={0} Änderungen
 lsp.rename.movesTo=wird zu {0}
+statusbar.tip.unreadErrors=Noch nicht gesehene Fehler — zum Öffnen des Meldungsprotokolls klicken

--- a/src/main/resources/com/editora/i18n/messages_es.properties
+++ b/src/main/resources/com/editora/i18n/messages_es.properties
@@ -3875,3 +3875,4 @@ settings.runConfig.beforeLaunchPrompt=Comando previo, p. ej. mvn -q compile (vac
 lsp.rename.previewTitle=Renombrar a "{0}" — {1} cambios en {2} archivos
 lsp.rename.editCount={0} cambios
 lsp.rename.movesTo=pasa a {0}
+statusbar.tip.unreadErrors=Errores que aún no has visto — haz clic para abrir el registro de mensajes

--- a/src/main/resources/com/editora/i18n/messages_fr.properties
+++ b/src/main/resources/com/editora/i18n/messages_fr.properties
@@ -3875,3 +3875,4 @@ settings.runConfig.beforeLaunchPrompt=Commande préalable, p. ex. mvn -q compile
 lsp.rename.previewTitle=Renommer en « {0} » — {1} modifications dans {2} fichiers
 lsp.rename.editCount={0} modifications
 lsp.rename.movesTo=devient {0}
+statusbar.tip.unreadErrors=Erreurs que vous navez pas encore consultées — cliquez pour ouvrir le journal

--- a/src/main/resources/com/editora/i18n/messages_it.properties
+++ b/src/main/resources/com/editora/i18n/messages_it.properties
@@ -3875,3 +3875,4 @@ settings.runConfig.beforeLaunchPrompt=Comando da eseguire prima, es. mvn -q comp
 lsp.rename.previewTitle=Rinomina in "{0}" — {1} modifiche in {2} file
 lsp.rename.editCount={0} modifiche
 lsp.rename.movesTo=diventa {0}
+statusbar.tip.unreadErrors=Errori non ancora letti — clicca per aprire il registro dei messaggi

--- a/src/main/resources/com/editora/i18n/messages_pt.properties
+++ b/src/main/resources/com/editora/i18n/messages_pt.properties
@@ -3875,3 +3875,4 @@ settings.runConfig.beforeLaunchPrompt=Comando a executar antes, p. ex. mvn -q co
 lsp.rename.previewTitle=Mudar o nome para "{0}" — {1} alterações em {2} ficheiros
 lsp.rename.editCount={0} alterações
 lsp.rename.movesTo=passa a {0}
+statusbar.tip.unreadErrors=Erros que ainda não viu — clique para abrir o registo de mensagens

--- a/src/main/resources/com/editora/styles/app.css
+++ b/src/main/resources/com/editora/styles/app.css
@@ -1334,6 +1334,30 @@
     -fx-border-width: 0 2 0 0;
 }
 
+/* Message severity. The echo line shows one message and is replaced by the next, so an error needs to be
+   distinguishable at a glance — and the unread-error badge keeps a marker up after the echo has moved on,
+   which is what stops a failure vanishing unnoticed. Semantic colors, so both track the theme. */
+.status-message.status-echo-error {
+    -fx-text-fill: -color-danger-fg;
+}
+.status-message.status-echo-warn {
+    -fx-text-fill: -color-warning-fg;
+}
+.status-unread-errors {
+    -fx-background-color: -color-danger-emphasis;
+    -fx-text-fill: -color-fg-emphasis;
+    -fx-background-radius: 8;
+    -fx-padding: 0 6 0 6;
+    -fx-font-size: 10px;
+    -fx-font-weight: bold;
+}
+.message-log-error {
+    -fx-text-fill: -color-danger-fg;
+}
+.message-log-warn {
+    -fx-text-fill: -color-warning-fg;
+}
+
 /* Dragging a tab onto an editor group's body: a translucent accent wash over the region the tab would
    occupy — the whole group when dropping into it, or the half it would split off at an edge. Semantic
    colors, so it tracks the theme. Mouse-transparent and unmanaged (set in EditorArea) so it can be drawn

--- a/src/test/java/com/editora/ui/BackgroundTasksTest.java
+++ b/src/test/java/com/editora/ui/BackgroundTasksTest.java
@@ -1,0 +1,89 @@
+package com.editora.ui;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class BackgroundTasksTest {
+
+    @Test
+    void aStartedTaskIsListedUntilItFinishes() {
+        BackgroundTasks tasks = new BackgroundTasks();
+        assertTrue(tasks.isIdle());
+
+        BackgroundTasks.Handle h = tasks.start("Searching…");
+        assertEquals(1, tasks.count());
+        assertEquals("Searching…", tasks.current().label());
+
+        h.done();
+        assertTrue(tasks.isIdle());
+        assertNull(tasks.current());
+    }
+
+    /** The indicator names the oldest task, so it doesn't flicker between concurrent ones. */
+    @Test
+    void theOldestRunningTaskIsTheCurrentOne() {
+        BackgroundTasks tasks = new BackgroundTasks();
+        BackgroundTasks.Handle first = tasks.start("Building…");
+        tasks.start("Searching…");
+
+        assertEquals("Building…", tasks.current().label());
+        assertEquals(2, tasks.count());
+
+        first.done();
+        assertEquals("Searching…", tasks.current().label(), "the next oldest takes over");
+    }
+
+    /**
+     * A service that both completes and errors, or retries its own cleanup, will close a handle twice. Since
+     * ids are never reused, the second call must be a no-op rather than removing some other task.
+     */
+    @Test
+    void closingAHandleTwiceDoesNotRemoveAnotherTask() {
+        BackgroundTasks tasks = new BackgroundTasks();
+        BackgroundTasks.Handle first = tasks.start("A");
+        BackgroundTasks.Handle second = tasks.start("B");
+
+        first.done();
+        first.done();
+        first.done();
+
+        assertEquals(1, tasks.count(), "B is untouched");
+        assertEquals("B", tasks.current().label());
+        second.done();
+        assertTrue(tasks.isIdle());
+    }
+
+    @Test
+    void listenersFireOnEveryStartAndFinish() {
+        BackgroundTasks tasks = new BackgroundTasks();
+        AtomicInteger changes = new AtomicInteger();
+        tasks.addListener(changes::incrementAndGet);
+
+        BackgroundTasks.Handle h = tasks.start("A");
+        assertEquals(1, changes.get());
+        h.done();
+        assertEquals(2, changes.get());
+        h.done(); // already gone
+        assertEquals(2, changes.get(), "a no-op close does not fire a spurious change");
+    }
+
+    @Test
+    void cancelAllStopsOnlyWhatCanBeStopped() {
+        BackgroundTasks tasks = new BackgroundTasks();
+        AtomicInteger cancels = new AtomicInteger();
+        tasks.start("cancellable", cancels::incrementAndGet);
+        tasks.start("not cancellable");
+
+        tasks.cancelAll();
+
+        assertEquals(1, cancels.get(), "only the one that could be cancelled was");
+        assertEquals(2, tasks.count(), "cancelling asks it to stop; the service removes it when it has");
+        assertFalse(tasks.running().get(1).cancellable());
+    }
+}

--- a/src/test/java/com/editora/ui/CoordinatorHostStub.java
+++ b/src/test/java/com/editora/ui/CoordinatorHostStub.java
@@ -46,6 +46,11 @@ class CoordinatorHostStub implements CoordinatorHost {
     public void setStatus(String message) {}
 
     @Override
+    public void setError(String message) {
+        setStatus(message);
+    }
+
+    @Override
     public long fileSize(Path file) {
         return 0;
     }

--- a/src/test/java/com/editora/ui/CoordinatorHostStub.java
+++ b/src/test/java/com/editora/ui/CoordinatorHostStub.java
@@ -51,6 +51,11 @@ class CoordinatorHostStub implements CoordinatorHost {
     }
 
     @Override
+    public AutoCloseable startBackgroundTask(String label) {
+        return () -> {};
+    }
+
+    @Override
     public long fileSize(Path file) {
         return 0;
     }

--- a/src/test/java/com/editora/ui/MessageLogSeverityTest.java
+++ b/src/test/java/com/editora/ui/MessageLogSeverityTest.java
@@ -1,0 +1,75 @@
+package com.editora.ui;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class MessageLogSeverityTest {
+
+    @Test
+    void messagesDefaultToInfo() {
+        MessageLog log = new MessageLog();
+        log.add("saved", 1L);
+
+        assertEquals(MessageLog.Severity.INFO, log.entries().get(0).severity());
+        assertEquals(0, log.unreadErrors(), "nothing to flag");
+    }
+
+    @Test
+    void errorsAreCountedUntilRead() {
+        MessageLog log = new MessageLog();
+        log.add("routine", MessageLog.Severity.INFO, 1L);
+        log.add("could not save", MessageLog.Severity.ERROR, 2L);
+        log.add("also broke", MessageLog.Severity.ERROR, 3L);
+        log.add("routine again", MessageLog.Severity.INFO, 4L);
+
+        assertEquals(2, log.unreadErrors(), "warnings and info do not count");
+
+        log.markRead();
+        assertEquals(0, log.unreadErrors());
+    }
+
+    @Test
+    void warningsDoNotCountAsUnreadErrors() {
+        MessageLog log = new MessageLog();
+        log.add("careful", MessageLog.Severity.WARN, 1L);
+
+        assertEquals(0, log.unreadErrors());
+        assertEquals(MessageLog.Severity.WARN, log.entries().get(0).severity());
+    }
+
+    /**
+     * The count tracks "something failed that you haven't looked at", not "this entry is still retained" — so
+     * an error pushed out by the 200-entry cap must not silently take its marker with it.
+     */
+    @Test
+    void anEvictedErrorStillCounts() {
+        MessageLog log = new MessageLog();
+        log.add("the failure", MessageLog.Severity.ERROR, 1L);
+        for (int i = 0; i < MessageLog.MAX_ENTRIES + 5; i++) {
+            log.add("chatter " + i, MessageLog.Severity.INFO, 10L + i);
+        }
+
+        assertEquals(MessageLog.MAX_ENTRIES, log.size(), "the error was evicted");
+        assertEquals(1, log.unreadErrors(), "but it is still flagged as unseen");
+    }
+
+    @Test
+    void clearingTheLogCountsAsHavingSeenThem() {
+        MessageLog log = new MessageLog();
+        log.add("boom", MessageLog.Severity.ERROR, 1L);
+        log.clear();
+
+        assertEquals(0, log.unreadErrors());
+    }
+
+    @Test
+    void blankMessagesAreStillIgnoredWhateverTheirSeverity() {
+        MessageLog log = new MessageLog();
+        log.add("  ", MessageLog.Severity.ERROR, 1L);
+        log.add(null, MessageLog.Severity.ERROR, 2L);
+
+        assertEquals(0, log.size());
+        assertEquals(0, log.unreadErrors(), "a blank error is not a failure to flag");
+    }
+}


### PR DESCRIPTION
Second half of #770. **Stacked on #786** (the notifications half) — review that first; this branch contains its commits until it merges.

## The problem

Editora starts plenty of work the user can't see: a find-in-files sweep, a build, an install, a Gradle task enumeration that takes ~90 seconds. Each announced itself once with a transient status message and then went quiet — **indistinguishable from a hang**. The only visible progress anywhere was two bars hard-wired to LSP startup and debugging.

## The registry

`BackgroundTasks` is plain Java — a registry of what's running plus a change callback — so the bookkeeping is unit-testable without a toolkit. The interesting cases aren't visual:

- **Ids are never reused**, so closing a handle twice is a no-op rather than removing somebody else's task. A service that both completes *and* errors will do exactly that, and the failure would be a task silently vanishing from the indicator while it's still running.
- The indicator names the **oldest** running task, not the newest, so it doesn't flicker between concurrent ones.
- It **hides entirely when idle** rather than sitting there empty, and the bar is indeterminate only while something runs — an indeterminate `ProgressBar` drives an animation timeline that keeps pulsing the scene, which is why the LSP bar already rests at a fixed value.

Find in Files is wired as the first consumer. Build, install and the render services are mechanical from here.

## How this was built — worth reading

The first attempt was written against anchors that **only exist on the unmerged #786 branch**, so several edits silently matched nothing and the compiler surfaced it as unrelated missing symbols. I initially read that as four separate mistakes; it was one — a branch cut from `master` being edited as though it had #786's changes.

Rather than patch around it, I restacked this branch on #786 (both halves are the same issue) and re-applied every edit through a helper that **asserts its anchor exists and is unique**. That's now how I'll make these edits: all four silent no-ops this session had the same cause, and an unasserted textual replace is simply not safe against a file I'm not looking at.

## Verification

3399 tests green (5 new, all pure), **clean** `verify` (after the incremental-compile miss on #786, clean is what I run before pushing), spotless and the JaCoCo floors pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)