### PR TITLE
style(toolwindow): fill a side panel's top inset with the chrome ground

### DIFF
--- a/src/main/resources/com/editora/styles/app.css
+++ b/src/main/resources/com/editora/styles/app.css
@@ -1142,8 +1142,13 @@
     -fx-border-width: 0 2 0 0;
 }
 
+/* Subtle ground, NOT the content's default: a panel's own fill is visible only in the top inset that
+   ToolWindowManager.applyPanelTopInset pads in to drop the header to its stripe button — the header and
+   the content paint over everything else. That inset sits in the same row as the editor's tab strip and
+   the tool stripes' matching inset, both of which are -color-bg-subtle, so a default-ground panel cut a
+   white notch out of an otherwise continuous band across the top of the window. */
 .tool-window {
-    -fx-background-color: -color-bg-default;
+    -fx-background-color: -color-bg-subtle;
 }
 
 .tool-window-header {
@@ -3313,7 +3318,12 @@
    fill, which separates it from the content without a rule under it.
    NOT touched: `.split-pane-divider`, the resize handle. */
 .tool-window {
-    -fx-background-radius: 8;
+    /* Square at the top: the panel's own fill shows only in its top inset, which is meant to read as
+       part of the chrome band across the window (see the fill rule above) — rounding it there would
+       punch two corner nicks of the ground behind into that band. The card rounding a reader actually
+       sees is the header's, below. The bottom corners never show (the content paints square over
+       them), so they keep the 8 the rest of the kit uses. */
+    -fx-background-radius: 0 0 8 8;
     -fx-border-width: 0;
 }
 .tool-window-header {

--- a/src/test/java/com/editora/ui/ToolWindowStripeAlignmentFxTest.java
+++ b/src/test/java/com/editora/ui/ToolWindowStripeAlignmentFxTest.java
@@ -8,6 +8,8 @@ import javafx.geometry.Bounds;
 import javafx.scene.Node;
 import javafx.scene.Scene;
 import javafx.scene.control.Button;
+import javafx.scene.layout.BackgroundFill;
+import javafx.scene.layout.CornerRadii;
 import javafx.scene.layout.Pane;
 import javafx.scene.layout.Region;
 import javafx.stage.Stage;
@@ -163,6 +165,53 @@ class ToolWindowStripeAlignmentFxTest {
                         inScene(header).getMinY(),
                         TOLERANCE,
                         "the panel header should start level with the stripe button that opened it");
+            } finally {
+                stripeButton.fire(); // leave the layout as the other tests here expect to find it
+            }
+        });
+    }
+
+    /**
+     * That same inset must also be the same COLOUR as the chrome it sits in.
+     *
+     * <p>The inset is padding <em>inside</em> the panel, so the panel's own fill paints it — and with the
+     * content's default ground that put a white notch in the band the toolbar, the tab strip and the
+     * stripes' matching insets otherwise make across the top of the window. Aligning the header without
+     * matching the fill fixes half the problem, and the half that is left is only visible to the eye.
+     *
+     * <p>The corner radii are asserted with it: rounding the panel's background would punch the ground
+     * behind it back through the band at both ends, which is the same defect a few pixels smaller.
+     */
+    @Test
+    void anOpenSidePanelsTopInsetContinuesTheChromeBandAbove() throws Exception {
+        FxTestSupport.runOnFx(() -> {
+            Button stripeButton = firstRightStripeButton();
+            stripeButton.fire();
+            try {
+                Scene scene = FxTestSupport.<Stage>field(fx.controller, "stage").getScene();
+                scene.getRoot().applyCss();
+                scene.getRoot().layout();
+
+                ToolWindowManager twm = FxTestSupport.field(fx.controller, "toolWindows");
+                java.util.Map<ToolWindow, Region> panels = FxTestSupport.field(twm, "panels");
+                Region panel = panels.values().iterator().next();
+                assertTrue(
+                        panel.getInsets().getTop() > 0,
+                        "precondition: a side panel is inset at the top, so its own fill is what paints there");
+
+                Region toolBar = (Region) scene.lookup(".tool-bar");
+                assertNotNull(toolBar, "the toolbar should be in the scene");
+                BackgroundFill panelFill = panel.getBackground().getFills().get(0);
+                assertEquals(
+                        toolBar.getBackground().getFills().get(0).getFill(),
+                        panelFill.getFill(),
+                        "a side panel's top inset should carry the same ground as the chrome above it");
+
+                CornerRadii radii = panelFill.getRadii();
+                assertEquals(
+                        0.0,
+                        radii.getTopLeftHorizontalRadius() + radii.getTopRightHorizontalRadius(),
+                        "the panel's background should be square at the top, where it meets that band");
             } finally {
                 stripeButton.fire(); // leave the layout as the other tests here expect to find it
             }


### PR DESCRIPTION
The strip above an open side panel's header was white while everything else in that row — the toolbar, the editor's tab strip, the tool stripes' matching insets — is `-color-bg-subtle`, so it cut a notch out of a band that is otherwise continuous across the top of the window.

That strip is the panel's **own** background: `ToolWindowManager.applyPanelTopInset` pads the panel at the top so its header drops to the stripe button that opened it, and the header and content paint over everything else, so the panel's fill is visible *only* there.

- `.tool-window` fill → `-color-bg-subtle`
- `.tool-window` background radius → `0 0 8 8`. With the fill now visible against the band, an 8px top radius would punch two corner nicks of the ground behind back through it. The card rounding a reader actually sees is the header's own `7 7 0 0`; the bottom corners never show (the content paints square over them).

## Consequence worth knowing

An **unfocused** panel's header is also `-color-bg-subtle`, so the inset and the header now read as one taller band (the title and the content edge below still delimit it). Focused, the header goes `-color-accent-subtle`, so the inset stays distinct.

## Testing

`ToolWindowStripeAlignmentFxTest` already pins the *alignment* half of this; the fill was the other half and visible only to the eye. The new `anOpenSidePanelsTopInsetContinuesTheChromeBandAbove` reads the live computed fills and asserts the panel's matches the toolbar's, plus square top corners. Against the old CSS it fails with `expected: <0xf4f5f9ff> but was: <0xffffffff>`.

Full suite: 3651 tests, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)