### PR TITLE
fix(cli): stop a foreign flag's value being opened as a file

### DIFF
--- a/src/main/java/com/editora/App.java
+++ b/src/main/java/com/editora/App.java
@@ -395,28 +395,108 @@ public class App extends Application {
         return null;
     }
 
+    /** Editora's own two-token options — the token after one of these is its value, never a file. */
+    private static final java.util.Set<String> VALUE_OPTIONS = java.util.Set.of("--config-dir", "--project");
+
+    /** Editora's own options that consume no separate value token (the bare forms of the optional-value ones
+     *  included: {@code --new-file} / {@code --single-window} mean "blank" / "no project" on their own). */
+    private static final java.util.Set<String> KNOWN_FLAGS = java.util.Set.of(
+            "--dev",
+            "--zen",
+            "--expert",
+            "--simple",
+            "--no-session",
+            "--new-file",
+            "--single-window",
+            "--version",
+            "-V",
+            "--help",
+            "-h");
+
+    /** Prefixes of Editora's own single-token {@code --option=value} spellings. */
+    private static final java.util.List<String> KNOWN_PREFIXES =
+            java.util.List.of("--config-dir=", "--project=", "--new-file=", "--single-window=");
+
+    /** Whether {@code a} is an option Editora itself defines (any spelling). Anything else starting with a
+     *  dash is foreign — a JVM/launcher flag whose arity we cannot know. */
+    static boolean isEditoraOption(String a) {
+        if (a == null) {
+            return false;
+        }
+        if (VALUE_OPTIONS.contains(a) || KNOWN_FLAGS.contains(a)) {
+            return true;
+        }
+        for (String p : KNOWN_PREFIXES) {
+            if (a.startsWith(p)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
     /**
      * Positional file arguments (parsed for an optional {@code :LINE[:COLUMN]} suffix), skipping option
      * flags and the value tokens consumed by {@code --config-dir} / {@code --project}.
+     *
+     * <p>The rule is <b>not</b> "anything that doesn't start with a dash is a file". A two-token flag Editora
+     * doesn't define — {@code --add-exports javafx.graphics/com.sun.glass.ui=com.editora}, any JVM flag that
+     * leaks into the program arguments — has a <em>value</em> that starts with no dash, so it used to be
+     * resolved against the working directory and opened, surfacing as a bogus {@code Failed to open:} for a
+     * path the user never typed (#791). So a token directly after a <b>foreign</b> option is admitted only if
+     * it exists on disk. A token after one of <em>our</em> flags, or after no flag at all, is admitted
+     * regardless — {@code editora typo.txt} must still report that the file is missing rather than silently
+     * do nothing, which is why a blanket must-exist rule (the obvious fix) is the wrong one.
+     *
+     * <p>Deliberately keyed on Editora's own option set rather than a list of JVM flags to skip: that list
+     * would go stale the way {@code commandsForAllServers} did (#723), whereas this one we own — and if it
+     * <em>does</em> drift, the cost is one missing-file message, not a broken feature.
+     *
+     * <p>No {@code --} end-of-options separator: eleven independent scanners parse these arguments, so only
+     * this one would honour it and {@code editora -- --zen} would open a file <em>and</em> enter Zen mode. It
+     * would only ever matter for a not-yet-existing file sitting directly after a foreign flag, since a file
+     * that is really there already wins.
      */
     static java.util.List<com.editora.ui.MainController.OpenTarget> fileTargets(java.util.List<String> args) {
+        return fileTargets(args, java.nio.file.Files::exists);
+    }
+
+    /** {@link #fileTargets(java.util.List)} with the on-disk check injected, so the decision stays pure and
+     *  unit-testable (the {@code PathKeys.findKeyByIdentity} idiom). */
+    static java.util.List<com.editora.ui.MainController.OpenTarget> fileTargets(
+            java.util.List<String> args, java.util.function.Predicate<java.nio.file.Path> exists) {
         java.util.List<com.editora.ui.MainController.OpenTarget> out = new java.util.ArrayList<>();
         if (args == null) {
             return out;
         }
+        boolean afterForeignOption = false;
         for (int i = 0; i < args.size(); i++) {
             String a = args.get(i);
             if (a == null || a.isEmpty()) {
                 continue;
             }
-            if (a.equals("--config-dir") || a.equals("--project")) {
+            if (VALUE_OPTIONS.contains(a)) {
                 i++; // skip the value token
+                afterForeignOption = false;
                 continue;
             }
             if (a.startsWith("-")) {
-                continue; // any other option (incl. --xxx=yyy, --zen, --expert, --version, --help)
+                afterForeignOption = !isEditoraOption(a);
+                continue;
             }
-            out.add(parseTarget(a));
+            com.editora.ui.MainController.OpenTarget target;
+            try {
+                target = parseTarget(a);
+            } catch (java.nio.file.InvalidPathException e) {
+                // A leaked flag value need not be representable as a path at all (illegal characters on
+                // Windows). Skipping beats propagating out of start() and failing the launch outright.
+                afterForeignOption = false;
+                continue;
+            }
+            boolean leakedValue = afterForeignOption && !exists.test(target.file());
+            afterForeignOption = false;
+            if (!leakedValue) {
+                out.add(target);
+            }
         }
         return out;
     }

--- a/src/test/java/com/editora/AppArgsTest.java
+++ b/src/test/java/com/editora/AppArgsTest.java
@@ -1,10 +1,13 @@
 package com.editora;
 
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
+import java.util.function.Predicate;
 
 import com.editora.ui.MainController.OpenTarget;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -108,6 +111,107 @@ class AppArgsTest {
     void fileTargetsSkipsEqualsFormOptions() {
         List<OpenTarget> targets = App.fileTargets(List.of("--config-dir=/cfg", "--project=/repo", "x.md"));
         assertEquals(List.of(new OpenTarget(Path.of("x.md"), 0, 0)), targets);
+    }
+
+    // --- #791: a foreign two-token flag's value must not be opened as a file --------------------------
+
+    /** Nothing exists on disk — the strictest setting for the "is this a leaked flag value?" decision. */
+    private static final Predicate<Path> NOTHING_EXISTS = p -> false;
+
+    @Test
+    void foreignTwoTokenFlagValueIsNotAFileTarget() {
+        // The reported case: --add-exports' value doesn't start with a dash, so it used to be resolved
+        // against the working directory and opened ("Failed to open: <cwd>/javafx.graphics/...=com.editora").
+        assertEquals(
+                List.of(),
+                App.fileTargets(
+                        List.of("--add-exports", "javafx.graphics/com.sun.glass.ui=com.editora"), NOTHING_EXISTS));
+        assertEquals(
+                List.of(), App.fileTargets(List.of("--add-opens", "java.base/java.lang=ALL-UNNAMED"), NOTHING_EXISTS));
+        assertEquals(List.of(), App.fileTargets(List.of("-p", "/some/module/path"), NOTHING_EXISTS));
+    }
+
+    @Test
+    void aRealFileAfterAForeignFlagIsStillOpened() {
+        // Existence is what distinguishes a leaked value from a genuine argument, so a file that is really
+        // there wins even in the ambiguous position.
+        assertEquals(
+                List.of(new OpenTarget(Path.of("a.txt"), 0, 0)),
+                App.fileTargets(List.of("--add-exports", "a.txt"), p -> true));
+    }
+
+    @Test
+    void aMissingFileTheUserTypedIsStillATargetSoItReportsAsMissing() {
+        // The whole point of not using a blanket must-exist rule: `editora typo.txt` has to keep reaching
+        // openPath, which is what produces "Failed to open: typo.txt". Silently dropping it would be worse
+        // than the bug being fixed.
+        assertEquals(
+                List.of(new OpenTarget(Path.of("typo.txt"), 0, 0)),
+                App.fileTargets(List.of("typo.txt"), NOTHING_EXISTS));
+        // ...including after one of Editora's own flags, whose arity we know.
+        assertEquals(
+                List.of(new OpenTarget(Path.of("typo.txt"), 0, 0)),
+                App.fileTargets(List.of("--zen", "typo.txt"), NOTHING_EXISTS));
+        assertEquals(
+                List.of(new OpenTarget(Path.of("typo.txt"), 0, 0)),
+                App.fileTargets(List.of("--new-file", "typo.txt"), NOTHING_EXISTS));
+        // ...and after a value option, where the value is consumed and the file follows.
+        assertEquals(
+                List.of(new OpenTarget(Path.of("typo.txt"), 0, 0)),
+                App.fileTargets(List.of("--project", "/repo", "typo.txt"), NOTHING_EXISTS));
+    }
+
+    @Test
+    void onlyTheTokenDirectlyAfterAForeignFlagIsSuspect() {
+        // The suspicion must not carry past the value it belongs to, or one stray JVM flag would swallow
+        // every later argument.
+        assertEquals(
+                List.of(new OpenTarget(Path.of("b.txt"), 0, 0)),
+                App.fileTargets(List.of("--add-exports", "m/p=x", "b.txt"), NOTHING_EXISTS));
+    }
+
+    @Test
+    void theReportedArgvThroughTheOriginalSignature() {
+        // Exactly the argv from #791, through the one-arg overload that existed before the fix, so this
+        // fails against the old "anything without a leading dash is a file" rule rather than only against
+        // the injected-predicate helper added alongside it.
+        assertEquals(
+                List.of(), App.fileTargets(List.of("--add-exports", "javafx.graphics/com.sun.glass.ui=com.editora")));
+    }
+
+    @Test
+    void anUnrepresentablePathIsSkippedRatherThanFailingTheLaunch() {
+        // A leaked value need not be a legal path at all; parseTarget's Path.of would otherwise throw
+        // InvalidPathException straight out of App.start and the app would not come up.
+        String nul = "bad\0name"; // a NUL is illegal in a path on every supported OS
+        assertEquals(List.of(), App.fileTargets(List.of("--add-exports", nul), NOTHING_EXISTS));
+        assertEquals(List.of(), App.fileTargets(List.of(nul), NOTHING_EXISTS));
+    }
+
+    @Test
+    void editoraOwnsItsOptionSpellings() {
+        assertTrue(App.isEditoraOption("--zen"));
+        assertTrue(App.isEditoraOption("--no-session"));
+        assertTrue(App.isEditoraOption("--new-file"));
+        assertTrue(App.isEditoraOption("--new-file=foo.txt"));
+        assertTrue(App.isEditoraOption("--config-dir"));
+        assertTrue(App.isEditoraOption("--config-dir=/cfg"));
+        assertTrue(App.isEditoraOption("--single-window=MyProj"));
+        assertTrue(App.isEditoraOption("-V"));
+        assertFalse(App.isEditoraOption("--add-exports"));
+        assertFalse(App.isEditoraOption("-p"));
+        assertFalse(App.isEditoraOption(null));
+    }
+
+    @Test
+    void theDefaultOverloadChecksTheRealFilesystem(@TempDir Path dir) throws Exception {
+        // Proves the injected predicate is wired to Files::exists, not merely that the pure decision is right.
+        Path real = dir.resolve("real.txt");
+        Files.writeString(real, "x");
+        Path missing = dir.resolve("missing.txt");
+
+        assertEquals(List.of(new OpenTarget(real, 0, 0)), App.fileTargets(List.of("--add-exports", real.toString())));
+        assertEquals(List.of(), App.fileTargets(List.of("--add-exports", missing.toString())));
     }
 
     @Test


### PR DESCRIPTION
Closes #791.

`App.fileTargets` treated every token without a leading dash as a file to open, so a two-token flag Editora does not define — any JVM flag that leaks into the program arguments — had its **value** resolved against the working directory and opened:

```
Failed to open: <cwd>/javafx.graphics/com.sun.glass.ui=com.editora
```

A token directly after a **foreign** option is now admitted only if it exists on disk.

## Judgement calls that differ from the issue

**Not the blanket must-exist rule the issue preferred (option 2).** A missing path today reaches `openPath` and reports `Failed to open: typo.txt`. Requiring existence everywhere would silently swallow a typo'd filename, trading a useful error for nothing. The check is scoped to the one ambiguous position, so `editora typo.txt` and `editora --zen typo.txt` still report as before.

**The issue's option 1 would not have fixed the reported case.** "Contains `=` with no path separator before it" does not match `javafx.graphics/com.sun.glass.ui=com.editora`, which has a `/` *before* the `=`.

**Keyed on Editora's own option set rather than a list of JVM flags to skip.** That list would go stale the way `commandsForAllServers` did (#723); this one we own, and if it does drift the cost is one missing-file message rather than a broken feature.

**No `--` end-of-options separator.** It was written and then removed: eleven independent scanners parse these arguments, so only `fileTargets` would honour it and `editora -- --zen` would open a file *and* enter Zen mode. It would only ever matter for a not-yet-existing file directly after a foreign flag, since a file that is really there already wins.

## Also

Guards `InvalidPathException` — a leaked value need not be representable as a path at all, and `Path.of` would otherwise throw straight out of `start()` and fail the launch.

The on-disk check is injected (`fileTargets(args, Predicate<Path> exists)`) so the decision stays pure and unit-testable, following the `PathKeys.findKeyByIdentity` idiom.

## Verification

- Full `./mvnw verify`: **3462 tests, 0 failures, 0 errors** (the 2 skips are the pre-existing jdtls probe tests).
- Confirmed the new regression test **fails against the old rule**, producing exactly the reported `OpenTarget[file=javafx.graphics/com.sun.glass.ui=com.editora]` — so it pins the bug rather than only the new helper.

🤖 Generated with [Claude Code](https://claude.com/claude-code)