### PR TITLE
feat(git): add a Git: Initialize Repository command

### DIFF
--- a/src/main/java/com/editora/git/GitService.java
+++ b/src/main/java/com/editora/git/GitService.java
@@ -581,6 +581,40 @@ public final class GitService {
         });
     }
 
+    /**
+     * Creates a repository in {@code dir} ({@code git init}).
+     *
+     * <p>Runs <em>in</em> {@code dir} rather than a repo root, like {@link #clone}: this is one of the two
+     * commands whose whole point is that there is no repository yet.
+     *
+     * <p>The already-a-repo check happens here, on the service thread, precisely because answering it means
+     * running {@code git rev-parse} — doing that from the caller would block the FX thread. {@code existing}
+     * is non-null when {@code dir} already sits inside a repository, in which case nothing was run: nesting
+     * a repo inside another is nearly always a mistake and awkward to undo.
+     *
+     * @param onResult receives the {@code git init} result and, when refused, the enclosing repo's root
+     */
+    public void init(Path dir, java.util.function.BiConsumer<ProcessRunner.Result, Path> onResult) {
+        exec.submit(() -> {
+            Path abs = dir.toAbsolutePath();
+            if (!gitAvailable()) {
+                ProcessRunner.Result r = new ProcessRunner.Result(-1, "", "Git is not installed");
+                Platform.runLater(() -> onResult.accept(r, null));
+                return;
+            }
+            Path existing = resolveRoot(abs);
+            if (existing != null) {
+                Platform.runLater(() -> onResult.accept(new ProcessRunner.Result(-1, "", ""), existing));
+                return;
+            }
+            ProcessRunner.Result r = gitLogged(abs, QUICK, "init");
+            if (r.ok()) {
+                invalidateCaches(); // the cached "not a repo" for this folder is now wrong
+            }
+            Platform.runLater(() -> onResult.accept(r, null));
+        });
+    }
+
     // --- mutations (run a command, post the raw result for status/error reporting) ---------------
 
     /**

--- a/src/main/java/com/editora/ui/Chrome.java
+++ b/src/main/java/com/editora/ui/Chrome.java
@@ -277,6 +277,12 @@ final class Chrome {
             java.util.Set.of("debug.stop", "debug.restart", "debug.pause");
 
     /** Debug commands that only mean anything while a thread is suspended at a stop. */
+    /**
+     * Git commands that must stay enabled <b>outside</b> a repository — creating one is the whole point.
+     * Gating these on {@code inRepo()} would grey them out in the only situation they exist for.
+     */
+    private static final java.util.Set<String> NEEDS_NO_REPO = java.util.Set.of("git.clone", "git.init");
+
     private static final java.util.Set<String> DEBUG_NEEDS_SUSPENDED = java.util.Set.of(
             "debug.continue",
             "debug.stepOver",
@@ -311,10 +317,13 @@ final class Chrome {
         if (id.startsWith("preview.")) {
             return c.hasPreview() ? null : new DisabledReason("palette.disabled.needsPreview", null);
         }
-        // Git acts on the repo the active file lives in — except cloning, which is what you run when you
-        // have no repo yet.
+        // Git acts on the repo the active file lives in — except cloning and init, which are exactly what
+        // you run when you have no repo yet. Gating those on inRepo() would grey them out in the only
+        // situation they exist for.
         if (id.startsWith("git.") || id.equals("tool.commit") || id.equals("tool.gitLog")) {
-            return c.inRepo() || id.equals("git.clone") ? null : new DisabledReason("palette.disabled.needsRepo", null);
+            return c.inRepo() || NEEDS_NO_REPO.contains(id)
+                    ? null
+                    : new DisabledReason("palette.disabled.needsRepo", null);
         }
         if (DEBUG_NEEDS_SUSPENDED.contains(id)) {
             return c.debugSuspended() ? null : new DisabledReason("palette.disabled.needsSuspended", null);

--- a/src/main/java/com/editora/ui/GitCoordinator.java
+++ b/src/main/java/com/editora/ui/GitCoordinator.java
@@ -896,6 +896,53 @@ final class GitCoordinator {
      * yourself). Clones into that folder, then opens a file from it (its README, if any) so Git lights up.
      * Clone and Projects are independent — no project is created.
      */
+    /**
+     * Creates a repository in a folder ({@code git init}) — the other half of {@link #cloneRepo()}, and the
+     * only way to start version control on a folder that Editora opened but that has no repo yet.
+     *
+     * <p>Defaults to this window's project root, else the active file's folder. Refuses a folder that is
+     * already inside a repository rather than nesting one, which is almost always a mistake and is
+     * confusing to undo. On success the whole Git UI lights up through the normal
+     * {@link #afterMutation()} path — status bar, Commit window, gutter change bars.
+     */
+    void initRepo() {
+        Path fromProject = ops.projectRoot();
+        EditorBuffer active = host.activeBuffer();
+        final Path suggested = fromProject != null
+                ? fromProject
+                : (active != null && active.getPath() != null ? active.getPath().getParent() : null);
+        host.promptText(
+                tr("dialog.gitInit.title"),
+                tr("dialog.gitInit.folder"),
+                suggested == null ? "" : suggested.toString(),
+                text -> {
+                    if (text == null || text.isBlank()) {
+                        return;
+                    }
+                    Path dir = com.editora.config.PathKeys.resolveUserInput(
+                            text.strip(), suggested, System.getProperty("user.home"));
+                    if (dir == null || !java.nio.file.Files.isDirectory(dir)) {
+                        host.setError(tr("status.gitInit.notAFolder", text.strip()));
+                        return;
+                    }
+                    host.setStatus(tr("status.gitInit.initializing", dir.toString()));
+                    // The already-a-repo check lives in the service: answering it runs git rev-parse, which
+                    // must not happen on the FX thread.
+                    service.init(dir, (r, existing) -> {
+                        if (existing != null) {
+                            host.setError(tr("status.gitInit.alreadyRepo", existing.toString()));
+                            return;
+                        }
+                        if (!r.ok()) {
+                            gitError(tr("status.gitInit.failed"), r.message());
+                            return;
+                        }
+                        host.setStatus(tr("status.gitInit.done", dir.toString()));
+                        afterMutation(); // status bar, Commit window, gutter bars all light up
+                    });
+                });
+    }
+
     void cloneRepo() {
         KeymapManager keymap = ops.keymap();
         TextField urlField = new TextField();

--- a/src/main/java/com/editora/ui/MainController.java
+++ b/src/main/java/com/editora/ui/MainController.java
@@ -15619,6 +15619,7 @@ public class MainController implements com.editora.mcp.McpBridge {
         registry.register(Command.of("remote.settings", () -> settingsWindow.showRemote(stage)));
         registry.register(Command.of("remote.disconnect", remoteCoordinator::disconnect));
         registry.register(Command.of("git.clone", () -> git.ifEnabled(git::cloneRepo)));
+        registry.register(Command.of("git.init", () -> git.ifEnabled(git::initRepo)));
         registry.register(Command.of("git.commit", () -> git.ifEnabled(git::gitCommitFocus)));
         registry.register(Command.of("git.stageFile", () -> git.ifEnabled(git::gitStageActiveFile)));
         registry.register(Command.of("git.unstageFile", () -> git.ifEnabled(git::gitUnstageActiveFile)));

--- a/src/main/resources/com/editora/i18n/messages.properties
+++ b/src/main/resources/com/editora/i18n/messages.properties
@@ -3983,3 +3983,14 @@ settings.maven.archetypeCatalog.hint=Where Load full catalog fetches archetypes 
 project.menu.newMavenProject=New Maven Project…
 status.mavenProject.disabled=Maven support is turned off. Enable it in Settings, Build Tools.
 status.run.mainClassIsAFile={0} is a file name, not a class name. Use the fully-qualified class, e.g. com.example.App.
+
+# --- git init ---
+command.git.init=Git: Initialize Repository…
+command.git.init.desc=Create a Git repository in a folder (git init), then light up the Git integration for it.
+dialog.gitInit.title=Initialize Git Repository
+dialog.gitInit.folder=Folder
+status.gitInit.initializing=Initializing a repository in {0}…
+status.gitInit.done=Initialized a Git repository in {0}
+status.gitInit.failed=Could not initialize the repository
+status.gitInit.alreadyRepo=That folder is already inside a Git repository ({0}).
+status.gitInit.notAFolder={0} is not a folder.

--- a/src/main/resources/com/editora/i18n/messages_de.properties
+++ b/src/main/resources/com/editora/i18n/messages_de.properties
@@ -3974,3 +3974,14 @@ settings.maven.archetypeCatalog.hint=Quelle, von der Vollständigen Katalog lade
 project.menu.newMavenProject=Neues Maven-Projekt…
 status.mavenProject.disabled=Die Maven-Unterstützung ist deaktiviert. Aktivieren Sie sie unter Einstellungen, Build-Werkzeuge.
 status.run.mainClassIsAFile={0} ist ein Dateiname, kein Klassenname. Verwenden Sie die vollqualifizierte Klasse, z. B. com.example.App.
+
+# --- git init ---
+command.git.init=Git: Repository initialisieren…
+command.git.init.desc=Erstellt ein Git-Repository in einem Ordner (git init) und aktiviert die Git-Integration.
+dialog.gitInit.title=Git-Repository initialisieren
+dialog.gitInit.folder=Ordner
+status.gitInit.initializing=Repository wird in {0} initialisiert…
+status.gitInit.done=Git-Repository in {0} initialisiert
+status.gitInit.failed=Repository konnte nicht initialisiert werden
+status.gitInit.alreadyRepo=Dieser Ordner liegt bereits in einem Git-Repository ({0}).
+status.gitInit.notAFolder={0} ist kein Ordner.

--- a/src/main/resources/com/editora/i18n/messages_es.properties
+++ b/src/main/resources/com/editora/i18n/messages_es.properties
@@ -3974,3 +3974,14 @@ settings.maven.archetypeCatalog.hint=Origen desde el que Cargar el catálogo com
 project.menu.newMavenProject=Nuevo proyecto Maven…
 status.mavenProject.disabled=El soporte de Maven está desactivado. Actívalo en Ajustes, Herramientas de compilación.
 status.run.mainClassIsAFile={0} es un nombre de archivo, no de clase. Usa la clase completa, por ejemplo com.example.App.
+
+# --- git init ---
+command.git.init=Git: inicializar repositorio…
+command.git.init.desc=Crea un repositorio Git en una carpeta (git init) y activa la integración de Git.
+dialog.gitInit.title=Inicializar repositorio Git
+dialog.gitInit.folder=Carpeta
+status.gitInit.initializing=Inicializando un repositorio en {0}…
+status.gitInit.done=Repositorio Git inicializado en {0}
+status.gitInit.failed=No se pudo inicializar el repositorio
+status.gitInit.alreadyRepo=Esa carpeta ya está dentro de un repositorio Git ({0}).
+status.gitInit.notAFolder={0} no es una carpeta.

--- a/src/main/resources/com/editora/i18n/messages_fr.properties
+++ b/src/main/resources/com/editora/i18n/messages_fr.properties
@@ -3974,3 +3974,14 @@ settings.maven.archetypeCatalog.hint=Source depuis laquelle Charger le catalogue
 project.menu.newMavenProject=Nouveau projet Maven…
 status.mavenProject.disabled=La prise en charge de Maven est désactivée. Activez-la dans Réglages, Outils de build.
 status.run.mainClassIsAFile={0} est un nom de fichier, pas de classe. Utilisez la classe complète, par exemple com.example.App.
+
+# --- git init ---
+command.git.init=Git : initialiser un dépôt…
+command.git.init.desc=Crée un dépôt Git dans un dossier (git init) et active l''intégration Git.
+dialog.gitInit.title=Initialiser un dépôt Git
+dialog.gitInit.folder=Dossier
+status.gitInit.initializing=Initialisation d''un dépôt dans {0}…
+status.gitInit.done=Dépôt Git initialisé dans {0}
+status.gitInit.failed=Impossible d''initialiser le dépôt
+status.gitInit.alreadyRepo=Ce dossier est déjà dans un dépôt Git ({0}).
+status.gitInit.notAFolder={0} n''est pas un dossier.

--- a/src/main/resources/com/editora/i18n/messages_it.properties
+++ b/src/main/resources/com/editora/i18n/messages_it.properties
@@ -3974,3 +3974,14 @@ settings.maven.archetypeCatalog.hint=Origine da cui Carica il catalogo completo 
 project.menu.newMavenProject=Nuovo progetto Maven…
 status.mavenProject.disabled=Il supporto Maven è disattivato. Attivalo in Impostazioni, Strumenti di build.
 status.run.mainClassIsAFile={0} è un nome di file, non di classe. Usa la classe completa, ad esempio com.example.App.
+
+# --- git init ---
+command.git.init=Git: inizializza repository…
+command.git.init.desc=Crea un repository Git in una cartella (git init) e attiva l''integrazione Git.
+dialog.gitInit.title=Inizializza repository Git
+dialog.gitInit.folder=Cartella
+status.gitInit.initializing=Inizializzazione di un repository in {0}…
+status.gitInit.done=Repository Git inizializzato in {0}
+status.gitInit.failed=Impossibile inizializzare il repository
+status.gitInit.alreadyRepo=Quella cartella è già dentro un repository Git ({0}).
+status.gitInit.notAFolder={0} non è una cartella.

--- a/src/main/resources/com/editora/i18n/messages_pt.properties
+++ b/src/main/resources/com/editora/i18n/messages_pt.properties
@@ -3974,3 +3974,14 @@ settings.maven.archetypeCatalog.hint=Origem de onde Carregar o catálogo complet
 project.menu.newMavenProject=Novo projeto Maven…
 status.mavenProject.disabled=O suporte a Maven está desativado. Ative-o em Definições, Ferramentas de compilação.
 status.run.mainClassIsAFile={0} é um nome de ficheiro, não de classe. Use a classe completa, por exemplo com.example.App.
+
+# --- git init ---
+command.git.init=Git: inicializar repositório…
+command.git.init.desc=Cria um repositório Git numa pasta (git init) e ativa a integração Git.
+dialog.gitInit.title=Inicializar repositório Git
+dialog.gitInit.folder=Pasta
+status.gitInit.initializing=A inicializar um repositório em {0}…
+status.gitInit.done=Repositório Git inicializado em {0}
+status.gitInit.failed=Não foi possível inicializar o repositório
+status.gitInit.alreadyRepo=Essa pasta já está dentro de um repositório Git ({0}).
+status.gitInit.notAFolder={0} não é uma pasta.

--- a/src/test/java/com/editora/ui/ChromeTest.java
+++ b/src/test/java/com/editora/ui/ChromeTest.java
@@ -531,4 +531,15 @@ class ChromeTest {
         // Neither -> disabled.
         assertFalse(Chrome.paletteEnabled("git.push", only("git"), noBuffer()));
     }
+
+    @Test
+    void repoCreatingCommandsStayEnabledOutsideARepository() {
+        // git.clone and git.init are the two commands whose whole point is that there is no repo yet.
+        // Gating them on inRepo() would grey them out in exactly the situation they exist for.
+        Chrome.PaletteContext noRepo =
+                new Chrome.PaletteContext(true, false, false, false, false, false, false, false, false);
+        assertTrue(Chrome.contextEnabled("git.clone", noRepo), "clone is how you get a repo");
+        assertTrue(Chrome.contextEnabled("git.init", noRepo), "init is the other way");
+        assertFalse(Chrome.contextEnabled("git.commit", noRepo), "an ordinary git command still needs one");
+    }
 }


### PR DESCRIPTION
There was no way to create a Git repository from Editora. You could clone one, and everything downstream (status bar, gutter change bars, Commit window, blame, log) lit up for a folder that already was one — but a new folder had to be taken to a terminal first.

`git.init` prompts for a folder (pre-filled with the active project, else the active file's folder), runs `git init`, and then refreshes so the whole Git integration comes up for it immediately.

## Notes

- The already-a-repository check runs on `GitService`'s own worker thread, alongside the `init` itself — reporting the existing root rather than silently creating a nested repository inside it, which is the mistake this command would otherwise make easy.
- `Chrome` gates every `git.*` command on being inside a repository, which would have greyed this one out exactly when it is useful. It joins `git.clone` in the `NEEDS_NO_REPO` carve-out, and `ChromeTest` pins that both stay lit outside a repo.

## Verification

`./mvnw verify` — 3569 tests, coverage floors met, spotless clean. i18n keys added to all six catalogs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)