### PR TITLE
chore(deps): the safe half of the available updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Internal
+
+- Routine dependency bumps, taken as one batch: JavaFX 26.0.1 → 26.0.2, Jackson 2.19.0 → 2.22.1, Gson
+  2.11.0 → 2.14.0, Lucene 10.2.2 → 10.5.0, java-diff-utils 4.12 → 4.17, joni 2.2.6 → 2.2.7, jcodings
+  1.0.58 → 1.0.64, JUnit 5.11.4 → 5.14.4. All patch or minor.
+
+  Verified with a packaged build as well as the suite, because a dependency change here can break the
+  *installer* while every test passes: java-diff-utils is an automatic module carrying a moditect
+  descriptor, and JavaFX is linked into the runtime image. The app image builds and its AOT training run —
+  which launches the real GUI — completes, which is what says the jimage is whole.
+
+  Deliberately not taken: PDFBox, POI and MINA SSHD, whose jlink descriptors are hand-written and want a
+  build and a launch of their own; commonmark, where a 0.x minor can move the API; and the early-access,
+  alpha, milestone and major offers (JavaFX 28-ea, slf4j 2.1.0-alpha1, SSHD 3.0.0-M5, JUnit 6, LSP4J 1.0.0,
+  JSVG 2.1.0).
+
 ### Fixed
 
 - **"Failed to open" for a file that had just opened.** Launching Editora with a position —

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
         <build.timestamp>${maven.build.timestamp}</build.timestamp>
         <!-- JavaFX 26 (runs on JDK 24+, we stay on JDK 25) — adds the macOS Metal Prism pipeline
              (com.sun.prism.mtl), enabled per-OS via ${prism.order} below. -->
-        <javafx.version>26.0.1</javafx.version>
+        <javafx.version>26.0.2</javafx.version>
         <javafx.plugin.version>0.0.8</javafx.plugin.version>
         <!-- Prism pipeline order (passed as -Dprism.order to both javafx:run and the packaged app). Set
              per-OS in the os-* profiles: mac=mtl,es2,sw (Metal, the M-series rendering fix; es2/sw fallback),
@@ -33,12 +33,12 @@
              Source: https://github.com/adriandeleon/RichTextFX (feat/multi-caret-box-selection). -->
         <richtextfx.version>0.11.7-inlay.1</richtextfx.version>
         <atlantafx.version>2.1.0</atlantafx.version>
-        <jackson.version>2.19.0</jackson.version>
-        <junit.version>5.11.4</junit.version>
+        <jackson.version>2.22.1</jackson.version>
+        <junit.version>5.14.4</junit.version>
         <tm4e.version>RELEASE260</tm4e.version>
-        <joni.version>2.2.6</joni.version>
-        <jcodings.version>1.0.58</jcodings.version>
-        <gson.version>2.11.0</gson.version>
+        <joni.version>2.2.7</joni.version>
+        <jcodings.version>1.0.64</jcodings.version>
+        <gson.version>2.14.0</gson.version>
         <lsp4j.version>0.23.1</lsp4j.version>
         <commonmark.version>0.28.0</commonmark.version>
         <autolink.version>0.12.0</autolink.version>
@@ -48,8 +48,8 @@
         <jlatexmath.version>1.0.7</jlatexmath.version>
         <pdfbox.version>3.0.5</pdfbox.version>
         <poi.version>5.4.1</poi.version>
-        <lucene.version>10.2.2</lucene.version>
-        <javadiffutils.version>4.12</javadiffutils.version>
+        <lucene.version>10.5.0</lucene.version>
+        <javadiffutils.version>4.17</javadiffutils.version>
         <sshd.version>2.15.0</sshd.version>
         <slf4j.version>2.0.17</slf4j.version>
         <moditect.version>1.2.2.Final</moditect.version>


### PR DESCRIPTION
JavaFX 26.0.1 → 26.0.2, Jackson 2.19.0 → 2.22.1, Gson 2.11.0 → 2.14.0, Lucene 10.2.2 → 10.5.0, java-diff-utils 4.12 → 4.17, joni 2.2.6 → 2.2.7, jcodings 1.0.58 → 1.0.64, JUnit 5.11.4 → 5.14.4. All patch or minor.

The JavaFX one is worth its own line: **Termina already runs 26.0.2**, so the two applications were on different patch levels of the same toolkit.

## Checked with a packaged build

A dependency change here can break the *installer* while every test passes — java-diff-utils is an automatic module carrying a hand-written moditect descriptor, and JavaFX is linked into the runtime image. So `-Pdist` was built, and the check that means something is that the app image's **AOT training run completes**: that step launches the real GUI, so a jimage missing a class fails there rather than in front of a user.

```
[aot] cache present: …/Editora.app/Contents/app/editora.aot (71 MB)
[aot] app image -> …/target/dist/Editora.app
```

3805 tests green.

## Deliberately not in this batch

- **PDFBox 3.0.8, POI 5.5.1, MINA SSHD 2.19.0** — all three carry jlink descriptors we maintain by hand (`requires org.apache.commons.logging` that jdeps drops; four automatic leaf deps named after POI's own `requires`; a 106-export `module-info-sshd-osgi.java`). Each deserves its own build and launch rather than riding along with eight others.
- **commonmark 0.28 → 0.30** — a 0.x minor, where the API can move, over a dependency this uses heavily including a custom `AttributeProvider`.
- Everything early-access, alpha, milestone or major that the report offered: JavaFX 28-ea+2, slf4j 2.1.0-alpha1, SSHD 3.0.0-M5, JUnit 6, LSP4J 1.0.0, JSVG 2.1.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)