### PR TITLE
Prefill a new run configuration from the active Java file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -113,6 +113,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   so the old name undersold it. Your stripe placement and any keybinding are unaffected (only the label
   changed).
 
+### Changed
+
+- **Adding a run configuration starts from the file you are looking at.** Settings → Run Configurations →
+  **Add** used to create a wholly blank entry called "New Configuration". It now prefills the main class from
+  the active Java file (or the one your Gradle build declares), names the configuration after that class, and
+  puts the cursor in the field that still needs you — the main class when there was nothing to suggest, the
+  name otherwise. Adding twice from the same file gets you "App" and "App (2)" rather than two entries with
+  the same name, which previously collided into a single palette command.
+
 ### Fixed
 
 - **A run configuration with no main class now says so**, instead of reporting a Java language server stack

--- a/src/main/java/com/editora/run/RunConfigDefaults.java
+++ b/src/main/java/com/editora/run/RunConfigDefaults.java
@@ -1,0 +1,90 @@
+package com.editora.run;
+
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Locale;
+import java.util.Set;
+
+/**
+ * What a newly added run configuration starts out as.
+ *
+ * <p>Settings → Run Configurations → <b>Add</b> used to create a wholly blank Java configuration, which is
+ * unrunnable until you fill the main class in — and running it before you did reported a language-server
+ * stack trace (#795). It now starts from whatever the window can tell about the active file, which is usually
+ * the configuration you wanted.
+ *
+ * <p>Pure, so the naming rules are unit-testable; the caller supplies the suggestion.
+ */
+public final class RunConfigDefaults {
+
+    private RunConfigDefaults() {}
+
+    /**
+     * The configuration Settings → Run Configurations → <b>Add</b> creates.
+     *
+     * @param suggestedMainClass the active Java file's main class, or null when there is nothing to suggest
+     * @param existingNames the names already in the list, so the new one does not collide with them
+     * @param fallbackName the localized "New Configuration", used when there is nothing to name it after
+     */
+    public static com.editora.config.RunConfiguration newConfiguration(
+            String suggestedMainClass, Collection<String> existingNames, String fallbackName) {
+        String name = uniqueName(nameFor(suggestedMainClass, fallbackName), existingNames);
+        return new com.editora.config.RunConfiguration(
+                name, "run", suggestedMainClass == null ? "" : suggestedMainClass.strip(), "", "", "", "");
+    }
+
+    /**
+     * A name for a configuration launching {@code mainClass} — its simple name ({@code com.example.App} →
+     * {@code App}), or {@code fallback} when there is nothing to name it after.
+     *
+     * <p>Named after the class rather than left as "New configuration" for the same reason IDEs do it: the
+     * list is read at a glance, and three entries all reading "New configuration" tell you nothing.
+     */
+    public static String nameFor(String mainClass, String fallback) {
+        if (mainClass == null || mainClass.isBlank()) {
+            return fallback;
+        }
+        String fqn = mainClass.strip();
+        int dot = fqn.lastIndexOf('.');
+        // A trailing dot leaves an empty simple name, which the isBlank check below turns into the fallback
+        // — returning the whole string would name the configuration "com.example.".
+        String simple = dot < 0 ? fqn : fqn.substring(dot + 1);
+        return simple.isBlank() ? fallback : simple;
+    }
+
+    /**
+     * {@code base}, or {@code base (2)}, {@code base (3)}… until it collides with nothing in {@code existing}.
+     *
+     * <p><b>Not cosmetic.</b> Each configuration is registered as a synthetic {@code run.config.<slug>}
+     * command so it can be found in the palette and given a keybinding, and the slug comes from the name — so
+     * two configurations sharing a name share an id, and the second silently overwrites the first's command.
+     * Adding twice from the same file would otherwise produce that collision every time, since both would be
+     * named after the same class.
+     *
+     * <p>Compared case-insensitively, because the slug is: {@code App} and {@code app} both slug to
+     * {@code app} and would collide just the same.
+     */
+    public static String uniqueName(String base, Collection<String> existing) {
+        Set<String> taken = new HashSet<>();
+        if (existing != null) {
+            for (String e : existing) {
+                if (e != null) {
+                    taken.add(e.strip().toLowerCase(Locale.ROOT));
+                }
+            }
+        }
+        String stem = base == null ? "" : base.strip();
+        if (!taken.contains(stem.toLowerCase(Locale.ROOT))) {
+            return stem;
+        }
+        // Bounded so a pathological list cannot spin; past the cap the caller gets a colliding name, which is
+        // the behaviour it had before this existed rather than a hang.
+        for (int n = 2; n < 1000; n++) {
+            String candidate = stem + " (" + n + ")";
+            if (!taken.contains(candidate.toLowerCase(Locale.ROOT))) {
+                return candidate;
+            }
+        }
+        return stem;
+    }
+}

--- a/src/main/java/com/editora/ui/MainController.java
+++ b/src/main/java/com/editora/ui/MainController.java
@@ -726,6 +726,8 @@ public class MainController implements com.editora.mcp.McpBridge {
                 });
         this.settingsWindow.setInstallServerActions(installCoordinator::installServer); // per-LSP-server Install
         this.settingsWindow.setSnippetManager(snippets); // backs the Settings → Snippets management page
+        // Read on each Add click, not now: the Settings window outlives whichever tab is in front.
+        this.settingsWindow.setRunConfigSuggestion(this::suggestedMainClass);
         this.settingsWindow.setTemplateRegistry(templates); // backs the Settings → Templates management page
         this.settingsWindow.setMcpConfirm(this::confirmEnableMcp); // security notice before enabling MCP
         this.settingsWindow.setTrustActions(new SettingsWindow.TrustActions() {
@@ -9676,23 +9678,41 @@ public class MainController implements com.editora.mcp.McpBridge {
     }
 
     /** {@code run.saveConfig}: save the active Java file's main class as a run configuration. */
+    /**
+     * The main class a new run configuration should start from: the one the active Java file's project
+     * declares, else the first {@code main} in that file. Null when there is nothing to suggest.
+     *
+     * <p>Shared by {@code run.saveConfig} and Settings → Run Configurations → Add, so the two cannot disagree
+     * about what "the obvious main class here" is.
+     */
+    String suggestedMainClass() {
+        EditorBuffer b = activeBuffer();
+        if (b == null || b.getPath() == null || !"java".equals(b.getLanguage())) {
+            return null;
+        }
+        // Prefer the main class a Gradle `application` block declares — that's what `gradle run` would launch,
+        // so a config saved in such a project matches the build rather than whichever file happens to be open.
+        String declared =
+                com.editora.build.GradleApplication.mainClass(readGradleBuildFile(JavaProjectRoot.find(b.getPath())));
+        if (declared != null) {
+            return declared;
+        }
+        List<com.editora.run.MainMethodScanner.MainMethod> mains =
+                com.editora.run.MainMethodScanner.scan(b.getContent());
+        return mains.isEmpty() ? null : mains.get(0).fqn();
+    }
+
     private void saveRunConfig() {
         EditorBuffer b = activeBuffer();
         if (b == null || b.getPath() == null || !"java".equals(b.getLanguage())) {
             setStatus(tr("status.run.needJavaFile"));
             return;
         }
-        // Prefer the main class a Gradle `application` block declares — that's what `gradle run` would launch,
-        // so a config saved in such a project matches the build rather than whichever file happens to be open.
-        String declared =
-                com.editora.build.GradleApplication.mainClass(readGradleBuildFile(JavaProjectRoot.find(b.getPath())));
-        List<com.editora.run.MainMethodScanner.MainMethod> mains =
-                com.editora.run.MainMethodScanner.scan(b.getContent());
-        if (declared == null && mains.isEmpty()) {
+        String fqn = suggestedMainClass();
+        if (fqn == null) {
             setStatus(tr("status.run.noMainInFile"));
             return;
         }
-        String fqn = declared != null ? declared : mains.get(0).fqn();
         String simple = com.editora.test.TestSourceLocator.simpleName(fqn);
         String args = programArgsFor(b.getPath());
         promptText(tr("run.config.saveTitle"), tr("run.config.saveName"), simple, name -> {

--- a/src/main/java/com/editora/ui/SettingsWindow.java
+++ b/src/main/java/com/editora/ui/SettingsWindow.java
@@ -4038,6 +4038,20 @@ public class SettingsWindow {
      * immutable, so a commit rebuilds the {@link com.editora.config.RunConfiguration} and replaces it in the
      * list at the selected index (unlike External Tools, which mutates a POJO in place).
      */
+    /** Supplies the main class a newly added run configuration should start from; see {@link #setRunConfigSuggestion}. */
+    private java.util.function.Supplier<String> runConfigSuggestion;
+
+    /**
+     * Injects what Add should prefill a new run configuration with — the active Java file's main class, or
+     * null when there is none.
+     *
+     * <p>A supplier rather than a value: the Settings window outlives any one tab, so the suggestion has to
+     * be read when Add is clicked, not when the page was built.
+     */
+    public void setRunConfigSuggestion(java.util.function.Supplier<String> suggestion) {
+        this.runConfigSuggestion = suggestion;
+    }
+
     private javafx.scene.Node runConfigsEditor() {
         reloadRunConfigs();
 
@@ -4155,11 +4169,22 @@ public class SettingsWindow {
 
         Button add = new Button(tr("settings.runConfig.add"));
         add.setOnAction(e -> {
-            com.editora.config.RunConfiguration c = new com.editora.config.RunConfiguration(
-                    tr("settings.runConfig.newName"), "run", "", "", "", "", "");
+            // Start from the active Java file rather than wholly blank: a blank Java configuration is
+            // unrunnable, and running one before you fill the main class in used to report a language-server
+            // stack trace (#795). Null when nothing is open to suggest from — then it is blank as before.
+            String suggested = runConfigSuggestion == null ? null : runConfigSuggestion.get();
+            List<String> taken = new ArrayList<>();
+            for (com.editora.config.RunConfiguration existing : runConfigItems) {
+                taken.add(existing.name());
+            }
+            com.editora.config.RunConfiguration c = com.editora.run.RunConfigDefaults.newConfiguration(
+                    suggested, taken, tr("settings.runConfig.newName"));
             runConfigItems.add(c);
             persistRunConfigs();
             list.getSelectionModel().select(c);
+            // Land on the field that still needs attention: the main class when there was nothing to suggest,
+            // otherwise the name, which is the only part left as a guess.
+            javafx.application.Platform.runLater(() -> (suggested == null ? mainClass : name).requestFocus());
         });
         Button remove = new Button(tr("settings.runConfig.remove"));
         remove.setOnAction(e -> {

--- a/src/test/java/com/editora/run/RunConfigDefaultsTest.java
+++ b/src/test/java/com/editora/run/RunConfigDefaultsTest.java
@@ -1,0 +1,96 @@
+package com.editora.run;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class RunConfigDefaultsTest {
+
+    @Test
+    void namesAConfigurationAfterItsClass() {
+        assertEquals("App", RunConfigDefaults.nameFor("com.example.App", "New"));
+        assertEquals("App", RunConfigDefaults.nameFor("App", "New"), "a default-package class");
+    }
+
+    @Test
+    void fallsBackWhenThereIsNothingToNameItAfter() {
+        assertEquals("New", RunConfigDefaults.nameFor(null, "New"));
+        assertEquals("New", RunConfigDefaults.nameFor("", "New"));
+        assertEquals("New", RunConfigDefaults.nameFor("   ", "New"));
+        assertEquals("New", RunConfigDefaults.nameFor("com.example.", "New"), "a trailing dot names nothing");
+    }
+
+    @Test
+    void leavesAnUncontestedNameAlone() {
+        assertEquals("App", RunConfigDefaults.uniqueName("App", List.of("Server", "Client")));
+        assertEquals("App", RunConfigDefaults.uniqueName("App", List.of()));
+        assertEquals("App", RunConfigDefaults.uniqueName("App", null));
+    }
+
+    /**
+     * The collision that matters: each configuration registers a {@code run.config.<slug>} command keyed on
+     * its name, so a duplicate name silently overwrites the other's command.
+     */
+    @Test
+    void disambiguatesACollidingName() {
+        assertEquals("App (2)", RunConfigDefaults.uniqueName("App", List.of("App")));
+        assertEquals("App (3)", RunConfigDefaults.uniqueName("App", List.of("App", "App (2)")));
+    }
+
+    /** The slug is case-insensitive, so the uniqueness check has to be too, or the ids still collide. */
+    @Test
+    void comparesCaseInsensitivelyBecauseTheSlugDoes() {
+        assertEquals("App (2)", RunConfigDefaults.uniqueName("App", List.of("app")));
+        assertEquals("app (2)", RunConfigDefaults.uniqueName("app", List.of("APP")));
+    }
+
+    @Test
+    void ignoresSurroundingWhitespaceOnBothSides() {
+        assertEquals("App (2)", RunConfigDefaults.uniqueName("  App  ", List.of(" App ")));
+    }
+
+    /**
+     * With a Java file open, Add produces something you can actually run — the shape #795 was about.
+     */
+    @Test
+    void addProducesARunnableConfigurationWhenThereIsSomethingToSuggest() {
+        var c = RunConfigDefaults.newConfiguration("com.example.App", List.of(), "New Configuration");
+        assertEquals("App", c.name(), "named after the class, not \"New Configuration\"");
+        assertEquals("com.example.App", c.mainClass());
+        assertEquals("java", c.type());
+        assertEquals("run", c.kind());
+        assertFalse(c.missingMainClass(), "runnable straight away");
+    }
+
+    /** Nothing to suggest: blank as before, so Add still works with no Java file in front. */
+    @Test
+    void addStillProducesABlankConfigurationWithNothingToSuggest() {
+        var c = RunConfigDefaults.newConfiguration(null, List.of(), "New Configuration");
+        assertEquals("New Configuration", c.name());
+        assertEquals("", c.mainClass());
+        assertTrue(c.missingMainClass(), "and the #795 guard still reports it clearly");
+    }
+
+    /** Adding twice from the same file is the case that would otherwise collide two command ids into one. */
+    @Test
+    void addingTwiceFromTheSameFileDoesNotCollide() {
+        var first = RunConfigDefaults.newConfiguration("com.example.App", List.of(), "New Configuration");
+        var second = RunConfigDefaults.newConfiguration("com.example.App", List.of(first.name()), "New Configuration");
+        assertEquals("App", first.name());
+        assertEquals("App (2)", second.name());
+        assertNotEquals(
+                com.editora.config.RunConfiguration.commandIdFor(first.name()),
+                com.editora.config.RunConfiguration.commandIdFor(second.name()),
+                "distinct command ids, so neither overwrites the other in the palette");
+    }
+
+    @Test
+    void toleratesNullsInTheExistingNames() {
+        assertEquals("App", RunConfigDefaults.uniqueName("App", java.util.Arrays.asList("Server", null)));
+    }
+}

--- a/src/test/java/com/editora/ui/RunConfigSuggestionFxTest.java
+++ b/src/test/java/com/editora/ui/RunConfigSuggestionFxTest.java
@@ -1,0 +1,86 @@
+package com.editora.ui;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import com.editora.editor.EditorBuffer;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.io.TempDir;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+/**
+ * What Settings → Run Configurations → <b>Add</b> prefills from, and {@code run.saveConfig} saves.
+ *
+ * <p>The pure naming rules are covered by {@code RunConfigDefaultsTest}; what only the controller can answer
+ * is which buffers count as a source of a main class at all.
+ */
+@Tag("fx")
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class RunConfigSuggestionFxTest {
+
+    private static final String WITH_MAIN = """
+            package com.example;
+
+            public class App {
+                public static void main(String[] args) {
+                    System.out.println("hi");
+                }
+            }
+            """;
+
+    private FxWindowFixture fx;
+
+    @BeforeAll
+    void setUp() throws Exception {
+        FxTestSupport.bootToolkit();
+        fx = FxWindowFixture.create();
+    }
+
+    @AfterAll
+    void tearDown() throws Exception {
+        if (fx != null) {
+            fx.dispose();
+        }
+    }
+
+    private String suggestion() throws Exception {
+        return FxTestSupport.callOnFx(
+                () -> (String) FxTestSupport.call(fx.controller, "suggestedMainClass", new Class[] {}));
+    }
+
+    private void open(Path file, String content) throws Exception {
+        Files.writeString(file, content);
+        FxTestSupport.runOnFx(() -> {
+            EditorBuffer b = new EditorBuffer();
+            b.setContent(content);
+            b.setPath(file);
+            FxTestSupport.call(fx.controller, "addBuffer", new Class[] {EditorBuffer.class, boolean.class}, b, true);
+        });
+    }
+
+    @Test
+    void suggestsTheMainClassOfTheActiveJavaFile(@TempDir Path dir) throws Exception {
+        open(dir.resolve("App.java"), WITH_MAIN);
+        assertEquals("com.example.App", suggestion());
+    }
+
+    /** A Java file with no {@code main} has nothing to suggest — Add falls back to a blank configuration. */
+    @Test
+    void suggestsNothingForAJavaFileWithNoMain(@TempDir Path dir) throws Exception {
+        open(dir.resolve("Helper.java"), "package com.example;\n\npublic class Helper {}\n");
+        assertNull(suggestion());
+    }
+
+    /** A Markdown file is not a source of a Java main class, however much it may contain the word. */
+    @Test
+    void suggestsNothingForANonJavaFile(@TempDir Path dir) throws Exception {
+        open(dir.resolve("notes.md"), "# public static void main(String[] args)\n");
+        assertNull(suggestion());
+    }
+}


### PR DESCRIPTION
The two follow-ups to #796.

Settings → Run Configurations → **Add** created a wholly blank Java configuration. #796 stopped that reporting a language-server stack trace when you ran it, but it was still an entry called "New Configuration" that could not run until you filled it in.

**Add now starts from what the window knows:** the main class the active Java file's Gradle build declares, else the first `main` in that file. The configuration is named after that class, and focus lands on the field that still needs you — the main class when there was nothing to suggest, the name otherwise.

### The third thing, which I did not propose but should have

Naming a configuration after its class makes a collision the *norm*, not an edge case: add twice from the same file and you get two entries called "App". That matters because each configuration registers a synthetic `run.config.<slug>` command keyed on its name — so two named "App" share an id, and the second silently overwrites the first's palette entry and any keybinding on it.

`uniqueName` disambiguates to `App (2)`, compared **case-insensitively** because the slug is: `App` and `app` both slug to `app` and would collide just the same. The test asserts the resulting command ids differ, not merely the names.

(The underlying duplicate-name collision predates this PR — you could always name two configurations the same by hand. This stops the new prefill from making it routine; it does not fix the manual case.)

### Shape

`suggestedMainClass()` is extracted from `run.saveConfig` and shared with Add, so the two cannot disagree about what "the obvious main class here" is. `saveRunConfig` keeps its own non-Java-file check, so its two distinct messages (`needJavaFile` vs `noMainInFile`) are preserved rather than collapsed.

The whole construction is the pure `RunConfigDefaults.newConfiguration`, so the naming rules are unit-tested rather than living inside a UI lambda. The Settings side is one call plus a focus request.

### Tests

10 unit tests on the pure rules — including that Add's output is runnable (`missingMainClass()` false), that it still degrades to blank with nothing to suggest, and that adding twice yields distinct command ids — plus 3 FX tests on what the controller counts as a source of a main class (a Java file with a `main`, one without, and a Markdown file that merely contains the words).

`mvn clean verify` green — 3450 tests, coverage floors met.

### Not covered by a test

The **focus** behaviour. It is a `requestFocus` in a `Platform.runLater` on a Settings window that tests never show, so any assertion I could write would pass whether or not it works. Worth a click when you next open the page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)