### PR TITLE
fix(startup): give a file-manager launch its own window

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **A file opened from the file manager now gets a window of its own** instead of landing as a tab in
+  whatever window you were working in.
+
+  Before the single-instance handoff, such a click started its own process and therefore its own window. The
+  handoff was meant to stop duplicating the *process* — a second JVM, a second set of language servers — not
+  to change what the click does; but it took over the window in front of you, and with the "Editora Expert
+  Mode" entry restyled that window's chrome as well. The requested focus mode now applies to the new window,
+  where it is unambiguous, rather than being imposed on one already in use.
+
+  **Unless the file is already open**, in which case the window holding it is brought forward instead. Two
+  independent buffers over one file loses edits — save one and the other is silently stale behind an
+  external-change prompt — and re-opening a file you already have open is an ordinary thing to do.
+
+  These windows are deliberately left out of the saved layout, so a file opened from the file manager does not
+  come back as an empty window on the next launch.
+
 ## [0.12.2] - 2026-08-17
 
 ### Fixed

--- a/src/main/java/com/editora/App.java
+++ b/src/main/java/com/editora/App.java
@@ -157,7 +157,10 @@ public class App extends Application {
         try {
             // fileTargets, not a second parser: these are the argv the forwarding process would itself have
             // parsed, so they must resolve identically here.
-            windows.openExternalFiles(fileTargets(args), zenFlag(args), expertFlag(args), simpleFlag(args));
+            // In a NEW window: had this launch not been forwarded it would have started its own process, and
+            // so its own window. Reusing the process is the point of the handoff; reusing the window was not,
+            // and it silently took over whatever the user was working in.
+            windows.openExternalLaunchInNewWindow(fileTargets(args), zenFlag(args), expertFlag(args), simpleFlag(args));
         } catch (RuntimeException e) {
             LOG.log(Level.WARNING, "Could not apply a forwarded launch", e);
         }

--- a/src/main/java/com/editora/ui/MainController.java
+++ b/src/main/java/com/editora/ui/MainController.java
@@ -8763,6 +8763,16 @@ public class MainController implements com.editora.mcp.McpBridge {
         return buffer != null && buffer.isDirty();
     }
 
+    /**
+     * Whether this window already has {@code file} open. Used by {@link WindowManager} to route an
+     * externally-delivered launch to the window that already holds the file, rather than opening a second
+     * buffer on it in a new window — two independent buffers over one file is an edit-loss hazard rather than
+     * mere clutter, since saving one leaves the other stale behind an external-change prompt.
+     */
+    boolean hasFileOpen(Path file) {
+        return file != null && tabForPath(file) != null;
+    }
+
     private Tab tabForPath(Path file) {
         String target = pathKey(file);
         for (Tab tab : editorArea.tabs()) {

--- a/src/main/java/com/editora/ui/WindowManager.java
+++ b/src/main/java/com/editora/ui/WindowManager.java
@@ -51,6 +51,16 @@ public class WindowManager {
      *  one-window run never shrinks the saved multi-window layout). See {@link #reconcileOpenSet()}. */
     private boolean singleWindowSession;
 
+    /**
+     * Windows opened by an externally-delivered launch (a file-manager click routed here by
+     * {@code ipc.SingleInstance}). They are live windows in every other respect, but are deliberately kept
+     * out of the persisted restore set: before the single-instance handoff existed, such a launch was its own
+     * {@code --single-window --no-session} process, which never touched the saved layout. Without this, every
+     * file ever opened from the file manager would come back as a window on the next launch — and, since a
+     * {@code --no-session} window never writes a session file, come back empty.
+     */
+    private final java.util.Set<String> transientWindows = new java.util.HashSet<>();
+
     /** Set by {@code --no-session}: open only the command line's files, skipping the saved session's.
      *  Session-only — the saved session is never rewritten from a {@code --no-session} run. */
     private boolean noSession;
@@ -296,6 +306,73 @@ public class WindowManager {
      * no-op in the common case where the running window is already in that mode. All three flags false (the
      * plain overload, and every OS-delivered event) leaves the window's chrome exactly as it was.
      */
+    /**
+     * Opens an externally-delivered launch — a file-manager "Open With" click that {@code ipc.SingleInstance}
+     * handed to this already-running process — in a <b>new window of its own</b>.
+     *
+     * <p>A new window, not a tab in whatever the user was working in. Before the single-instance handoff, such
+     * a click started its own process and therefore its own window; the handoff was meant to stop duplicating
+     * the <em>process</em> (a second JVM, a second set of language servers), not to change what the click
+     * does. Landing the file as a tab in the current window silently took over the window the user was in the
+     * middle of using — and, with a launcher entry like "Editora Expert Mode", restyled its chrome as well.
+     * Giving the launch its own window also makes the requested focus mode unambiguous: it applies to the new
+     * window, at build time (so the first frame is already correct), instead of being imposed on an existing one.
+     *
+     * <p><b>Unless the file is already open somewhere</b>, in which case that window is focused instead. Two
+     * independent buffers over one file is an edit-loss hazard, not just clutter: save one and the other is
+     * silently stale behind an external-change prompt. Re-clicking a file you already have open is a normal
+     * thing to do, so this is the common case rather than a corner one.
+     *
+     * <p>The macOS Apple-Event path keeps the existing-window behaviour ({@link #openExternalFiles(List)}):
+     * that platform never duplicated a process, so nothing about it regressed and there is nothing to restore.
+     */
+    public void openExternalLaunchInNewWindow(
+            List<MainController.OpenTarget> files, boolean zen, boolean expert, boolean simple) {
+        if (files == null || files.isEmpty()) {
+            return;
+        }
+        Holder holding = holderWithAnyOf(files);
+        if (holding != null) {
+            presentForExternalLaunch(holding.stage());
+            holding.controller().openExternalFiles(files); // focuses the tab, honours a :line
+            return;
+        }
+        String key = WindowKeys.UNTITLED_PREFIX
+                + java.util.UUID.randomUUID().toString().substring(0, 8);
+        boolean restoreNoSession = noSession;
+        // This window shows the requested file and nothing else — restoring the saved session into it would
+        // reproduce exactly the tab-pile the user is trying to get away from. It also keeps the window from
+        // writing a session file of its own (persistSession returns early under --no-session).
+        noSession = true;
+        try {
+            Stage stage = buildWindow(key, null, untitledStateFile(key), files, zen, expert, null, simple);
+            transientWindows.add(key);
+            presentForExternalLaunch(stage);
+        } catch (RuntimeException | Error t) {
+            java.util.logging.Logger.getLogger(WindowManager.class.getName())
+                    .log(java.util.logging.Level.WARNING, "Failed to open a window for an external launch", t);
+            // Fall back to the old behaviour rather than dropping the user's file on the floor.
+            openExternalFiles(files, zen, expert, simple);
+        } finally {
+            noSession = restoreNoSession;
+        }
+    }
+
+    /** The live window that already has any of {@code files} open, or {@code null} if none does. */
+    private Holder holderWithAnyOf(List<MainController.OpenTarget> files) {
+        for (Holder h : windows) {
+            if (h.controller() == null) {
+                continue;
+            }
+            for (MainController.OpenTarget t : files) {
+                if (t != null && h.controller().hasFileOpen(t.file())) {
+                    return h;
+                }
+            }
+        }
+        return null;
+    }
+
     public void openExternalFiles(List<MainController.OpenTarget> files, boolean zen, boolean expert, boolean simple) {
         if (files == null || files.isEmpty()) {
             return;
@@ -430,6 +507,7 @@ public class WindowManager {
         }
         controller.disposePlugins(); // stop() the window's plugins
         windows.remove(holder);
+        transientWindows.remove(holder.key);
         if (windows.isEmpty()) {
             pluginManager.closeAll(); // last window gone — close every plugin class loader, freeing jar handles (#442)
         }
@@ -497,7 +575,13 @@ public class WindowManager {
         }
         List<String> keys = new ArrayList<>();
         for (Holder h : windows) {
+            if (transientWindows.contains(h.key)) {
+                continue; // a file-manager launch's window; see transientWindows
+            }
             keys.add(h.key);
+        }
+        if (keys.isEmpty()) {
+            return; // only transient windows are live — leave the saved layout as it is
         }
         projects().setOpenWindows(keys);
         projects().save();

--- a/src/test/java/com/editora/ui/ExternalLaunchWindowFxTest.java
+++ b/src/test/java/com/editora/ui/ExternalLaunchWindowFxTest.java
@@ -1,0 +1,101 @@
+package com.editora.ui;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * A file-manager launch handed to a running Editora gets a <b>window of its own</b>, and does not take over
+ * the one already in use.
+ *
+ * <p>Before the single-instance handoff, such a click started its own process and therefore its own window.
+ * The handoff was meant to stop duplicating the <em>process</em>, not to change what the click does — but it
+ * landed the file as a tab in whatever window was in front, taking over work in progress and, for the "Expert
+ * Mode" launcher entry, restyling that window's chrome too.
+ *
+ * <p>The exception pinned here is just as important: if the file is <em>already</em> open, the window holding
+ * it is reused rather than a second one opened. Two independent buffers over one file loses edits — save one
+ * and the other is silently stale — and re-clicking a file you already have open is an ordinary thing to do.
+ */
+@Tag("fx")
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class ExternalLaunchWindowFxTest {
+
+    @BeforeAll
+    void setUp() throws Exception {
+        FxTestSupport.bootToolkit();
+    }
+
+    @Test
+    void aForwardedLaunchOpensItsOwnWindowInsteadOfTakingOverTheCurrentOne() throws Exception {
+        Path dir = Files.createTempDirectory("editora-external-window");
+        Path working = Files.writeString(dir.resolve("working-on.txt"), "in progress\n");
+        Path clicked = Files.writeString(dir.resolve("clicked.txt"), "from the file manager\n");
+
+        FxWindowFixture fx = FxWindowFixture.create(
+                dir, false, false, false, List.of(new MainController.OpenTarget(working, 0, 0)), true, c -> {});
+        try {
+            assertEquals(1, windowCount(fx), "precondition: one window");
+
+            deliver(fx, clicked);
+
+            assertEquals(2, windowCount(fx), "the launch should have opened a window of its own");
+            assertTrue(hasFileOpen(fx, clicked), "the clicked file should be open somewhere");
+        } finally {
+            fx.dispose();
+        }
+    }
+
+    @Test
+    void relaunchingAFileThatIsAlreadyOpenReusesItsWindowRatherThanDuplicatingTheBuffer() throws Exception {
+        Path dir = Files.createTempDirectory("editora-external-window");
+        Path clicked = Files.writeString(dir.resolve("clicked.txt"), "from the file manager\n");
+
+        FxWindowFixture fx = FxWindowFixture.create(
+                dir, false, false, false, List.of(new MainController.OpenTarget(clicked, 0, 0)), true, c -> {});
+        try {
+            assertEquals(1, windowCount(fx));
+            assertTrue(hasFileOpen(fx, clicked), "precondition: the file is already open");
+
+            deliver(fx, clicked);
+
+            assertEquals(1, windowCount(fx), "a file already open must not get a second window and buffer");
+        } finally {
+            fx.dispose();
+        }
+    }
+
+    /** Applies an external launch the way {@code App.openForwardedLaunch} does. */
+    private static void deliver(FxWindowFixture fx, Path file) throws Exception {
+        FxTestSupport.runOnFx(() -> fx.windowManager.openExternalLaunchInNewWindow(
+                List.of(new MainController.OpenTarget(file, 0, 0)), false, true, false));
+    }
+
+    private static int windowCount(FxWindowFixture fx) throws Exception {
+        return FxTestSupport.callOnFx(() -> {
+            List<?> windows = FxTestSupport.field(fx.windowManager, "windows");
+            return windows.size();
+        });
+    }
+
+    private static boolean hasFileOpen(FxWindowFixture fx, Path file) throws Exception {
+        return FxTestSupport.callOnFx(() -> {
+            List<?> windows = FxTestSupport.field(fx.windowManager, "windows");
+            for (Object holder : windows) {
+                MainController c = FxTestSupport.field(holder, "controller");
+                if (c != null && c.hasFileOpen(file)) {
+                    return true;
+                }
+            }
+            return false;
+        });
+    }
+}


### PR DESCRIPTION
Opening a file from the file manager landed it as a **tab in whatever window was in front**, taking over work in progress — and with the "Editora Expert Mode" entry, restyling that window's chrome too. Reported against 0.12.2; confirmed fixed by hand.

This is a regression from the single-instance handoff, not a preference. Before it, such a click started its own process and therefore **its own window**. The handoff was meant to stop duplicating the *process* — a second JVM, a second set of language servers — not to change what the click does. This restores the window half while keeping the process saving.

The requested focus mode now applies to the **new** window at build time, so its first frame is already correct, rather than being imposed on a window already in use.

## Three decisions worth reviewing

- **A file that is already open reuses its window** rather than getting a second one. Two independent buffers over one file loses edits — save one and the other is silently stale behind an external-change prompt — and re-clicking a file you already have open is ordinary, not a corner case. Needed a small `MainController.hasFileOpen` so `WindowManager` can ask across windows.

- **These windows stay out of the persisted restore set** (`transientWindows`). Before the handoff the equivalent process ran `--single-window --no-session` and never touched the saved layout. Without this, every file ever opened from the file manager returns as a window on the next launch — and returns **empty**, since a `--no-session` window writes no session file.

- **macOS is unchanged.** The Apple Event path never duplicated a process, so nothing regressed there and there is nothing to restore. The two paths differ in window placement by intent, not by drift.

## Tests

4002 green. The new FX test pins both behaviours — own window for a new file, reuse for one already open — and is mutation-checked: reverting to the take-over behaviour fails it with `expected: <2> but was: <1>`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)