### PR TITLE
fix(startup): bring the window to the front on a forwarded launch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **A file opened from the file manager now brings the running Editora to the front**, instead of leaving it
+  behind the file manager with a GNOME notification you have to click.
+
+  This was the cost of the single-instance handoff added in 0.12.1, and the cause is the compositor rather
+  than Editora. When a file manager launches a **new** process it hands that process an activation token, so
+  the window it maps counts as user-initiated and gets focused. Forwarding breaks the chain: the token goes to
+  the forwarder, which delivers the file and exits *without ever mapping a window*, while the process that
+  owns the window is an older one you have not touched recently — so its raise is an unsolicited focus request
+  from a background application, which GNOME refuses, flagging the window as demanding attention instead.
+
+  The window is now briefly pinned above the others to bring it forward — which the compositor honours,
+  because that is a window *state* rather than a focus request — and released straight after, so nothing stays
+  on top. The raise also happens *before* the file is opened rather than after, so it is immediate instead of
+  waiting on the file to load, and still happens if opening fails.
+
 ## [0.12.1] - 2026-08-17
 
 ### Added

--- a/src/main/java/com/editora/ui/WindowManager.java
+++ b/src/main/java/com/editora/ui/WindowManager.java
@@ -308,11 +308,15 @@ public class WindowManager {
         if (target == null) {
             return;
         }
+        // Raise BEFORE opening, not after. Two reasons: the window should come forward the instant the click
+        // is delivered rather than after a file read, tab build and first highlight (on a busy FX thread that
+        // is visibly late); and if opening throws, the user would otherwise be left with a window that never
+        // came forward at all.
+        presentForExternalLaunch(target.stage());
         if (zen || expert || simple) {
             target.controller().applyStartupChrome(zen, expert, simple);
         }
         target.controller().openExternalFiles(files);
-        focus(target.stage());
     }
 
     /** The currently-focused window, else the most recently built one (null when no window is open). */
@@ -832,6 +836,48 @@ public class WindowManager {
         }
         stage.toFront();
         stage.requestFocus();
+    }
+
+    /** How long the window is pinned above others while the compositor settles the raise; see below. */
+    private static final Duration EXTERNAL_RAISE_PIN = Duration.millis(300);
+
+    /**
+     * Brings a window forward for a launch that arrived from <em>outside</em> the app — a file-manager click
+     * handed over by {@code ipc.SingleInstance}, or an OS open-files event.
+     *
+     * <p>{@link #focus} alone is not enough here, and the reason is the compositor rather than JavaFX. When a
+     * file manager launches a <b>new</b> process it hands it an activation token
+     * ({@code XDG_ACTIVATION_TOKEN} / {@code DESKTOP_STARTUP_ID}), so the window that process maps counts as
+     * user-initiated and is focused. A forwarded launch breaks that chain: the token goes to the forwarder,
+     * which delivers its files and exits <em>without ever mapping a window</em>, while the process that does
+     * own the window is an older one the user has not touched recently. Its {@code toFront()} is then an
+     * unsolicited focus request from a background application, and GNOME/Mutter refuses it — raising
+     * {@code _NET_WM_STATE_DEMANDS_ATTENTION} instead, which is the "click to bring it forward" notification,
+     * with the window still sitting under the file manager.
+     *
+     * <p>The workaround asks for something the compositor does not arbitrate: {@code alwaysOnTop} maps to
+     * {@code _NET_WM_STATE_ABOVE}, a window <em>state</em> rather than a focus request, so it is honoured from
+     * a background app. Pinning briefly puts the window physically in front, then it is released so it does
+     * not stay above everything else. {@code toFront}/{@code requestFocus} are still issued, because where
+     * they are permitted (macOS, and X11 sessions that allow it) they additionally give keyboard focus, which
+     * the ABOVE state alone does not.
+     *
+     * <p>Scoped deliberately to externally-delivered launches. Internal callers (switching project windows,
+     * {@code focusKey}) run while Editora is already the active application, where a plain focus request is
+     * granted and pinning a window above every other app would be an unpleasant surprise.
+     */
+    private static void presentForExternalLaunch(Stage stage) {
+        focus(stage);
+        try {
+            stage.setAlwaysOnTop(true);
+            PauseTransition release = new PauseTransition(EXTERNAL_RAISE_PIN);
+            // Unconditionally cleared: a window left permanently above every other application would be a
+            // far worse bug than the one this fixes.
+            release.setOnFinished(e -> stage.setAlwaysOnTop(false));
+            release.play();
+        } catch (RuntimeException e) {
+            stage.setAlwaysOnTop(false); // never leave it pinned
+        }
     }
 
     /** Restores a window's size/position/maximized state from its session (see {@code App} original). */

--- a/src/test/java/com/editora/ui/ExternalLaunchRaiseFxTest.java
+++ b/src/test/java/com/editora/ui/ExternalLaunchRaiseFxTest.java
@@ -1,0 +1,89 @@
+package com.editora.ui;
+
+import java.lang.reflect.Method;
+import java.util.concurrent.TimeUnit;
+
+import javafx.scene.Scene;
+import javafx.scene.layout.StackPane;
+import javafx.stage.Stage;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Bringing a window forward for an externally-delivered launch pins it above other windows briefly — and
+ * must always let go again.
+ *
+ * <p>The pin exists because GNOME/Mutter refuses a background application's focus request (it raises
+ * {@code _NET_WM_STATE_DEMANDS_ATTENTION} instead, which is the "click to bring it forward" notification),
+ * while {@code alwaysOnTop} maps to a window <em>state</em> the compositor does not arbitrate. Whether that
+ * actually beats a given compositor's focus-stealing prevention cannot be asserted headlessly — it is a
+ * property of the desktop, not of this code.
+ *
+ * <p>What <em>can</em> be pinned down is the half that would be a worse bug than the one it fixes: a window
+ * left permanently above every other application. So this asserts the pin is taken and, without any further
+ * help, released again.
+ */
+@Tag("fx")
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class ExternalLaunchRaiseFxTest {
+
+    @BeforeAll
+    void setUp() throws Exception {
+        FxTestSupport.bootToolkit();
+    }
+
+    @Test
+    void presentingForAnExternalLaunchPinsTheWindowAndThenReleasesIt() throws Exception {
+        Stage stage = FxTestSupport.callOnFx(() -> {
+            Stage s = new Stage();
+            s.setScene(new Scene(new StackPane(), 300, 200));
+            s.show();
+            return s;
+        });
+        try {
+            assertFalse(FxTestSupport.callOnFx(stage::isAlwaysOnTop), "precondition: not pinned");
+
+            Method present = WindowManager.class.getDeclaredMethod("presentForExternalLaunch", Stage.class);
+            present.setAccessible(true);
+            FxTestSupport.runOnFx(() -> {
+                try {
+                    present.invoke(null, stage);
+                } catch (ReflectiveOperationException e) {
+                    throw new IllegalStateException(e);
+                }
+            });
+
+            // Taken synchronously: the raise has to happen the moment the launch is delivered, not a frame
+            // later, or the window sits behind the file manager for exactly as long as it takes to notice.
+            assertTrue(FxTestSupport.callOnFx(stage::isAlwaysOnTop), "the window should be pinned to raise it");
+
+            assertTrue(
+                    waitUntil(() -> !FxTestSupport.callOnFx(stage::isAlwaysOnTop)),
+                    "the pin was never released — the window would stay above every other application");
+        } finally {
+            FxTestSupport.runOnFx(stage::close);
+        }
+    }
+
+    /** Polls for up to ~5 s; the release rides a short animation timer, not the caller's thread. */
+    private static boolean waitUntil(BooleanCheck condition) throws Exception {
+        for (int i = 0; i < 250; i++) {
+            if (condition.get()) {
+                return true;
+            }
+            TimeUnit.MILLISECONDS.sleep(20);
+        }
+        return false;
+    }
+
+    /** A condition that may throw, since reading FX state hops threads. */
+    private interface BooleanCheck {
+        boolean get() throws Exception;
+    }
+}


### PR DESCRIPTION
Opening a file from the file manager left the running Editora **behind the file manager**, with a GNOME notification you had to click to bring it forward. Reported against 0.12.1 on GNOME/Wayland, and confirmed fixed by hand with this build.

This is the cost of the single-instance handoff added in 0.12.1 — but the cause is the **compositor**, not the handoff logic.

## Why it happens

When a file manager launches a **new** process, it hands that process an activation token (`XDG_ACTIVATION_TOKEN` / `DESKTOP_STARTUP_ID`). The window that process maps therefore counts as user-initiated, and Mutter focuses it. That is why it worked before the handoff existed.

Forwarding breaks the chain:

- the token goes to the **forwarder**, which delivers its files and exits *without ever mapping a window*;
- the process that owns the window is an **older** one the user hasn't touched recently.

So its `toFront()` is an unsolicited focus request from a background application. GNOME refuses it and raises `_NET_WM_STATE_DEMANDS_ATTENTION` instead — which **is** the notification.

## The fix

`alwaysOnTop` maps to `_NET_WM_STATE_ABOVE`: a window **state** rather than a focus request, so the compositor doesn't arbitrate it and honours it from a background app. The window is pinned for 300 ms to bring it forward, then released so nothing stays on top. `toFront`/`requestFocus` still run, because where they *are* permitted (macOS, permissive X11) they additionally grant keyboard focus, which ABOVE alone does not.

Scoped to externally-delivered launches only — switching project windows happens while Editora is already the active app, where a plain focus request is granted and pinning would be obnoxious.

The raise also moved **before** the file open. It previously ran last, so it waited on the file read, tab build and first highlight — and never happened at all if opening threw.

## What is and isn't verified

**Not assertable headlessly:** whether this beats a given compositor's focus-stealing prevention is a property of the desktop, not of this code. Every probe I wrote raised successfully even *without* the fix, because the target window's user-time was recent; the real state (stale background window + genuine file-manager click) can't be synthesized without injecting input. Verified by hand on the reporting machine instead.

**What the new FX test does pin** is the half that would be worse than the bug: the pin is *always* released, so a window can never be left above every other application. Mutation-checked by making the release a no-op — the test fails with `the pin was never released`.

4000 tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)