### PR TITLE
fix(scripts): make measure-startup.sh run on macOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   beyond the noise. A test now fails if the trainer's options and the launcher's drift apart again, since the
   next flag to diverge may not be as harmless.
 
+- `scripts/measure-startup.sh` runs on macOS. It used `timeout` and `date +%s%3N`, both GNU-only and
+  neither present on a stock macOS, so the startup harness `CLAUDE.md` presents as the permanent way to
+  measure cold start could not run on the primary development machine at all. Both are now capability-
+  detected. Three further defects surfaced while fixing it: a `grep` that matched nothing killed the script
+  under `set -e` before its own diagnostic could print, so a failed measurement exited 1 explaining nothing;
+  the log that diagnostic pointed at was deleted by the exit trap before anyone could read it; and the usage
+  text was a hardcoded line range that had already drifted. Measured impact of the missing timestamp: the
+  fallback origin overstated time-to-first-paint by roughly 30% on macOS, all of it in the pre-`main` phase.
+
 ## [0.11.0] - 2026-08-11
 
 ### Added

--- a/scripts/measure-startup.sh
+++ b/scripts/measure-startup.sh
@@ -13,7 +13,38 @@
 #   scripts/measure-startup.sh -n 7 -c /tmp/cfg /opt/editora/bin/Editora --no-session ~/Downloads/cv.typ
 #
 # Needs a display (it renders a real window). Each run is killed as soon as it reports.
+#
+# Portable across Linux and macOS: `timeout` and `date +%s%3N` are GNU-only and neither exists on a
+# stock macOS, so both are capability-detected below rather than assumed.
 set -euo pipefail
+
+# --- portability ------------------------------------------------------------------------------
+#
+# A millisecond clock. GNU date does it directly; BSD date has no %N and emits a literal (measured
+# on macOS: `date +%s%3N` -> "17864736693N"), which is digits followed by junk and so would survive
+# a laxer check than the fully-numeric one below. Perl is the fallback because macOS ships it at
+# /usr/bin/perl and every Linux has it; python3 is third because a clean macOS has no python3 until
+# the Xcode tools are installed. Resolved once, not per run.
+if date +%s%3N 2>/dev/null | grep -Eq '^[0-9]+$'; then
+    now_ms() { date +%s%3N; }
+elif command -v perl >/dev/null 2>&1; then
+    now_ms() { perl -MTime::HiRes=time -e 'printf "%d\n", time() * 1000'; }
+elif command -v python3 >/dev/null 2>&1; then
+    now_ms() { python3 -c 'import time; print(int(time.time() * 1000))'; }
+else
+    echo "need a millisecond clock: GNU date, perl, or python3 (none found)" >&2
+    exit 2
+fi
+
+# `timeout` is only a backstop — the app halts itself at first paint under EDITORA_PERF_EXIT — so
+# when it is missing (stock macOS; `gtimeout` is the Homebrew coreutils name) the run simply goes
+# without one rather than failing, which is what it used to do.
+runner=()
+if command -v timeout >/dev/null 2>&1; then
+    runner=(timeout 60)
+elif command -v gtimeout >/dev/null 2>&1; then
+    runner=(gtimeout 60)
+fi
 
 runs=5
 config_dir=""
@@ -27,7 +58,9 @@ while [ $# -gt 0 ]; do
 done
 
 if [ $# -lt 1 ]; then
-    sed -n '2,17p' "$0" >&2
+    # The header block itself, rather than a hardcoded line range: the range had already drifted out
+    # of date once, silently truncating the help.
+    awk 'NR > 1 && /^#/ { print; next } NR > 1 { exit }' "$0" >&2
     exit 2
 fi
 
@@ -49,11 +82,23 @@ for i in $(seq 1 "$runs"); do
     # falls back to ProcessHandle's process start, which on Linux is derived from boot time and drifted
     # ~500 ms high here — inflating every phase. stderr carries the [perf] report; the app halts itself at
     # first paint, so the timeout is only a backstop.
-    EDITORA_PERF_T0=$(date +%s%3N) timeout 60 "$launcher" "$@" >/dev/null 2>"$tmp/run$i.txt" || true
-    ttfp=$(grep -o 'TIME-TO-FIRST-PAINT [0-9]*' "$tmp/run$i.txt" | awk '{print $2}' | head -1)
+    EDITORA_PERF_T0=$(now_ms) ${runner[@]+"${runner[@]}"} "$launcher" "$@" >/dev/null 2>"$tmp/run$i.txt" || true
+    # `|| true` matters: with `set -e` and `pipefail`, a grep that matches nothing fails the whole
+    # pipeline and kills the script HERE — so the diagnostic below was unreachable on the one path
+    # that needs it, and a failed measurement exited 1 having explained nothing.
+    ttfp=$(grep -o 'TIME-TO-FIRST-PAINT [0-9]*' "$tmp/run$i.txt" | awk '{print $2}' | head -1 || true)
     if [ -z "$ttfp" ]; then
-        echo "run $i: NO REPORT — the run never painted (see $tmp/run$i.txt); is a display available?" >&2
-        cat "$tmp/run$i.txt" >&2
+        # Keep the log: $tmp goes away with the EXIT trap, so naming a path inside it sent the reader
+        # to a file that had already been deleted.
+        # An explicit template, not `mktemp -t`: BSD mktemp treats -t's argument as a prefix and adds
+        # its own suffix, leaving a literal "XXXXXX" in the middle of the name.
+        tmpbase=${TMPDIR:-/tmp}
+        kept=$(mktemp "${tmpbase%/}/editora-startup-run.XXXXXX")
+        cp "$tmp/run$i.txt" "$kept"
+        echo "run $i: NO REPORT — the run produced no [perf] line. Its output is below and kept at $kept." >&2
+        echo "Common causes: no display (it renders a real window), a launcher that is not Editora, or a" >&2
+        echo "build without the perf instrumentation. EDITORA_PERF=1 and EDITORA_PERF_EXIT=1 were set." >&2
+        cat "$kept" >&2
         exit 1
     fi
     echo "run $i: ${ttfp} ms"


### PR DESCRIPTION
Closes #842.

The startup harness `CLAUDE.md` presents as the permanent way to measure cold start could not run on the primary development machine at all. Both offenders are GNU-only and on the same line.

## The two in the issue

- **`timeout`** — coreutils, absent on a stock macOS. Now `timeout` → `gtimeout` → neither, since it was only a backstop and the app halts itself at first paint.
- **`date +%s%3N`** — `%N` is a GNU extension. Now falls back to `perl` (system `/usr/bin/perl` on macOS, universal on Linux) then `python3`. The probe requires a **fully numeric** result, because BSD `date` emits `17864736693N` — digits followed by junk, which a leading-digit check would accept.

## Three more found while verifying

| defect | effect |
| --- | --- |
| `grep` with no match kills the script under `set -e` + `pipefail` | the error diagnostic was **unreachable**; a failed run exited 1 in silence |
| the diagnostic named a path inside `$tmp` | the `EXIT` trap deleted it first, so the file was always gone |
| usage was a hardcoded `sed -n '2,17p'` | already drifted past its own header |

The first is why I originally read this as a display problem instead of seeing the launcher's own error. Also dropped `mktemp -t`, which BSD reads as a prefix and leaves a literal `XXXXXX` in the name.

## Verified

- **End to end on macOS** against a real `-Pdist` app image: 5 runs, phases, median.
- **Under `/bin/bash` 3.2** — what a stock macOS resolves `env bash` to, and where the empty `runner` array under `set -u` is the classic breakage. The `${runner[@]+"${runner[@]}"}` idiom holds.
- **Both failure paths** with a stub launcher: no report, and a launcher that errors.
- `./mvnw verify`: **3799 tests, 0 failures, 0 errors.**

**Measured impact of the missing timestamp:** the `ProcessHandle` fallback origin overstated time-to-first-paint by ~30% on macOS (1352 ms vs 1039 ms), all of it in the pre-`main` phase. Not merely unrunnable — misleading if forced.

One unrelated flake surfaced on the first verify and is filed as #845; it passed 3/3 in isolation and on a full re-run, and nothing here can affect it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)