### PR TITLE
test(install): enforce that the jdtls pin agrees across its two files

### DIFF
--- a/src/test/java/com/editora/install/InstallCatalogTest.java
+++ b/src/test/java/com/editora/install/InstallCatalogTest.java
@@ -1,7 +1,11 @@
 package com.editora.install;
 
+import java.io.IOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import com.editora.install.InstallCatalog.ArchiveSpec;
 import com.editora.install.InstallCatalog.Kind;
@@ -98,6 +102,32 @@ class InstallCatalogTest {
                 url.endsWith("/jdt-language-server-" + InstallCatalog.JDTLS_VERSION + "-" + InstallCatalog.JDTLS_BUILD
                         + ".tar.gz"),
                 url);
+    }
+
+    /**
+     * The shell installer and the in-app installer must pin the <b>same</b> jdtls build. The version lives in two
+     * files, and nothing but this test makes them agree — so a one-sided bump would silently hand script users and
+     * in-app users different servers, which matters because Editora's documented jdtls behaviour is measured against
+     * one build (see {@code InstallCatalog.JDTLS_VERSION}).
+     */
+    @Test
+    void installScriptPinsTheSameJdtlsBuildAsTheCatalog() throws IOException {
+        Path script = Path.of("scripts/install-jdtls.sh");
+        assertTrue(Files.isRegularFile(script), "missing " + script.toAbsolutePath());
+        String text = Files.readString(script);
+
+        String bumpBoth = " — scripts/install-jdtls.sh and com.editora.install.InstallCatalog pin the jdtls build"
+                + " separately and must be bumped together (and the behaviours in JDTLS_VERSION's javadoc re-checked).";
+        assertEquals(
+                InstallCatalog.JDTLS_VERSION, shellDefault(text, "JDTLS_VERSION"), "jdtls version differs" + bumpBoth);
+        assertEquals(
+                InstallCatalog.JDTLS_BUILD, shellDefault(text, "JDTLS_BUILD"), "jdtls build stamp differs" + bumpBoth);
+
+        // The two variables only count if the download URL is still built from them.
+        assertTrue(
+                text.contains("$JDTLS_VERSION") && text.contains("$JDTLS_BUILD"),
+                "scripts/install-jdtls.sh no longer builds its download URL from JDTLS_VERSION/JDTLS_BUILD,"
+                        + bumpBoth);
     }
 
     @Test
@@ -311,5 +341,16 @@ class InstallCatalogTest {
                         "/home/u/.editora/plugins/lsp/maven" + sep + "*",
                         "org.eclipse.lemminx.XMLServerLauncher"),
                 com.editora.lsp.LspServerRegistry.tokenize(cmd));
+    }
+
+    /** Extracts {@code <default>} from a {@code NAME="${NAME:-<default>}"} line of a shell script. */
+    private static String shellDefault(String script, String var) {
+        Matcher m = Pattern.compile("(?m)^" + var + "=\"\\$\\{" + var + ":-([^}\"]+)\\}\"")
+                .matcher(script);
+        assertTrue(
+                m.find(),
+                "scripts/install-jdtls.sh no longer defines " + var + " as " + var + "=\"${" + var
+                        + ":-<default>}\"; update this test's extraction to match the script.");
+        return m.group(1);
     }
 }


### PR DESCRIPTION
Follow-up to 7c5b118b (#849), which pinned the Eclipse JDT-LS install to a milestone.

## Why

The version + build stamp now live in **two** places:

- `scripts/install-jdtls.sh` — the `${JDTLS_VERSION:-1.60.0}` / `${JDTLS_BUILD:-202606262232}` defaults
- `com.editora.install.InstallCatalog` — the `JDTLS_VERSION` / `JDTLS_BUILD` constants that build `JDTLS_TARBALL_URL`

Both files' comments say "keep the two in sync", and nothing enforced it. The existing `jdtlsTarballIsAPinnedMilestoneNotTheNightly` only guards the Java side's URL *shape*, so it would stay green while the shell script pointed at a different — or still nightly — build, and a user installing via the script and a user installing in-app would silently get different servers.

That matters more for jdtls than for most servers because Editora's documented jdtls behaviour is *measured* against a specific build: the `extendedClientCapabilities` code-action set, the inlay-hint line-range off-by-one, the `java/…` raw requests that never appear in `executeCommandProvider.commands`.

Same drift shape as `LspCoordinator.SERVER_IDS` vs the hand-listed `configure` command map, which rotted to 22 entries against 23 ids (#723) and made one server unstartable while Settings and Doctor both reported it present and configured.

## What

One test in `InstallCatalogTest`, beside its companion guard. It reads `scripts/install-jdtls.sh` relative to the project root (the `SamplesCorpusTest` idiom — Surefire's cwd is the basedir), extracts both defaults out of the `${VAR:-…}` parameter expansions, and asserts they equal the constants. Failure messages name both files and say to bump them together.

Two guards beyond the literal comparison, both covering the same drift:

- The extraction helper **fails loudly if its regex matches nothing**, so a future change to the script's variable shape reports what changed instead of passing vacuously.
- One assertion that the download URL is **still built from** the two variables — hardcoding the URL while leaving the variables in place would otherwise keep this green while installing a different build.

## Verification

Mutating the script's build stamp fails the test with the intended message — a sync guard that can't fail is worth nothing:

```
AssertionFailedError: jdtls build stamp differs — scripts/install-jdtls.sh and
com.editora.install.InstallCatalog pin the jdtls build separately and must be
bumped together (…) ==> expected: <202606262232> but was: <209901010000>
```

`./mvnw test -Dtest=InstallCatalogTest` → 23 tests green; `spotless:check` clean. Test-only change, no production code touched.

**Not covered:** neither file is checked against a milestone that actually exists on `download.eclipse.org` — a build stamp typo'd identically in both places stays green here and fails at download time. That needs a network call, which doesn't belong in the unit suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)