### PR TITLE
fix(run): a configuration added on the Settings page reaches the toolbar selector

### DIFF
--- a/src/main/java/com/editora/ui/MainController.java
+++ b/src/main/java/com/editora/ui/MainController.java
@@ -819,6 +819,8 @@ public class MainController implements com.editora.mcp.McpBridge {
                 resetAllShortcuts();
             }
         });
+        this.settingsWindow.setRunConfigsChangedHandler(
+                this::refreshRunConfigs); // Run Configurations page edits → repopulate the toolbar selector
         this.settingsWindow.setMacrosChangedHandler(
                 this::refreshSavedMacroCommandsAllWindows); // Macros page edits → re-register commands everywhere
         this.settingsWindow.setAgentCoordinator(agentCoordinator); // AI Agent page: per-client status + combo

--- a/src/main/java/com/editora/ui/SettingsWindow.java
+++ b/src/main/java/com/editora/ui/SettingsWindow.java
@@ -317,6 +317,8 @@ public class SettingsWindow {
     private String macroOriginalName; // the saved name of the selected macro (to detect rename)
     /** Re-registers the {@code macro.run.*} commands across windows after a Macros-page edit. */
     private Runnable onMacrosChanged = () -> {};
+
+    private Runnable onRunConfigsChanged = () -> {};
     /** Shared snippet manager (injected after construction); backs the Snippets management page. */
     private com.editora.snippet.SnippetManager snippetManager;
     /** Working copy of the snippets (bundled + user) for the language selected on the Snippets page. */
@@ -1900,6 +1902,15 @@ public class SettingsWindow {
                 .map(Shortcut::title)
                 .findFirst()
                 .orElse(commandId);
+    }
+
+    /**
+     * Injects the toolbar-selector refresh hook (→ {@code MainController.refreshRunConfigs}); used by the Run
+     * Configurations page. Run configurations live in the per-window {@code WorkspaceState}, so this refreshes
+     * only this window — unlike the macro hook, which re-registers commands everywhere.
+     */
+    public void setRunConfigsChangedHandler(Runnable handler) {
+        this.onRunConfigsChanged = handler == null ? () -> {} : handler;
     }
 
     /** Injects the cross-window macro re-register hook (→ {@code MainController}); used by the Macros page. */
@@ -4440,6 +4451,9 @@ public class SettingsWindow {
     private void persistRunConfigs() {
         config.getWorkspaceState().setRunConfigurations(new java.util.ArrayList<>(runConfigItems));
         config.save();
+        // This page does not go through apply() — it edits WorkspaceState, not Settings — so nothing else
+        // would tell the toolbar selector (and the run.config.<slug> commands) that the list changed.
+        onRunConfigsChanged.run();
     }
 
     /** Re-reads the live per-window run-config list into the editor, restoring the selection by name. */

--- a/src/test/java/com/editora/ui/RunConfigToolbarFxTest.java
+++ b/src/test/java/com/editora/ui/RunConfigToolbarFxTest.java
@@ -64,6 +64,34 @@ class RunConfigToolbarFxTest {
     }
 
     /**
+     * The Settings page's edits must reach the toolbar selector.
+     *
+     * <p>The Run Configurations page edits {@code WorkspaceState}, not {@code Settings}, so it never goes
+     * through {@code SettingsWindow.apply()} — and {@code apply()} → {@code onApply} is the only thing that
+     * reaches {@code refreshRunConfigs()}. So a configuration added there was saved to disk and then simply
+     * never appeared in the selector until the next launch, with nothing logged. This drives the hook the
+     * page now fires; a no-op hook fails it.
+     */
+    @Test
+    void aConfigurationAddedOnTheSettingsPageReachesTheSelector() throws Exception {
+        setConfigs(List.of());
+
+        SettingsWindow settings = FxTestSupport.field(fx.controller, "settingsWindow");
+        Runnable pageEdited = FxTestSupport.field(settings, "onRunConfigsChanged");
+
+        FxTestSupport.runOnFx(() -> {
+            com.editora.config.ConfigManager cfg = FxTestSupport.field(fx.controller, "config");
+            cfg.getWorkspaceState().setRunConfigurations(new java.util.ArrayList<>(List.of(java("demo"))));
+            pageEdited.run(); // exactly what persistRunConfigs() does after writing the list
+        });
+
+        ComboBox<RunConfiguration> combo = combo();
+        assertTrue(
+                combo.getItems().stream().anyMatch(c -> c != null && "demo".equals(c.name())),
+                "the added configuration is missing from the toolbar selector");
+    }
+
+    /**
      * Every catalog item the toolbar can show must resolve to a real node.
      *
      * <p>The gap this closes: a special widget declared in {@code ToolbarCatalog} but never mapped in


### PR DESCRIPTION
Adding a run configuration on Settings → Run Configurations saved it to disk and then did nothing visible: it never appeared in the toolbar selector, nor as a `run.config.<slug>` palette command, until the next launch — with nothing logged. It reads as the save having failed.

## Cause

The Settings live-apply contract is "write the field, then `apply()` → `onApply` → the controller re-applies". This page cannot use it, because it edits `WorkspaceState` rather than `Settings` — so `persistRunConfigs()` only wrote the list and called `config.save()`. `MainController.refreshRunConfigs()`, which rebuilds the combo *and* re-registers the synthetic commands, is reachable only through `onApply`, so it never ran.

## Fix

`persistRunConfigs()` fires an injected hook, mirroring the existing `setMacrosChangedHandler`. One deliberate difference: it refreshes **only this window**, because run configurations live in the per-window `WorkspaceState` — macros are app-global, which is why their hook re-registers across every window.

This covers all three edit paths on the page (Add, Remove, Save). The reverse direction already worked: `show()` calls `reloadRunConfigs()`, so a configuration created by the toolbar's `run.saveConfig` shows up on an already-open Settings page.

## Verification

`./mvnw verify` — 3569 tests, coverage floors met, spotless clean.

The regression test is in `RunConfigToolbarFxTest`; I confirmed it by reverting the wiring, where it fails with "the added configuration is missing from the toolbar selector".

🤖 Generated with [Claude Code](https://claude.com/claude-code)