### PR TITLE
chore(release): 0.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.10.0] - 2026-08-03
+
 ### Added
 
 - **Per-project settings you can commit** — a project can carry `.editora/settings.toml` saying which
@@ -48,6 +50,39 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   macros and external tools already work.
 
 ### Changed
+
+- **Editora has its own look.** The palette comes from the app's own icon — a teal accent, an ink-navy
+  ground and a periwinkle reserved for one job: the keyboard. **Editora Light** and **Editora Dark** ship as
+  a matched pair and are the theme a fresh install starts in. **Nothing changes for an existing install** —
+  your saved theme is kept, and the new pair is simply two more entries in Settings → Appearance alongside
+  Primer, Nord, Dracula and the community themes.
+
+- **One vocabulary for state, everywhere.** Amber now means "not saved yet" in every place it can appear —
+  the tab, the Switcher, the file tree, pickers — and it follows the theme instead of being one fixed ochre
+  that suited a light background and little else. Red is broken, green is verified, olive and violet are
+  git's untracked and renamed, and periwinkle is only ever a keybinding.
+
+- **The interface is set in Inter.** Editora already bundled it for the Markdown preview and PDF export;
+  now the whole interface uses it, on every platform, instead of whatever default font each system supplied.
+
+- **Settings has been rebuilt.** Every page reads the same way: one background, with each group of settings
+  on a card, and every setting stated as a name, a plain-English line saying what it does, and its control
+  on the right — instead of a stack of bare checkboxes whose labels had to carry the whole explanation. A
+  tool's detection result is a green or red pill on its own row, and a setting whose feature has a
+  keybinding shows that chord beside its switch, so Settings teaches the keyboard instead of hiding it.
+
+- **Less line, more space.** Editora used to draw a hairline at nearly every seam, and in several places two
+  at once — a panel's frame plus the frame the tree inside it drew for itself. Those are gone; surfaces are
+  told apart by their shade and their spacing. Menus, tab strips and toolbars are tighter, tabs are shorter,
+  and the rounded corners are consistent from the command palette down to a spinner in Settings.
+
+- **Menu keybindings line up.** Each menu's shortcuts share one column instead of trailing after their
+  labels at whatever width each one happened to be, so a menu can be read down its right edge. (On macOS,
+  where the menu bar belongs to the system, they stay beside the label — the native menu draws text only.)
+
+- **Language, Tab Size and Line Endings open a picker, not a dialog.** Clicking those status-bar segments
+  used to open a separate window with a dropdown; they now use the same in-scene picker as everything else,
+  which you can type into. The language list is around a hundred grammars, and it was not searchable before.
 
 - **Projects are on by default.** The feature shipped opt-in, behind a checkbox most people never found —
   and much of what Editora has grown since is anchored to a project: the file tree, per-project bookmarks and

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.editora</groupId>
     <artifactId>editora</artifactId>
-    <version>0.9.11-SNAPSHOT</version>
+    <version>0.10.0</version>
     <packaging>jar</packaging>
 
     <name>Editora</name>

--- a/src/main/java/com/editora/ui/Icons.java
+++ b/src/main/java/com/editora/ui/Icons.java
@@ -518,16 +518,6 @@ final class Icons {
         return line("M1.7000000000000002 8.0a6.3 6.3 0 1 0 12.6 0a6.3 6.3 0 1 0 -12.6 0M8 7.4V11M8 5.1v.2");
     }
 
-    /** Markdown view: Editor only (Material "subject" — text lines). */
-    static Node previewEditor() {
-        return of("M14 17H4v2h10v-2zm6-8H4v2h16V9zM4 15h16v-2H4v2zM4 5v2h16V5H4z");
-    }
-
-    /** Markdown view: Editor + Preview (two side-by-side panes). */
-    static Node previewSplit() {
-        return of("M4 5h6v14H4V5zm10 0h6v14h-6V5z");
-    }
-
     /** Markdown view: Preview only (Material "visibility" — eye). */
     static Node previewOnly() {
         return of("M12 4.5C7 4.5 2.73 7.61 1 12c1.73 4.39 6 7.5 11 7.5s9.27-3.11 11-7.5c-1.73-4.39-6-7.5-"

--- a/src/main/java/com/editora/ui/MainController.java
+++ b/src/main/java/com/editora/ui/MainController.java
@@ -10604,7 +10604,8 @@ public class MainController implements com.editora.mcp.McpBridge {
         // An in-scene picker, like every other status-bar selector — filterable, keyboard-first, and it
         // does not open a second window over the editor. (The list is ~100 grammars; a ChoiceDialog's
         // combo made that unsearchable.)
-        chooseSetting("buffer.setLanguage", () -> names, name -> name, name -> {
+        String current = names.contains(buffer.getLanguage()) ? buffer.getLanguage() : names.get(0);
+        chooseSetting("buffer.setLanguage", () -> names, name -> name, () -> current, name -> {
             buffer.setLanguageOverride(name);
             statusBar.refresh();
             setStatus(tr("status.language", name));
@@ -10614,14 +10615,19 @@ public class MainController implements com.editora.mcp.McpBridge {
     /** Changes the (persisted) tab width and applies it to every buffer. */
     private void chooseTabSize() {
         Settings s = config.getSettings();
-        chooseSetting("buffer.setTabSize", () -> List.of("2", "4", "8"), size -> size, choice -> {
-            int size = Integer.parseInt(choice);
-            s.setTabSize(size);
-            requestSave();
-            applyViewSettingsToAllBuffers(s);
-            statusBar.refresh();
-            setStatus(tr("status.tabSize", size));
-        });
+        chooseSetting(
+                "buffer.setTabSize",
+                () -> List.of("2", "4", "8"),
+                size -> size,
+                () -> String.valueOf(s.getTabSize()),
+                choice -> {
+                    int size = Integer.parseInt(choice);
+                    s.setTabSize(size);
+                    requestSave();
+                    applyViewSettingsToAllBuffers(s);
+                    statusBar.refresh();
+                    setStatus(tr("status.tabSize", size));
+                });
     }
 
     // --- Settings palette commands ----------------------------------------------------------------
@@ -10716,12 +10722,25 @@ public class MainController implements com.editora.mcp.McpBridge {
             java.util.function.Supplier<List<String>> options,
             java.util.function.Function<String, String> label,
             java.util.function.Consumer<String> onChoose) {
+        chooseSetting(commandId, options, label, null, onChoose);
+    }
+
+    /** As above, but opens on {@code current} — the value in force — instead of the first row. */
+    private void chooseSetting(
+            String commandId,
+            java.util.function.Supplier<List<String>> options,
+            java.util.function.Function<String, String> label,
+            java.util.function.Supplier<String> current,
+            java.util.function.Consumer<String> onChoose) {
         QuickOpen<String> picker = new QuickOpen<>(
                 commandTitle(commandId), tr("palette.setting.pick"), options::get, label::apply, id -> "", id -> {
                     if (id != null) {
                         onChoose.accept(id);
                     }
                 });
+        if (current != null) {
+            picker.setCurrentItem(current);
+        }
         picker.setOverlayHost(overlayHost);
         picker.show(stage);
     }
@@ -10853,11 +10872,12 @@ public class MainController implements com.editora.mcp.McpBridge {
         if (buffer == null) {
             return;
         }
-        chooseSetting("buffer.convertLineEndings", () -> List.of("LF", "CRLF"), c -> c, choice -> {
-            buffer.convertLineEndings("CRLF".equals(choice));
-            statusBar.refresh();
-            setStatus(tr("status.lineEndingsSet", choice));
-        });
+        chooseSetting(
+                "buffer.convertLineEndings", () -> List.of("LF", "CRLF"), c -> c, buffer::getLineEnding, choice -> {
+                    buffer.convertLineEndings("CRLF".equals(choice));
+                    statusBar.refresh();
+                    setStatus(tr("status.lineEndingsSet", choice));
+                });
     }
 
     /** Persists the buffer's collapsed fold regions + manual fold ranges, keyed by its file path. */

--- a/src/main/java/com/editora/ui/QuickOpen.java
+++ b/src/main/java/com/editora/ui/QuickOpen.java
@@ -63,6 +63,10 @@ public class QuickOpen<T> {
 
     private final TextField input = new TextField();
     private final ListView<T> list = new ListView<>();
+
+    /** Supplies the value currently in force, pre-selected on open (see {@link #setCurrentItem}). */
+    private java.util.function.Supplier<T> currentItem;
+
     private final ObservableList<T> items = FXCollections.observableArrayList();
     private List<T> all = List.of();
 
@@ -110,6 +114,18 @@ public class QuickOpen<T> {
     /** Sets a per-item leading icon shown on the row's title label (e.g. a file-type glyph). */
     public void setItemIcon(Function<T, Node> itemIcon) {
         this.itemIcon = itemIcon;
+    }
+
+    /**
+     * Marks one item as the current value, so opening the picker lands on it rather than on the first
+     * row. Restores what a {@code ChoiceDialog} gave for free when these were native dialogs: for a
+     * "change this setting" picker, the value in force is the useful starting point — the user is
+     * usually moving one step from it, and it says what the current value IS.
+     *
+     * <p>Only honoured while the query is empty; once the user types, the best match leads as before.
+     */
+    public void setCurrentItem(java.util.function.Supplier<T> currentItem) {
+        this.currentItem = currentItem;
     }
 
     /** Injects the shared overlay host used to show the picker card. */
@@ -247,9 +263,20 @@ public class QuickOpen<T> {
             }
         }
         items.setAll(matches);
-        if (!items.isEmpty()) {
-            list.getSelectionModel().select(0);
+        if (items.isEmpty()) {
+            return;
         }
+        // With no query, start on the value in force when one was supplied; otherwise the first row.
+        int start = 0;
+        if (q.isEmpty() && currentItem != null) {
+            T current = currentItem.get();
+            int idx = current == null ? -1 : items.indexOf(current);
+            if (idx >= 0) {
+                start = idx;
+            }
+        }
+        list.getSelectionModel().select(start);
+        list.scrollTo(start);
     }
 
     /** Shows the picker as a centered in-scene overlay. {@code owner} is unused (kept for call-site

--- a/src/main/java/com/editora/ui/SettingsWindow.java
+++ b/src/main/java/com/editora/ui/SettingsWindow.java
@@ -6302,18 +6302,6 @@ public class SettingsWindow {
     private Card card(VBox page, String title) {
         VBox body = new VBox();
         body.getStyleClass().add("settings-card-body");
-        // Rows carry a bottom separator, which must not be drawn under the last one. JavaFX CSS has no
-        // structural pseudo-classes (`:last-child` parses but matches nothing), so tag the final row
-        // here and let .settings-row-last drop the border.
-        body.getChildren().addListener((javafx.collections.ListChangeListener<Node>) ch -> {
-            var kids = body.getChildren();
-            for (int i = 0; i < kids.size(); i++) {
-                kids.get(i).getStyleClass().remove("settings-row-last");
-            }
-            if (!kids.isEmpty()) {
-                kids.get(kids.size() - 1).getStyleClass().add("settings-row-last");
-            }
-        });
         VBox box = new VBox();
         box.getStyleClass().add("settings-card");
         if (title != null && !title.isBlank()) {

--- a/src/main/resources/com/editora/styles/app.css
+++ b/src/main/resources/com/editora/styles/app.css
@@ -2024,16 +2024,6 @@
     -fx-text-fill: -color-fg-muted;
     -fx-padding: 12 0 2 0;
 }
-/* A separator between rows rather than around them, so the card reads as one block. JavaFX has no
-   structural pseudo-classes (`:last-child` would never match), so the final row is tagged
-   `settings-row-last` in code — see SettingsWindow.card(). */
-.settings-card-body > .settings-row {
-    -fx-border-color: transparent transparent -color-border-muted transparent;
-    -fx-border-width: 0 0 1 0;
-}
-.settings-card-body > .settings-row-last {
-    -fx-border-width: 0;
-}
 .settings-row {
     -fx-padding: 13 0 13 0;
 }
@@ -3289,9 +3279,7 @@
 .settings-footer {
     -fx-border-width: 0;
 }
-.settings-card-body > .settings-row {
-    -fx-border-width: 0;
-}
+
 
 /* One ground for the whole window: rail, page and footer all sit on -color-bg-subtle, and the white
    cards are the only raised surface. Previously the rail was bg-default, so the window read as two


### PR DESCRIPTION
Prepares the 0.10.0 release, plus the loose ends found while surveying for it.

## Release prep

- `pom.xml` → `0.10.0` (drops `-SNAPSHOT`), per `docs/release.md` step 1. Verified the version filters through: `build-info.properties` reads `build.version=0.10.0`.
- `CHANGELOG.md` → `[Unreleased]` rolled into `[0.10.0] - 2026-08-03`.

**A minor bump rather than a patch.** This release changes what Editora looks like on first run — its own theme as the default, Inter across the interface, a new icon set, every Settings page rebuilt — on top of 45 commits of feature work. The 0.9.x patch cadence would undersell that to anyone reading the tag.

### The changelog was missing the release's headline change

The `[Unreleased]` section covered the other 43 commits in 137 lines and said **nothing** about the UI Kit work — the first thing every user meets on upgrade. Seven `### Changed` entries added, in the existing voice, leading with the question a reader asks immediately: **an existing install keeps its theme.** Jackson persists every modelled field, so only a fresh config dir starts in the new default.

## Loose ends

- **Dead code.** `Icons.previewEditor`/`previewSplit` lost their only call sites when the preview toggle became text segments. The `settings-row-last` machinery was inert in a subtler way — a `ListChangeListener` still ran on every card build to tag the last row, feeding a CSS rule that became a no-op once the row separators were removed.
- **Picker pre-selection.** Converting Language / Tab Size / Line Endings off `ChoiceDialog` lost something the native dialog gave for free: it opened on the value in force. `QuickOpen.setCurrentItem` restores it, honoured only while the query is empty so typing still puts the best match first.

## Testing

`mvn verify` green — **3547 tests** — at `0.10.0`.

**Packaged build smoke-tested**: `mvn clean -Pdist -DskipTests -Djpackage.type=APP_IMAGE package` succeeds, the AOT trainer produces a 72 MB cache (worth checking explicitly — a silently-failing trainer ships an uncached build and did so on macOS arm64 for eight tagged releases), and the resulting app image launches with **zero bytes on stdout/stderr**, writing a valid config at `schemaVersion 93`.

**Not covered by that test:** launching does not exercise the first-keypress path — the missing synthetic `$SwitchMap` class that makes a packaged build die with `ClassNotFoundException` on the first key. The build used `clean`, which is the documented mitigation, but nothing here proves it.

**Not verified at all:** every visual change in this release has only been seen on Linux, and the theme is now the first-run default on every platform. The macOS menu bar in particular takes a different rendering path (native menus draw text only, so keybindings stay inline rather than column-aligned).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
