### PR TITLE
feat(config): per-project settings in a committed file (#771)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Per-project settings you can commit** — a project can carry `.editora/settings.toml` saying which
+  language server to run and whether to run it, overriding your global preferences for anyone who opens that
+  project. The case it's for: one repository needs a JDK 17 server and another a JDK 25 one, and you no
+  longer have to remember to flip a global preference between them. **Project: Edit Project Settings…**
+  creates the file with a commented example. Only toolchain settings can be overridden — appearance, keymap
+  and fonts stay personal, because checking out a repository shouldn't rearrange somebody's editor.
+
 - **New Project From Template** — scaffold a whole project and open it in its own window, rather than
   pointing Editora at a folder you made yourself. Pick a multi-file template, fill in its variables, choose
   where it goes, and the new folder is registered as a project and opened. Ships with a **Python Project**

--- a/src/main/java/com/editora/config/ProjectSettings.java
+++ b/src/main/java/com/editora/config/ProjectSettings.java
@@ -1,0 +1,109 @@
+package com.editora.config;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.dataformat.toml.TomlMapper;
+
+/**
+ * Settings a project overrides for everyone who opens it, kept in a <b>committed file in the project</b> —
+ * {@code .editora/settings.toml} — the way IntelliJ, Eclipse, NetBeans and Visual Studio all do it (#771).
+ *
+ * <p>The case this exists for is concrete: one repository needs a JDK 17 language server and another a JDK
+ * 25 one, and until now that was a single global preference you had to remember to flip. Putting it beside
+ * the code means it travels with the repository and a colleague gets it by checking out.
+ *
+ * <p>TOML, and named {@code settings.toml}, to match the global {@code settings.toml} it overrides — this is
+ * a file people will hand-edit, and having the two look alike is worth more than matching the JSON of
+ * {@code .editora/run-configurations.json} next to it.
+ *
+ * <p><b>Deliberately a curated subset, not "any setting".</b> Overriding appearance, keymap or font from a
+ * repository would let a checkout silently rearrange someone's editor, which is a different and much more
+ * invasive thing than telling it which toolchain the project needs. What is here is toolchain configuration:
+ * which language server to run, and whether to run it.
+ *
+ * <p>Absent, unreadable or half-written ⇒ no overrides. A malformed file in someone's repository must not
+ * stop the project opening, so every failure path yields empty rather than throwing.
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class ProjectSettings {
+
+    /** Folder Editora keeps project-local, committable files in — shared with the run configurations. */
+    public static final String DIR = ".editora";
+
+    public static final String FILE = "settings.toml";
+
+    /** Server id → command line, overriding the global per-server command. */
+    private Map<String, String> lspCommands = new LinkedHashMap<>();
+
+    /** Server id → whether to run it, overriding the global per-server enable. */
+    private Map<String, Boolean> lspEnabled = new LinkedHashMap<>();
+
+    /** Where a project's overrides live. */
+    public static Path fileFor(Path projectRoot) {
+        return projectRoot.resolve(DIR).resolve(FILE);
+    }
+
+    /** Reads a project's overrides; empty (never null, never throwing) when absent or unreadable. */
+    public static ProjectSettings load(TomlMapper mapper, Path projectRoot) {
+        if (projectRoot == null) {
+            return new ProjectSettings();
+        }
+        Path file = fileFor(projectRoot);
+        if (!Files.isReadable(file)) {
+            return new ProjectSettings();
+        }
+        try {
+            ProjectSettings loaded = mapper.readValue(file.toFile(), ProjectSettings.class);
+            return loaded == null ? new ProjectSettings() : loaded;
+        } catch (Exception e) {
+            // Hand-edited and committed by anyone on the team: a typo must not stop the project opening.
+            return new ProjectSettings();
+        }
+    }
+
+    /** Whether this overrides anything at all — lets callers skip the resolution entirely. */
+    @JsonIgnore
+    public boolean isEmpty() {
+        return lspCommands.isEmpty() && lspEnabled.isEmpty();
+    }
+
+    /**
+     * The command for {@code serverId}: the project's override when it sets a non-blank one, else
+     * {@code global}.
+     *
+     * <p>A blank override falls through rather than meaning "no command". An empty string in the global
+     * settings already means "use the registry default", so treating a blank override as an override would
+     * make it impossible to express, and would silently disable a server for the whole team.
+     */
+    public String commandFor(String serverId, String global) {
+        String override = lspCommands.get(serverId);
+        return override == null || override.isBlank() ? global : override;
+    }
+
+    /** Whether {@code serverId} runs: the project's override when it sets one, else {@code global}. */
+    public boolean enabledFor(String serverId, boolean global) {
+        Boolean override = lspEnabled.get(serverId);
+        return override == null ? global : override;
+    }
+
+    public Map<String, String> getLspCommands() {
+        return lspCommands;
+    }
+
+    public void setLspCommands(Map<String, String> lspCommands) {
+        this.lspCommands = lspCommands == null ? new LinkedHashMap<>() : new LinkedHashMap<>(lspCommands);
+    }
+
+    public Map<String, Boolean> getLspEnabled() {
+        return lspEnabled;
+    }
+
+    public void setLspEnabled(Map<String, Boolean> lspEnabled) {
+        this.lspEnabled = lspEnabled == null ? new LinkedHashMap<>() : new LinkedHashMap<>(lspEnabled);
+    }
+}

--- a/src/main/java/com/editora/ui/LspCoordinator.java
+++ b/src/main/java/com/editora/ui/LspCoordinator.java
@@ -642,6 +642,11 @@ final class LspCoordinator {
 
     /** Whether a server's own enable toggle is on (under the global LSP enable). */
     boolean serverEnabled(String serverId) {
+        return projectSettings().enabledFor(serverId, globalServerEnabled(serverId));
+    }
+
+    /** The global (non-project) enable for {@code serverId}. */
+    private boolean globalServerEnabled(String serverId) {
         var s = host.settings();
         return switch (serverId) {
             case "typescript" -> s.isTypescriptLspEnabled();
@@ -671,8 +676,41 @@ final class LspCoordinator {
     }
 
     /** The configured command for a server id (blank ⇒ the server's default). */
+    /** Shared "no overrides" instance, so a window with no project allocates nothing per read. */
+    private static final com.editora.config.ProjectSettings EMPTY_PROJECT_SETTINGS =
+            new com.editora.config.ProjectSettings();
+
+    private Path projectSettingsRoot;
+    private com.editora.config.ProjectSettings projectSettingsCache = EMPTY_PROJECT_SETTINGS;
+
     private String serverCommand(String serverId) {
-        return serverCommand(host.settings(), serverId);
+        return projectSettings().commandFor(serverId, serverCommand(host.settings(), serverId));
+    }
+
+    /**
+     * This window's project overrides, from the committed {@code .editora/settings.toml} (#771).
+     *
+     * <p>Cached per project root because these are read on every gating pass, and a settings apply re-runs
+     * gating for every open buffer — re-reading a file each time would be disk I/O on the FX thread for a
+     * value that changes only when someone edits it. {@link #reloadProjectSettings()} drops the cache.
+     */
+    private com.editora.config.ProjectSettings projectSettings() {
+        Path root = ops.lspProjectRoot();
+        if (root == null) {
+            return EMPTY_PROJECT_SETTINGS;
+        }
+        if (!root.equals(projectSettingsRoot)) {
+            projectSettingsRoot = root;
+            projectSettingsCache = com.editora.config.ProjectSettings.load(
+                    new com.fasterxml.jackson.dataformat.toml.TomlMapper(), root);
+        }
+        return projectSettingsCache;
+    }
+
+    /** Forgets the cached project overrides, so the next read picks up an edited file. */
+    void reloadProjectSettings() {
+        projectSettingsRoot = null;
+        projectSettingsCache = EMPTY_PROJECT_SETTINGS;
     }
 
     /** Pure: {@code serverId}'s configured command from {@code s} — the id→Settings-field mapping, kept

--- a/src/main/java/com/editora/ui/MainController.java
+++ b/src/main/java/com/editora/ui/MainController.java
@@ -1434,6 +1434,7 @@ public class MainController implements com.editora.mcp.McpBridge {
         maybeOfferInstall(activeBuffer()); // the install-prompts toggle / a feature gate may have changed
         applyAdminSaveSupport(); // the admin-save toggle may have flipped
         refreshRunConfigs(); // the Settings page edits the same list this selector shows
+        lspCoordinator.reloadProjectSettings(); // pick up an edited .editora/settings.toml
     }
 
     /**
@@ -11361,6 +11362,32 @@ public class MainController implements com.editora.mcp.McpBridge {
     }
 
     /**
+     * {@code project.editSettings}: opens this project's committed {@code .editora/settings.toml}, seeding a
+     * commented example when it doesn't exist yet.
+     *
+     * <p>Seeded rather than created empty because the file's whole value is being discoverable and editable
+     * by hand — an empty buffer tells nobody which keys exist.
+     */
+    private void editProjectSettings() {
+        Path root = activeProjectRoot();
+        if (root == null) {
+            setError(tr("status.project.settingsNeedProject"));
+            return;
+        }
+        Path file = com.editora.config.ProjectSettings.fileFor(root);
+        try {
+            if (!java.nio.file.Files.exists(file)) {
+                java.nio.file.Files.createDirectories(file.getParent());
+                java.nio.file.Files.writeString(file, tr("project.settings.template"));
+            }
+            openPath(file);
+            lspCoordinator.reloadProjectSettings(); // an edit here should take effect without a restart
+        } catch (java.io.IOException e) {
+            setError(tr("status.project.settingsFailed", e.getMessage()));
+        }
+    }
+
+    /**
      * {@code project.newFromTemplate}: scaffolds a new project from a multi-file template and opens it.
      *
      * <p>Reuses the ordinary template flow — the picker, the variable wizard and its target-folder field
@@ -14632,6 +14659,7 @@ public class MainController implements com.editora.mcp.McpBridge {
         registry.register(Command.of("template.new", () -> newFromTemplate(null)));
         registry.register(Command.of("template.newInFolder", () -> newFromTemplate(defaultNewDir())));
         registry.register(Command.of("project.newFromTemplate", this::newProjectFromTemplate));
+        registry.register(Command.of("project.editSettings", this::editProjectSettings));
         registry.register(Command.of("template.reload", () -> {
             templates.reload();
             setStatus(tr("status.templatesReloaded"));

--- a/src/main/resources/com/editora/i18n/messages.properties
+++ b/src/main/resources/com/editora/i18n/messages.properties
@@ -3888,3 +3888,8 @@ statusbar.tip.unreadErrors=Errors you have not looked at — click to open the m
 command.project.newFromTemplate=Project: New Project From Template…
 command.project.newFromTemplate.desc=Scaffold a new project from a multi-file template and open it in its own window.
 status.project.createdFromTemplate=Created project {0}
+command.project.editSettings=Project: Edit Project Settings…
+command.project.editSettings.desc=Open this project's committed .editora/settings.toml, which overrides your global toolchain settings for everyone who opens it.
+status.project.settingsNeedProject=Open a project to edit its settings
+status.project.settingsFailed=Could not open the project settings: {0}
+project.settings.template=# Project settings for Editora. Commit this file — it applies to everyone who opens\n# the project, and overrides their own global settings for the keys listed here.\n#\n# Only toolchain settings can be overridden. Appearance, keymap and fonts stay personal:\n# checking out a repository should not rearrange somebody else's editor.\n\n# Which language server to run for a given language, e.g. a project pinned to an older JDK.\n# [lspCommands]\n# java = "/opt/jdk17/bin/jdtls"\n\n# Whether to run a server at all in this project.\n# [lspEnabled]\n# rust = false\n

--- a/src/main/resources/com/editora/i18n/messages_de.properties
+++ b/src/main/resources/com/editora/i18n/messages_de.properties
@@ -3879,3 +3879,8 @@ statusbar.tip.unreadErrors=Noch nicht gesehene Fehler — zum Öffnen des Meldun
 command.project.newFromTemplate=Projekt: neues Projekt aus Vorlage…
 command.project.newFromTemplate.desc=Erstellt ein neues Projekt aus einer mehrdateiigen Vorlage und öffnet es in einem eigenen Fenster.
 status.project.createdFromTemplate=Projekt {0} erstellt
+command.project.editSettings=Projekt: Projekteinstellungen bearbeiten…
+command.project.editSettings.desc=Öffnet die Datei .editora/settings.toml des Projekts, die die globalen Toolchain-Einstellungen für alle überschreibt, die es öffnen.
+status.project.settingsNeedProject=Öffne ein Projekt, um seine Einstellungen zu bearbeiten
+status.project.settingsFailed=Projekteinstellungen konnten nicht geöffnet werden: {0}
+project.settings.template=# Projekteinstellungen für Editora. Diese Datei gehört ins Repository: sie gilt für alle,\n# die das Projekt öffnen, und überschreibt deren globale Einstellungen für die genannten Schlüssel.\n#\n# Nur Toolchain-Einstellungen sind überschreibbar. Aussehen, Tastenbelegung und Schriften\n# bleiben persönlich.\n\n# Welcher Sprachserver verwendet wird, z. B. ein Projekt mit älterem JDK.\n# [lspCommands]\n# java = "/opt/jdk17/bin/jdtls"\n\n# Ob ein Server in diesem Projekt läuft.\n# [lspEnabled]\n# rust = false\n

--- a/src/main/resources/com/editora/i18n/messages_es.properties
+++ b/src/main/resources/com/editora/i18n/messages_es.properties
@@ -3879,3 +3879,8 @@ statusbar.tip.unreadErrors=Errores que aún no has visto — haz clic para abrir
 command.project.newFromTemplate=Proyecto: nuevo proyecto desde plantilla…
 command.project.newFromTemplate.desc=Crea un proyecto nuevo a partir de una plantilla multiarchivo y lo abre en su propia ventana.
 status.project.createdFromTemplate=Proyecto {0} creado
+command.project.editSettings=Proyecto: editar la configuración del proyecto…
+command.project.editSettings.desc=Abre el archivo .editora/settings.toml del proyecto, que sobrescribe la configuración global de herramientas para quien lo abra.
+status.project.settingsNeedProject=Abre un proyecto para editar su configuración
+status.project.settingsFailed=No se pudo abrir la configuración del proyecto: {0}
+project.settings.template=# Configuración de proyecto de Editora. Súbela al repositorio: se aplica a quien abra\n# el proyecto y sobrescribe su configuración global para las claves indicadas.\n#\n# Solo se puede sobrescribir la configuración de herramientas. La apariencia, el teclado\n# y las fuentes siguen siendo personales.\n\n# Qué servidor de lenguaje usar, p. ej. un proyecto fijado a un JDK anterior.\n# [lspCommands]\n# java = "/opt/jdk17/bin/jdtls"\n\n# Si ejecutar o no un servidor en este proyecto.\n# [lspEnabled]\n# rust = false\n

--- a/src/main/resources/com/editora/i18n/messages_fr.properties
+++ b/src/main/resources/com/editora/i18n/messages_fr.properties
@@ -3879,3 +3879,8 @@ statusbar.tip.unreadErrors=Erreurs que vous navez pas encore consultées — cli
 command.project.newFromTemplate=Projet : nouveau projet à partir dun modèle…
 command.project.newFromTemplate.desc=Crée un projet à partir dun modèle multi-fichier et louvre dans sa propre fenêtre.
 status.project.createdFromTemplate=Projet {0} créé
+command.project.editSettings=Projet : modifier les paramètres du projet…
+command.project.editSettings.desc=Ouvre le fichier .editora/settings.toml du projet, qui remplace les paramètres globaux de chaîne doutils pour quiconque louvre.
+status.project.settingsNeedProject=Ouvrez un projet pour modifier ses paramètres
+status.project.settingsFailed=Impossible douvrir les paramètres du projet : {0}
+project.settings.template=# Paramètres de projet Editora. Versionnez ce fichier : il sapplique à quiconque ouvre\n# le projet et remplace ses paramètres globaux pour les clés indiquées.\n#\n# Seuls les paramètres de chaîne doutils sont remplaçables. Lapparence, le clavier et\n# les polices restent personnels.\n\n# Quel serveur de langage utiliser, p. ex. un projet fixé à un JDK plus ancien.\n# [lspCommands]\n# java = "/opt/jdk17/bin/jdtls"\n\n# Faut-il exécuter un serveur dans ce projet.\n# [lspEnabled]\n# rust = false\n

--- a/src/main/resources/com/editora/i18n/messages_it.properties
+++ b/src/main/resources/com/editora/i18n/messages_it.properties
@@ -3879,3 +3879,8 @@ statusbar.tip.unreadErrors=Errori non ancora letti — clicca per aprire il regi
 command.project.newFromTemplate=Progetto: nuovo progetto da modello…
 command.project.newFromTemplate.desc=Crea un nuovo progetto da un modello multi-file e lo apre in una finestra dedicata.
 status.project.createdFromTemplate=Progetto {0} creato
+command.project.editSettings=Progetto: modifica le impostazioni del progetto…
+command.project.editSettings.desc=Apre il file .editora/settings.toml del progetto, che sovrascrive le impostazioni globali della toolchain per chiunque lo apra.
+status.project.settingsNeedProject=Apri un progetto per modificarne le impostazioni
+status.project.settingsFailed=Impossibile aprire le impostazioni del progetto: {0}
+project.settings.template=# Impostazioni di progetto per Editora. Aggiungi questo file al repository: vale per\n# chiunque apra il progetto e sovrascrive le impostazioni globali per le chiavi elencate.\n#\n# Si possono sovrascrivere solo le impostazioni della toolchain. Aspetto, tastiera e font\n# restano personali: aprire un repository non deve riorganizzare l'editor di qualcun altro.\n\n# Quale language server usare per un linguaggio, es. un progetto legato a un JDK precedente.\n# [lspCommands]\n# java = "/opt/jdk17/bin/jdtls"\n\n# Se eseguire o meno un server in questo progetto.\n# [lspEnabled]\n# rust = false\n

--- a/src/main/resources/com/editora/i18n/messages_pt.properties
+++ b/src/main/resources/com/editora/i18n/messages_pt.properties
@@ -3879,3 +3879,8 @@ statusbar.tip.unreadErrors=Erros que ainda não viu — clique para abrir o regi
 command.project.newFromTemplate=Projeto: novo projeto a partir de modelo…
 command.project.newFromTemplate.desc=Cria um projeto a partir de um modelo multi-ficheiro e abre-o na sua própria janela.
 status.project.createdFromTemplate=Projeto {0} criado
+command.project.editSettings=Projeto: editar as definições do projeto…
+command.project.editSettings.desc=Abre o ficheiro .editora/settings.toml do projeto, que substitui as definições globais de ferramentas para quem o abrir.
+status.project.settingsNeedProject=Abra um projeto para editar as suas definições
+status.project.settingsFailed=Não foi possível abrir as definições do projeto: {0}
+project.settings.template=# Definições de projeto do Editora. Adicione este ficheiro ao repositório: aplica-se a\n# quem abrir o projeto e substitui as definições globais para as chaves indicadas.\n#\n# Só as definições de ferramentas podem ser substituídas. Aparência, teclado e tipos de\n# letra continuam pessoais.\n\n# Que servidor de linguagem usar, p. ex. um projeto preso a um JDK anterior.\n# [lspCommands]\n# java = "/opt/jdk17/bin/jdtls"\n\n# Se deve executar um servidor neste projeto.\n# [lspEnabled]\n# rust = false\n

--- a/src/test/java/com/editora/config/ProjectSettingsTest.java
+++ b/src/test/java/com/editora/config/ProjectSettingsTest.java
@@ -1,0 +1,75 @@
+package com.editora.config;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import com.fasterxml.jackson.dataformat.toml.TomlMapper;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ProjectSettingsTest {
+
+    private static final TomlMapper MAPPER = new TomlMapper();
+
+    private static Path write(Path root, String toml) throws Exception {
+        Path file = ProjectSettings.fileFor(root);
+        Files.createDirectories(file.getParent());
+        Files.writeString(file, toml);
+        return file;
+    }
+
+    @Test
+    void aProjectOverridesTheServerCommand(@TempDir Path root) throws Exception {
+        write(root, "[lspCommands]\njava = \"/opt/jdk17/bin/jdtls\"\n");
+
+        ProjectSettings ps = ProjectSettings.load(MAPPER, root);
+
+        assertFalse(ps.isEmpty());
+        assertEquals("/opt/jdk17/bin/jdtls", ps.commandFor("java", "jdtls"), "the project's toolchain wins");
+        assertEquals("gopls", ps.commandFor("go", "gopls"), "an unmentioned server keeps the global value");
+    }
+
+    @Test
+    void aProjectCanTurnAServerOffOrOn(@TempDir Path root) throws Exception {
+        write(root, "[lspEnabled]\nrust = false\npython = true\n");
+
+        ProjectSettings ps = ProjectSettings.load(MAPPER, root);
+
+        assertFalse(ps.enabledFor("rust", true), "explicitly off beats a global on");
+        assertTrue(ps.enabledFor("python", false), "and explicitly on beats a global off");
+        assertTrue(ps.enabledFor("java", true), "unmentioned falls through");
+    }
+
+    /**
+     * A blank override must fall through. An empty command already means "use the registry default"
+     * globally, so treating blank as an override would make that impossible to express — and would silently
+     * disable a server for everyone who checked the repository out.
+     */
+    @Test
+    void aBlankCommandFallsThroughRatherThanDisabling() throws Exception {
+        ProjectSettings ps = new ProjectSettings();
+        ps.setLspCommands(java.util.Map.of("java", "   "));
+
+        assertEquals("jdtls", ps.commandFor("java", "jdtls"));
+    }
+
+    /** This file is committed and hand-edited by anyone on the team; a typo must not stop the project opening. */
+    @Test
+    void aMalformedOrAbsentFileYieldsNoOverrides(@TempDir Path root) throws Exception {
+        assertTrue(ProjectSettings.load(MAPPER, root).isEmpty(), "absent");
+
+        write(root, "[lspCommands\nthis is not toml");
+        ProjectSettings ps = ProjectSettings.load(MAPPER, root);
+        assertTrue(ps.isEmpty(), "malformed");
+        assertEquals("jdtls", ps.commandFor("java", "jdtls"), "and everything falls through to global");
+    }
+
+    @Test
+    void noProjectMeansNoOverrides() {
+        assertTrue(ProjectSettings.load(MAPPER, null).isEmpty());
+    }
+}


### PR DESCRIPTION
#771, using the **committed-file** model you chose — what IntelliJ, Eclipse, NetBeans and Visual Studio all do, so the settings travel with the repository and a colleague gets them on checkout.

`.editora/settings.toml`, beside the run configurations from #784. TOML, and named to match the global `settings.toml` it overrides: this is a file people hand-edit, and having the two look alike is worth more than matching the JSON of the run-configurations file sitting next to it.

## A curated subset, not "any setting"

Only **toolchain** settings are overridable: which language server runs, and whether it runs at all — the JDK 17 vs JDK 25 case that motivated the issue.

Appearance, keymap and fonts stay personal. Letting a repository override those means **checking out someone's code silently rearranges your editor**, which is a categorically more invasive thing than telling it which toolchain the project needs. Worth flagging explicitly since "per-project settings" could reasonably be read as "all of them" — say if you'd rather it were broader.

## Two resolution rules, both tested

- **A blank command falls through** rather than meaning "no command". An empty command already means "use the registry default" globally, so treating blank as an override would make that inexpressible — and would silently disable a server for the whole team.
- **A malformed or absent file yields no overrides**, never an exception. This file is committed and hand-edited by anyone; a typo must not stop the project opening.

## Where it hooks in

Layered at the two existing choke points (`serverCommand`, `serverEnabled`) rather than threaded through call sites. Cached per project root, because gating re-reads these on every settings apply and for every open buffer — re-reading a file there would be disk I/O on the FX thread for a value that changes only when someone edits it. The cache drops on apply and when the file is opened, so an edit takes effect without a restart.

**Project: Edit Project Settings…** creates the file seeded with a commented example, since the whole value of a hand-edited file is knowing which keys exist.

## Verification

3404 tests green (5 new, all pure), clean `verify`, spotless and the JaCoCo floors pass.

**Not covered:** that an override actually changes which server starts. That needs a real language server; the resolution is unit-tested and the hook is two lines, but the round trip is worth a manual check on a project with `.editora/settings.toml` pinning a different `java` command.

## Follow-ups

- Extend the overridable set to build-tool commands and external tools — one map each, same shape.
- Surface it in Settings → an "Enable project-specific settings" indicator, the Eclipse idiom, so the UI shows which level is in effect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)