### PR TITLE
feat(lsp): auto-import for pasted Java code (jdtls handlePasteEvent)

### DIFF
--- a/src/main/java/com/editora/config/Settings.java
+++ b/src/main/java/com/editora/config/Settings.java
@@ -40,7 +40,7 @@ public class Settings {
     }
 
     /** Current on-disk schema version of {@code settings.toml}; bump when the format changes (+ a migration). */
-    public static final int SCHEMA_VERSION = 90;
+    public static final int SCHEMA_VERSION = 91;
 
     private int schemaVersion = SCHEMA_VERSION;
 
@@ -141,6 +141,8 @@ public class Settings {
      *  Enter). Default <b>off</b>: it acts on very common keystrokes and overlaps the local auto-indent
      *  assists, so it is opt-in until it has proven itself in the field (#740). */
     private boolean lspOnTypeFormatting = false;
+    /** Auto-import for pasted code via jdtls's paste event (#742): on by default, as in VS Code. */
+    private boolean lspPasteImports = true;
     /** Honor a project's {@code .editorconfig} (indent, EOL, charset, trim/final-newline, max line length). */
     private boolean editorConfigSupport = true;
     /** Highlight configured patterns (TODO/FIXME/…) in the editor + list them in the TODO tool window. */
@@ -1065,6 +1067,14 @@ public class Settings {
 
     public boolean isLspOnTypeFormatting() {
         return lspOnTypeFormatting;
+    }
+
+    public boolean isLspPasteImports() {
+        return lspPasteImports;
+    }
+
+    public void setLspPasteImports(boolean lspPasteImports) {
+        this.lspPasteImports = lspPasteImports;
     }
 
     public void setLspOnTypeFormatting(boolean lspOnTypeFormatting) {

--- a/src/main/java/com/editora/config/migration/ConfigSchema.java
+++ b/src/main/java/com/editora/config/migration/ConfigSchema.java
@@ -152,7 +152,8 @@ public enum ConfigSchema {
                     // v88→89: Projects went from opt-in to on. NOT identity — the default change alone reaches
                     // only a fresh config dir, since every existing settings.toml stores the old false.
                     Map.entry(88, (Migration) ConfigMigrations::enableProjectSupport),
-                    Map.entry(89, (Migration) ConfigMigrations::identity))), // v89→90: + bracketColors (additive)
+                    Map.entry(89, (Migration) ConfigMigrations::identity), // v89→90: + bracketColors (additive)
+                    Map.entry(90, (Migration) ConfigMigrations::identity))), // v90→91: + lspPasteImports (additive)
     // v1 → v2 added the editor-group layout + OpenFile.group. Both default to the old single-group
     // behaviour, so the step is identity.
     // v1→v2 editor-group layout, v2→v3 RunConfiguration type/target, v3→v4 selectedRunConfig — all additive

--- a/src/main/java/com/editora/editor/EditorBuffer.java
+++ b/src/main/java/com/editora/editor/EditorBuffer.java
@@ -3761,6 +3761,66 @@ public class EditorBuffer implements TabContent {
         this.lspRenameAvailable = available;
     }
 
+    /** Requests jdtls's paste auto-import for the freshly pasted range (#742); controller-wired. The
+     *  positions are line/character pairs of the post-paste span; {@code stillValid} must be consulted
+     *  before applying the async answer. Keeps {@code editor} free of lsp4j. */
+    public interface LspPasteImportsRequester {
+        void request(
+                int startLine,
+                int startChar,
+                int endLine,
+                int endChar,
+                String pastedText,
+                java.util.function.BooleanSupplier stillValid);
+    }
+
+    private LspPasteImportsRequester lspPasteImportsRequester;
+    /** Master gate for paste auto-import ({@code Settings.lspPasteImports}), pushed from the controller. */
+    private boolean lspPasteImportsEnabled = true;
+
+    public void setLspPasteImportsRequester(LspPasteImportsRequester requester) {
+        this.lspPasteImportsRequester = requester;
+    }
+
+    public void setLspPasteImportsEnabled(boolean enabled) {
+        this.lspPasteImportsEnabled = enabled;
+    }
+
+    /**
+     * After a paste inserted {@code [start..end)} (absolute offsets), asks the language server for the
+     * imports the pasted code needs (#742). No-op unless the feature is on, a requester is wired, the
+     * buffer is an editable, non-narrowed LSP buffer (a narrowed buffer's coordinates are region-relative
+     * — the same reason LSP sync is suspended there), and the span is non-empty.
+     *
+     * <p>The pending didChange is flushed FIRST ({@link #sendLspChange}) so the server computes against
+     * the post-paste document — JSON-RPC preserves order, the {@code requestLspCompletion} idiom. The
+     * {@code stillValid} supplier the requester must consult before applying is a {@link #docVersion}
+     * check: an answer that arrives after the user kept typing is dropped, never applied to text it
+     * wasn't computed for.
+     */
+    public void requestLspPasteImports(int start, int end) {
+        if (!lspPasteImportsEnabled
+                || lspPasteImportsRequester == null
+                || !lspActive
+                || isNarrowed()
+                || !isEditable()
+                || end <= start
+                || end > area.getLength()) {
+            return;
+        }
+        sendLspChange();
+        long version = docVersion;
+        var s = area.offsetToPosition(start, org.fxmisc.richtext.model.TwoDimensional.Bias.Forward);
+        var e = area.offsetToPosition(end, org.fxmisc.richtext.model.TwoDimensional.Bias.Backward);
+        lspPasteImportsRequester.request(
+                s.getMajor(),
+                s.getMinor(),
+                e.getMajor(),
+                e.getMinor(),
+                area.getText(start, end),
+                () -> docVersion == version);
+    }
+
     /** Async range-formatter for Tab line re-indent: requests the edits the server would apply to a line
      *  range and delivers them on the FX thread. Keeps {@code editor} free of lsp4j. */
     public interface LspRangeFormatter {

--- a/src/main/java/com/editora/lsp/JdtlsPaste.java
+++ b/src/main/java/com/editora/lsp/JdtlsPaste.java
@@ -1,0 +1,90 @@
+package com.editora.lsp;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+
+/**
+ * The wire shapes of jdtls's {@code java.edit.handlePasteEvent} (#742) — auto-import for pasted code,
+ * the one paste behaviour nothing else in the stack can approximate (it needs the type resolver).
+ *
+ * <p>Both shapes were established <b>empirically</b> against a live jdtls ({@code JdtlsPasteProbeTest}),
+ * because both defy the obvious guess:
+ *
+ * <ul>
+ *   <li><b>The params must be sent as a stringified JSON</b>, not a JSON object. An object argument
+ *       deserializes to {@code null} server-side and the command answers an internal error naming
+ *       {@code PasteEventParams.getLocation()} — the same delegate-command quirk family #746 records
+ *       ({@code projectConfigurationUpdate} hangs as a request, {@code organizeImports} silently no-ops
+ *       on a position).
+ *   <li><b>The answer is not a {@code WorkspaceEdit}</b> — it is VS Code's {@code DocumentPasteEdit}
+ *       shape, {@code {insertText, additionalEdit}}. Editora invokes the command <em>after</em> the paste
+ *       has landed (unlike VS Code's paste provider, which intercepts it), so only {@code additionalEdit}
+ *       — the import insertion — is applied; {@code insertText} just echoes the pasted text.
+ * </ul>
+ *
+ * Pure; unit-tested against the captured shapes.
+ */
+public final class JdtlsPaste {
+
+    /** The delegate command id, as advertised in {@code executeCommandProvider.commands}. */
+    public static final String COMMAND = "java.edit.handlePasteEvent";
+
+    private JdtlsPaste() {}
+
+    /** Whether {@code caps} advertises the paste-event command (only jdtls does today). */
+    public static boolean supportsPasteEvent(org.eclipse.lsp4j.ServerCapabilities caps) {
+        return caps != null
+                && caps.getExecuteCommandProvider() != null
+                && caps.getExecuteCommandProvider().getCommands() != null
+                && caps.getExecuteCommandProvider().getCommands().contains(COMMAND);
+    }
+
+    /**
+     * The stringified {@code PasteEventParams}: the <b>post-paste</b> range of the inserted text, the
+     * pasted text itself, and the buffer's formatting options. Built with gson (not string concat) so the
+     * pasted text's quotes/newlines/unicode are escaped correctly.
+     */
+    public static String paramsJson(
+            String uri,
+            int startLine,
+            int startChar,
+            int endLine,
+            int endChar,
+            String pastedText,
+            int tabSize,
+            boolean insertSpaces) {
+        JsonObject start = new JsonObject();
+        start.addProperty("line", startLine);
+        start.addProperty("character", startChar);
+        JsonObject end = new JsonObject();
+        end.addProperty("line", endLine);
+        end.addProperty("character", endChar);
+        JsonObject range = new JsonObject();
+        range.add("start", start);
+        range.add("end", end);
+        JsonObject location = new JsonObject();
+        location.addProperty("uri", uri);
+        location.add("range", range);
+        JsonObject fmt = new JsonObject();
+        fmt.addProperty("tabSize", tabSize);
+        fmt.addProperty("insertSpaces", insertSpaces);
+        JsonObject params = new JsonObject();
+        params.add("location", location);
+        params.addProperty("text", pastedText);
+        params.add("formattingOptions", fmt);
+        return params.toString();
+    }
+
+    /**
+     * The {@code additionalEdit} member of the answer — the {@code WorkspaceEdit}-shaped import insertion
+     * — or {@code null} when the answer carries none (nothing to import) or isn't the expected shape (a
+     * defensive null rather than a throw: the reply crosses a version boundary we don't control).
+     */
+    public static JsonElement additionalEdit(Object rawResult) {
+        if (!(rawResult instanceof JsonElement json) || !json.isJsonObject()) {
+            return null;
+        }
+        JsonElement edit = json.getAsJsonObject().get("additionalEdit");
+        return edit == null || edit.isJsonNull() || !edit.isJsonObject() ? null : edit;
+    }
+}

--- a/src/main/java/com/editora/lsp/LspManager.java
+++ b/src/main/java/com/editora/lsp/LspManager.java
@@ -2341,6 +2341,49 @@ public final class LspManager {
         return raw == null ? null : new com.google.gson.Gson().toJsonTree(raw);
     }
 
+    /**
+     * Auto-import for pasted code (#742): asks jdtls's {@code java.edit.handlePasteEvent} what the text
+     * pasted at {@code [start..end]} (post-paste coordinates) needs, and applies the answered
+     * {@code additionalEdit} — the import insertion — through the normal workspace-edit path. Gated on
+     * the server actually advertising the command ({@link JdtlsPaste#supportsPasteEvent}), so a non-jdtls
+     * java setup (or any other language's server) never even sends the request.
+     *
+     * <p>{@code stillValid} is consulted on the FX thread immediately before applying: the round trip is
+     * asynchronous and the edit was computed against the post-paste document, so if the user typed in the
+     * meantime the answer is dropped rather than applied against text it wasn't computed for (the
+     * {@code docVersion} idiom — the caller supplies the check because only it can see the buffer).
+     * {@code cb} reports whether an edit was applied.
+     */
+    public void handlePasteEvent(
+            Path file,
+            int startLine,
+            int startChar,
+            int endLine,
+            int endChar,
+            String pastedText,
+            int tabSize,
+            boolean insertSpaces,
+            java.util.function.BooleanSupplier stillValid,
+            Consumer<Boolean> cb) {
+        LanguageServerSession s = sessionFor(file);
+        if (s == null || !JdtlsPaste.supportsPasteEvent(s.capabilities())) {
+            Platform.runLater(() -> cb.accept(false));
+            return;
+        }
+        // The params go over the wire as a STRINGIFIED json — an object argument deserializes to null
+        // server-side (established empirically; see JdtlsPaste).
+        String params = JdtlsPaste.paramsJson(
+                uri(file), startLine, startChar, endLine, endChar, pastedText, tabSize, insertSpaces);
+        s.executeCommand(JdtlsPaste.COMMAND, List.of(params))
+                .orTimeout(30, java.util.concurrent.TimeUnit.SECONDS)
+                .whenComplete((r, e) -> {
+                    org.eclipse.lsp4j.WorkspaceEdit edit =
+                            e != null ? null : asWorkspaceEdit(JdtlsPaste.additionalEdit(asJson(r)));
+                    Platform.runLater(
+                            () -> cb.accept(edit != null && stillValid.getAsBoolean() && applyWorkspaceEditNow(edit)));
+                });
+    }
+
     /** Decodes a {@code java/generate…} answer (an untyped {@code WorkspaceEdit}) into the typed form. */
     private static org.eclipse.lsp4j.WorkspaceEdit asWorkspaceEdit(Object raw) {
         try {

--- a/src/main/java/com/editora/ui/LspCoordinator.java
+++ b/src/main/java/com/editora/ui/LspCoordinator.java
@@ -1260,6 +1260,24 @@ final class LspCoordinator {
                 cb.accept(java.util.List.of());
             }
         });
+        // Paste auto-import (#742): ask jdtls what the pasted code needs; only jdtls advertises the
+        // command, so any other server (or language) drops out inside handlePasteEvent's capability gate.
+        buffer.setLspPasteImportsRequester((sl, sc, el, ec, text, stillValid) -> {
+            if (buffer.getPath() != null && lspManager.isManaged(buffer.getPath())) {
+                int tabSize = host.settings().getTabSize();
+                lspManager.handlePasteEvent(
+                        buffer.getPath(),
+                        sl,
+                        sc,
+                        el,
+                        ec,
+                        text,
+                        tabSize,
+                        buffer.detectInsertSpaces(tabSize),
+                        stillValid,
+                        applied -> {});
+            }
+        });
         // On-type formatting (#740): re-indent the line after a server-declared trigger character.
         buffer.setLspOnTypeFormatter((line, character, ch, cb) -> {
             if (buffer.getPath() != null && lspManager.isManaged(buffer.getPath())) {

--- a/src/main/java/com/editora/ui/MainController.java
+++ b/src/main/java/com/editora/ui/MainController.java
@@ -8792,8 +8792,15 @@ public class MainController implements com.editora.mcp.McpBridge {
         if (area == null) {
             return;
         }
+        // Capture where the paste will land so the LSP paste auto-import (#742) can name the span: a
+        // selection is replaced from its start; otherwise text inserts at the caret.
+        int pasteStart =
+                area.getSelection().getLength() > 0 ? area.getSelection().getStart() : area.getCaretPosition();
         if (b == null || !yankFromRing(b, area)) {
             area.paste(); // nothing on the ring — fall back to the platform paste
+        }
+        if (b != null) {
+            b.requestLspPasteImports(pasteStart, area.getCaretPosition());
         }
         deactivateMark();
         setStatus(tr("status.pasted"));
@@ -12569,6 +12576,7 @@ public class MainController implements com.editora.mcp.McpBridge {
         }
         buffer.setAutoRenameTag(s.isAutoRenameTag()); // paired-tag rename mirroring (html/xml buffers only)
         buffer.setOnTypeFormattingEnabled(s.isLspOnTypeFormatting()); // #740 (inert without an LSP trigger set)
+        buffer.setLspPasteImportsEnabled(s.isLspPasteImports()); // #742 (inert without a jdtls session)
         buffer.setAutoCloseTags(s.isAutoCloseTags()); // ">" inserts the matching closer (html/xml buffers only)
         buffer.setFillColumn(s.getFillColumn());
         buffer.setAutoFillEnabled(s.isAutoFill()); // break prose lines at the fill column as you type (prose only)
@@ -15298,6 +15306,13 @@ public class MainController implements com.editora.mcp.McpBridge {
                         "view.toggleOnTypeFormatting",
                         () -> config.getSettings().isLspOnTypeFormatting(),
                         config.getSettings()::setLspOnTypeFormatting,
+                        () -> applyViewSettingsToAllBuffers(config.getSettings()))));
+        registry.register(Command.of(
+                "view.togglePasteImports",
+                () -> toggleSetting(
+                        "view.togglePasteImports",
+                        () -> config.getSettings().isLspPasteImports(),
+                        config.getSettings()::setLspPasteImports,
                         () -> applyViewSettingsToAllBuffers(config.getSettings()))));
         registry.register(Command.of(
                 "view.toggleInlayHints",

--- a/src/main/java/com/editora/ui/SettingsWindow.java
+++ b/src/main/java/com/editora/ui/SettingsWindow.java
@@ -207,6 +207,7 @@ public class SettingsWindow {
     private CheckBox semanticHighlightCheck;
     private CheckBox inlayHintsCheck;
     private CheckBox onTypeFormattingCheck;
+    private CheckBox pasteImportsCheck;
     private CheckBox spellCheckBox;
     private ComboBox<String> spellLanguageCombo;
     /** The Personal Dictionary list on the Spell Check page; refreshed from {@code dictionary.txt} on show. */
@@ -986,6 +987,7 @@ public class SettingsWindow {
         semanticHighlightCheck = viewCheck(tr("settings.semanticHighlight"), Settings::setSemanticHighlight);
         inlayHintsCheck = viewCheck(tr("settings.inlayHints"), Settings::setInlayHints);
         onTypeFormattingCheck = viewCheck(tr("settings.onTypeFormatting"), Settings::setLspOnTypeFormatting);
+        pasteImportsCheck = viewCheck(tr("settings.lspPasteImports"), Settings::setLspPasteImports);
         // The per-source toggles are only meaningful while the master switch is on.
         autocompleteCheck.selectedProperty().addListener((obs, was, now) -> {
             autocompleteProseCheck.setDisable(!now);
@@ -2810,6 +2812,7 @@ public class SettingsWindow {
                 completion,
                 onTypeFormattingCheck,
                 "on-type formatting reindent semicolon brace enter lsp");
+        row(p, Category.COMPLETION, completion, pasteImportsCheck, "paste import auto imports java jdtls clipboard");
         onTypeFormattingCheck.disableProperty().bind(lspCheck.selectedProperty().not());
         // Semantic highlighting comes from LSP: disable it (+ explain why) when LSP is off.
         semanticHighlightCheck
@@ -6369,6 +6372,7 @@ public class SettingsWindow {
             semanticHighlightCheck.setSelected(settings.isSemanticHighlight());
             inlayHintsCheck.setSelected(settings.isInlayHints());
             onTypeFormattingCheck.setSelected(settings.isLspOnTypeFormatting());
+            pasteImportsCheck.setSelected(settings.isLspPasteImports());
             pdfLineNumbersCheck.setSelected(settings.isPdfLineNumbers());
             pdfHighlightCheck.setSelected(settings.isPdfSyntaxHighlighting());
             pdfPageSizeCombo.setValue(settings.getPdfPageSize());
@@ -6944,6 +6948,7 @@ public class SettingsWindow {
             semanticHighlightCheck.setSelected(s.isSemanticHighlight());
             inlayHintsCheck.setSelected(s.isInlayHints());
             onTypeFormattingCheck.setSelected(s.isLspOnTypeFormatting());
+            pasteImportsCheck.setSelected(s.isLspPasteImports());
         } finally {
             loading = prev;
         }

--- a/src/main/resources/com/editora/i18n/messages.properties
+++ b/src/main/resources/com/editora/i18n/messages.properties
@@ -2260,8 +2260,11 @@ command.view.toggleInlayHints=View: Toggle Inlay Hints
 command.view.toggleOnTypeFormatting=View: Toggle On-Type Formatting
 command.view.toggleInlayHints.desc=Show or hide the language server’s parameter-name and type hints drawn after each line (off by default)
 command.view.toggleOnTypeFormatting.desc=Re-indent the current line when the language server's trigger character is typed.
+command.view.togglePasteImports=View: Toggle Paste Auto-Import
+command.view.togglePasteImports.desc=Enable or disable adding the imports pasted Java code needs.
 settings.inlayHints=Inlay hints (parameter names / types, after the line)
 settings.onTypeFormatting=Re-indent as you type (on-type formatting)
+settings.lspPasteImports=Add imports for pasted code (Java)
 command.view.toggleSemanticHighlight.desc=Turn LSP semantic token highlighting on or off.
 settings.semanticHighlight=Semantic highlighting (LSP)
 # TODO / highlight patterns

--- a/src/main/resources/com/editora/i18n/messages_de.properties
+++ b/src/main/resources/com/editora/i18n/messages_de.properties
@@ -2252,8 +2252,11 @@ command.view.toggleInlayHints=Ansicht: Inlay-Hinweise umschalten
 command.view.toggleOnTypeFormatting=Ansicht: Formatierung bei Eingabe umschalten
 command.view.toggleInlayHints.desc=Zeigt oder verbirgt die Parameternamen- und Typ-Hinweise des Sprachservers, die nach jeder Zeile gezeichnet werden (standardmäßig aus)
 command.view.toggleOnTypeFormatting.desc=Rückt die aktuelle Zeile neu ein, wenn das Auslösezeichen des Language-Servers getippt wird.
+command.view.togglePasteImports=Ansicht: Auto-Import beim Einfügen umschalten
+command.view.togglePasteImports.desc=Aktiviert oder deaktiviert das Hinzufügen der Importe, die eingefügter Java-Code benötigt.
 settings.inlayHints=Inlay-Hinweise (Parameternamen / Typen, nach der Zeile)
 settings.onTypeFormatting=Beim Tippen neu einrücken (Formatierung bei Eingabe)
+settings.lspPasteImports=Importe für eingefügten Code hinzufügen (Java)
 command.view.toggleSemanticHighlight.desc=Die semantische Token-Hervorhebung über LSP ein- oder ausschalten.
 settings.semanticHighlight=Semantische Hervorhebung (LSP)
 # TODO / highlight patterns

--- a/src/main/resources/com/editora/i18n/messages_es.properties
+++ b/src/main/resources/com/editora/i18n/messages_es.properties
@@ -2252,8 +2252,11 @@ command.view.toggleInlayHints=Ver: Alternar sugerencias en línea
 command.view.toggleOnTypeFormatting=Vista: alternar formato al escribir
 command.view.toggleInlayHints.desc=Muestra u oculta las sugerencias de nombres de parámetros y tipos del servidor de lenguaje dibujadas al final de cada línea (desactivado por defecto)
 command.view.toggleOnTypeFormatting.desc=Reindenta la línea actual al escribir el carácter activador del servidor de lenguaje.
+command.view.togglePasteImports=Ver: Alternar auto-importación al pegar
+command.view.togglePasteImports.desc=Habilita o deshabilita añadir las importaciones que necesita el código Java pegado.
 settings.inlayHints=Sugerencias en línea (nombres de parámetros / tipos, al final de la línea)
 settings.onTypeFormatting=Reindentar al escribir (formato automático)
+settings.lspPasteImports=Añadir importaciones al pegar código (Java)
 command.view.toggleSemanticHighlight.desc=Activar o desactivar el resaltado mediante tokens semánticos de LSP.
 settings.semanticHighlight=Resaltado semántico (LSP)
 # TODO / highlight patterns

--- a/src/main/resources/com/editora/i18n/messages_fr.properties
+++ b/src/main/resources/com/editora/i18n/messages_fr.properties
@@ -2252,8 +2252,11 @@ command.view.toggleInlayHints=Affichage : Basculer les indications en ligne
 command.view.toggleOnTypeFormatting=Affichage : activer/désactiver le formatage à la frappe
 command.view.toggleInlayHints.desc=Affiche ou masque les indications de noms de paramètres et de types du serveur de langage dessinées après chaque ligne (désactivé par défaut)
 command.view.toggleOnTypeFormatting.desc=Réindente la ligne courante lors de la saisie du caractère déclencheur du serveur de langage.
+command.view.togglePasteImports=Affichage : Basculer l'auto-import au collage
+command.view.togglePasteImports.desc=Active ou désactive l'ajout des imports dont le code Java collé a besoin.
 settings.inlayHints=Indications en ligne (noms de paramètres / types, après la ligne)
 settings.onTypeFormatting=Réindenter à la frappe (formatage automatique)
+settings.lspPasteImports=Ajouter les imports du code collé (Java)
 command.view.toggleSemanticHighlight.desc=Activer ou désactiver la coloration par jetons sémantiques LSP.
 settings.semanticHighlight=Coloration sémantique (LSP)
 # TODO / highlight patterns

--- a/src/main/resources/com/editora/i18n/messages_it.properties
+++ b/src/main/resources/com/editora/i18n/messages_it.properties
@@ -2252,8 +2252,11 @@ command.view.toggleInlayHints=Vista: Attiva/disattiva suggerimenti inline
 command.view.toggleOnTypeFormatting=Vista: attiva/disattiva formattazione durante la digitazione
 command.view.toggleInlayHints.desc=Mostra o nasconde i suggerimenti di nomi parametro e tipi del language server disegnati dopo ogni riga (disattivato per impostazione predefinita)
 command.view.toggleOnTypeFormatting.desc=Reindenta la riga corrente quando si digita il carattere attivatore del language server.
+command.view.togglePasteImports=Vista: Attiva/disattiva l'auto-import all'incollaggio
+command.view.togglePasteImports.desc=Abilita o disabilita l'aggiunta delle importazioni necessarie al codice Java incollato.
 settings.inlayHints=Suggerimenti inline (nomi parametro / tipi, dopo la riga)
 settings.onTypeFormatting=Reindenta durante la digitazione (formattazione automatica)
+settings.lspPasteImports=Aggiungi le importazioni per il codice incollato (Java)
 command.view.toggleSemanticHighlight.desc=Attiva o disattiva l'evidenziazione tramite token semantici LSP.
 settings.semanticHighlight=Evidenziazione semantica (LSP)
 # TODO / highlight patterns

--- a/src/main/resources/com/editora/i18n/messages_pt.properties
+++ b/src/main/resources/com/editora/i18n/messages_pt.properties
@@ -2252,8 +2252,11 @@ command.view.toggleInlayHints=Exibir: Alternar dicas inline
 command.view.toggleOnTypeFormatting=Exibir: alternar formatação ao digitar
 command.view.toggleInlayHints.desc=Mostra ou oculta as dicas de nomes de parâmetros e tipos do servidor de linguagem desenhadas após cada linha (desativado por padrão)
 command.view.toggleOnTypeFormatting.desc=Reindenta a linha atual ao digitar o caractere acionador do servidor de linguagem.
+command.view.togglePasteImports=Exibir: Alternar auto-importação ao colar
+command.view.togglePasteImports.desc=Ativa ou desativa a adição das importações de que o código Java colado precisa.
 settings.inlayHints=Dicas inline (nomes de parâmetros / tipos, após a linha)
 settings.onTypeFormatting=Reindentar ao digitar (formatação automática)
+settings.lspPasteImports=Adicionar importações para código colado (Java)
 command.view.toggleSemanticHighlight.desc=Ativa ou desativa o realce por tokens semânticos do LSP.
 settings.semanticHighlight=Realce semântico (LSP)
 # TODO / highlight patterns

--- a/src/test/java/com/editora/lsp/JdtlsPasteProbeTest.java
+++ b/src/test/java/com/editora/lsp/JdtlsPasteProbeTest.java
@@ -1,0 +1,170 @@
+package com.editora.lsp;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+import org.eclipse.lsp4j.*;
+import org.eclipse.lsp4j.jsonrpc.Launcher;
+import org.eclipse.lsp4j.launch.LSPLauncher;
+import org.eclipse.lsp4j.services.LanguageClient;
+import org.eclipse.lsp4j.services.LanguageServer;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+/**
+ * MANUAL PROBE (not part of the suite — @Tag("probe"), opt-in via {@code -Dlsp.probe=true}). Establishes
+ * the exact wire shape of jdtls's {@code java.edit.handlePasteEvent} (#742) before wiring it into the
+ * paste path: what the params look like, what comes back, and whether it needs an extended capability.
+ * Self-contained — builds its own throwaway project, so it only needs a local jdtls.
+ */
+@Tag("probe")
+class JdtlsPasteProbeTest {
+
+    private static final String[] JDTLS_CANDIDATES = {
+        System.getProperty("user.home") + "/.editora/plugins/lsp/java/bin/jdtls",
+        System.getProperty("user.home") + "/.editora-dev/plugins/lsp/java/bin/jdtls",
+        "/opt/homebrew/bin/jdtls",
+        "/usr/local/bin/jdtls",
+    };
+
+    private static String jdtls() {
+        for (String c : JDTLS_CANDIDATES) {
+            if (Files.isExecutable(Path.of(c))) {
+                return c;
+            }
+        }
+        return null;
+    }
+
+    static final class ProbeClient implements LanguageClient {
+        @Override
+        public void telemetryEvent(Object o) {}
+
+        @Override
+        public void publishDiagnostics(PublishDiagnosticsParams p) {}
+
+        @Override
+        public void showMessage(MessageParams p) {}
+
+        @Override
+        public java.util.concurrent.CompletableFuture<MessageActionItem> showMessageRequest(
+                ShowMessageRequestParams p) {
+            return java.util.concurrent.CompletableFuture.completedFuture(null);
+        }
+
+        @Override
+        public void logMessage(MessageParams p) {}
+    }
+
+    @Test
+    void probePasteEvent() throws Exception {
+        org.junit.jupiter.api.Assumptions.assumeTrue(Boolean.getBoolean("lsp.probe"), "opt-in: pass -Dlsp.probe=true");
+        String jdtls = jdtls();
+        org.junit.jupiter.api.Assumptions.assumeTrue(jdtls != null, "needs a local jdtls");
+
+        // Throwaway project: a bare source tree, no build file (jdtls's invisible-project mode).
+        Path project = Files.createTempDirectory("jdtls-paste-probe");
+        Path src = project.resolve("src/demo");
+        Files.createDirectories(src);
+        Path file = src.resolve("App.java");
+        String original =
+                "package demo;\n\npublic class App {\n    public static void main(String[] args) {\n" + "    }\n}\n";
+        Files.writeString(file, original);
+        String uri = file.toUri().toString();
+
+        Path data = Files.createTempDirectory("jdtls-paste-data");
+        ProcessBuilder pb = new ProcessBuilder(jdtls, "-data", data.toString());
+        pb.redirectError(ProcessBuilder.Redirect.DISCARD);
+        Process proc = pb.start();
+        try {
+            Launcher<LanguageServer> launcher =
+                    LSPLauncher.createClientLauncher(new ProbeClient(), proc.getInputStream(), proc.getOutputStream());
+            LanguageServer server = launcher.getRemoteProxy();
+            launcher.startListening();
+
+            InitializeParams ip = new InitializeParams();
+            ip.setProcessId((int) ProcessHandle.current().pid());
+            ip.setRootUri(project.toUri().toString());
+            ip.setWorkspaceFolders(List.of(new WorkspaceFolder(project.toUri().toString(), "probe")));
+            ip.setCapabilities(new ClientCapabilities());
+            // Mirror production: Editora sends extendedClientCapabilities (see LspManager.initOptionsFor).
+            ip.setInitializationOptions(Map.of("extendedClientCapabilities", Map.of("classFileContentsSupport", true)));
+            InitializeResult init = server.initialize(ip).get(120, TimeUnit.SECONDS);
+            server.initialized(new InitializedParams());
+
+            var cmds = init.getCapabilities().getExecuteCommandProvider();
+            boolean advertised = cmds != null && cmds.getCommands().contains("java.edit.handlePasteEvent");
+            System.out.println("=== handlePasteEvent advertised: " + advertised);
+            System.out.println("=== all java.edit.* commands: "
+                    + (cmds == null
+                            ? "none"
+                            : cmds.getCommands().stream()
+                                    .filter(c -> c.startsWith("java.edit"))
+                                    .toList()));
+
+            server.getTextDocumentService()
+                    .didOpen(new DidOpenTextDocumentParams(new TextDocumentItem(uri, "java", 1, original)));
+            System.out.println("=== waiting 30s for the (invisible) project to settle ===");
+            Thread.sleep(30_000);
+
+            // Simulate the paste: insert a line that needs java.util imports into main()'s body.
+            String pasted = "        List<String> xs = new ArrayList<>();\n";
+            String after = original.replace(
+                    "    public static void main(String[] args) {\n", // splice below the brace
+                    "    public static void main(String[] args) {\n" + pasted);
+            var change = new DidChangeTextDocumentParams(
+                    new VersionedTextDocumentIdentifier(uri, 2), List.of(new TextDocumentContentChangeEvent(after)));
+            server.getTextDocumentService().didChange(change);
+            Thread.sleep(2_000);
+
+            // The pasted text spans line 4 col 0 .. line 5 col 0 (it ends in \n).
+            com.google.gson.JsonObject range = new com.google.gson.JsonObject();
+            com.google.gson.JsonObject start = new com.google.gson.JsonObject();
+            start.addProperty("line", 4);
+            start.addProperty("character", 0);
+            com.google.gson.JsonObject end = new com.google.gson.JsonObject();
+            end.addProperty("line", 5);
+            end.addProperty("character", 0);
+            range.add("start", start);
+            range.add("end", end);
+            com.google.gson.JsonObject location = new com.google.gson.JsonObject();
+            location.addProperty("uri", uri);
+            location.add("range", range);
+            com.google.gson.JsonObject fmt = new com.google.gson.JsonObject();
+            fmt.addProperty("tabSize", 4);
+            fmt.addProperty("insertSpaces", true);
+            com.google.gson.JsonObject params = new com.google.gson.JsonObject();
+            params.add("location", location);
+            params.addProperty("text", pasted);
+            params.add("formattingOptions", fmt);
+
+            // Shape A: the params object itself. Shape B: the object as a JSON string (several jdt.ls
+            // delegate commands take stringified json). Shape C: a lsp4j-typed Location + separate args.
+            List<List<Object>> attempts = List.of(
+                    List.of(params),
+                    List.of(params.toString()),
+                    List.of(new Location(uri, new Range(new Position(4, 0), new Position(5, 0))), pasted));
+            String[] names = {"A: JsonObject", "B: json string", "C: positional"};
+            for (int i = 0; i < attempts.size(); i++) {
+                System.out.println("=== attempt " + names[i] + " ===");
+                try {
+                    Object r = server.getWorkspaceService()
+                            .executeCommand(new ExecuteCommandParams("java.edit.handlePasteEvent", attempts.get(i)))
+                            .get(30, TimeUnit.SECONDS);
+                    System.out.println("RESULT: " + r);
+                    break;
+                } catch (Exception e) {
+                    System.out.println("THREW: " + String.valueOf(e).replace('\n', ' '));
+                }
+            }
+
+            server.shutdown().get(20, TimeUnit.SECONDS);
+            server.exit();
+        } finally {
+            proc.destroyForcibly();
+        }
+    }
+}

--- a/src/test/java/com/editora/lsp/JdtlsPasteTest.java
+++ b/src/test/java/com/editora/lsp/JdtlsPasteTest.java
@@ -1,0 +1,81 @@
+package com.editora.lsp;
+
+import java.util.List;
+
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import org.eclipse.lsp4j.ExecuteCommandOptions;
+import org.eclipse.lsp4j.ServerCapabilities;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Pins the {@code java.edit.handlePasteEvent} wire shapes (no toolkit). Both were established against a
+ * live jdtls ({@code JdtlsPasteProbeTest}); these tests keep them from drifting — a shape regression here
+ * fails no compile and no other test, the paste just silently stops importing (#723's failure mode).
+ */
+class JdtlsPasteTest {
+
+    @Test
+    void paramsJsonMatchesTheShapeTheLiveServerAccepted() {
+        String json = JdtlsPaste.paramsJson("file:///tmp/App.java", 4, 0, 5, 0, "List<String> xs;\n", 4, true);
+        JsonObject p = JsonParser.parseString(json).getAsJsonObject();
+        JsonObject location = p.getAsJsonObject("location");
+        assertEquals("file:///tmp/App.java", location.get("uri").getAsString());
+        JsonObject range = location.getAsJsonObject("range");
+        assertEquals(4, range.getAsJsonObject("start").get("line").getAsInt());
+        assertEquals(0, range.getAsJsonObject("start").get("character").getAsInt());
+        assertEquals(5, range.getAsJsonObject("end").get("line").getAsInt());
+        assertEquals("List<String> xs;\n", p.get("text").getAsString());
+        JsonObject fmt = p.getAsJsonObject("formattingOptions");
+        assertEquals(4, fmt.get("tabSize").getAsInt());
+        assertTrue(fmt.get("insertSpaces").getAsBoolean());
+    }
+
+    @Test
+    void paramsJsonEscapesThePastedTextItself() {
+        // The pasted text is arbitrary source — quotes, newlines, backslashes. Built by gson, not concat,
+        // so it must survive a parse round-trip verbatim.
+        String nasty = "String s = \"a\\\"b\";\n\t// \\ tricky\n";
+        String json = JdtlsPaste.paramsJson("file:///x", 0, 0, 2, 0, nasty, 2, false);
+        assertEquals(
+                nasty,
+                JsonParser.parseString(json).getAsJsonObject().get("text").getAsString());
+    }
+
+    @Test
+    void supportsPasteEventReadsTheAdvertisedCommandList() {
+        ServerCapabilities caps = new ServerCapabilities();
+        assertFalse(JdtlsPaste.supportsPasteEvent(caps), "no provider");
+        caps.setExecuteCommandProvider(new ExecuteCommandOptions(List.of("java.edit.organizeImports")));
+        assertFalse(JdtlsPaste.supportsPasteEvent(caps), "provider without the command");
+        caps.setExecuteCommandProvider(
+                new ExecuteCommandOptions(List.of("java.edit.organizeImports", "java.edit.handlePasteEvent")));
+        assertTrue(JdtlsPaste.supportsPasteEvent(caps));
+        assertFalse(JdtlsPaste.supportsPasteEvent(null));
+    }
+
+    @Test
+    void additionalEditIsExtractedFromTheDocumentPasteEditShape() {
+        // The captured live answer: {insertText: ..., additionalEdit: {changes: {uri: [textEdit...]}}}.
+        String answer = "{\"insertText\":\"        List<String> xs;\\n\",\"additionalEdit\":{\"changes\":"
+                + "{\"file:///tmp/App.java\":[{\"range\":{\"start\":{\"line\":0,\"character\":13},"
+                + "\"end\":{\"line\":2,\"character\":0}},\"newText\":\"\\n\\nimport java.util.List;\\n\\n\"}]}}}";
+        var edit = JdtlsPaste.additionalEdit(JsonParser.parseString(answer));
+        assertTrue(edit != null && edit.isJsonObject());
+        assertTrue(edit.getAsJsonObject().has("changes"));
+    }
+
+    @Test
+    void anAnswerWithoutAnEditYieldsNullNotAThrow() {
+        assertNull(JdtlsPaste.additionalEdit(null));
+        assertNull(JdtlsPaste.additionalEdit("not json"));
+        assertNull(JdtlsPaste.additionalEdit(JsonParser.parseString("{\"insertText\":\"x\"}")));
+        assertNull(JdtlsPaste.additionalEdit(JsonParser.parseString("{\"additionalEdit\":null}")));
+        assertNull(JdtlsPaste.additionalEdit(JsonParser.parseString("[]")));
+    }
+}

--- a/src/test/java/com/editora/lsp/LspPasteEventFxTest.java
+++ b/src/test/java/com/editora/lsp/LspPasteEventFxTest.java
@@ -1,0 +1,168 @@
+package com.editora.lsp;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import com.google.gson.JsonParser;
+import org.eclipse.lsp4j.ExecuteCommandOptions;
+import org.eclipse.lsp4j.ServerCapabilities;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.testfx.api.FxToolkit;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * The {@code handlePasteEvent} round-trip (#742) against the recording fake: what goes on the wire —
+ * the params, not that the call compiles (#725's lesson) — and what the answer does. The wire shapes
+ * themselves are pinned pure in {@link JdtlsPasteTest}; this proves {@link LspManager} actually sends
+ * them, honours the capability gate, and drops a stale answer instead of applying it.
+ */
+@Tag("fx")
+class LspPasteEventFxTest {
+
+    @BeforeAll
+    static void bootToolkit() throws Exception {
+        FxToolkit.registerPrimaryStage();
+    }
+
+    @TempDir
+    Path root;
+
+    private LspManager manager;
+    private final List<FakeLanguageServer> fakes = new CopyOnWriteArrayList<>();
+    private Path file;
+    private ServerCapabilities capabilities = new ServerCapabilities();
+
+    @BeforeEach
+    void setUp() throws Exception {
+        fakes.clear();
+        capabilities = new ServerCapabilities();
+        capabilities.setExecuteCommandProvider(new ExecuteCommandOptions(List.of(JdtlsPaste.COMMAND)));
+        manager = new LspManager((f, d) -> {}, (t, m) -> {});
+        manager.setSessionStarterForTest(session -> {
+            FakeLanguageServer fake = new FakeLanguageServer();
+            fakes.add(fake);
+            session.attachForTest(fake, capabilities);
+        });
+        manager.configure(true, Map.of("java", "jdtls"));
+        file = root.resolve("A.java");
+        Files.writeString(file, "class A {}\n");
+    }
+
+    @AfterEach
+    void tearDown() {
+        manager.shutdownAll();
+    }
+
+    private FakeLanguageServer open() {
+        manager.openDocument(file, root, "java", "class A {}");
+        return fakes.get(0);
+    }
+
+    private boolean paste(java.util.function.BooleanSupplier stillValid) throws Exception {
+        var result = new AtomicReference<Boolean>();
+        var latch = new CountDownLatch(1);
+        manager.handlePasteEvent(file, 4, 0, 5, 0, "List<String> xs;\n", 4, true, stillValid, applied -> {
+            result.set(applied);
+            latch.countDown();
+        });
+        assertTrue(latch.await(10, TimeUnit.SECONDS), "the callback never fired");
+        return result.get();
+    }
+
+    /** The captured live-jdtls answer shape: {@code {insertText, additionalEdit}}. */
+    private static com.google.gson.JsonElement pasteAnswer(String uri) {
+        return JsonParser.parseString("{\"insertText\":\"List<String> xs;\\n\",\"additionalEdit\":{\"changes\":{\""
+                + uri
+                + "\":[{\"range\":{\"start\":{\"line\":0,\"character\":13},\"end\":{\"line\":2,\"character\":0}},"
+                + "\"newText\":\"\\n\\nimport java.util.List;\\n\\n\"}]}}}");
+    }
+
+    @Test
+    void sendsTheStringifiedParamsTheLiveServerRequires() throws Exception {
+        FakeLanguageServer fake = open();
+        fake.executeCommandResponse = pasteAnswer(file.toUri().toString());
+        manager.setApplyEditHandler(edits -> true);
+
+        assertTrue(paste(() -> true));
+
+        assertEquals(1, fake.executedCommands.size());
+        var sent = fake.executedCommands.get(0);
+        assertEquals(JdtlsPaste.COMMAND, sent.getCommand());
+        assertEquals(1, sent.getArguments().size(), "exactly one argument");
+        Object arg = sent.getArguments().get(0);
+        // THE point: a JSON *string*, not an object — an object deserializes to null server-side.
+        String json = arg instanceof com.google.gson.JsonPrimitive p ? p.getAsString() : (String) arg;
+        var parsed = JsonParser.parseString(json).getAsJsonObject();
+        assertEquals(
+                file.toUri().toString(),
+                parsed.getAsJsonObject("location").get("uri").getAsString());
+        assertEquals("List<String> xs;\n", parsed.get("text").getAsString());
+        assertTrue(
+                parsed.getAsJsonObject("formattingOptions").get("insertSpaces").getAsBoolean());
+    }
+
+    @Test
+    void theAdditionalEditReachesTheApplyHandler() throws Exception {
+        FakeLanguageServer fake = open();
+        fake.executeCommandResponse = pasteAnswer(file.toUri().toString());
+        var applied = new AtomicReference<WorkspaceEditMapper.Mapped>();
+        manager.setApplyEditHandler(edits -> {
+            applied.set(edits);
+            return true;
+        });
+
+        assertTrue(paste(() -> true));
+        assertTrue(applied.get() != null, "the import edit was handed to the apply handler");
+    }
+
+    @Test
+    void aStaleAnswerIsDroppedNotApplied() throws Exception {
+        FakeLanguageServer fake = open();
+        fake.executeCommandResponse = pasteAnswer(file.toUri().toString());
+        var applied = new AtomicReference<WorkspaceEditMapper.Mapped>();
+        manager.setApplyEditHandler(edits -> {
+            applied.set(edits);
+            return true;
+        });
+
+        assertFalse(paste(() -> false), "the user typed during the round trip — the answer must be dropped");
+        assertTrue(applied.get() == null, "nothing may reach the apply handler for a stale answer");
+    }
+
+    @Test
+    void aServerWithoutTheCommandIsNeverAsked() throws Exception {
+        capabilities = new ServerCapabilities(); // no executeCommandProvider at all
+        FakeLanguageServer fake = open();
+
+        assertFalse(paste(() -> true));
+        assertTrue(fake.executedCommands.isEmpty(), "no request may go out — the server never advertised it");
+    }
+
+    @Test
+    void anAnswerWithNoEditReportsFalseWithoutApplying() throws Exception {
+        FakeLanguageServer fake = open();
+        fake.executeCommandResponse = JsonParser.parseString("{\"insertText\":\"x\"}"); // nothing to import
+        var applied = new AtomicReference<WorkspaceEditMapper.Mapped>();
+        manager.setApplyEditHandler(edits -> {
+            applied.set(edits);
+            return true;
+        });
+
+        assertFalse(paste(() -> true));
+        assertTrue(applied.get() == null);
+    }
+}

--- a/src/test/java/com/editora/ui/PasteImportsBufferFxTest.java
+++ b/src/test/java/com/editora/ui/PasteImportsBufferFxTest.java
@@ -1,0 +1,137 @@
+package com.editora.ui;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+import com.editora.editor.EditorBuffer;
+import org.fxmisc.richtext.CodeArea;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * {@link EditorBuffer#requestLspPasteImports}'s buffer-side contract (#742): the gates that keep it
+ * silent, the positions it derives from the pasted span, and the {@code stillValid} supplier that turns
+ * a later edit into a dropped answer. The wire itself is covered in {@code LspPasteEventFxTest}.
+ */
+@Tag("fx")
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class PasteImportsBufferFxTest {
+
+    private record Captured(int startLine, int startChar, int endLine, int endChar, String text) {}
+
+    @BeforeAll
+    void setUp() throws Exception {
+        FxTestSupport.bootToolkit();
+    }
+
+    private static final String SRC = "class A {\n    void m() {\n    }\n}\n";
+
+    /** A java-ish buffer with the paste requester stubbed; returns [buffer, captured, validHolder]. */
+    private EditorBuffer buffer(
+            AtomicReference<Captured> captured, AtomicReference<java.util.function.BooleanSupplier> valid)
+            throws Exception {
+        return FxTestSupport.callOnFx(() -> {
+            EditorBuffer b = new EditorBuffer();
+            b.setLanguageOverride("java");
+            b.getNode();
+            b.setContent(SRC);
+            b.setLspActive(true);
+            b.setLspPasteImportsRequester((sl, sc, el, ec, text, stillValid) -> {
+                captured.set(new Captured(sl, sc, el, ec, text));
+                valid.set(stillValid);
+            });
+            return b;
+        });
+    }
+
+    @Test
+    void reportsThePostPasteSpanAsPositionsAndText() throws Exception {
+        var captured = new AtomicReference<Captured>();
+        var valid = new AtomicReference<java.util.function.BooleanSupplier>();
+        EditorBuffer b = buffer(captured, valid);
+
+        FxTestSupport.runOnFx(() -> {
+            CodeArea area = FxTestSupport.field(b, "area");
+            int at = SRC.indexOf("    }\n"); // start of line 2
+            String pasted = "        int x;\n";
+            area.insertText(at, pasted);
+            b.requestLspPasteImports(at, at + pasted.length());
+        });
+
+        Captured c = captured.get();
+        assertTrue(c != null, "the requester fired");
+        assertEquals(2, c.startLine());
+        assertEquals(0, c.startChar());
+        assertEquals(3, c.endLine());
+        assertEquals(0, c.endChar());
+        assertEquals("        int x;\n", c.text());
+        assertTrue(valid.get().getAsBoolean(), "no edit since the paste — the answer would apply");
+    }
+
+    @Test
+    void stillValidFlipsFalseOnceTheUserKeepsTyping() throws Exception {
+        var captured = new AtomicReference<Captured>();
+        var valid = new AtomicReference<java.util.function.BooleanSupplier>();
+        EditorBuffer b = buffer(captured, valid);
+
+        FxTestSupport.runOnFx(() -> {
+            CodeArea area = FxTestSupport.field(b, "area");
+            area.insertText(0, "// pasted\n");
+            b.requestLspPasteImports(0, 10);
+        });
+        assertTrue(valid.get().getAsBoolean());
+
+        FxTestSupport.runOnFx(() -> {
+            CodeArea area = FxTestSupport.field(b, "area");
+            area.insertText(0, "x"); // the round trip lost the race
+        });
+        assertFalse(valid.get().getAsBoolean(), "an edit after the request must invalidate the answer");
+    }
+
+    @Test
+    void theGatesKeepItSilent() throws Exception {
+        var captured = new AtomicReference<Captured>();
+        var valid = new AtomicReference<java.util.function.BooleanSupplier>();
+        EditorBuffer b = buffer(captured, valid);
+
+        FxTestSupport.runOnFx(() -> {
+            b.setLspPasteImportsEnabled(false); // the Settings gate
+            b.requestLspPasteImports(0, 5);
+        });
+        assertNull(captured.get(), "disabled → no request");
+
+        FxTestSupport.runOnFx(() -> {
+            b.setLspPasteImportsEnabled(true);
+            b.setLspActive(false); // no live server for this buffer
+            b.requestLspPasteImports(0, 5);
+        });
+        assertNull(captured.get(), "no LSP → no request");
+
+        FxTestSupport.runOnFx(() -> {
+            b.setLspActive(true);
+            b.setViewMode(true); // read-only
+            b.requestLspPasteImports(0, 5);
+        });
+        assertNull(captured.get(), "read-only → no request");
+
+        FxTestSupport.runOnFx(() -> {
+            b.setViewMode(false);
+            b.requestLspPasteImports(5, 5); // empty span
+        });
+        assertNull(captured.get(), "empty span → no request");
+
+        FxTestSupport.runOnFx(() -> {
+            CodeArea area = FxTestSupport.field(b, "area");
+            area.selectRange(1, 0, 2, 0);
+            b.narrowTo(area.getSelection().getStart(), area.getSelection().getEnd());
+            b.requestLspPasteImports(0, 3);
+        });
+        assertNull(captured.get(), "narrowed → coordinates are region-relative, so no request");
+    }
+}


### PR DESCRIPTION
Closes #742. Pasting code into a java buffer now asks jdtls what imports the pasted text needs and applies them — the one paste behaviour nothing else in the stack can approximate, since it needs the type resolver.

## Two wire shapes, both established empirically

Both defy the obvious guess; both were pinned against a live jdtls (`JdtlsPasteProbeTest`, kept in-tree as an opt-in probe) and are locked by pure tests so a drift fails a test instead of silently un-importing (#723's failure mode):

1. **The params must be a stringified JSON**, not a JSON object. An object argument deserializes to `null` server-side, answering an internal error naming `PasteEventParams.getLocation()` — the same delegate-command quirk family #746 records.
2. **The answer is not a `WorkspaceEdit`** — it is VS Code's `DocumentPasteEdit` shape, `{insertText, additionalEdit}`. Editora invokes the command *after* the paste has landed (VS Code's paste provider intercepts it), so only `additionalEdit` — the import insertion — is applied; `insertText` just echoes the paste.

## A divergence from the issue

The issue anticipated reusing `LspEditShift` (#410's guard). It is unnecessary here: the request is sent **post-paste** with the pending didChange flushed first (the `requestLspCompletion` idiom — JSON-RPC preserves order), so the server computes against exactly the on-screen text. What *is* needed instead is a staleness guard for the round trip — the requester carries a `docVersion`-check `BooleanSupplier` consulted on the FX thread immediately before applying, so an answer that lost a race with the user's typing is dropped, never applied to text it wasn't computed for.

## Gating, outermost-in

`Settings.lspPasteImports` (default on, as in VS Code; schema 90→91; Settings → Code Completion checkbox + palette `view.togglePasteImports`) → an editable, non-narrowed, LSP-managed buffer (narrowed coordinates are region-relative — the same reason LSP sync is suspended there) → **the server actually advertising the command** (`JdtlsPaste.supportsPasteEvent`), so a non-jdtls setup never even sends a request and no other language pays anything.

The hook rides `MainController.onPaste`'s single-caret text path; the markdown-image, smart-link and multi-caret paste branches return before it, and the editor context-menu paste (a direct `area.paste()`) is deliberately not covered. The import edit applies through the existing workspace-edit path, so it behaves like every other server edit under undo.

## Verification

- Full `./mvnw verify`: **3533 tests, 0 failures** (skips: the 2 pre-existing jdtls probes + this PR's own opt-in probe).
- 5 pure (`JdtlsPasteTest` — the wire shapes, from the captured live answers) + 5 FX (`LspPasteEventFxTest` — what actually goes on the wire against the recording fake, the capability gate, the stale-answer drop) + 3 FX (`PasteImportsBufferFxTest` — the buffer-side gates, position derivation, the version supplier flipping on a later edit).
- The live end-to-end (a real paste in the running app) remains a manual device check; the probe pinned the server side and the fakes pin everything between.

🤖 Generated with [Claude Code](https://claude.com/claude-code)