### PR TITLE
fix(lsp): keep the caret put when an auto-import is inserted above it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -147,6 +147,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     The end only ever extends *past* the caret and never beyond the current line: anything you typed while
     the popup was open is still absorbed, and a stale range can't eat the lines below.
 
+- **Accepting a completion that adds an import no longer moves your cursor.** Typing `List<Item` and hitting
+  Tab inserted `import demo.Inventory.Item;` correctly, but then left the cursor at the end of that new import
+  line — so the next thing you typed went into the import statement. The cursor now stays on the identifier
+  you were typing, following its own text down as the import is added above it.
+
 - **A long status-bar message no longer squashes the segments beside it.** The echo line and the state
   segments share one row, and when they did not all fit every one of them was shrunk — so a wordy message
   reduced `LSP: jdtls`, `Editable`, the caret position and the rest to bare ellipses. The message now

--- a/TODO.md
+++ b/TODO.md
@@ -22,6 +22,19 @@ A backlog of planned features and improvements. Unordered within each section.
       `Completion.ReplaceStart` became `ReplaceRange` to carry it.
       *Deferred: nothing re-triggers completion after accepting, so reaching the class list still needs the
       user to type over the `*`; VS Code behaves the same way.*
+
+- [x] **Auto-import no longer steals the caret** (#834) — accepting a completion whose
+      `additionalTextEdits` add an `import` left the caret at the end of the inserted import line, because
+      **both** of `applyLspEdits`' apply paths (`replaceText` and `MultiChangeBuilder.commit`) leave the caret
+      at the end of what they inserted, and the import lands *above* the caret. `LspEditShift` already
+      translated the server's edit *positions* across the accept (#410); nothing translated the **caret**
+      across the edits. New pure `LspEditShift.caretAfterEdits(caret, ranges, texts)`: edits ending at or
+      before the caret move it by their net length change, edits after it leave it alone, and an edit
+      straddling it collapses to the end of its replacement (correct because the ranges are ascending and
+      non-overlapping, so nothing later can move it again). Wired through a private `applyLspEdits(edits,
+      preserveCaret)` overload, so the **public** behaviour is unchanged and **Format Document still leaves
+      the caret exactly where it did** — pinned by a control test, since silently changing that would be a
+      second, unrequested behaviour change. *Deferred: caret preservation for Format Document itself.*
 - [x] **New ▸ &lt;file type&gt; on the Project tree** — the IDE-standard "New ▸ Java Class / Python File / YAML"
       catalog: ~50 types in seven category submenus, driven by the pure `template/NewFileCatalog` table (one
       row per type, so the menu, the `file.newFileOfType` palette picker and the tests all pick a new type up

--- a/src/main/java/com/editora/editor/EditorBuffer.java
+++ b/src/main/java/com/editora/editor/EditorBuffer.java
@@ -9332,7 +9332,10 @@ public class EditorBuffer implements TabContent {
      * computed them — see {@link LspEditShift}.
      */
     public void applyCompletionAdditionalEdits(java.util.List<LspTextEdit> edits) {
-        applyLspEdits(LspEditShift.shift(edits, pendingCompletionShift));
+        // Keep the caret where the accept left it. The import lands *above* the caret, and both apply paths
+        // (replaceText, and MultiChangeBuilder.commit) leave the caret at the end of what they inserted — so
+        // without this, accepting `List<Item` threw the caret onto the newly inserted `import` line (#834).
+        applyLspEdits(LspEditShift.shift(edits, pendingCompletionShift), true);
     }
 
     /**
@@ -9344,10 +9347,20 @@ public class EditorBuffer implements TabContent {
      * clamping it onto the last line would apply the edit at a wrong place (#667). Inert when not editable.
      */
     public void applyLspEdits(java.util.List<LspTextEdit> edits) {
+        applyLspEdits(edits, false);
+    }
+
+    /**
+     * As {@link #applyLspEdits(java.util.List)}, but optionally restoring the caret to the position it
+     * addressed <em>before</em> the edits. Used by the auto-import path, where the inserted line sits above
+     * the caret and would otherwise drag it away from what the user was typing (#834).
+     */
+    private void applyLspEdits(java.util.List<LspTextEdit> edits, boolean preserveCaret) {
         if (edits == null || edits.isEmpty() || !isEditable()) {
             return;
         }
         CodeArea a = focusedArea != null ? focusedArea : area;
+        int caretBefore = a.getCaretPosition();
         // Resolve each edit to an absolute [start,end] against the current document, keep valid + non-overlapping,
         // sorted ascending. Applying them as ONE MultiChangeBuilder commit makes the whole set a single undo
         // unit — a multi-line Format Document (or an auto-import's additional edits) was previously one
@@ -9383,6 +9396,7 @@ public class EditorBuffer implements TabContent {
         }
         if (ranges.size() == 1) {
             a.replaceText(ranges.get(0)[0], ranges.get(0)[1], texts.get(0));
+            restoreCaretAfterEdits(a, preserveCaret, caretBefore, ranges, texts);
             return;
         }
         // Apply BOTTOM-TO-TOP. The fork's MultiChangeBuilder applies its replacements *sequentially against
@@ -9397,6 +9411,22 @@ public class EditorBuffer implements TabContent {
             builder.replaceTextAbsolutely(ranges.get(i)[0], ranges.get(i)[1], texts.get(i));
         }
         builder.commit(); // one undo unit for the whole edit set
+        restoreCaretAfterEdits(a, preserveCaret, caretBefore, ranges, texts);
+    }
+
+    /** Puts the caret back where it was, translated across the edits just applied; see {@code LspEditShift}. */
+    private static void restoreCaretAfterEdits(
+            CodeArea a,
+            boolean preserveCaret,
+            int caretBefore,
+            java.util.List<int[]> ranges,
+            java.util.List<String> texts) {
+        if (!preserveCaret) {
+            return;
+        }
+        int target = LspEditShift.caretAfterEdits(caretBefore, ranges, texts);
+        a.moveTo(Math.max(0, Math.min(target, a.getLength())));
+        a.requestFollowCaret();
     }
 
     private static int lspEditOffset(CodeArea a, LspTextEdit e) {

--- a/src/main/java/com/editora/editor/LspEditShift.java
+++ b/src/main/java/com/editora/editor/LspEditShift.java
@@ -82,4 +82,36 @@ public final class LspEditShift {
     private static boolean strictlyBefore(int line, int col, int atLine, int atCol) {
         return line < atLine || (line == atLine && col < atCol);
     }
+
+    /**
+     * Where a caret at absolute offset {@code caret} ends up once a set of edits is applied — used to put the
+     * caret back where the user left it after an auto-import has been spliced in above it.
+     *
+     * <p>An {@code additionalTextEdits} import lands <em>before</em> the caret, and applying it leaves the caret
+     * at the end of the inserted line, which is nowhere the user was typing. Only edits ending at or before the
+     * caret move it, by their net length change; edits entirely after it leave it alone.
+     *
+     * <p>{@code ranges} are {@code {from, to}} absolute offsets against the document as it stood <b>before</b>
+     * these edits, ascending and non-overlapping — exactly what {@link EditorBuffer#applyLspEdits} resolves them
+     * to — with {@code texts} the parallel replacements.
+     */
+    public static int caretAfterEdits(int caret, List<int[]> ranges, List<String> texts) {
+        int shift = 0;
+        for (int i = 0; i < ranges.size(); i++) {
+            int from = ranges.get(i)[0];
+            int to = ranges.get(i)[1];
+            int newLen = texts.get(i) == null ? 0 : texts.get(i).length();
+            if (to <= caret) {
+                shift += newLen - (to - from);
+            } else if (from < caret) {
+                // This edit replaces the text the caret sits inside, so the offset it named is gone. Land at the
+                // end of the replacement — and because the ranges are ascending and non-overlapping, everything
+                // still to come starts after the caret and cannot move it.
+                return from + shift + newLen;
+            } else {
+                break; // ascending: this edit and every later one start after the caret
+            }
+        }
+        return caret + shift;
+    }
 }

--- a/src/test/java/com/editora/editor/LspEditShiftTest.java
+++ b/src/test/java/com/editora/editor/LspEditShiftTest.java
@@ -117,4 +117,69 @@ class LspEditShiftTest {
         List<LspTextEdit> out = LspEditShift.shift(List.of(importEdit(40)), shrink);
         assertEquals(37, out.get(0).startLine());
     }
+
+    // --- caretAfterEdits: keeping the caret put while an import is spliced in above it (#834) ---
+
+    private static List<int[]> ranges(int... pairs) {
+        List<int[]> out = new java.util.ArrayList<>();
+        for (int i = 0; i < pairs.length; i += 2) {
+            out.add(new int[] {pairs[i], pairs[i + 1]});
+        }
+        return out;
+    }
+
+    @Test
+    void anImportInsertedAboveTheCaretPushesItDownByExactlyTheInsertedText() {
+        // The reported case: caret sits in `List<Item` and the server adds an import line above it.
+        String imported = "import demo.Inventory.Item;\n";
+        int caret = 200;
+        assertEquals(caret + imported.length(), LspEditShift.caretAfterEdits(caret, ranges(60, 60), List.of(imported)));
+    }
+
+    @Test
+    void anEditAfterTheCaretLeavesItAlone() {
+        assertEquals(50, LspEditShift.caretAfterEdits(50, ranges(80, 90), List.of("whatever")));
+    }
+
+    @Test
+    void anEditEndingExactlyAtTheCaretStillMovesIt() {
+        // Boundary: text inserted immediately before the caret is text the caret must move past.
+        assertEquals(53, LspEditShift.caretAfterEdits(50, ranges(50, 50), List.of("abc")));
+    }
+
+    @Test
+    void aDeletionAboveTheCaretPullsItUp() {
+        assertEquals(40, LspEditShift.caretAfterEdits(50, ranges(10, 20), List.of("")));
+    }
+
+    @Test
+    void severalEditsAboveTheCaretAccumulate() {
+        assertEquals(50 + 3 + 2, LspEditShift.caretAfterEdits(50, ranges(0, 0, 10, 10), List.of("abc", "de")));
+    }
+
+    @Test
+    void editsAreCountedOnlyUpToTheCaret() {
+        // One before, one after: only the first may move the caret.
+        assertEquals(53, LspEditShift.caretAfterEdits(50, ranges(0, 0, 90, 95), List.of("abc", "replacement")));
+    }
+
+    @Test
+    void anEditStraddlingTheCaretLandsAtTheEndOfItsReplacement() {
+        // The offset the caret named is gone, so the honest landing spot is the end of the new text —
+        // offset by whatever earlier edits already shifted.
+        assertEquals(0 + 4, LspEditShift.caretAfterEdits(2, ranges(0, 5), List.of("abcd")));
+        assertEquals(3 + 10 + 4, LspEditShift.caretAfterEdits(12, ranges(0, 0, 10, 15), List.of("abc", "abcd")));
+    }
+
+    @Test
+    void noEditsLeavesTheCaretExactlyWhereItWas() {
+        assertEquals(7, LspEditShift.caretAfterEdits(7, List.of(), List.of()));
+    }
+
+    @Test
+    void aNullReplacementCountsAsADeletion() {
+        List<String> withNull = new java.util.ArrayList<>();
+        withNull.add(null);
+        assertEquals(45, LspEditShift.caretAfterEdits(50, ranges(0, 5), withNull));
+    }
 }

--- a/src/test/java/com/editora/ui/AutoImportCaretFxTest.java
+++ b/src/test/java/com/editora/ui/AutoImportCaretFxTest.java
@@ -1,0 +1,108 @@
+package com.editora.ui;
+
+import java.util.List;
+
+import com.editora.editor.EditorBuffer;
+import com.editora.editor.LspTextEdit;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Accepting a completion that carries an auto-import must not move the caret (#834).
+ *
+ * <p>The import lands <em>above</em> the caret, and both of {@code applyLspEdits}' apply paths leave the caret
+ * at the end of what they inserted — so the caret was thrown onto the newly inserted {@code import} line,
+ * away from the identifier the user was in the middle of typing. Driven through the real
+ * {@code applyCompletionAdditionalEdits} rather than the pure helper, because the defect was in what
+ * {@code replaceText} does to the caret, not in the arithmetic.
+ */
+@Tag("fx")
+class AutoImportCaretFxTest {
+
+    private static final String SOURCE = "package demo;\n"
+            + "\n"
+            + "import java.util.ArrayList;\n"
+            + "import java.util.List;\n"
+            + "import java.util.Optional;\n"
+            + "\n"
+            + "public class Inventory2 {\n"
+            + "\n"
+            + "    private final List<Item\n"
+            + "}\n";
+
+    private static final String IMPORT_LINE = "import demo.Inventory.Item;\n";
+
+    @BeforeAll
+    static void boot() throws Exception {
+        FxTestSupport.bootToolkit();
+    }
+
+    /** A buffer holding SOURCE with the caret just after `List<Item`, as in the report. */
+    private static EditorBuffer atItem() throws Exception {
+        return FxTestSupport.callOnFx(() -> {
+            EditorBuffer b = new EditorBuffer();
+            b.setContent(SOURCE);
+            b.getArea().moveTo(SOURCE.indexOf("List<Item") + "List<Item".length());
+            return b;
+        });
+    }
+
+    @Test
+    void theCaretStaysOnTheIdentifierWhenTheImportIsInsertedAboveIt() throws Exception {
+        EditorBuffer b = atItem();
+        int before = FxTestSupport.callOnFx(() -> b.getArea().getCaretPosition());
+
+        // What jdtls sends back from completionItem/resolve: insert the import line at line 5, col 0.
+        FxTestSupport.runOnFx(
+                () -> b.applyCompletionAdditionalEdits(List.of(new LspTextEdit(5, 0, 5, 0, IMPORT_LINE))));
+
+        assertEquals(
+                before + IMPORT_LINE.length(),
+                FxTestSupport.callOnFx(() -> b.getArea().getCaretPosition()),
+                "the caret must follow its own text down, not land on the inserted import");
+    }
+
+    @Test
+    void theCaretIsStillRightAfterTheTypedIdentifier() throws Exception {
+        EditorBuffer b = atItem();
+        FxTestSupport.runOnFx(
+                () -> b.applyCompletionAdditionalEdits(List.of(new LspTextEdit(5, 0, 5, 0, IMPORT_LINE))));
+
+        // Expressed as text rather than an offset: whatever the numbers, the caret sits just past "List<Item".
+        String content = FxTestSupport.callOnFx(b::getContent);
+        int caret = FxTestSupport.callOnFx(() -> b.getArea().getCaretPosition());
+        assertEquals("List<Item", content.substring(caret - "List<Item".length(), caret));
+    }
+
+    @Test
+    void theImportIsStillActuallyInserted() throws Exception {
+        EditorBuffer b = atItem();
+        FxTestSupport.runOnFx(
+                () -> b.applyCompletionAdditionalEdits(List.of(new LspTextEdit(5, 0, 5, 0, IMPORT_LINE))));
+
+        // Guard against "fixing" the caret by not applying the edit at all.
+        assertEquals(
+                1,
+                FxTestSupport.callOnFx(() -> b.getContent().split("import demo\\.Inventory\\.Item;", -1).length - 1));
+    }
+
+    @Test
+    void formatDocumentEditsAreUnaffected() throws Exception {
+        // applyLspEdits keeps its old behaviour: only the auto-import path opts into caret preservation, so
+        // this change cannot alter where Format Document leaves the caret.
+        EditorBuffer b = atItem();
+        FxTestSupport.runOnFx(() -> b.applyLspEdits(List.of(new LspTextEdit(5, 0, 5, 0, IMPORT_LINE))));
+        // Line 5 is the blank line after the Optional import, so the insert starts there and the caret is
+        // left at its end — dragged off "List<Item", which is precisely the behaviour the auto-import path
+        // now opts out of.
+        String upToLine5 = SOURCE.substring(
+                0, SOURCE.indexOf("import java.util.Optional;\n") + "import java.util.Optional;\n".length());
+        assertEquals(
+                upToLine5.length() + IMPORT_LINE.length(),
+                FxTestSupport.callOnFx(() -> b.getArea().getCaretPosition()),
+                "unchanged: replaceText still leaves the caret at the end of its insertion");
+    }
+}


### PR DESCRIPTION
Closes #834.

Typing `private final List<Item` and accepting the `Item - demo.Inventory` completion inserted the import correctly — and then dropped the caret at the end of that new import line, so the next keystroke went into the import statement.

## Cause

`EditorBuffer.applyLspEdits` finishes with `a.replaceText(...)` (single edit) or `MultiChangeBuilder.commit()`, and **both leave the caret at the end of what they inserted**. An `additionalTextEdits` import lands *above* the caret, so the caret got dragged up to it.

`LspEditShift` already translates the server's edit *positions* across the accept (#410). Nothing translated the **caret** across the edits themselves — the symmetric half of the same problem.

## Fix

Pure `LspEditShift.caretAfterEdits(caret, ranges, texts)`:

- edits ending **at or before** the caret move it by their net length change,
- edits **after** it leave it alone (and the scan stops there — the ranges are ascending),
- an edit **straddling** it collapses to the end of its replacement, which is safe precisely because the ranges are ascending and non-overlapping, so nothing later can move it again.

Wired through a private `applyLspEdits(edits, preserveCaret)` overload.

## Deliberately scoped

The public `applyLspEdits` is unchanged, so **Format Document still leaves the caret exactly where it did.** That is arguably also worth fixing — but it is a different command with a different feel, and quietly changing it while fixing an import bug is the kind of unrequested behaviour change that is hard to attribute later. `formatDocumentEditsAreUnaffected` pins the current behaviour so it cannot drift in by accident; a follow-up can change it on purpose.

## Testing

- 9 new pure cases in `LspEditShiftTest` (boundaries, deletions, accumulation, straddle, null replacement).
- `AutoImportCaretFxTest` drives the real `applyCompletionAdditionalEdits` on your exact source, since the defect was in what `replaceText` does to the caret, not in the arithmetic — a pure test alone would have passed against the broken code.
- **Both new behavioural tests were confirmed to fail against the unfixed code**: without the fix the caret lands after `ry.Item;`, i.e. on the import line, reproducing the report.
- Full suite: **3764 tests, 0 failures**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)