### PR TITLE
fix(menu): stop a menu's own popup covering the menu bar

### DIFF
--- a/src/main/resources/com/editora/styles/app.css
+++ b/src/main/resources/com/editora/styles/app.css
@@ -3320,8 +3320,20 @@
 .tooltip {
     -fx-background-radius: 8px, 7px;
 }
+/* The offset must be >= the radius, and this is not a cosmetic choice.
+   A context menu is a real native WINDOW, and JavaFX sizes it to its root's bounds INCLUDING the effect —
+   so a shadow inflates the window by `radius` in every direction, shifted by the offset, and that margin is
+   transparent to the eye but not to the pointer: the window manager routes the mouse to whichever window is
+   topmost. The kit's card shadow (44 / offset 18) left 26px of invisible window ABOVE each menu, against a
+   menu-bar row 24px tall — measured, the popup began 2px above the TOP of the bar and reached 44px past it
+   on either side. It therefore covered its own neighbours' titles, and sliding the mouse from one menu to
+   the next landed on the open popup instead of the next button, so the bar did not switch.
+   `offsetY >= radius` puts the whole shadow below the menu, leaving nothing over the bar it hangs from.
+   The other kit surfaces keep the wide 44/18 shadow: the palette, switcher and message log are in-scene
+   overlay cards (see OverlayHost), not windows, so their effect bounds route nothing.
+   Pinned by MenuPopupBoundsFxTest. */
 .context-menu {
-    -fx-effect: dropshadow(gaussian, rgba(27, 30, 42, 0.28), 44, 0.16, 0, 18);
+    -fx-effect: dropshadow(gaussian, rgba(27, 30, 42, 0.28), 16, 0.16, 0, 16);
 }
 
 /* Tool window panels: rounded corners, no drawn frame. The panel is bounded by the editor on one

--- a/src/test/java/com/editora/ui/MenuPopupBoundsFxTest.java
+++ b/src/test/java/com/editora/ui/MenuPopupBoundsFxTest.java
@@ -1,0 +1,130 @@
+package com.editora.ui;
+
+import javafx.geometry.Bounds;
+import javafx.scene.Scene;
+import javafx.scene.control.Menu;
+import javafx.scene.control.MenuBar;
+import javafx.scene.effect.DropShadow;
+import javafx.stage.Stage;
+import javafx.stage.Window;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * An open menu's popup must not cover the menu bar it hangs from.
+ *
+ * <p>A JavaFX popup is a real native window sized to its root's bounds <em>including the effect</em>, and a
+ * drop shadow inflates those bounds by {@code radius - offsetY} upward and about {@code radius} sideways —
+ * transparent to the eye, but not to the pointer. The UI Kit pass gave every {@code .context-menu} the
+ * card shadow ({@code radius 44 / offsetY 18}), i.e. ~26px of invisible window above the menu and ~44px
+ * either side, against a menu-bar row 24px tall. Measured, the popup began 2px above the <em>top</em> of
+ * the bar and reached 44px past it on either side, so the open menu covered its own neighbours' titles:
+ * sliding the mouse from one menu to the next landed on the popup instead of the menu button and the bar
+ * did not switch — the "menu to menu is not smooth on Linux" report.
+ *
+ * <p>Asserted on the popup's <b>screen</b> bounds against the menu bar's, because that is what the window
+ * manager routes the pointer by; the visible geometry says nothing about it.
+ */
+@Tag("fx")
+class MenuPopupBoundsFxTest {
+
+    private static FxWindowFixture fx;
+
+    @BeforeAll
+    static void setUp() throws Exception {
+        FxTestSupport.bootToolkit();
+        fx = FxWindowFixture.create();
+        FxTestSupport.runOnFx(() -> {
+            Scene scene = FxTestSupport.<Stage>field(fx.controller, "stage").getScene();
+            scene.getRoot().resize(1500, 800);
+            scene.getRoot().applyCss();
+            scene.getRoot().layout();
+        });
+    }
+
+    @AfterAll
+    static void tearDown() throws Exception {
+        if (fx != null) {
+            fx.dispose();
+        }
+    }
+
+    @Test
+    void anOpenMenusPopupDoesNotOverlapTheMenuBar() throws Exception {
+        MenuBar bar = FxTestSupport.callOnFx(() -> (MenuBar)
+                FxTestSupport.<MainMenuBar>field(fx.controller, "menuBar").node());
+        assertTrue(FxTestSupport.callOnFx(() -> !bar.getMenus().isEmpty()), "precondition: the bar has menus");
+
+        Bounds barOnScreen = FxTestSupport.callOnFx(() -> bar.localToScreen(bar.getBoundsInLocal()));
+        assertNotNull(barOnScreen, "the menu bar should be in a shown scene");
+
+        FxTestSupport.runOnFx(() -> {
+            Menu first = bar.getMenus().get(0);
+            first.show();
+        });
+        try {
+            Window popup = FxTestSupport.callOnFx(() -> Window.getWindows().stream()
+                    .filter(w -> w.isShowing() && w instanceof javafx.stage.PopupWindow)
+                    .findFirst()
+                    .orElse(null));
+            org.junit.jupiter.api.Assumptions.assumeTrue(
+                    popup != null, "the headless platform did not map a popup window; run this on a desktop");
+
+            double popupTop = FxTestSupport.callOnFx(popup::getY);
+            double popupLeft = FxTestSupport.callOnFx(popup::getX);
+            double popupRight = FxTestSupport.callOnFx(() -> popup.getX() + popup.getWidth());
+            System.out.printf(
+                    "menu bar y=[%.1f..%.1f]  popup y=%.1f x=[%.1f..%.1f]%n",
+                    barOnScreen.getMinY(), barOnScreen.getMaxY(), popupTop, popupLeft, popupRight);
+
+            assertTrue(
+                    popupTop >= barOnScreen.getMaxY(),
+                    "the open menu's popup window starts " + (barOnScreen.getMaxY() - popupTop)
+                            + "px above the bottom of the menu bar, so it covers the neighbouring menu titles"
+                            + " and swallows the hover that should switch menus");
+        } finally {
+            FxTestSupport.runOnFx(() -> bar.getMenus().get(0).hide());
+        }
+    }
+
+    /**
+     * The rule behind it, stated directly on the computed style: a popup's shadow must not reach above the
+     * popup.
+     *
+     * <p>The upward extent of a drop shadow is {@code radius - offsetY}, and that much invisible window sits
+     * over whatever the menu hangs from. Asserted separately from the geometry above because it is the
+     * constraint a future restyle has to keep — the number to change is in one CSS rule, and nothing else
+     * about the app would complain if it grew again.
+     */
+    @Test
+    void aPopupsShadowNeverReachesAboveThePopup() throws Exception {
+        DropShadow shadow = FxTestSupport.callOnFx(() -> {
+            javafx.scene.layout.Region r = new javafx.scene.layout.Region();
+            r.getStyleClass().add("context-menu");
+            r.setPrefSize(300, 400);
+            javafx.scene.layout.StackPane root = new javafx.scene.layout.StackPane(r);
+            Scene s = new Scene(root, 600, 700);
+            s.getStylesheets()
+                    .add(MenuPopupBoundsFxTest.class
+                            .getResource("/com/editora/styles/app.css")
+                            .toExternalForm());
+            root.applyCss();
+            root.layout();
+            return r.getEffect() instanceof DropShadow d ? d : null;
+        });
+        assertNotNull(shadow, ".context-menu should carry a drop shadow");
+
+        double up = shadow.getRadius() - shadow.getOffsetY();
+        assertTrue(
+                up <= 0,
+                "a context menu's shadow reaches " + up + "px above it (radius " + shadow.getRadius()
+                        + ", offsetY " + shadow.getOffsetY() + "), and that much invisible popup window"
+                        + " covers the menu bar / the surface the menu was opened from");
+    }
+}

--- a/src/test/java/com/editora/ui/MenuShadowCostProbeTest.java
+++ b/src/test/java/com/editora/ui/MenuShadowCostProbeTest.java
@@ -1,0 +1,119 @@
+package com.editora.ui;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import javafx.scene.Scene;
+import javafx.scene.control.Label;
+import javafx.scene.effect.BlurType;
+import javafx.scene.effect.DropShadow;
+import javafx.scene.effect.Effect;
+import javafx.scene.image.WritableImage;
+import javafx.scene.layout.VBox;
+import javafx.scene.paint.Color;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+/**
+ * MANUAL PROBE (not part of the suite — {@code @Tag("probe")}). Measures what the kit's popup drop shadow
+ * costs to render, because {@code app.css} puts it on {@code .context-menu} — i.e. on every menu-bar
+ * dropdown, submenu and right-click menu — and a menu popup is re-rendered every time one is shown.
+ *
+ * <p>Renders a menu-sized node repeatedly via {@code snapshot()} (synchronous, on the FX thread) with no
+ * effect, with the shipped shadow, and with a cheaper one.
+ *
+ * <p><b>Read the number with its caveat:</b> the harness runs {@code prism.order=sw}, so this is the
+ * SOFTWARE blur cost. With a working GPU pipeline the same blur is far cheaper. It therefore bounds the
+ * worst case — which is the case a Linux box falling back to {@code sw} actually hits.
+ *
+ * <p><b>Verdict when this was written</b> (menu-to-menu switching felt unsmooth on Linux): 340x620 popup,
+ * no effect 1.2 ms, the kit's 44px shadow 15.3 ms, a 16px one 5.5 ms. 15 ms is a dropped frame — but the
+ * reporting machine had a working GPU pipeline, so this was <em>not</em> the cause; the cause was the same
+ * shadow's effect on the popup's window GEOMETRY (see {@code MenuPopupBoundsFxTest}). Kept because the
+ * number is the reason not to put a wide gaussian on a popup that might render on {@code sw}.
+ *
+ * <p>Run: {@code ./mvnw test -Dtest=MenuShadowCostProbeTest -Dgroups=probe -Dui.probe=true}
+ */
+@Tag("probe")
+class MenuShadowCostProbeTest {
+
+    /** Roughly Editora's widest menu: ~24 rows of title + chord. */
+    private static final int MENU_W = 340;
+
+    private static final int MENU_H = 620;
+
+    private static final int WARMUP = 20;
+
+    private static final int RUNS = 60;
+
+    @BeforeAll
+    static void setUp() throws Exception {
+        FxTestSupport.bootToolkit();
+    }
+
+    @Test
+    void measure() throws Exception {
+        org.junit.jupiter.api.Assumptions.assumeTrue(Boolean.getBoolean("ui.probe"), "opt-in: -Dui.probe=true");
+
+        // The shipped rule: dropshadow(gaussian, rgba(27,30,42,0.28), 44, 0.16, 0, 18)
+        DropShadow shipped = shadow(44, 0.16, 18);
+        // A conventional menu shadow: tight, short offset.
+        DropShadow cheaper = shadow(16, 0.2, 6);
+
+        System.out.println("popup " + MENU_W + "x" + MENU_H + ", software pipeline, median of " + RUNS + " renders");
+        System.out.printf("  no effect        %6.2f ms%n", medianMillis(null));
+        System.out.printf("  shipped (r=44)   %6.2f ms%n", medianMillis(shipped));
+        System.out.printf("  cheaper (r=16)   %6.2f ms%n", medianMillis(cheaper));
+    }
+
+    private static DropShadow shadow(double radius, double spread, double offsetY) {
+        DropShadow d = new DropShadow(BlurType.GAUSSIAN, Color.rgb(27, 30, 42, 0.28), radius, spread, 0, offsetY);
+        return d;
+    }
+
+    /** Median wall time of one synchronous render of a menu-sized node carrying {@code effect}. */
+    private static double medianMillis(Effect effect) throws Exception {
+        return FxTestSupport.callOnFx(() -> {
+            VBox menu = new VBox();
+            menu.setStyle("-fx-background-color: white; -fx-background-radius: 8; -fx-padding: 6;");
+            for (int i = 0; i < 24; i++) {
+                menu.getChildren().add(new Label("Menu item " + i + "     C-x C-" + (char) ('a' + i % 26)));
+            }
+            menu.setPrefSize(MENU_W, MENU_H);
+            menu.setEffect(effect);
+
+            // A shadow paints OUTSIDE the node, so give the scene room or it is clipped away unmeasured.
+            VBox root = new VBox(menu);
+            root.setStyle("-fx-padding: 80;");
+            new Scene(root, MENU_W + 160, MENU_H + 160);
+            root.applyCss();
+            root.layout();
+
+            List<Double> times = new ArrayList<>();
+            for (int i = 0; i < WARMUP + RUNS; i++) {
+                // A fresh target each time: reusing one lets the render cache the blurred result, which is
+                // precisely what a freshly-shown popup does not get.
+                WritableImage target = new WritableImage(
+                        (int) root.getWidth() == 0 ? MENU_W + 160 : (int) root.getWidth(),
+                        (int) root.getHeight() == 0 ? MENU_H + 160 : (int) root.getHeight());
+                menu.setEffect(effect == null ? null : copyOf(effect));
+                long t0 = System.nanoTime();
+                root.snapshot(null, target);
+                long t1 = System.nanoTime();
+                if (i >= WARMUP) {
+                    times.add((t1 - t0) / 1_000_000.0);
+                }
+            }
+            times.sort(Double::compareTo);
+            return times.get(times.size() / 2);
+        });
+    }
+
+    /** A fresh Effect instance per render, so no blurred result is reused between measurements. */
+    private static Effect copyOf(Effect e) {
+        DropShadow d = (DropShadow) e;
+        return new DropShadow(d.getBlurType(), d.getColor(), d.getRadius(), d.getSpread(), 0, d.getOffsetY());
+    }
+}


### PR DESCRIPTION
Moving the mouse from one menu to the next often did not switch menus on Linux.

## Cause

A JavaFX context menu is a real **native window**, and JavaFX sizes it to its root's bounds *including the effect* — so a drop shadow inflates the window by `radius` in every direction, shifted by the offset. That margin is transparent to the eye but **not to the pointer**: the window manager routes the mouse to whichever window is topmost.

The UI Kit pass put the wide card shadow (`radius 44, offsetY 18`) on `.context-menu`, leaving **26px of invisible window above every menu** and 44px either side. Measured against the live bar:

```
menu bar y=[100.0..124.0]   popup y=98.0  x=[-40.0..415.0]
```

The popup's window began 2px above the **top** of a 24px-tall bar and reached 44px past it on either side — covering its own neighbours' titles. Sliding toward the next menu landed on the open popup instead of the next button, so the bar did not switch. Intermittent because it depended on how far along the bar you travelled before clearing the margin.

## Fix

`.context-menu`'s shadow becomes `16 / offsetY 16`. **`offsetY >= radius` puts the whole shadow below the menu**, so nothing reaches over the bar it hangs from:

```
menu bar y=[100.0..124.0]   popup y=124.0  x=[-12.0..387.0]
```

The other kit surfaces keep the wide 44/18 shadow deliberately — the palette, switcher and message log are **in-scene overlay cards** (`OverlayHost`), not windows, so their effect bounds route nothing.

## Testing

`MenuPopupBoundsFxTest` pins both halves:
- the end-to-end geometry — the open popup's **screen** bounds against the live menu bar's, since that is what the WM routes the pointer by;
- the rule a future restyle has to keep — a popup shadow's upward extent (`radius - offsetY`) must be `<= 0`. Nothing else in the app would complain if that number grew again.

Against the old CSS the first fails with *"the open menu's popup window starts 26.0px above the bottom of the menu bar"*.

`MenuShadowCostProbeTest` (opt-in probe) records the hypothesis measured and **ruled out** on the way: on the software pipeline the 44px blur costs 15.3 ms per render vs 1.2 ms with none — a dropped frame — but the reporting machine has a working GPU pipeline (RTX 4080, direct rendering), so render cost was not the cause. Kept because it is the reason not to put a wide gaussian on a popup that might render on `sw`.

Full suite: 3784 tests, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)