### PR TITLE
feat(lsp): smart semicolon placement for Java (jdtls)

### DIFF
--- a/src/main/java/com/editora/config/Settings.java
+++ b/src/main/java/com/editora/config/Settings.java
@@ -40,7 +40,7 @@ public class Settings {
     }
 
     /** Current on-disk schema version of {@code settings.toml}; bump when the format changes (+ a migration). */
-    public static final int SCHEMA_VERSION = 91;
+    public static final int SCHEMA_VERSION = 92;
 
     private int schemaVersion = SCHEMA_VERSION;
 
@@ -143,6 +143,8 @@ public class Settings {
     private boolean lspOnTypeFormatting = false;
     /** Auto-import for pasted code via jdtls's paste event (#742): on by default, as in VS Code. */
     private boolean lspPasteImports = true;
+    /** Smart-semicolon detection (#746): OFF by default, as in VS Code — it moves a typed character. */
+    private boolean lspSmartSemicolon;
     /** Honor a project's {@code .editorconfig} (indent, EOL, charset, trim/final-newline, max line length). */
     private boolean editorConfigSupport = true;
     /** Highlight configured patterns (TODO/FIXME/…) in the editor + list them in the TODO tool window. */
@@ -1075,6 +1077,14 @@ public class Settings {
 
     public void setLspPasteImports(boolean lspPasteImports) {
         this.lspPasteImports = lspPasteImports;
+    }
+
+    public boolean isLspSmartSemicolon() {
+        return lspSmartSemicolon;
+    }
+
+    public void setLspSmartSemicolon(boolean lspSmartSemicolon) {
+        this.lspSmartSemicolon = lspSmartSemicolon;
     }
 
     public void setLspOnTypeFormatting(boolean lspOnTypeFormatting) {

--- a/src/main/java/com/editora/config/migration/ConfigSchema.java
+++ b/src/main/java/com/editora/config/migration/ConfigSchema.java
@@ -153,7 +153,8 @@ public enum ConfigSchema {
                     // only a fresh config dir, since every existing settings.toml stores the old false.
                     Map.entry(88, (Migration) ConfigMigrations::enableProjectSupport),
                     Map.entry(89, (Migration) ConfigMigrations::identity), // v89→90: + bracketColors (additive)
-                    Map.entry(90, (Migration) ConfigMigrations::identity))), // v90→91: + lspPasteImports (additive)
+                    Map.entry(90, (Migration) ConfigMigrations::identity), // v90→91: + lspPasteImports (additive)
+                    Map.entry(91, (Migration) ConfigMigrations::identity))), // v91→92: + lspSmartSemicolon (additive)
     // v1 → v2 added the editor-group layout + OpenFile.group. Both default to the old single-group
     // behaviour, so the step is identity.
     // v1→v2 editor-group layout, v2→v3 RunConfiguration type/target, v3→v4 selectedRunConfig — all additive

--- a/src/main/java/com/editora/editor/EditorBuffer.java
+++ b/src/main/java/com/editora/editor/EditorBuffer.java
@@ -7677,9 +7677,91 @@ public class EditorBuffer implements TabContent {
                 return;
             }
             char typed = e.getCharacter().charAt(0);
+            // Fires while the caret is still where the user typed and the document has no ';' yet — the
+            // state the server's answer is expressed in. Never consumes, so the char inserts as normal.
+            maybeSmartSemicolon(a, typed); // #746
             applyCloserDedent(a, typed);
             maybeOnTypeFormat(a, typed); // #740 — after the local assist, which usually already got it right
         });
+    }
+
+    /** Async smart-semicolon lookup; delivers the target {@code {line, character}} or null on the FX thread. */
+    public interface LspSmartSemicolonRequester {
+        void request(int line, int character, java.util.function.Consumer<int[]> callback);
+    }
+
+    private LspSmartSemicolonRequester smartSemicolonRequester;
+    /** {@code Settings.lspSmartSemicolon} — OFF by default, as in VS Code. */
+    private boolean smartSemicolonEnabled;
+
+    private long smartSemicolonGen;
+
+    public void setLspSmartSemicolonRequester(LspSmartSemicolonRequester requester) {
+        this.smartSemicolonRequester = requester;
+    }
+
+    public void setSmartSemicolonEnabled(boolean enabled) {
+        this.smartSemicolonEnabled = enabled;
+    }
+
+    /**
+     * Smart-semicolon detection (#746): a {@code ;} typed part-way through an expression belongs at the end
+     * of the statement — {@code compute(1, 2|)} should become {@code compute(1, 2);|}.
+     *
+     * <p><b>Type first, correct after</b> — the semicolon is never held back waiting for the server. Making
+     * a keystroke wait on a round trip is exactly the latency the performance rules forbid, and a slow or
+     * cold server would let the character land after whatever was typed next. So the {@code ;} inserts
+     * normally and the answer, if it disagrees, moves it — as a single ranged {@code replaceText}, hence one
+     * undo step rather than a delete plus an insert.
+     *
+     * <p>The consequence, stated rather than hidden: if the user types straight through (a very common
+     * {@code ;}-then-Enter), {@link #docVersion} has moved by more than the semicolon and the correction is
+     * <b>dropped</b>. That is deliberate — the alternative is rewriting text the user has already moved past
+     * — and it leaves the semicolon exactly where it would have been with the feature off, never worse.
+     */
+    private void maybeSmartSemicolon(CodeArea a, char typed) {
+        if (typed != ';' || !smartSemicolonEnabled || !lspActive || smartSemicolonRequester == null) {
+            return;
+        }
+        if (!isEditable() || hugeFile || largeFile || isNarrowed() || hasActiveSnippet()) {
+            return;
+        }
+        int typedAt = a.getCaretPosition();
+        int line = a.getCurrentParagraph();
+        int column = a.getCaretColumn();
+        long version = docVersion;
+        long gen = ++smartSemicolonGen;
+        sendLspChange(); // the position refers to the pre-';' text, so the server must have exactly that
+        smartSemicolonRequester.request(line, column, target -> {
+            // docVersion bumps once per change, so "+1" is precisely "only the semicolon landed since".
+            if (gen != smartSemicolonGen || target == null || a.getScene() == null || docVersion != version + 1) {
+                return;
+            }
+            moveTypedSemicolon(a, typedAt, line, column, target);
+        });
+    }
+
+    /**
+     * Moves the just-typed semicolon from {@code typedAt} to the server's target, which is expressed in
+     * <b>pre-insert</b> coordinates — so a target on the same line has to be shifted past the semicolon
+     * that now sits before it, while a target on a later line needs no adjustment (its columns are
+     * untouched and its absolute offset already includes the inserted character).
+     */
+    private void moveTypedSemicolon(CodeArea a, int typedAt, int typedLine, int typedColumn, int[] target) {
+        int targetPost;
+        try {
+            targetPost = target[0] == typedLine && target[1] >= typedColumn
+                    ? a.getAbsolutePosition(target[0], target[1] + 1)
+                    : a.getAbsolutePosition(target[0], target[1]);
+        } catch (RuntimeException outOfRange) {
+            return; // a target the document can no longer address
+        }
+        if (targetPost <= typedAt + 1 || targetPost > a.getLength()) {
+            return; // already where it was typed (the ordinary answer), or past the end
+        }
+        // Rewrite [typedAt, targetPost) as "the text after the semicolon, then the semicolon" — one edit,
+        // so one Ctrl-Z puts it back where it was typed.
+        a.replaceText(typedAt, targetPost, a.getText(typedAt + 1, targetPost) + ";");
     }
 
     /**

--- a/src/main/java/com/editora/lsp/JdtlsSmartSemicolon.java
+++ b/src/main/java/com/editora/lsp/JdtlsSmartSemicolon.java
@@ -1,0 +1,83 @@
+package com.editora.lsp;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+
+/**
+ * The wire shape of jdtls's {@code java.edit.smartSemicolonDetection} (#746): typing {@code ;} part-way
+ * through an expression should put it at the end of the statement instead, so {@code compute(1, 2|)}
+ * becomes {@code compute(1, 2);|} rather than {@code compute(1, 2;)}.
+ *
+ * <p>Established <b>empirically</b> against a live jdtls ({@code JdtlsPasteProbeTest}), because two things
+ * about it are invisible from the protocol:
+ *
+ * <ul>
+ *   <li>The params are a <b>stringified JSON</b> {@code {uri, position}} — the same encoding
+ *       {@link JdtlsPaste} needs, and passing an object instead fails with a gson type error.
+ *   <li>The handler answers <b>{@code null} until {@code java.edit.smartSemicolonDetection.enabled} is
+ *       pushed via {@code didChangeConfiguration}</b> — the {@code signatureHelp.enabled} (#674) and
+ *       {@code provideFormatter} (#468) pattern again: advertised unconditionally, inert by preference.
+ *       Before the push every argument shape answered null, which is indistinguishable from "nothing to
+ *       do here" and would have read as the wrong params.
+ * </ul>
+ *
+ * Pure; unit-tested against the captured shapes.
+ */
+public final class JdtlsSmartSemicolon {
+
+    /** The delegate command id, as advertised in {@code executeCommandProvider.commands}. */
+    public static final String COMMAND = "java.edit.smartSemicolonDetection";
+
+    private JdtlsSmartSemicolon() {}
+
+    /** Whether {@code caps} advertises the command (only jdtls does today). */
+    public static boolean supported(org.eclipse.lsp4j.ServerCapabilities caps) {
+        return caps != null
+                && caps.getExecuteCommandProvider() != null
+                && caps.getExecuteCommandProvider().getCommands() != null
+                && caps.getExecuteCommandProvider().getCommands().contains(COMMAND);
+    }
+
+    /** The stringified {@code {uri, position}} params, built with gson so a URI never needs escaping care. */
+    public static String paramsJson(String uri, int line, int character) {
+        JsonObject position = new JsonObject();
+        position.addProperty("line", line);
+        position.addProperty("character", character);
+        JsonObject params = new JsonObject();
+        params.addProperty("uri", uri);
+        params.add("position", position);
+        return params.toString();
+    }
+
+    /**
+     * The {@code position} of the answer as {@code {line, character}}, or {@code null} when the server
+     * answered nothing (the ordinary case — the caret is already at the statement end, or the preference
+     * is off). Defensive rather than throwing: the reply crosses a version boundary we don't control, and
+     * a malformed one must degrade to "type the semicolon normally".
+     *
+     * <p>The numbers arrive as JSON doubles through gson's untyped mapping, so they are read as such and
+     * truncated — reading them as ints throws on a {@code 29.0}.
+     */
+    public static int[] answeredPosition(Object rawResult) {
+        if (!(rawResult instanceof JsonElement json) || !json.isJsonObject()) {
+            return null;
+        }
+        JsonElement pos = json.getAsJsonObject().get("position");
+        if (pos == null || !pos.isJsonObject()) {
+            return null;
+        }
+        JsonObject p = pos.getAsJsonObject();
+        JsonElement line = p.get("line");
+        JsonElement character = p.get("character");
+        if (line == null || character == null || !line.isJsonPrimitive() || !character.isJsonPrimitive()) {
+            return null;
+        }
+        try {
+            int l = (int) line.getAsDouble();
+            int c = (int) character.getAsDouble();
+            return l < 0 || c < 0 ? null : new int[] {l, c};
+        } catch (RuntimeException malformed) {
+            return null;
+        }
+    }
+}

--- a/src/main/java/com/editora/lsp/LanguageServerSession.java
+++ b/src/main/java/com/editora/lsp/LanguageServerSession.java
@@ -471,8 +471,18 @@ final class LanguageServerSession implements LanguageClient {
             java.util.Map<String, Object> signatureHelp = new java.util.HashMap<>();
             signatureHelp.put("enabled", true);
             signatureHelp.put("description", true); // include the javadoc in the signature popup
+            // Same shape of gate for smart-semicolon detection (#746): jdtls advertises
+            // java.edit.smartSemicolonDetection unconditionally, but its handler answers null until this
+            // preference is set — verified against a real jdtls (null for every argument shape before,
+            // the target position after). Editora then gates the *behaviour* on its own setting, so
+            // enabling the server-side capability here costs nothing when the feature is off.
+            java.util.Map<String, Object> smartSemicolon = new java.util.HashMap<>();
+            smartSemicolon.put("enabled", true);
+            java.util.Map<String, Object> edit = new java.util.HashMap<>();
+            edit.put("smartSemicolonDetection", smartSemicolon);
             java.util.Map<String, Object> java_ = new java.util.HashMap<>();
             java_.put("signatureHelp", signatureHelp);
+            java_.put("edit", edit);
             java.util.Map<String, Object> settings = new java.util.HashMap<>();
             settings.put("python", python);
             settings.put("java", java_);

--- a/src/main/java/com/editora/lsp/LspManager.java
+++ b/src/main/java/com/editora/lsp/LspManager.java
@@ -2384,6 +2384,30 @@ public final class LspManager {
                 });
     }
 
+    /**
+     * Smart-semicolon detection (#746): asks jdtls where a {@code ;} typed at {@code (line, character)}
+     * belongs — normally the end of the enclosing statement. Delivers the answered {@code {line, char}} on
+     * the FX thread, or {@code null} when the server has nothing to say (already at the statement end, or
+     * not a jdtls session). Gated on the command being advertised, so no other language pays a request.
+     *
+     * <p>The document must be in the state the caret refers to — i.e. <b>before</b> the semicolon is typed —
+     * which is why the caller flushes its pending didChange first.
+     */
+    public void smartSemicolonPosition(Path file, int line, int character, Consumer<int[]> cb) {
+        LanguageServerSession s = sessionFor(file);
+        if (s == null || !JdtlsSmartSemicolon.supported(s.capabilities())) {
+            Platform.runLater(() -> cb.accept(null));
+            return;
+        }
+        String params = JdtlsSmartSemicolon.paramsJson(uri(file), line, character);
+        s.executeCommand(JdtlsSmartSemicolon.COMMAND, List.of(params))
+                .orTimeout(5, java.util.concurrent.TimeUnit.SECONDS)
+                .whenComplete((r, e) -> {
+                    int[] at = e != null ? null : JdtlsSmartSemicolon.answeredPosition(asJson(r));
+                    Platform.runLater(() -> cb.accept(at));
+                });
+    }
+
     /** Decodes a {@code java/generate…} answer (an untyped {@code WorkspaceEdit}) into the typed form. */
     private static org.eclipse.lsp4j.WorkspaceEdit asWorkspaceEdit(Object raw) {
         try {

--- a/src/main/java/com/editora/ui/LspCoordinator.java
+++ b/src/main/java/com/editora/ui/LspCoordinator.java
@@ -1278,6 +1278,14 @@ final class LspCoordinator {
                         applied -> {});
             }
         });
+        // Smart-semicolon detection (#746): where does a ';' typed here belong?
+        buffer.setLspSmartSemicolonRequester((line, character, cb) -> {
+            if (buffer.getPath() != null && lspManager.isManaged(buffer.getPath())) {
+                lspManager.smartSemicolonPosition(buffer.getPath(), line, character, cb);
+            } else {
+                cb.accept(null);
+            }
+        });
         // On-type formatting (#740): re-indent the line after a server-declared trigger character.
         buffer.setLspOnTypeFormatter((line, character, ch, cb) -> {
             if (buffer.getPath() != null && lspManager.isManaged(buffer.getPath())) {

--- a/src/main/java/com/editora/ui/MainController.java
+++ b/src/main/java/com/editora/ui/MainController.java
@@ -12577,6 +12577,7 @@ public class MainController implements com.editora.mcp.McpBridge {
         buffer.setAutoRenameTag(s.isAutoRenameTag()); // paired-tag rename mirroring (html/xml buffers only)
         buffer.setOnTypeFormattingEnabled(s.isLspOnTypeFormatting()); // #740 (inert without an LSP trigger set)
         buffer.setLspPasteImportsEnabled(s.isLspPasteImports()); // #742 (inert without a jdtls session)
+        buffer.setSmartSemicolonEnabled(s.isLspSmartSemicolon()); // #746 (inert without a jdtls session)
         buffer.setAutoCloseTags(s.isAutoCloseTags()); // ">" inserts the matching closer (html/xml buffers only)
         buffer.setFillColumn(s.getFillColumn());
         buffer.setAutoFillEnabled(s.isAutoFill()); // break prose lines at the fill column as you type (prose only)
@@ -15313,6 +15314,13 @@ public class MainController implements com.editora.mcp.McpBridge {
                         "view.togglePasteImports",
                         () -> config.getSettings().isLspPasteImports(),
                         config.getSettings()::setLspPasteImports,
+                        () -> applyViewSettingsToAllBuffers(config.getSettings()))));
+        registry.register(Command.of(
+                "view.toggleSmartSemicolon",
+                () -> toggleSetting(
+                        "view.toggleSmartSemicolon",
+                        () -> config.getSettings().isLspSmartSemicolon(),
+                        config.getSettings()::setLspSmartSemicolon,
                         () -> applyViewSettingsToAllBuffers(config.getSettings()))));
         registry.register(Command.of(
                 "view.toggleInlayHints",

--- a/src/main/java/com/editora/ui/SettingsWindow.java
+++ b/src/main/java/com/editora/ui/SettingsWindow.java
@@ -208,6 +208,7 @@ public class SettingsWindow {
     private CheckBox inlayHintsCheck;
     private CheckBox onTypeFormattingCheck;
     private CheckBox pasteImportsCheck;
+    private CheckBox smartSemicolonCheck;
     private CheckBox spellCheckBox;
     private ComboBox<String> spellLanguageCombo;
     /** The Personal Dictionary list on the Spell Check page; refreshed from {@code dictionary.txt} on show. */
@@ -988,6 +989,7 @@ public class SettingsWindow {
         inlayHintsCheck = viewCheck(tr("settings.inlayHints"), Settings::setInlayHints);
         onTypeFormattingCheck = viewCheck(tr("settings.onTypeFormatting"), Settings::setLspOnTypeFormatting);
         pasteImportsCheck = viewCheck(tr("settings.lspPasteImports"), Settings::setLspPasteImports);
+        smartSemicolonCheck = viewCheck(tr("settings.lspSmartSemicolon"), Settings::setLspSmartSemicolon);
         // The per-source toggles are only meaningful while the master switch is on.
         autocompleteCheck.selectedProperty().addListener((obs, was, now) -> {
             autocompleteProseCheck.setDisable(!now);
@@ -2813,6 +2815,12 @@ public class SettingsWindow {
                 onTypeFormattingCheck,
                 "on-type formatting reindent semicolon brace enter lsp");
         row(p, Category.COMPLETION, completion, pasteImportsCheck, "paste import auto imports java jdtls clipboard");
+        row(
+                p,
+                Category.COMPLETION,
+                completion,
+                smartSemicolonCheck,
+                "smart semicolon detection statement end java jdtls");
         onTypeFormattingCheck.disableProperty().bind(lspCheck.selectedProperty().not());
         // Semantic highlighting comes from LSP: disable it (+ explain why) when LSP is off.
         semanticHighlightCheck
@@ -6373,6 +6381,7 @@ public class SettingsWindow {
             inlayHintsCheck.setSelected(settings.isInlayHints());
             onTypeFormattingCheck.setSelected(settings.isLspOnTypeFormatting());
             pasteImportsCheck.setSelected(settings.isLspPasteImports());
+            smartSemicolonCheck.setSelected(settings.isLspSmartSemicolon());
             pdfLineNumbersCheck.setSelected(settings.isPdfLineNumbers());
             pdfHighlightCheck.setSelected(settings.isPdfSyntaxHighlighting());
             pdfPageSizeCombo.setValue(settings.getPdfPageSize());
@@ -6949,6 +6958,7 @@ public class SettingsWindow {
             inlayHintsCheck.setSelected(s.isInlayHints());
             onTypeFormattingCheck.setSelected(s.isLspOnTypeFormatting());
             pasteImportsCheck.setSelected(s.isLspPasteImports());
+            smartSemicolonCheck.setSelected(s.isLspSmartSemicolon());
         } finally {
             loading = prev;
         }

--- a/src/main/resources/com/editora/i18n/messages.properties
+++ b/src/main/resources/com/editora/i18n/messages.properties
@@ -2262,9 +2262,12 @@ command.view.toggleInlayHints.desc=Show or hide the language server’s paramete
 command.view.toggleOnTypeFormatting.desc=Re-indent the current line when the language server's trigger character is typed.
 command.view.togglePasteImports=View: Toggle Paste Auto-Import
 command.view.togglePasteImports.desc=Enable or disable adding the imports pasted Java code needs.
+command.view.toggleSmartSemicolon=View: Toggle Smart Semicolon Placement
+command.view.toggleSmartSemicolon.desc=Move a semicolon typed mid-expression to the end of the statement.
 settings.inlayHints=Inlay hints (parameter names / types, after the line)
 settings.onTypeFormatting=Re-indent as you type (on-type formatting)
 settings.lspPasteImports=Add imports for pasted code (Java)
+settings.lspSmartSemicolon=Smart semicolon placement (Java)
 command.view.toggleSemanticHighlight.desc=Turn LSP semantic token highlighting on or off.
 settings.semanticHighlight=Semantic highlighting (LSP)
 # TODO / highlight patterns

--- a/src/main/resources/com/editora/i18n/messages_de.properties
+++ b/src/main/resources/com/editora/i18n/messages_de.properties
@@ -2254,9 +2254,12 @@ command.view.toggleInlayHints.desc=Zeigt oder verbirgt die Parameternamen- und T
 command.view.toggleOnTypeFormatting.desc=Rückt die aktuelle Zeile neu ein, wenn das Auslösezeichen des Language-Servers getippt wird.
 command.view.togglePasteImports=Ansicht: Auto-Import beim Einfügen umschalten
 command.view.togglePasteImports.desc=Aktiviert oder deaktiviert das Hinzufügen der Importe, die eingefügter Java-Code benötigt.
+command.view.toggleSmartSemicolon=Ansicht: Intelligente Semikolon-Platzierung umschalten
+command.view.toggleSmartSemicolon.desc=Verschiebt ein mitten im Ausdruck getipptes Semikolon an das Ende der Anweisung.
 settings.inlayHints=Inlay-Hinweise (Parameternamen / Typen, nach der Zeile)
 settings.onTypeFormatting=Beim Tippen neu einrücken (Formatierung bei Eingabe)
 settings.lspPasteImports=Importe für eingefügten Code hinzufügen (Java)
+settings.lspSmartSemicolon=Intelligente Semikolon-Platzierung (Java)
 command.view.toggleSemanticHighlight.desc=Die semantische Token-Hervorhebung über LSP ein- oder ausschalten.
 settings.semanticHighlight=Semantische Hervorhebung (LSP)
 # TODO / highlight patterns

--- a/src/main/resources/com/editora/i18n/messages_es.properties
+++ b/src/main/resources/com/editora/i18n/messages_es.properties
@@ -2254,9 +2254,12 @@ command.view.toggleInlayHints.desc=Muestra u oculta las sugerencias de nombres d
 command.view.toggleOnTypeFormatting.desc=Reindenta la línea actual al escribir el carácter activador del servidor de lenguaje.
 command.view.togglePasteImports=Ver: Alternar auto-importación al pegar
 command.view.togglePasteImports.desc=Habilita o deshabilita añadir las importaciones que necesita el código Java pegado.
+command.view.toggleSmartSemicolon=Ver: Alternar colocación inteligente del punto y coma
+command.view.toggleSmartSemicolon.desc=Mueve al final de la instrucción un punto y coma escrito en mitad de una expresión.
 settings.inlayHints=Sugerencias en línea (nombres de parámetros / tipos, al final de la línea)
 settings.onTypeFormatting=Reindentar al escribir (formato automático)
 settings.lspPasteImports=Añadir importaciones al pegar código (Java)
+settings.lspSmartSemicolon=Colocación inteligente del punto y coma (Java)
 command.view.toggleSemanticHighlight.desc=Activar o desactivar el resaltado mediante tokens semánticos de LSP.
 settings.semanticHighlight=Resaltado semántico (LSP)
 # TODO / highlight patterns

--- a/src/main/resources/com/editora/i18n/messages_fr.properties
+++ b/src/main/resources/com/editora/i18n/messages_fr.properties
@@ -2254,9 +2254,12 @@ command.view.toggleInlayHints.desc=Affiche ou masque les indications de noms de 
 command.view.toggleOnTypeFormatting.desc=Réindente la ligne courante lors de la saisie du caractère déclencheur du serveur de langage.
 command.view.togglePasteImports=Affichage : Basculer l'auto-import au collage
 command.view.togglePasteImports.desc=Active ou désactive l'ajout des imports dont le code Java collé a besoin.
+command.view.toggleSmartSemicolon=Affichage : Basculer le placement intelligent du point-virgule
+command.view.toggleSmartSemicolon.desc=Déplace à la fin de l'instruction un point-virgule saisi au milieu d'une expression.
 settings.inlayHints=Indications en ligne (noms de paramètres / types, après la ligne)
 settings.onTypeFormatting=Réindenter à la frappe (formatage automatique)
 settings.lspPasteImports=Ajouter les imports du code collé (Java)
+settings.lspSmartSemicolon=Placement intelligent du point-virgule (Java)
 command.view.toggleSemanticHighlight.desc=Activer ou désactiver la coloration par jetons sémantiques LSP.
 settings.semanticHighlight=Coloration sémantique (LSP)
 # TODO / highlight patterns

--- a/src/main/resources/com/editora/i18n/messages_it.properties
+++ b/src/main/resources/com/editora/i18n/messages_it.properties
@@ -2254,9 +2254,12 @@ command.view.toggleInlayHints.desc=Mostra o nasconde i suggerimenti di nomi para
 command.view.toggleOnTypeFormatting.desc=Reindenta la riga corrente quando si digita il carattere attivatore del language server.
 command.view.togglePasteImports=Vista: Attiva/disattiva l'auto-import all'incollaggio
 command.view.togglePasteImports.desc=Abilita o disabilita l'aggiunta delle importazioni necessarie al codice Java incollato.
+command.view.toggleSmartSemicolon=Vista: Attiva/disattiva il posizionamento intelligente del punto e virgola
+command.view.toggleSmartSemicolon.desc=Sposta alla fine dell'istruzione un punto e virgola digitato a metà espressione.
 settings.inlayHints=Suggerimenti inline (nomi parametro / tipi, dopo la riga)
 settings.onTypeFormatting=Reindenta durante la digitazione (formattazione automatica)
 settings.lspPasteImports=Aggiungi le importazioni per il codice incollato (Java)
+settings.lspSmartSemicolon=Posizionamento intelligente del punto e virgola (Java)
 command.view.toggleSemanticHighlight.desc=Attiva o disattiva l'evidenziazione tramite token semantici LSP.
 settings.semanticHighlight=Evidenziazione semantica (LSP)
 # TODO / highlight patterns

--- a/src/main/resources/com/editora/i18n/messages_pt.properties
+++ b/src/main/resources/com/editora/i18n/messages_pt.properties
@@ -2254,9 +2254,12 @@ command.view.toggleInlayHints.desc=Mostra ou oculta as dicas de nomes de parâme
 command.view.toggleOnTypeFormatting.desc=Reindenta a linha atual ao digitar o caractere acionador do servidor de linguagem.
 command.view.togglePasteImports=Exibir: Alternar auto-importação ao colar
 command.view.togglePasteImports.desc=Ativa ou desativa a adição das importações de que o código Java colado precisa.
+command.view.toggleSmartSemicolon=Exibir: Alternar posicionamento inteligente do ponto e vírgula
+command.view.toggleSmartSemicolon.desc=Move para o fim da instrução um ponto e vírgula digitado no meio de uma expressão.
 settings.inlayHints=Dicas inline (nomes de parâmetros / tipos, após a linha)
 settings.onTypeFormatting=Reindentar ao digitar (formatação automática)
 settings.lspPasteImports=Adicionar importações para código colado (Java)
+settings.lspSmartSemicolon=Posicionamento inteligente do ponto e vírgula (Java)
 command.view.toggleSemanticHighlight.desc=Ativa ou desativa o realce por tokens semânticos do LSP.
 settings.semanticHighlight=Realce semântico (LSP)
 # TODO / highlight patterns

--- a/src/test/java/com/editora/lsp/JdtlsPasteProbeTest.java
+++ b/src/test/java/com/editora/lsp/JdtlsPasteProbeTest.java
@@ -59,6 +59,109 @@ class JdtlsPasteProbeTest {
         public void logMessage(MessageParams p) {}
     }
 
+    /**
+     * The two siblings #746 lists as pairing with the paste path. Round two, narrowed by round one:
+     * stringFormatting reads TWO arguments (arg0 a String, arg1 an object — arg0-as-object threw a
+     * cast error and a lone arg threw index-1-out-of-bounds), and smartSemicolonDetection accepted every
+     * shape but answered null, which in vscode-java means its preference is off by default.
+     */
+    private static void probeSiblings(LanguageServer server, String uri, String original) throws Exception {
+        String text = "package demo;\n\npublic class App {\n    public static void main(String[] args) {\n"
+                + "        String s = \"hello\";\n        int n = compute(1, 2)\n    }\n"
+                + "    static int compute(int a, int b) { return a + b; }\n}\n";
+        server.getTextDocumentService()
+                .didChange(new DidChangeTextDocumentParams(
+                        new VersionedTextDocumentIdentifier(uri, 3),
+                        List.of(new TextDocumentContentChangeEvent(text))));
+        Thread.sleep(3_000);
+
+        // Turn on both features' preferences the way vscode-java does, then re-ask.
+        java.util.Map<String, Object> javaCfg = new java.util.HashMap<>();
+        javaCfg.put(
+                "edit",
+                java.util.Map.of(
+                        "smartSemicolonDetection",
+                        java.util.Map.of("enabled", true),
+                        "validateAllOpenBuffersOnChanges",
+                        false));
+        server.getWorkspaceService()
+                .didChangeConfiguration(new DidChangeConfigurationParams(java.util.Map.of("java", javaCfg)));
+        Thread.sleep(3_000);
+
+        com.google.gson.JsonObject pos = new com.google.gson.JsonObject();
+        pos.addProperty("line", 5);
+        pos.addProperty("character", 28); // just after the '2', before the ')'
+        com.google.gson.JsonObject semi = new com.google.gson.JsonObject();
+        semi.addProperty("uri", uri);
+        semi.add("position", pos);
+        tryShapes(
+                server,
+                "java.edit.smartSemicolonDetection",
+                List.of(List.of(semi.toString()), List.of(uri, pos.toString()), List.of(uri, pos)));
+
+        // stringFormatting: arg0 String, arg1 object. Try the plausible splits of (uri, text, position).
+        com.google.gson.JsonObject spos = new com.google.gson.JsonObject();
+        spos.addProperty("line", 4);
+        spos.addProperty("character", 26); // between the quotes of "hello"
+        com.google.gson.JsonObject fmt2 = new com.google.gson.JsonObject();
+        fmt2.addProperty("tabSize", 4);
+        fmt2.addProperty("insertSpaces", true);
+        String pasted = "line one\nline \"two\"\n";
+
+        com.google.gson.JsonObject payload = new com.google.gson.JsonObject();
+        payload.addProperty("text", pasted);
+        payload.add("position", spos);
+        payload.add("formattingOptions", fmt2);
+
+        com.google.gson.JsonObject withRange = new com.google.gson.JsonObject();
+        com.google.gson.JsonObject r2 = new com.google.gson.JsonObject();
+        r2.add("start", spos);
+        r2.add("end", spos);
+        withRange.add("range", r2);
+        withRange.addProperty("text", pasted);
+
+        // line 4 is `        String s = "hello";` — the quotes are at 19 and 25, so 22 is really inside.
+        com.google.gson.JsonObject inLiteral = new com.google.gson.JsonObject();
+        inLiteral.addProperty("line", 4);
+        inLiteral.addProperty("character", 22);
+        com.google.gson.JsonObject inLiteralRange = new com.google.gson.JsonObject();
+        com.google.gson.JsonObject lr = new com.google.gson.JsonObject();
+        lr.add("start", inLiteral);
+        lr.add("end", inLiteral);
+        inLiteralRange.add("range", lr);
+        inLiteralRange.addProperty("uri", uri);
+
+        com.google.gson.JsonObject uriAndPos = new com.google.gson.JsonObject();
+        uriAndPos.addProperty("uri", uri);
+        uriAndPos.add("position", inLiteral);
+
+        tryShapes(
+                server,
+                "java.edit.stringFormatting",
+                List.of(
+                        List.of(pasted, inLiteral, "4"),
+                        List.of(pasted, uriAndPos, "4"),
+                        List.of(pasted, inLiteral, "0"),
+                        List.of(uri, inLiteral, "4")));
+    }
+
+    /** Sends {@code command} once per candidate argument list, printing what each answers. */
+    private static void tryShapes(LanguageServer server, String command, List<List<Object>> shapes) {
+        System.out.println("\n########## " + command + " ##########");
+        for (int i = 0; i < shapes.size(); i++) {
+            System.out.println("--- shape " + i + ": " + shapes.get(i));
+            try {
+                Object r = server.getWorkspaceService()
+                        .executeCommand(new ExecuteCommandParams(command, shapes.get(i)))
+                        .get(30, TimeUnit.SECONDS);
+                System.out.println("RESULT[" + i + "] ("
+                        + (r == null ? "null" : r.getClass().getSimpleName()) + "): " + r);
+            } catch (Exception e) {
+                System.out.println("THREW[" + i + "]: " + String.valueOf(e).replace('\n', ' '));
+            }
+        }
+    }
+
     @Test
     void probePasteEvent() throws Exception {
         org.junit.jupiter.api.Assumptions.assumeTrue(Boolean.getBoolean("lsp.probe"), "opt-in: pass -Dlsp.probe=true");
@@ -160,6 +263,8 @@ class JdtlsPasteProbeTest {
                     System.out.println("THREW: " + String.valueOf(e).replace('\n', ' '));
                 }
             }
+
+            probeSiblings(server, uri, original);
 
             server.shutdown().get(20, TimeUnit.SECONDS);
             server.exit();

--- a/src/test/java/com/editora/lsp/JdtlsSmartSemicolonTest.java
+++ b/src/test/java/com/editora/lsp/JdtlsSmartSemicolonTest.java
@@ -1,0 +1,68 @@
+package com.editora.lsp;
+
+import java.util.List;
+
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import org.eclipse.lsp4j.ExecuteCommandOptions;
+import org.eclipse.lsp4j.ServerCapabilities;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/** Pins the {@code java.edit.smartSemicolonDetection} wire shapes captured from a live jdtls. */
+class JdtlsSmartSemicolonTest {
+
+    @Test
+    void paramsJsonIsTheStringifiedUriAndPosition() {
+        String json = JdtlsSmartSemicolon.paramsJson("file:///tmp/App.java", 5, 28);
+        JsonObject p = JsonParser.parseString(json).getAsJsonObject();
+        assertEquals("file:///tmp/App.java", p.get("uri").getAsString());
+        assertEquals(5, p.getAsJsonObject("position").get("line").getAsInt());
+        assertEquals(28, p.getAsJsonObject("position").get("character").getAsInt());
+    }
+
+    @Test
+    void supportedReadsTheAdvertisedCommandList() {
+        ServerCapabilities caps = new ServerCapabilities();
+        assertFalse(JdtlsSmartSemicolon.supported(caps));
+        caps.setExecuteCommandProvider(new ExecuteCommandOptions(List.of("java.edit.organizeImports")));
+        assertFalse(JdtlsSmartSemicolon.supported(caps));
+        caps.setExecuteCommandProvider(new ExecuteCommandOptions(List.of(JdtlsSmartSemicolon.COMMAND)));
+        assertTrue(JdtlsSmartSemicolon.supported(caps));
+        assertFalse(JdtlsSmartSemicolon.supported(null));
+    }
+
+    @Test
+    void readsThePositionOutOfTheCapturedAnswer() {
+        // Verbatim from the live probe: caret before the ')' at char 28 → the ';' belongs at 29.
+        String answer = "{\"uri\":\"file:///tmp/App.java\",\"position\":{\"line\":5.0,\"character\":29.0}}";
+        assertArrayEquals(new int[] {5, 29}, JdtlsSmartSemicolon.answeredPosition(JsonParser.parseString(answer)));
+    }
+
+    @Test
+    void theNumbersSurviveArrivingAsJsonDoubles() {
+        // gson's untyped mapping makes every number a double; reading them as ints throws on "29.0".
+        assertArrayEquals(
+                new int[] {0, 0},
+                JdtlsSmartSemicolon.answeredPosition(
+                        JsonParser.parseString("{\"position\":{\"line\":0.0,\"character\":0.0}}")));
+    }
+
+    @Test
+    void anythingUnusableIsNullNotAThrow() {
+        assertNull(JdtlsSmartSemicolon.answeredPosition(null), "no answer (the ordinary case)");
+        assertNull(JdtlsSmartSemicolon.answeredPosition("not json"));
+        assertNull(JdtlsSmartSemicolon.answeredPosition(JsonParser.parseString("{}")));
+        assertNull(JdtlsSmartSemicolon.answeredPosition(JsonParser.parseString("{\"position\":null}")));
+        assertNull(JdtlsSmartSemicolon.answeredPosition(JsonParser.parseString("{\"position\":{\"line\":1}}")));
+        assertNull(
+                JdtlsSmartSemicolon.answeredPosition(
+                        JsonParser.parseString("{\"position\":{\"line\":-1,\"character\":2}}")),
+                "a negative position is not addressable");
+    }
+}

--- a/src/test/java/com/editora/ui/SmartSemicolonFxTest.java
+++ b/src/test/java/com/editora/ui/SmartSemicolonFxTest.java
@@ -1,0 +1,170 @@
+package com.editora.ui;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+import javafx.scene.input.KeyEvent;
+
+import com.editora.editor.EditorBuffer;
+import org.fxmisc.richtext.CodeArea;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+/**
+ * The buffer half of smart-semicolon placement (#746): the coordinate translation that moves a just-typed
+ * {@code ;} to where the server said it belongs. That translation is the part most easily wrong and least
+ * visible — the server answers in <b>pre-insert</b> coordinates while the document already contains the
+ * semicolon, so a same-line target needs shifting past it and a later-line target does not.
+ *
+ * <p>The requester is stubbed, so no server is involved; the wire shapes are pinned in
+ * {@code JdtlsSmartSemicolonTest}.
+ */
+@Tag("fx")
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class SmartSemicolonFxTest {
+
+    private FxWindowFixture fx;
+
+    @BeforeAll
+    void setUp() throws Exception {
+        FxTestSupport.bootToolkit();
+        fx = FxWindowFixture.create();
+    }
+
+    @org.junit.jupiter.api.AfterAll
+    void tearDown() throws Exception {
+        if (fx != null) {
+            fx.dispose();
+        }
+    }
+
+    /**
+     * Answers {@code target} to every request, and records what it was asked. The buffer goes into a real
+     * window: the correction refuses to touch a detached buffer (a {@code getScene() == null} guard), so a
+     * bare buffer would silently exercise nothing.
+     */
+    private EditorBuffer buffer(String src, int[] target, AtomicReference<int[]> asked) throws Exception {
+        return FxTestSupport.callOnFx(() -> {
+            EditorBuffer b = new EditorBuffer();
+            b.setLanguageOverride("java");
+            FxTestSupport.call(fx.controller, "addBuffer", new Class[] {EditorBuffer.class, boolean.class}, b, true);
+            b.setContent(src);
+            b.setLspActive(true);
+            b.setSmartSemicolonEnabled(true);
+            b.setLspSmartSemicolonRequester((line, character, cb) -> {
+                asked.set(new int[] {line, character});
+                // Answer on a LATER pulse, as LspManager always does — the correction is only valid once
+                // the semicolon has actually landed, and a synchronous answer arrives before it has.
+                javafx.application.Platform.runLater(() -> cb.accept(target));
+            });
+            return b;
+        });
+    }
+
+    /**
+     * Types {@code ;} at (line, col) exactly as production does: the real KEY_TYPED event runs the capture
+     * filter (where the smart-semicolon hook lives) and then RichTextFX's own handler performs the
+     * insertion, because the hook never consumes. Inserting the character by hand as well would double it.
+     */
+    private void typeSemicolon(EditorBuffer b, int line, int col) throws Exception {
+        FxTestSupport.runOnFx(() -> {
+            CodeArea area = FxTestSupport.field(b, "area");
+            area.moveTo(line, col);
+            area.fireEvent(new KeyEvent(KeyEvent.KEY_TYPED, ";", ";", null, false, false, false, false));
+        });
+    }
+
+    private String text(EditorBuffer b) throws Exception {
+        return FxTestSupport.callOnFx(() -> ((CodeArea) FxTestSupport.field(b, "area")).getText());
+    }
+
+    @Test
+    void aSameLineTargetMovesTheSemicolonPastTheRestOfTheExpression() throws Exception {
+        // line 1 is "int n = compute(1, 2)"; caret at col 20 sits just before the ')'. The server answers
+        // col 21 — one past it — in PRE-insert coordinates.
+        String src = "class A {\nint n = compute(1, 2)\n}\n";
+        var asked = new AtomicReference<int[]>();
+        EditorBuffer b = buffer(src, new int[] {1, 21}, asked);
+
+        typeSemicolon(b, 1, 20);
+
+        assertEquals("class A {\nint n = compute(1, 2);\n}\n", text(b), "the ';' moved past the ')'");
+        assertEquals(1, asked.get()[0], "asked about the typed line");
+        assertEquals(20, asked.get()[1], "asked with the PRE-insert column");
+    }
+
+    @Test
+    void aLaterLineTargetNeedsNoColumnShift() throws Exception {
+        // A statement wrapped over two lines: typing ';' inside the call on line 1, the statement ends on
+        // line 2 after the ')'. Columns on line 2 are untouched by the insertion on line 1.
+        String src = "class A {\nint n = compute(1,\n2)\n}\n";
+        var asked = new AtomicReference<int[]>();
+        EditorBuffer b = buffer(src, new int[] {2, 2}, asked);
+
+        typeSemicolon(b, 1, 18); // just after the ',' … inside the argument list
+
+        assertEquals("class A {\nint n = compute(1,\n2);\n}\n", text(b), "the ';' landed at the statement end");
+    }
+
+    @Test
+    void anAnswerAtTheTypedPositionLeavesItAlone() throws Exception {
+        // The ordinary answer: the caret is already at the statement end, so nothing should move.
+        String src = "class A {\nint n = 1\n}\n";
+        var asked = new AtomicReference<int[]>();
+        EditorBuffer b = buffer(src, new int[] {1, 9}, asked);
+
+        typeSemicolon(b, 1, 9);
+
+        assertEquals("class A {\nint n = 1;\n}\n", text(b));
+    }
+
+    @Test
+    void aNullAnswerLeavesTheSemicolonWhereItWasTyped() throws Exception {
+        String src = "class A {\nint n = compute(1, 2)\n}\n";
+        var asked = new AtomicReference<int[]>();
+        EditorBuffer b = buffer(src, null, asked);
+
+        typeSemicolon(b, 1, 20);
+
+        assertEquals("class A {\nint n = compute(1, 2;)\n}\n", text(b), "no answer → exactly the typed result");
+    }
+
+    @Test
+    void theMoveIsOneUndoStep() throws Exception {
+        String src = "class A {\nint n = compute(1, 2)\n}\n";
+        var asked = new AtomicReference<int[]>();
+        EditorBuffer b = buffer(src, new int[] {1, 21}, asked);
+
+        FxTestSupport.runOnFx(() ->
+                ((CodeArea) FxTestSupport.field(b, "area")).getUndoManager().forgetHistory());
+        typeSemicolon(b, 1, 20);
+        assertEquals("class A {\nint n = compute(1, 2);\n}\n", text(b));
+
+        // One undo takes back the move — the correction is a single ranged replaceText, not a
+        // delete-plus-insert that would need two.
+        FxTestSupport.runOnFx(() -> ((CodeArea) FxTestSupport.field(b, "area")).undo());
+        assertEquals("class A {\nint n = compute(1, 2;)\n}\n", text(b), "back to the as-typed text");
+    }
+
+    @Test
+    void theGatesKeepItSilent() throws Exception {
+        String src = "class A {\nint n = compute(1, 2)\n}\n";
+        var asked = new AtomicReference<int[]>();
+        EditorBuffer b = buffer(src, new int[] {1, 21}, asked);
+
+        FxTestSupport.runOnFx(() -> b.setSmartSemicolonEnabled(false));
+        typeSemicolon(b, 1, 20);
+        assertNull(asked.get(), "disabled → the server is never asked");
+
+        FxTestSupport.runOnFx(() -> {
+            b.setSmartSemicolonEnabled(true);
+            b.setLspActive(false);
+        });
+        typeSemicolon(b, 1, 20);
+        assertNull(asked.get(), "no LSP → the server is never asked");
+    }
+}


### PR DESCRIPTION
Part of #746 — the sibling the issue says pairs with #742. Typing `;` part-way through an expression now puts it at the end of the statement: `compute(1, 2|)` becomes `compute(1, 2);|` rather than `compute(1, 2;)`.

## Two things invisible from the protocol

Both established by probing a real jdtls (the #742 probe, extended and kept in-tree):

1. The params are a **stringified JSON** `{uri, position}` — the same encoding `handlePasteEvent` needs; an object argument fails with a gson type error.
2. **The handler answers `null` until `java.edit.smartSemicolonDetection.enabled` is pushed** via `didChangeConfiguration`. Before that push *every* argument shape answered null, which is indistinguishable from "nothing to do here" and reads as wrong params. This is the **third** instance of the same pattern — advertised unconditionally, inert by preference — after `signatureHelp.enabled` (#674) and `provideFormatter` (#468), so the preference now goes out alongside those in `pushConfiguration`.

## Type first, correct after

The semicolon is **never held back waiting for the server**: making a keystroke wait on a round trip is the latency the performance rules forbid, and a cold server would let the character land after whatever was typed next. So it inserts normally and the answer, if it disagrees, moves it — as a **single ranged `replaceText`**, hence one undo step rather than a delete plus an insert.

The consequence is stated rather than hidden: typing straight through (a very common `;`-then-Enter) moves `docVersion` by more than the semicolon and the correction is **dropped**. That is deliberate — the alternative is rewriting text the user has already moved past — and it leaves the semicolon exactly where it would have been with the feature off, never worse.

## The coordinate trap

The server answers in **pre-insert** coordinates while the document already contains the semicolon, so a same-line target must be shifted past it and a later-line target must not. That translation is the easiest part to get subtly wrong and the least visible when it is; deleting the compensation fails two of the six FX cases, which is how it was checked.

Default **OFF**, as in VS Code — it moves a character the user typed. Schema 91→92 additive; Settings → Code Completion checkbox + palette `view.toggleSmartSemicolon`; i18n ×6.

## Deliberately not included: `java.edit.stringFormatting`

Five probe rounds narrowed its signature to `(String text, Object, String numeric)` — arg0-as-object throws a cast error, two args throw index-2-out-of-bounds, a non-numeric third arg throws `NumberFormatException` — but **every accepted shape returns the text unchanged**. Wiring a call that provably does nothing would look finished and not be, so it stays open on #746 with these findings recorded.

## Verification

- Full `./mvnw verify`: **3544 tests, 0 failures**.
- 5 pure (`JdtlsSmartSemicolonTest` — the wire shapes from the captured live answers) + 6 FX (`SmartSemicolonFxTest` — the coordinate translation, the one-undo-step property, the null answer, the gates), with the translation confirmed to fail when broken.
- Two harness bugs worth recording, both of which made the *test* wrong rather than the code: firing a real `KEY_TYPED` already inserts the character (adding one by hand doubles it), and the stub must answer on a **later** pulse like `LspManager` does — a synchronous answer arrives before the semicolon has landed and is correctly rejected by the version guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)