### PR TITLE
fix(debug): parse jdtls's resolveMainClass reply as a plain List

### DIFF
--- a/src/main/java/com/editora/dap/DapManager.java
+++ b/src/main/java/com/editora/dap/DapManager.java
@@ -5,6 +5,7 @@ import java.net.ServerSocket;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -537,11 +538,16 @@ public final class DapManager implements DapClient.Host {
             cb.accept(List.of());
             return;
         }
-        lsp.executeCommand(
-                routingFile,
-                "vscode.java.resolveMainClass",
-                List.of(),
-                (res, err) -> cb.accept(err != null ? List.of() : parseMainClasses(res)));
+        lsp.executeCommand(routingFile, "vscode.java.resolveMainClass", List.of(), (res, err) -> {
+            if (err != null) {
+                // The caller cannot tell this from "the project has none" — it reports the same thing either
+                // way — so the log is the only place the difference can survive.
+                LOG.log(Level.WARNING, err, () -> "vscode.java.resolveMainClass failed for " + routingFile);
+                cb.accept(List.of());
+                return;
+            }
+            cb.accept(parseMainClasses(res));
+        });
     }
 
     /**
@@ -1165,8 +1171,32 @@ public final class DapManager implements DapClient.Host {
 
     // --- gson result parsing (jdtls executeCommand returns untyped JsonElements) -----------------
 
+    /**
+     * Reads {@code vscode.java.resolveMainClass}'s reply — {@code [{mainClass, projectName, filePath}, …]}.
+     *
+     * <p>Handles a raw {@link java.util.List} of {@link Map}s as well as a gson {@link JsonElement}, for the
+     * same reason {@link #parseClasspath} does — and here it was not merely a hazard but the whole feature:
+     * lsp4j hands this particular result back as an {@code ArrayList<LinkedTreeMap>}, so {@link #asJson}'s
+     * {@code String.valueOf} fallback fed gson Java's {@code toString()} form,
+     * {@code [{mainClass=com.example.App, filePath=/home/…}]}. Gson's lenient parser reads unquoted keys and
+     * {@code =} separators, but not an unquoted value beginning {@code /} (it scans as a comment) — so every
+     * absolute file path threw {@code MalformedJsonException}, {@code asJson} logged it at {@code FINE} and
+     * returned null, and Editora reported "no main class was found" for a project whose main class jdtls had
+     * just named. Confirmed against a real jdtls in {@code JdtlsResolveMainClassProbeTest}. Reading the list
+     * directly removes the round trip entirely.
+     */
     private static List<MainClassOption> parseMainClasses(Object res) {
         List<MainClassOption> out = new ArrayList<>();
+        if (res instanceof List<?> list) {
+            for (Object e : list) {
+                if (e instanceof Map<?, ?> m) {
+                    out.add(new MainClassOption(str(m, "mainClass"), str(m, "projectName"), str(m, "filePath")));
+                } else if (e instanceof JsonObject o) {
+                    out.add(new MainClassOption(str(o, "mainClass"), str(o, "projectName"), str(o, "filePath")));
+                }
+            }
+            return out;
+        }
         JsonElement el = asJson(res);
         if (el != null && el.isJsonArray()) {
             for (JsonElement e : el.getAsJsonArray()) {
@@ -1267,6 +1297,12 @@ public final class DapManager implements DapClient.Host {
         return e != null && e.isJsonPrimitive() ? e.getAsString() : null;
     }
 
+    /** The {@link Map} twin of the above, for a reply lsp4j deserialized to plain collections. */
+    private static String str(Map<?, ?> m, String key) {
+        Object v = m.get(key);
+        return v == null ? null : String.valueOf(v);
+    }
+
     /** Bounded rendering of a server reply for a log line — a classpath can be very long. */
     private static String abbreviate(String s) {
         if (s == null) {
@@ -1286,7 +1322,14 @@ public final class DapManager implements DapClient.Host {
         try {
             return com.google.gson.JsonParser.parseString(String.valueOf(res));
         } catch (RuntimeException e) {
-            LOG.log(Level.FINE, "could not parse executeCommand result", e);
+            // WARNING, not FINE: every caller turns null into an empty result, which reaches the user as a
+            // statement about their project ("no main class was found"). A swallowed parse failure reported
+            // as a fact about the workspace is how the resolveMainClass bug survived — say so in the log.
+            LOG.log(
+                    Level.WARNING,
+                    e,
+                    () -> "could not parse an executeCommand result of type "
+                            + res.getClass().getName() + ": " + abbreviate(String.valueOf(res)));
             return null;
         }
     }

--- a/src/test/java/com/editora/dap/FxlessAccess.java
+++ b/src/test/java/com/editora/dap/FxlessAccess.java
@@ -16,4 +16,16 @@ final class FxlessAccess {
             throw new AssertionError("parseClasspath is the contract under test", e);
         }
     }
+
+    /** The same, for {@code vscode.java.resolveMainClass}'s reply. */
+    @SuppressWarnings("unchecked")
+    static List<DapManager.MainClassOption> parseMainClasses(Object res) {
+        try {
+            Method m = DapManager.class.getDeclaredMethod("parseMainClasses", Object.class);
+            m.setAccessible(true);
+            return (List<DapManager.MainClassOption>) m.invoke(null, res);
+        } catch (ReflectiveOperationException e) {
+            throw new AssertionError("parseMainClasses is the contract under test", e);
+        }
+    }
 }

--- a/src/test/java/com/editora/dap/MainClassParseTest.java
+++ b/src/test/java/com/editora/dap/MainClassParseTest.java
@@ -1,0 +1,110 @@
+package com.editora.dap;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import com.google.gson.JsonParser;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * jdtls answers {@code vscode.java.resolveMainClass} with {@code [{mainClass, projectName, filePath}, …]}.
+ *
+ * <p>Captured verbatim from a real jdtls 1.60 + java-debug 0.53.2 against the generated Maven quickstart
+ * ({@code JdtlsResolveMainClassProbeTest}), <b>including the Java type lsp4j hands back</b>:
+ *
+ * <pre>
+ * type  = java.util.ArrayList
+ * value = [{mainClass=com.example.adltest.App, projectName=adltest,
+ *           filePath=/home/adl/src/adl/adltest/src/main/java/com/example/adltest/App.java}]
+ * </pre>
+ *
+ * <p>That type is the whole point of this class. The parser used to route every reply through
+ * {@code JsonParser.parseString(String.valueOf(res))}, and gson's lenient reader cannot read an unquoted
+ * value starting with {@code /} — so an absolute {@code filePath}, i.e. every real project on every
+ * platform, threw and was swallowed into an empty list. Debugging a saved run configuration then reported
+ * "No main class was found in this project" about a project whose main class jdtls had just named, and the
+ * gutter's Debug quietly took its compile-it-ourselves fallback instead of the real launch.
+ */
+class MainClassParseTest {
+
+    /** Exactly what lsp4j delivered: a List of Maps, not a JsonElement. */
+    private static Object lsp4jReply(String mainClass, String projectName, String filePath) {
+        Map<String, String> m = new LinkedHashMap<>();
+        m.put("mainClass", mainClass);
+        m.put("projectName", projectName);
+        m.put("filePath", filePath);
+        return new java.util.ArrayList<>(List.of(m));
+    }
+
+    @Test
+    void readsTheRealJdtlsReplyAsAPlainListOfMaps() {
+        List<DapManager.MainClassOption> out = FxlessAccess.parseMainClasses(lsp4jReply(
+                "com.example.adltest.App",
+                "adltest",
+                "/home/adl/src/adl/adltest/src/main/java/com/example/adltest/App.java"));
+
+        assertEquals(1, out.size(), "the reply names one main class");
+        assertEquals("com.example.adltest.App", out.get(0).mainClass());
+        assertEquals("adltest", out.get(0).projectName());
+        assertEquals(
+                "/home/adl/src/adl/adltest/src/main/java/com/example/adltest/App.java",
+                out.get(0).filePath(),
+                "the absolute path is the field the toString() round trip used to choke on");
+    }
+
+    /** A path with a space or comma does not survive a toString() round trip either — nor a Windows one. */
+    @Test
+    void awkwardPathsSurvive() {
+        List<DapManager.MainClassOption> out =
+                FxlessAccess.parseMainClasses(lsp4jReply("demo.App", "My, Project", "/home/My Projects/a,b/App.java"));
+        assertEquals("/home/My Projects/a,b/App.java", out.get(0).filePath());
+        assertEquals("My, Project", out.get(0).projectName());
+
+        out = FxlessAccess.parseMainClasses(lsp4jReply("demo.App", "demo", "C:\\Users\\me\\src\\App.java"));
+        assertEquals("C:\\Users\\me\\src\\App.java", out.get(0).filePath());
+    }
+
+    /** The gson shape still parses — a server (or lsp4j version) that hands back a JsonElement is unaffected. */
+    @Test
+    void readsTheSameReplyAsAGsonElement() {
+        Object res = JsonParser.parseString("[{\"mainClass\":\"com.example.adltest.App\",\"projectName\":\"adltest\","
+                + "\"filePath\":\"/home/adl/src/adl/adltest/src/main/java/com/example/adltest/App.java\"}]");
+        List<DapManager.MainClassOption> out = FxlessAccess.parseMainClasses(res);
+        assertEquals(1, out.size());
+        assertEquals("com.example.adltest.App", out.get(0).mainClass());
+        assertEquals(
+                "/home/adl/src/adl/adltest/src/main/java/com/example/adltest/App.java",
+                out.get(0).filePath());
+    }
+
+    @Test
+    void severalMainClassesAreAllReturned() {
+        Object res = new java.util.ArrayList<>(List.of(
+                Map.of("mainClass", "demo.A", "projectName", "p", "filePath", "/p/A.java"),
+                Map.of("mainClass", "demo.B", "projectName", "p", "filePath", "/p/B.java")));
+        assertEquals(
+                List.of("demo.A", "demo.B"),
+                FxlessAccess.parseMainClasses(res).stream()
+                        .map(DapManager.MainClassOption::mainClass)
+                        .toList());
+    }
+
+    /** A missing field is null rather than a crash — the caller matches on mainClass and tolerates the rest. */
+    @Test
+    void aReplyMissingFieldsDoesNotThrow() {
+        Object res = new java.util.ArrayList<>(List.of(Map.of("mainClass", "demo.App")));
+        List<DapManager.MainClassOption> out = FxlessAccess.parseMainClasses(res);
+        assertEquals("demo.App", out.get(0).mainClass());
+        assertEquals(null, out.get(0).filePath());
+    }
+
+    @Test
+    void junkYieldsEmptyRatherThanThrowing() {
+        assertEquals(List.of(), FxlessAccess.parseMainClasses(null));
+        assertEquals(List.of(), FxlessAccess.parseMainClasses("not a reply"));
+        assertEquals(List.of(), FxlessAccess.parseMainClasses(List.of()));
+    }
+}

--- a/src/test/java/com/editora/lsp/JdtlsResolveMainClassProbeTest.java
+++ b/src/test/java/com/editora/lsp/JdtlsResolveMainClassProbeTest.java
@@ -1,0 +1,159 @@
+package com.editora.lsp;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+import org.eclipse.lsp4j.DidOpenTextDocumentParams;
+import org.eclipse.lsp4j.ExecuteCommandParams;
+import org.eclipse.lsp4j.InitializeParams;
+import org.eclipse.lsp4j.InitializeResult;
+import org.eclipse.lsp4j.InitializedParams;
+import org.eclipse.lsp4j.TextDocumentItem;
+import org.eclipse.lsp4j.WorkspaceFolder;
+import org.eclipse.lsp4j.jsonrpc.Launcher;
+import org.eclipse.lsp4j.launch.LSPLauncher;
+import org.eclipse.lsp4j.services.LanguageClient;
+import org.eclipse.lsp4j.services.LanguageServer;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+/**
+ * MANUAL PROBE (not part of the suite — {@code @Tag("probe")}, run explicitly). Answers the one question a
+ * unit test cannot: what does a REAL jdtls, loaded with the java-debug bundle exactly as Editora loads it,
+ * hand back for {@code vscode.java.resolveMainClass} on a plain Maven project — and, just as important,
+ * <em>as which Java type</em>.
+ *
+ * <p>Why the type matters: lsp4j deserializes an untyped {@code workspace/executeCommand} result to whatever
+ * the payload maps to, which is not always a gson {@code JsonElement}. {@code DapManager.parseMainClasses}
+ * reads it through {@code asJson}, whose fallback is {@code JsonParser.parseString(String.valueOf(res))} —
+ * a round trip through Java's {@code toString()}. {@code parseClasspath} was already fixed to read a
+ * {@code List} directly for that reason; {@code parseMainClasses} was not.
+ *
+ * <p>Run: {@code ./mvnw test -Dtest=JdtlsResolveMainClassProbeTest -Dgroups=probe -Dlsp.probe=true}
+ * (optionally {@code -Dlsp.probe.project=/path/to/a/maven/project}). Self-skips without the flag.
+ */
+@Tag("probe")
+class JdtlsResolveMainClassProbeTest {
+
+    private static final Path JDTLS = Path.of(System.getProperty("user.home"), ".editora/plugins/lsp/java/bin/jdtls");
+
+    private static final Path DEBUG_PLUGIN_DIR = Path.of(System.getProperty("user.home"), ".editora/plugins/dap/java");
+
+    @Test
+    void probe() throws Exception {
+        org.junit.jupiter.api.Assumptions.assumeTrue(Boolean.getBoolean("lsp.probe"), "opt-in: pass -Dlsp.probe=true");
+        org.junit.jupiter.api.Assumptions.assumeTrue(Files.isExecutable(JDTLS), "needs a local jdtls at " + JDTLS);
+
+        Path project = Path.of(System.getProperty(
+                "lsp.probe.project",
+                Path.of(System.getProperty("user.home"), "src/adl/adltest").toString()));
+        org.junit.jupiter.api.Assumptions.assumeTrue(Files.isDirectory(project), "needs a Maven project: " + project);
+
+        Path file;
+        try (var walk = Files.walk(project.resolve("src/main/java"))) {
+            file = walk.filter(p -> p.toString().endsWith(".java")).findFirst().orElseThrow();
+        }
+        String bundle;
+        try (var jars = Files.list(DEBUG_PLUGIN_DIR)) {
+            bundle = jars.filter(p -> p.toString().endsWith(".jar"))
+                    .findFirst()
+                    .orElseThrow()
+                    .toString();
+        }
+        System.out.println("project = " + project);
+        System.out.println("file    = " + file);
+        System.out.println("bundle  = " + bundle);
+
+        Path data = Files.createTempDirectory("jdtls-mainclass-probe");
+        ProcessBuilder pb = new ProcessBuilder(JDTLS.toString(), "-data", data.toString());
+        pb.redirectError(ProcessBuilder.Redirect.INHERIT);
+        Process proc = pb.start();
+        try {
+            LanguageClient client = new ProbeClient();
+            Launcher<LanguageServer> launcher =
+                    LSPLauncher.createClientLauncher(client, proc.getInputStream(), proc.getOutputStream());
+            LanguageServer server = launcher.getRemoteProxy();
+            launcher.startListening();
+
+            InitializeParams ip = new InitializeParams();
+            ip.setProcessId((int) ProcessHandle.current().pid());
+            ip.setRootUri(project.toUri().toString());
+            ip.setWorkspaceFolders(List.of(new WorkspaceFolder(
+                    project.toUri().toString(), project.getFileName().toString())));
+            // Exactly what LspManager.initOptionsFor sends for jdtls with debugging on.
+            ip.setInitializationOptions(Map.of("bundles", List.of(bundle)));
+            InitializeResult init = server.initialize(ip).get(180, TimeUnit.SECONDS);
+            server.initialized(new InitializedParams());
+            System.out.println("executeCommandProvider = "
+                    + (init.getCapabilities().getExecuteCommandProvider() == null
+                            ? "none"
+                            : init.getCapabilities().getExecuteCommandProvider().getCommands().stream()
+                                    .filter(c -> c.contains("resolveMainClass") || c.contains("debug"))
+                                    .toList()));
+
+            server.getTextDocumentService()
+                    .didOpen(new DidOpenTextDocumentParams(
+                            new TextDocumentItem(file.toUri().toString(), "java", 1, Files.readString(file))));
+
+            // The project import is asynchronous; ask repeatedly rather than sleeping one arbitrary interval.
+            for (int attempt = 1; attempt <= 12; attempt++) {
+                Thread.sleep(10_000);
+                Object res;
+                String error = null;
+                try {
+                    res = server.getWorkspaceService()
+                            .executeCommand(new ExecuteCommandParams("vscode.java.resolveMainClass", List.of()))
+                            .get(60, TimeUnit.SECONDS);
+                } catch (Exception e) {
+                    res = null;
+                    error = String.valueOf(e.getCause() == null ? e : e.getCause());
+                }
+                System.out.println("--- attempt " + attempt + " (" + attempt * 10 + "s) ---");
+                System.out.println("  error = " + error);
+                System.out.println(
+                        "  type  = " + (res == null ? "null" : res.getClass().getName()));
+                System.out.println("  value = " + res);
+                if (res != null && !String.valueOf(res).equals("[]")) {
+                    // Close the loop: run OUR parser on the server's own object, not on a transcription of it.
+                    System.out.println("  >>> DapManager.parseMainClasses = " + parseMainClasses(res));
+                    break;
+                }
+            }
+        } finally {
+            proc.destroyForcibly();
+        }
+    }
+
+    /** {@code DapManager.parseMainClasses} is private and in another package; this probe is a diagnostic. */
+    private static Object parseMainClasses(Object res) throws Exception {
+        var m = Class.forName("com.editora.dap.DapManager").getDeclaredMethod("parseMainClasses", Object.class);
+        m.setAccessible(true);
+        return m.invoke(null, res);
+    }
+
+    /** Minimal client: jdtls talks a lot during an import and every notification needs somewhere to go. */
+    private static final class ProbeClient implements LanguageClient {
+        @Override
+        public void telemetryEvent(Object object) {}
+
+        @Override
+        public void publishDiagnostics(org.eclipse.lsp4j.PublishDiagnosticsParams diagnostics) {}
+
+        @Override
+        public void showMessage(org.eclipse.lsp4j.MessageParams messageParams) {
+            System.out.println("[showMessage] " + messageParams.getMessage());
+        }
+
+        @Override
+        public java.util.concurrent.CompletableFuture<org.eclipse.lsp4j.MessageActionItem> showMessageRequest(
+                org.eclipse.lsp4j.ShowMessageRequestParams requestParams) {
+            return java.util.concurrent.CompletableFuture.completedFuture(new org.eclipse.lsp4j.MessageActionItem());
+        }
+
+        @Override
+        public void logMessage(org.eclipse.lsp4j.MessageParams message) {}
+    }
+}


### PR DESCRIPTION
Debugging a saved Java run configuration always reported **"No main class was found in this project."** jdtls was answering correctly the whole time — we were discarding the answer.

## Root cause

lsp4j deserializes this untyped `workspace/executeCommand` result to a `java.util.ArrayList` of maps, not a gson `JsonElement`. `DapManager.parseMainClasses` read it through `asJson`, whose fallback is `JsonParser.parseString(String.valueOf(res))` — a round trip through Java's `toString()`, producing:

```
[{mainClass=com.example.adltest.App, projectName=adltest, filePath=/home/adl/.../App.java}]
```

Gson's lenient reader tolerates unquoted keys and `=` separators, but **not an unquoted value beginning `/`** (it scans as a comment). So every absolute `filePath` threw `MalformedJsonException ... path $[0].filePath`, `asJson` logged it at `FINE` and returned null, and the empty list surfaced as a statement about the user's project. Any absolute path triggers it, on every platform.

It degraded the **gutter** Debug too: an empty list there falls through to `compileAndLaunch`, so a project class was javac'd standalone to a temp dir instead of launched on its real classpath — which is why this looked like it half-worked.

`parseClasspath` was already hardened against exactly this (its javadoc describes the trap); `parseMainClasses` never was.

## Evidence

The new opt-in `JdtlsResolveMainClassProbeTest` (`@Tag("probe")`, self-skips) drives a **real** jdtls 1.60 + java-debug 0.53.2 against a generated Maven quickstart:

```
executeCommandProvider = [vscode.java.resolveMainClass]
type  = java.util.ArrayList
value = [{mainClass=com.example.adltest.App, projectName=adltest, filePath=/home/adl/.../App.java}]
>>> DapManager.parseMainClasses = [MainClassOption[mainClass=com.example.adltest.App, ...]]
```

That last line is with this change; before it, the same live object parsed to `[]`.

## Changes

- `parseMainClasses` reads a `List` of `Map`s (or `JsonObject`s) directly, keeping the `JsonElement` path for servers/lsp4j versions that return one.
- **Stop swallowing the failure.** `asJson` now logs a parse failure at `WARNING` with the payload's type and an abbreviation, and `resolveMainClasses` logs an `executeCommand` error instead of silently returning empty. Every caller turns null into "your project has none", so a swallowed failure reaching the user as a fact about their workspace is exactly how this survived.

## Testing

`MainClassParseTest` pins the captured live reply, plus paths with spaces, commas and Windows separators, and the gson shape. Against the old parser: 2 failures + 1 error, the headline one `expected: <1> but was: <0>`.

Full suite: 3657 tests, 0 failures.

## Known gap

`debugConfig` reports the same "no main class" message whether the project has none, the request failed, or the project has main classes but not the one the configuration names. The third deserves its own wording — follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)