### PR TITLE
feat(project): create a new project from a multi-file template (#769)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **New Project From Template** — scaffold a whole project and open it in its own window, rather than
+  pointing Editora at a folder you made yourself. Pick a multi-file template, fill in its variables, choose
+  where it goes, and the new folder is registered as a project and opened. Ships with a **Python Project**
+  template (package layout, a test, `pyproject.toml`, README and `.gitignore`); your own multi-file
+  templates appear in the same picker.
+
 - **Long-running work now says it's running** — a find-in-files sweep over a big tree used to announce itself
   once and then go quiet, which looks identical to a hang. The status bar now shows what's in progress with a
   spinner, and a count when several things run at once; it disappears entirely when nothing is happening.

--- a/src/main/java/com/editora/ui/MainController.java
+++ b/src/main/java/com/editora/ui/MainController.java
@@ -11325,7 +11325,23 @@ public class MainController implements com.editora.mcp.McpBridge {
      * non-null = write the file(s) into that folder and open the primary one.
      */
     private void newFromTemplate(java.nio.file.Path targetDir) {
-        List<com.editora.template.Template> all = templates.all();
+        newFromTemplate(targetDir, t -> true, null);
+    }
+
+    /**
+     * As above, but restricted to templates matching {@code filter} and calling {@code onCreated} with the
+     * folder that received the files.
+     *
+     * <p>The hook is what "New Project" needs: the generation, the variable wizard and the target-folder
+     * field are all already right for scaffolding a tree — the only thing missing was registering the result
+     * as a project afterwards, so that is threaded through rather than duplicating the flow.
+     */
+    private void newFromTemplate(
+            java.nio.file.Path targetDir,
+            java.util.function.Predicate<com.editora.template.Template> filter,
+            java.util.function.Consumer<java.nio.file.Path> onCreated) {
+        List<com.editora.template.Template> all =
+                templates.all().stream().filter(filter).toList();
         if (all.isEmpty()) {
             setStatus(tr("status.noTemplates"));
             return;
@@ -11336,7 +11352,7 @@ public class MainController implements com.editora.mcp.McpBridge {
                 () -> new ArrayList<>(all),
                 com.editora.template.Template::name,
                 com.editora.template.Template::description,
-                t -> beginTemplate(t, targetDir));
+                t -> beginTemplate(t, targetDir, onCreated));
         // Wider than the default picker + a taller minimum: template descriptions are long, so the
         // default 620px clipped them (and showed a horizontal scrollbar).
         picker.setPreferredSize(820, 8);
@@ -11344,8 +11360,33 @@ public class MainController implements com.editora.mcp.McpBridge {
         picker.show(stage);
     }
 
+    /**
+     * {@code project.newFromTemplate}: scaffolds a new project from a multi-file template and opens it.
+     *
+     * <p>Reuses the ordinary template flow — the picker, the variable wizard and its target-folder field
+     * already do the generation correctly — and only adds what was actually missing: registering the folder
+     * as a project and opening its window. Restricted to multi-file templates because a project is a tree; a
+     * single-file template produces a lone file, which is what {@code template.new} is already for.
+     */
+    private void newProjectFromTemplate() {
+        if (!projectsEnabled()) {
+            return; // the palette already hides project.* when the feature is off
+        }
+        newFromTemplate(defaultNewDir(), com.editora.template.Template::isMultiFile, dir -> {
+            Project project = projects.createOrGet(dir.getFileName().toString(), dir);
+            projects.save();
+            setStatus(tr("status.project.createdFromTemplate", project.name()));
+            if (windowManager != null) {
+                windowManager.openOrFocus(project);
+            }
+        });
+    }
+
     /** Discovers the template's unknown variables; prompts for them via a wizard, else applies directly. */
-    private void beginTemplate(com.editora.template.Template t, java.nio.file.Path targetDir) {
+    private void beginTemplate(
+            com.editora.template.Template t,
+            java.nio.file.Path targetDir,
+            java.util.function.Consumer<java.nio.file.Path> onCreated) {
         List<com.editora.template.TemplateEngine.TemplateVar> vars;
         if (t.isMultiFile()) {
             List<String> texts = new ArrayList<>();
@@ -11364,7 +11405,7 @@ public class MainController implements com.editora.mcp.McpBridge {
         // creates an untitled scratch buffer immediately — no wizard. A multi-file template always writes to
         // disk, so it goes through the wizard (to offer the target folder) even with no variables.
         if (vars.isEmpty() && targetDir == null && !t.isMultiFile()) {
-            applyTemplate(t, null, java.util.Map.of());
+            applyTemplate(t, null, java.util.Map.of(), onCreated);
             return;
         }
 
@@ -11420,7 +11461,7 @@ public class MainController implements com.editora.mcp.McpBridge {
                     java.nio.file.Path base = targetDir != null ? targetDir : defaultNewDir();
                     java.nio.file.Path dir = com.editora.config.PathKeys.resolveUserInput(
                             folderField.getText(), base, System.getProperty("user.home"));
-                    applyTemplate(t, dir, answers);
+                    applyTemplate(t, dir, answers, onCreated);
                 },
                 null,
                 false);
@@ -11442,7 +11483,10 @@ public class MainController implements com.editora.mcp.McpBridge {
 
     /** Renders {@code t} with {@code answers} and creates the file(s) (untitled buffer or written to disk). */
     private void applyTemplate(
-            com.editora.template.Template t, java.nio.file.Path targetDir, java.util.Map<String, String> answers) {
+            com.editora.template.Template t,
+            java.nio.file.Path targetDir,
+            java.util.Map<String, String> answers,
+            java.util.function.Consumer<java.nio.file.Path> onCreated) {
         Settings s = config.getSettings();
         String author = s.getAuthorName();
         String projectName = activeProjectName();
@@ -11451,7 +11495,14 @@ public class MainController implements com.editora.mcp.McpBridge {
 
         if (t.isMultiFile()) {
             applyMultiFileTemplate(
-                    t, targetDir != null ? targetDir : defaultNewDir(), answers, author, projectName, packageName, now);
+                    t,
+                    targetDir != null ? targetDir : defaultNewDir(),
+                    answers,
+                    author,
+                    projectName,
+                    packageName,
+                    now,
+                    onCreated);
             return;
         }
         // Resolve the file name first (so the body's ${fileName}/${baseName}/${extension} are correct).
@@ -11506,7 +11557,8 @@ public class MainController implements com.editora.mcp.McpBridge {
             String author,
             String projectName,
             String packageName,
-            java.time.LocalDateTime now) {
+            java.time.LocalDateTime now,
+            java.util.function.Consumer<java.nio.file.Path> onCreated) {
         com.editora.template.TemplateVariableResolver vars = new com.editora.template.TemplateVariableResolver(
                 answers, author, projectName, packageName, "", dir.toString(), "", now);
         java.nio.file.Path primary = null;
@@ -11529,6 +11581,9 @@ public class MainController implements com.editora.mcp.McpBridge {
                 projectPanel.refreshTree();
             }
             setStatus(tr("status.templateCreated", primary.getFileName().toString()));
+            if (onCreated != null) {
+                onCreated.accept(dir); // only after at least one file landed — an empty folder is not a project
+            }
         }
     }
 
@@ -14576,6 +14631,7 @@ public class MainController implements com.editora.mcp.McpBridge {
         registry.register(Command.of("edit.collapseCarets", () -> withMultiCaret(EditorBuffer::collapseCarets)));
         registry.register(Command.of("template.new", () -> newFromTemplate(null)));
         registry.register(Command.of("template.newInFolder", () -> newFromTemplate(defaultNewDir())));
+        registry.register(Command.of("project.newFromTemplate", this::newProjectFromTemplate));
         registry.register(Command.of("template.reload", () -> {
             templates.reload();
             setStatus(tr("status.templatesReloaded"));

--- a/src/main/java/com/editora/ui/MenuBarModel.java
+++ b/src/main/java/com/editora/ui/MenuBarModel.java
@@ -41,6 +41,7 @@ final class MenuBarModel {
                         List.of(
                                 "file.new",
                                 "template.new",
+                                "project.newFromTemplate",
                                 "file.open",
                                 "project.open",
                                 SEPARATOR,

--- a/src/main/resources/com/editora/i18n/messages.properties
+++ b/src/main/resources/com/editora/i18n/messages.properties
@@ -3885,3 +3885,6 @@ lsp.rename.previewTitle=Rename to "{0}" — {1} changes in {2} files
 lsp.rename.editCount={0} changes
 lsp.rename.movesTo=moves to {0}
 statusbar.tip.unreadErrors=Errors you have not looked at — click to open the message log
+command.project.newFromTemplate=Project: New Project From Template…
+command.project.newFromTemplate.desc=Scaffold a new project from a multi-file template and open it in its own window.
+status.project.createdFromTemplate=Created project {0}

--- a/src/main/resources/com/editora/i18n/messages_de.properties
+++ b/src/main/resources/com/editora/i18n/messages_de.properties
@@ -3876,3 +3876,6 @@ lsp.rename.previewTitle=Umbenennen in "{0}" — {1} Änderungen in {2} Dateien
 lsp.rename.editCount={0} Änderungen
 lsp.rename.movesTo=wird zu {0}
 statusbar.tip.unreadErrors=Noch nicht gesehene Fehler — zum Öffnen des Meldungsprotokolls klicken
+command.project.newFromTemplate=Projekt: neues Projekt aus Vorlage…
+command.project.newFromTemplate.desc=Erstellt ein neues Projekt aus einer mehrdateiigen Vorlage und öffnet es in einem eigenen Fenster.
+status.project.createdFromTemplate=Projekt {0} erstellt

--- a/src/main/resources/com/editora/i18n/messages_es.properties
+++ b/src/main/resources/com/editora/i18n/messages_es.properties
@@ -3876,3 +3876,6 @@ lsp.rename.previewTitle=Renombrar a "{0}" — {1} cambios en {2} archivos
 lsp.rename.editCount={0} cambios
 lsp.rename.movesTo=pasa a {0}
 statusbar.tip.unreadErrors=Errores que aún no has visto — haz clic para abrir el registro de mensajes
+command.project.newFromTemplate=Proyecto: nuevo proyecto desde plantilla…
+command.project.newFromTemplate.desc=Crea un proyecto nuevo a partir de una plantilla multiarchivo y lo abre en su propia ventana.
+status.project.createdFromTemplate=Proyecto {0} creado

--- a/src/main/resources/com/editora/i18n/messages_fr.properties
+++ b/src/main/resources/com/editora/i18n/messages_fr.properties
@@ -3876,3 +3876,6 @@ lsp.rename.previewTitle=Renommer en « {0} » — {1} modifications dans {2} fic
 lsp.rename.editCount={0} modifications
 lsp.rename.movesTo=devient {0}
 statusbar.tip.unreadErrors=Erreurs que vous navez pas encore consultées — cliquez pour ouvrir le journal
+command.project.newFromTemplate=Projet : nouveau projet à partir dun modèle…
+command.project.newFromTemplate.desc=Crée un projet à partir dun modèle multi-fichier et louvre dans sa propre fenêtre.
+status.project.createdFromTemplate=Projet {0} créé

--- a/src/main/resources/com/editora/i18n/messages_it.properties
+++ b/src/main/resources/com/editora/i18n/messages_it.properties
@@ -3876,3 +3876,6 @@ lsp.rename.previewTitle=Rinomina in "{0}" — {1} modifiche in {2} file
 lsp.rename.editCount={0} modifiche
 lsp.rename.movesTo=diventa {0}
 statusbar.tip.unreadErrors=Errori non ancora letti — clicca per aprire il registro dei messaggi
+command.project.newFromTemplate=Progetto: nuovo progetto da modello…
+command.project.newFromTemplate.desc=Crea un nuovo progetto da un modello multi-file e lo apre in una finestra dedicata.
+status.project.createdFromTemplate=Progetto {0} creato

--- a/src/main/resources/com/editora/i18n/messages_pt.properties
+++ b/src/main/resources/com/editora/i18n/messages_pt.properties
@@ -3876,3 +3876,6 @@ lsp.rename.previewTitle=Mudar o nome para "{0}" — {1} alterações em {2} fich
 lsp.rename.editCount={0} alterações
 lsp.rename.movesTo=passa a {0}
 statusbar.tip.unreadErrors=Erros que ainda não viu — clique para abrir o registo de mensagens
+command.project.newFromTemplate=Projeto: novo projeto a partir de modelo…
+command.project.newFromTemplate.desc=Cria um projeto a partir de um modelo multi-ficheiro e abre-o na sua própria janela.
+status.project.createdFromTemplate=Projeto {0} criado

--- a/src/main/resources/com/editora/templates/index.json
+++ b/src/main/resources/com/editora/templates/index.json
@@ -1,1 +1,1 @@
-["java-class", "java-compact", "html-page", "markdown-doc", "python-script", "shell-script", "zsh-script", "html-bundle"]
+["java-class", "java-compact", "html-page", "markdown-doc", "python-script", "shell-script", "zsh-script", "html-bundle", "python-project"]

--- a/src/main/resources/com/editora/templates/python-project.json
+++ b/src/main/resources/com/editora/templates/python-project.json
@@ -1,0 +1,78 @@
+{
+  "name": "Python Project",
+  "description": "A Python package with a main module, a test, a pyproject.toml and a README (multi-file)",
+  "language": "python",
+  "files": [
+    {
+      "path": "pyproject.toml",
+      "body": [
+        "[project]",
+        "name = \"${packageName:app}\"",
+        "version = \"0.1.0\"",
+        "description = \"${description:A Python project}\"",
+        "requires-python = \">=3.11\"",
+        "dependencies = []",
+        "",
+        "[build-system]",
+        "requires = [\"setuptools>=68\"]",
+        "build-backend = \"setuptools.build_meta\""
+      ]
+    },
+    {
+      "path": "src/${packageName:app}/__init__.py",
+      "body": ["\"\"\"${description:A Python project}.\"\"\"", "", "__version__ = \"0.1.0\""]
+    },
+    {
+      "path": "src/${packageName:app}/main.py",
+      "body": [
+        "\"\"\"Entry point for ${packageName:app}.\"\"\"",
+        "",
+        "",
+        "def main() -> None:",
+        "    ${cursor}print(\"Hello from ${packageName:app}\")",
+        "",
+        "",
+        "if __name__ == \"__main__\":",
+        "    main()"
+      ]
+    },
+    {
+      "path": "tests/test_main.py",
+      "body": [
+        "from ${packageName:app} import __version__",
+        "",
+        "",
+        "def test_version() -> None:",
+        "    assert __version__ == \"0.1.0\""
+      ]
+    },
+    {
+      "path": "README.md",
+      "body": [
+        "# ${packageName:app}",
+        "",
+        "${description:A Python project}",
+        "",
+        "## Run",
+        "",
+        "```bash",
+        "python -m ${packageName:app}.main",
+        "```",
+        "",
+        "## Test",
+        "",
+        "```bash",
+        "pytest",
+        "```",
+        "",
+        "---",
+        "",
+        "Created by ${author} on ${date}."
+      ]
+    },
+    {
+      "path": ".gitignore",
+      "body": ["__pycache__/", "*.py[cod]", ".venv/", "dist/", "build/", "*.egg-info/", ".pytest_cache/"]
+    }
+  ]
+}


### PR DESCRIPTION
First slice of #769. Editora could only ever *adopt* a folder that already existed — "New Project" meant making the directory yourself first.

## What I found before writing anything

**The issue understated what already existed.** Multi-file templates are implemented (`Template.files()`, the bundled `html-bundle`), the wizard already offers a target folder *and creates it if missing*, and generation already guards against a template path escaping that folder.

The only genuinely missing piece was **registering the result as a project and opening it**.

## What this adds

An `onCreated` hook threaded through the existing template flow — picker, variable wizard, generation all reused rather than duplicated — plus `project.newFromTemplate` which registers the folder and opens its window.

Two small decisions:

- The hook fires **only after at least one file actually landed**. An empty folder is not a project, and registering one because the user cancelled or every write failed would leave a broken entry behind.
- Restricted to **multi-file** templates. A project is a tree; a single-file template produces a lone file, which `template.new` already covers.

Ships a **Python Project** template — package layout, a test, `pyproject.toml`, README, `.gitignore` — so the feature has something real to scaffold rather than only working for users who write their own template first. User multi-file templates appear in the same picker.

## Verification

3399 tests green, clean `verify`, spotless and the JaCoCo floors pass.

**Not covered by tests:** the end-to-end flow — scaffold, register, open window. The generation and path-containment are already tested, and the new code is a hook plus a `createOrGet`, but the wiring itself is only proven by running it. Worth a manual check.

## Still open on #769

- **More project templates** — Maven/Gradle Java, Node. One JSON file each; the Python one is the pattern.
- **The start window** — a dedicated frame listing recent *projects* with New / Open / Clone, shown when there's no session to restore. That's the larger half and needs care not to fight the existing multi-window restore, so it's better on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)