### PR TITLE
fix(settings): File Templates is no longer beta

### DIFF
--- a/src/main/java/com/editora/ui/SettingsWindow.java
+++ b/src/main/java/com/editora/ui/SettingsWindow.java
@@ -108,7 +108,7 @@ public class SettingsWindow {
         EDITOR(tr("settings.cat.editor"), Group.EDITOR),
         COMPLETION(tr("settings.cat.completion"), Group.EDITOR),
         SNIPPETS(tr("settings.cat.snippets"), Group.EDITOR),
-        TEMPLATES(tr("settings.cat.templates"), Group.EDITOR, true),
+        TEMPLATES(tr("settings.cat.templates"), Group.EDITOR),
         TODO(tr("settings.cat.todo"), Group.EDITOR),
         SPELL_CHECK(tr("settings.cat.spellCheck"), Group.EDITOR),
         SEARCH(tr("settings.cat.search"), Group.EDITOR),


### PR DESCRIPTION
The Settings sidebar showed a **Beta** pill beside Templates. The feature has shipped bundled templates, a management page and a wizard for some time, so the flag is dropped from `Category.TEMPLATES`.

Seven categories still carry the pill: AI General, Agent, AI, LSP, Debugger, Remote, MCP.

`clean verify` green — 3882 tests, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)