### PR TITLE
Refuse a run configuration with no main class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -113,6 +113,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   so the old name undersold it. Your stripe placement and any keybinding are unaffected (only the label
   changed).
 
+### Fixed
+
+- **A run configuration with no main class now says so**, instead of reporting a Java language server stack
+  trace. Adding a configuration in Settings creates an empty one, and running it before filling in the main
+  class sent an empty search to the language server, which answered with an internal `SearchPattern … is
+  null` error. It now tells you which configuration is missing its main class — the same thing the script
+  configurations have always done about a missing script.
+
 ## [0.9.10] - 2026-07-26
 
 ### Added

--- a/src/main/java/com/editora/config/RunConfiguration.java
+++ b/src/main/java/com/editora/config/RunConfiguration.java
@@ -106,6 +106,24 @@ public record RunConfiguration(
         return "java".equals(type);
     }
 
+    /**
+     * Whether this is a Java configuration with no main class filled in — not launchable, and above all not
+     * a question worth asking jdtls.
+     *
+     * <p>jdtls turns the main class into an Eclipse {@code SearchPattern}, and {@code createPattern("")}
+     * returns null, so an empty one comes back as an internal NPE from deep inside its search engine
+     * ({@code Cannot invoke "SearchPattern.findIndexMatches(…)" because "pattern" is null}) rather than
+     * anything a user could act on. Settings → Run Configurations → <b>Add</b> creates exactly this shape —
+     * a Java configuration whose fields are all blank — so it is one click away, not a corner case.
+     *
+     * <p>The script types already refuse a missing target with a clear message ({@code
+     * ScriptRunCommand.needsTarget}); this is the Java half of the same check.
+     */
+    @JsonIgnore
+    public boolean missingMainClass() {
+        return isJava() && mainClass.isBlank();
+    }
+
     @JsonIgnore
     public boolean isDebug() {
         return "debug".equalsIgnoreCase(kind);

--- a/src/main/java/com/editora/dap/DapManager.java
+++ b/src/main/java/com/editora/dap/DapManager.java
@@ -484,6 +484,14 @@ public final class DapManager implements DapClient.Host {
      * in the same project.
      */
     public void resolveLaunch(Path routingFile, MainClassOption opt, Consumer<ResolvedLaunch> cb) {
+        // The chokepoint guard, so no future caller can reproduce the class of bug: jdtls builds an Eclipse
+        // SearchPattern from the main class, and createPattern("") returns null, surfacing as an internal
+        // NPE from its search engine instead of anything actionable. Callers check first and say something
+        // useful; this makes the unchecked path fail cleanly rather than incomprehensibly.
+        if (opt.mainClass() == null || opt.mainClass().isBlank()) {
+            cb.accept(ResolvedLaunch.failed("No main class to run — set one on the run configuration."));
+            return;
+        }
         String proj = opt.projectName() == null ? "" : opt.projectName();
         lsp.executeCommand(routingFile, "vscode.java.resolveClasspath", List.of(opt.mainClass(), proj), (res, err) -> {
             if (err != null) {

--- a/src/main/java/com/editora/ui/DebugCoordinator.java
+++ b/src/main/java/com/editora/ui/DebugCoordinator.java
@@ -769,6 +769,11 @@ final class DebugCoordinator {
             host.setStatus(tr("status.debug.configTypeUnsupported", cfg.type()));
             return;
         }
+        // Same guard as the Run path: a blank main class is an internal NPE from jdtls, not an error.
+        if (cfg.missingMainClass()) {
+            host.setStatus(tr("status.run.configNeedsMainClass", cfg.name()));
+            return;
+        }
         if (!debugEffectiveFor("java")) {
             host.setStatus(tr("status.debug.unavailable"));
             return;

--- a/src/main/java/com/editora/ui/RunCoordinator.java
+++ b/src/main/java/com/editora/ui/RunCoordinator.java
@@ -293,6 +293,12 @@ final class RunCoordinator {
 
     /** The Java half of {@link #runConfig}, after any before-launch step has succeeded. */
     private void runJavaConfig(RunConfiguration cfg) {
+        // Mirrors runScriptConfig's missing-target check. Without it the blank main class reaches jdtls and
+        // comes back as an internal NPE from its search engine — see RunConfiguration.missingMainClass.
+        if (cfg.missingMainClass()) {
+            host.setStatus(tr("status.run.configNeedsMainClass", cfg.name()));
+            return;
+        }
         // A named configuration is independent of whatever is on screen: any open Java file in its project
         // can route the classpath resolution, so this no longer refuses just because the active tab is a
         // README. Null means no Java file is open at all, which is the only genuinely unresolvable case.

--- a/src/main/resources/com/editora/i18n/messages.properties
+++ b/src/main/resources/com/editora/i18n/messages.properties
@@ -3853,6 +3853,7 @@ command.view.toggleMenuBar=View: Toggle Menu Bar
 command.view.toggleMenuBar.desc=Show or hide the menu bar.
 settings.showMenuBar=Show menu bar
 status.run.configNeedsJavaFile=Open a Java file from the project to run this configuration
+status.run.configNeedsMainClass=Run configuration "{0}" has no main class to run
 status.run.configNeedsTarget=Run configuration "{0}" has no script to run
 status.run.configBadType=Run configuration "{0}" has an unknown type
 status.run.configNeedsWorkingDir=Run configuration "{0}" needs a working directory

--- a/src/main/resources/com/editora/i18n/messages_de.properties
+++ b/src/main/resources/com/editora/i18n/messages_de.properties
@@ -3844,6 +3844,7 @@ command.view.toggleMenuBar=Ansicht: Menüleiste ein-/ausblenden
 command.view.toggleMenuBar.desc=Blendet die Menüleiste ein oder aus.
 settings.showMenuBar=Menüleiste anzeigen
 status.run.configNeedsJavaFile=Öffne eine Java-Datei des Projekts, um diese Konfiguration auszuführen
+status.run.configNeedsMainClass=Die Ausführungskonfiguration „{0}“ hat keine auszuführende Main-Klasse
 status.run.configNeedsTarget=Die Konfiguration "{0}" hat kein auszuführendes Skript
 status.run.configBadType=Die Konfiguration "{0}" hat einen unbekannten Typ
 status.run.configNeedsWorkingDir=Die Konfiguration "{0}" benötigt ein Arbeitsverzeichnis

--- a/src/main/resources/com/editora/i18n/messages_es.properties
+++ b/src/main/resources/com/editora/i18n/messages_es.properties
@@ -3844,6 +3844,7 @@ command.view.toggleMenuBar=Vista: mostrar u ocultar la barra de menús
 command.view.toggleMenuBar.desc=Muestra u oculta la barra de menús.
 settings.showMenuBar=Mostrar la barra de menús
 status.run.configNeedsJavaFile=Abre un archivo Java del proyecto para ejecutar esta configuración
+status.run.configNeedsMainClass=La configuración de ejecución "{0}" no tiene una clase main que ejecutar
 status.run.configNeedsTarget=La configuración "{0}" no tiene ningún script que ejecutar
 status.run.configBadType=La configuración "{0}" tiene un tipo desconocido
 status.run.configNeedsWorkingDir=La configuración "{0}" necesita un directorio de trabajo

--- a/src/main/resources/com/editora/i18n/messages_fr.properties
+++ b/src/main/resources/com/editora/i18n/messages_fr.properties
@@ -3844,6 +3844,7 @@ command.view.toggleMenuBar=Affichage : afficher ou masquer la barre de menus
 command.view.toggleMenuBar.desc=Affiche ou masque la barre de menus.
 settings.showMenuBar=Afficher la barre de menus
 status.run.configNeedsJavaFile=Ouvrez un fichier Java du projet pour exécuter cette configuration
+status.run.configNeedsMainClass=La configuration d’exécution « {0} » n’a aucune classe main à exécuter
 status.run.configNeedsTarget=La configuration "{0}" na aucun script à exécuter
 status.run.configBadType=La configuration "{0}" a un type inconnu
 status.run.configNeedsWorkingDir=La configuration "{0}" nécessite un répertoire de travail

--- a/src/main/resources/com/editora/i18n/messages_it.properties
+++ b/src/main/resources/com/editora/i18n/messages_it.properties
@@ -3844,6 +3844,7 @@ command.view.toggleMenuBar=Vista: mostra/nascondi la barra dei menu
 command.view.toggleMenuBar.desc=Mostra o nasconde la barra dei menu.
 settings.showMenuBar=Mostra la barra dei menu
 status.run.configNeedsJavaFile=Apri un file Java del progetto per eseguire questa configurazione
+status.run.configNeedsMainClass=La configurazione di esecuzione "{0}" non ha una classe main da eseguire
 status.run.configNeedsTarget=La configurazione "{0}" non ha uno script da eseguire
 status.run.configBadType=La configurazione "{0}" ha un tipo sconosciuto
 status.run.configNeedsWorkingDir=La configurazione "{0}" richiede una directory di lavoro

--- a/src/main/resources/com/editora/i18n/messages_pt.properties
+++ b/src/main/resources/com/editora/i18n/messages_pt.properties
@@ -3844,6 +3844,7 @@ command.view.toggleMenuBar=Ver: mostrar ou ocultar a barra de menus
 command.view.toggleMenuBar.desc=Mostra ou oculta a barra de menus.
 settings.showMenuBar=Mostrar a barra de menus
 status.run.configNeedsJavaFile=Abra um ficheiro Java do projeto para executar esta configuração
+status.run.configNeedsMainClass=A configuração de execução "{0}" não tem uma classe main para executar
 status.run.configNeedsTarget=A configuração "{0}" não tem nenhum script para executar
 status.run.configBadType=A configuração "{0}" tem um tipo desconhecido
 status.run.configNeedsWorkingDir=A configuração "{0}" precisa de um diretório de trabalho

--- a/src/test/java/com/editora/config/RunConfigurationTest.java
+++ b/src/test/java/com/editora/config/RunConfigurationTest.java
@@ -45,6 +45,38 @@ class RunConfigurationTest {
         assertEquals("", old.env());
     }
 
+    /**
+     * The exact shape Settings → Run Configurations → <b>Add</b> creates. It is a Java configuration (the
+     * type defaults to java) with a blank main class, so it was one click away from sending an empty search
+     * string to jdtls and getting an internal NPE back.
+     */
+    @Test
+    void aFreshlyAddedConfigurationIsMissingItsMainClass() {
+        RunConfiguration added = new RunConfiguration("New configuration", "run", "", "", "", "", "");
+        assertEquals("java", added.type(), "Add creates a Java configuration");
+        assertTrue(added.missingMainClass());
+    }
+
+    @Test
+    void aFilledInJavaConfigurationIsNotMissingItsMainClass() {
+        assertFalse(new RunConfiguration("A", "run", "com.example.App", "", "", "", "").missingMainClass());
+    }
+
+    /** Whitespace is not a main class — jdtls builds its search pattern from it just the same. */
+    @Test
+    void aWhitespaceOnlyMainClassCountsAsMissing() {
+        assertTrue(new RunConfiguration("A", "run", "   ", "", "", "", "").missingMainClass());
+    }
+
+    /** Script types have no main class by design; their own missing-target check covers them. */
+    @Test
+    void scriptConfigurationsAreNeverMissingAMainClass() {
+        for (String type : new String[] {"python", "shell", "make"}) {
+            RunConfiguration script = new RunConfiguration("S", "run", type, "app.py", "", "", "", "", "", "", "");
+            assertFalse(script.missingMainClass(), type);
+        }
+    }
+
     @Test
     void jacksonToleratesMissingFields() throws Exception {
         ObjectMapper m = new ObjectMapper();

--- a/src/test/java/com/editora/ui/BlankMainClassGuardFxTest.java
+++ b/src/test/java/com/editora/ui/BlankMainClassGuardFxTest.java
@@ -1,0 +1,81 @@
+package com.editora.ui;
+
+import com.editora.config.RunConfiguration;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Running a Java configuration with no main class must be refused here, not by jdtls.
+ *
+ * <p>jdtls builds an Eclipse {@code SearchPattern} from the main class and {@code createPattern("")} returns
+ * null, so the empty string came back as {@code Cannot invoke "SearchPattern.findIndexMatches(…)" because
+ * "pattern" is null} — an internal stack trace in the echo line, with nothing to act on. Settings → Run
+ * Configurations → <b>Add</b> creates exactly that shape, so it was one click away.
+ */
+@Tag("fx")
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class BlankMainClassGuardFxTest {
+
+    private FxWindowFixture fx;
+
+    @BeforeAll
+    void setUp() throws Exception {
+        FxTestSupport.bootToolkit();
+        fx = FxWindowFixture.create();
+    }
+
+    @AfterAll
+    void tearDown() throws Exception {
+        if (fx != null) {
+            fx.dispose();
+        }
+    }
+
+    /** What Settings → Run Configurations → Add produces, verbatim. */
+    private static RunConfiguration freshlyAdded() {
+        return new RunConfiguration("New configuration", "run", "", "", "", "", "");
+    }
+
+    private String runAndReadStatus(RunConfiguration cfg) throws Exception {
+        return FxTestSupport.callOnFx(() -> {
+            RunCoordinator run = FxTestSupport.field(fx.controller, "runCoordinator");
+            FxTestSupport.call(run, "runConfig", new Class[] {RunConfiguration.class}, cfg);
+            StatusBar bar = FxTestSupport.field(fx.controller, "statusBar");
+            javafx.scene.control.Label echo = FxTestSupport.field(bar, "echo");
+            return echo.getText();
+        });
+    }
+
+    @Test
+    void runningAConfigurationWithNoMainClassSaysSoInsteadOfCallingJdtls() throws Exception {
+        String status = runAndReadStatus(freshlyAdded());
+
+        assertTrue(status.contains("New configuration"), "names the configuration, got: " + status);
+        assertTrue(status.toLowerCase().contains("main class"), "says what is missing, got: " + status);
+        // The symptom this replaces. If any of it resurfaces the guard has stopped running and the empty
+        // search string is reaching jdtls again.
+        assertFalse(status.contains("SearchPattern"), "no jdtls internals leak through");
+        assertFalse(status.contains("Cannot invoke"), "no raw NPE message leaks through");
+    }
+
+    /** The debug half takes the same path and must refuse identically, not resolve a class that is not there. */
+    @Test
+    void debuggingAConfigurationWithNoMainClassSaysSoToo() throws Exception {
+        String status = FxTestSupport.callOnFx(() -> {
+            DebugCoordinator debug = FxTestSupport.field(fx.controller, "debugCoordinator");
+            FxTestSupport.call(debug, "debugConfig", new Class[] {RunConfiguration.class}, freshlyAdded());
+            StatusBar bar = FxTestSupport.field(fx.controller, "statusBar");
+            javafx.scene.control.Label echo = FxTestSupport.field(bar, "echo");
+            return echo.getText();
+        });
+
+        assertTrue(status.toLowerCase().contains("main class"), "says what is missing, got: " + status);
+        assertFalse(status.contains("SearchPattern"), "no jdtls internals leak through");
+    }
+}


### PR DESCRIPTION
Closes #795.

Running a Java run configuration whose main class is blank reported this:

```
Could not resolve the classpath: Cannot invoke "org.eclipse.jdt.core.search.SearchPattern.findIndexMatches(…)" because "pattern" is null
```

jdtls turns the main class into an Eclipse `SearchPattern`, and `SearchPattern.createPattern("")` returns **null**, so the empty string comes back as an NPE from inside its search engine rather than as anything a user could act on.

### One click away, not a corner case

**Settings → Run Configurations → Add** creates `new RunConfiguration(newName, "run", "", "", "", "", "")`. The 7-argument constructor defaults `type` to `java`, so a freshly added configuration is a *Java* configuration with a blank main class. Add one, hit Run, get the stack trace. And since #793 a saved configuration is also what makes the toolbar run group appear, so adding one is a natural thing to do just to see the selector.

### The asymmetry that hid it

The script types already handle this: `runScriptConfig` refuses a missing target with `status.run.configNeedsTarget` — *"Run configuration \"{0}\" has no script to run"*. The Java branch had no equivalent. This is the Java half of a guard that already existed.

### The ordering that matters

The check has to run **before** the routing check. With a Java file open, routing succeeds and the empty string reaches jdtls anyway — so "some error was reported" is not enough to prove the fix. The FX test asserts the message *names the configuration* and *says main class*, and separately that neither `SearchPattern` nor `Cannot invoke` appears; with the guard disabled it fails with `got: Open a Java file from the project to run this configuration`, which is the next check firing instead.

`DapManager.resolveLaunch` guards too. That is the shared chokepoint for Run and Debug, so the class of bug becomes unreachable rather than just this instance of it.

### Tests

4 unit tests on `RunConfiguration.missingMainClass()` — including the verbatim shape Add produces, a whitespace-only main class, and that script types are never flagged (their own target check covers them) — plus 2 FX tests that fail without the guard. i18n in all six catalogs.

`mvn clean verify` green — 3437 tests, coverage floors met.

### Not changed

The toolbar Run button stays *enabled* for an incomplete configuration. A clear message on click beats a mystery-disabled button with no explanation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)