### PR TITLE
fix(run): enable the toolbar Stop button while a program is running

### DIFF
--- a/src/main/java/com/editora/ui/MainController.java
+++ b/src/main/java/com/editora/ui/MainController.java
@@ -3788,6 +3788,11 @@ public class MainController implements com.editora.mcp.McpBridge {
         }
 
         @Override
+        public void onRunStateChanged() {
+            updateRunConfigButtons();
+        }
+
+        @Override
         public void editConfiguration(String name) {
             runConfigEditor.accept(name);
         }

--- a/src/main/java/com/editora/ui/RunCoordinator.java
+++ b/src/main/java/com/editora/ui/RunCoordinator.java
@@ -32,6 +32,17 @@ final class RunCoordinator {
         void openToolWindow();
 
         /**
+         * A program started or ended, so anything reading {@link RunCoordinator#isRunning()} must re-read it —
+         * today the toolbar's Stop button, which is enabled only while something is running.
+         *
+         * <p>Fired from the one place a run is launched and from the listener that ends it, rather than left
+         * to whatever else happens to refresh the toolbar: with no such call the Stop button only ever
+         * re-evaluated when the configuration list was rebuilt or its selection changed, so it sat disabled
+         * through the entire run it exists to interrupt.
+         */
+        void onRunStateChanged();
+
+        /**
          * Opens the Run Configurations page on {@code name}, so a configuration that cannot run takes you to
          * where you fix it rather than only saying what is wrong.
          */
@@ -756,14 +767,19 @@ final class RunCoordinator {
             public void onExit(int code) {
                 panel.finished(code);
                 host.setStatus(code == 0 ? tr("status.run.ok") : tr("status.run.exit", code));
+                ops.onRunStateChanged();
             }
 
             @Override
             public void onError(String message) {
                 panel.failed(message);
                 host.setStatus(tr("status.run.failed", message));
+                ops.onRunStateChanged();
             }
         });
+        // After the call, not inside onStart: RunService publishes the process before it notifies, so by here
+        // isRunning() is true whether the launch succeeded or failed back through onError above.
+        ops.onRunStateChanged();
     }
 
     /** Stops the currently running program (Run tool window Stop button / {@code run.stop} command). */

--- a/src/test/java/com/editora/ui/RunConfigLaunchFxTest.java
+++ b/src/test/java/com/editora/ui/RunConfigLaunchFxTest.java
@@ -70,6 +70,9 @@ class RunConfigLaunchFxTest {
         public void openToolWindow() {}
 
         @Override
+        public void onRunStateChanged() {}
+
+        @Override
         public void editConfiguration(String name) {}
 
         @Override

--- a/src/test/java/com/editora/ui/RunConfigToolbarFxTest.java
+++ b/src/test/java/com/editora/ui/RunConfigToolbarFxTest.java
@@ -378,6 +378,65 @@ class RunConfigToolbarFxTest {
                 "deleting them all leaves none behind");
     }
 
+    /**
+     * Stop follows the run, not the configuration list.
+     *
+     * <p>Its enabled state is computed from {@code RunCoordinator.isRunning()}, but nothing told the toolbar
+     * when that changed — {@code updateRunConfigButtons()} was reached only by a rebuild of the configuration
+     * list or a change of its selection. So the button sat disabled (and therefore grey rather than red)
+     * through the entire run it exists to interrupt, and no other test noticed because every one of them
+     * asserts after a rebuild, which is exactly when the stale value happens to be right.
+     *
+     * <p>The "while running" half is asserted <em>inside the runnable that launched it</em>: the exit is
+     * reported through {@code Platform.runLater}, so no queued callback can have run yet and a program that
+     * finishes quickly cannot race the assertion. The program is this JVM's own {@code java -version} —
+     * present on every platform the suite runs on, and it exits on its own if anything below fails.
+     */
+    @Test
+    void theStopButtonIsEnabledWhileAProgramIsRunning(@org.junit.jupiter.api.io.TempDir java.nio.file.Path dir)
+            throws Exception {
+        setConfigs(List.of(java("Server")));
+        javafx.scene.control.Button stop = FxTestSupport.field(fx.controller, "runConfigStopButton");
+        assertTrue(FxTestSupport.callOnFx(stop::isDisable), "disabled with nothing running");
+
+        Object runCoordinator = FxTestSupport.field(fx.controller, "runCoordinator");
+        List<String> command = List.of(javaExecutable(), "-version");
+        FxTestSupport.runOnFx(() -> {
+            FxTestSupport.call(
+                    runCoordinator,
+                    "streamRun",
+                    new Class[] {String.class, java.nio.file.Path.class, List.class},
+                    "probe",
+                    dir,
+                    command);
+            assertFalse(stop.isDisable(), "Stop should be enabled the moment a program starts");
+        });
+
+        assertTrue(awaitStopDisabled(stop), "and disabled again once it exits");
+        setConfigs(List.of());
+    }
+
+    /** Polls the FX thread (which also drains the exit callback) until Stop goes back to disabled. */
+    private boolean awaitStopDisabled(javafx.scene.control.Button stop) throws Exception {
+        long deadline = System.nanoTime() + java.time.Duration.ofSeconds(20).toNanos();
+        while (System.nanoTime() < deadline) {
+            if (FxTestSupport.callOnFx(stop::isDisable)) {
+                return true;
+            }
+            Thread.sleep(25);
+        }
+        return false;
+    }
+
+    /** This JVM's own launcher — an absolute path, so it needs no PATH lookup and carries any .exe suffix. */
+    private static String javaExecutable() {
+        return ProcessHandle.current()
+                .info()
+                .command()
+                .orElseGet(() -> java.nio.file.Path.of(System.getProperty("java.home"), "bin", "java")
+                        .toString());
+    }
+
     /** Run/Debug are meaningless with nothing selected, so they are disabled rather than silently no-op. */
     @Test
     void theButtonsDisableWithNoSelection() throws Exception {


### PR DESCRIPTION
The toolbar's run-cluster Stop button stayed grey and inert while a program was running.

`updateRunConfigButtons()` does set `runConfigStopButton.setDisable(!runCoordinator.isRunning())` — but nothing called it when a run started or ended. Its only callers were a rebuild of the configuration list, a change of its selection, and `onStopRun`. So the state was whatever the last rebuild left: permanently disabled.

The colour was never the problem. `app.css` already carries `.run-config-stop .icon-line { -fx-stroke: -state-red; }`; a *disabled* button's glyph is overridden to `-color-fg-subtle` by the higher-specificity `.button:disabled .icon-line`, so the grey was the symptom of the disabled state.

(`RunCoordinator.isRunning()`'s own javadoc already said "so the toolbar Stop button can reflect it" — only the notification was missing.)

## Change

New `RunCoordinator.Ops.onRunStateChanged()`, implemented in `MainController` as `updateRunConfigButtons()`, fired from:

- `streamRun` — the single place any run is launched, so the gutter ▶, `run.mainClass`, `run.rerun`, a make target and a saved configuration all go through it. The call sits **after** `service.runInDir(...)` returns, because `RunService` publishes the process before it notifies.
- the listener's `onExit` / `onError`.

## Testing

`RunConfigToolbarFxTest.theStopButtonIsEnabledWhileAProgramIsRunning` launches this JVM's own `java -version` and asserts Stop is enabled **inside the runnable that started it** — the exit is reported through `Platform.runLater`, so a fast-exiting program cannot race the assertion — then polls until it goes back to disabled. Without the notification it fails with `Stop should be enabled the moment a program starts ==> expected: <false> but was: <true>`.

Full suite: 3651 tests, 0 failures.

## Not included

While a **debug** session is live, Stop is still disabled: `updateRunConfigButtons` only consults `runCoordinator.isRunning()`, and `onStopRun` only calls `runCoordinator.stopRun()`. Wiring it to `DapManager.isActive()` is a behaviour change rather than a stale-state fix, so it's left for a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)