### PR TITLE
feat(packaging): describe the Linux package properly in software centres

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **The Linux package now describes itself properly in GNOME Software** (and other software centres),
+  instead of showing "editora / Editora", "Unknown License", "No details for this release" and a generic
+  gear icon.
+
+  None of that came from the desktop entry, which was already correct — a software centre describes an
+  installed application from **AppStream** metadata, and the `.deb` shipped none, so it fell back to the
+  dpkg control fields that jpackage fills with defaults. The package now carries an AppStream metainfo
+  file (name, summary, description, MIT licence, homepage, categories, release notes) plus a themed icon
+  set, installed by the maintainer script and removed on uninstall. The control fields it *does* read are
+  filled in too: a real description, a homepage, and a maintainer address instead of `Editora <Unknown>`.
+
+  The release entry is filled in from the version being packaged rather than hand-written, because a
+  block that has to be edited on every release is one that eventually is not — and that failure looks
+  exactly like the "No details for this release" being fixed here.
+
+  The application menu icon is untouched: the desktop entry keeps the absolute path it already resolves
+  correctly, and the themed icons are additive, for the software centre only.
+
+  One thing this cannot fix: **"Potentially Unsafe — Provided by a third party"**. That label is about
+  where a package came from, not what it says about itself — a software centre applies it to anything not
+  installed from a configured repository, and no file inside a `.deb` can assert otherwise.
+
 ### Added
 
 - **The Windows installer now registers Editora under Explorer's "Open with"** for the text and source

--- a/packaging/linux/com.editora.Editora.metainfo.xml
+++ b/packaging/linux/com.editora.Editora.metainfo.xml
@@ -1,0 +1,101 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  AppStream metadata — what a software centre (GNOME Software, KDE Discover, the "apt" front-ends)
+  reads to describe an installed application.
+
+  Without this file those tools fall back to the dpkg control fields, which jpackage fills with
+  defaults: the app page then reads "editora / Editora", "Unknown License" and "No details for this
+  release", with a generic gear for an icon. None of that is fixable from the .desktop entry — a
+  software centre deliberately prefers AppStream over it.
+
+  The postinst installs this to /usr/share/metainfo/ (and postrm removes it). It is NOT part of the
+  dpkg payload manifest directly: jpackage's resource dir only substitutes the template files it
+  knows about, so the file rides inside the app image (staged there by scripts/aot_build.java, the
+  same route the branding icon takes) and the maintainer script puts it in place — the pattern the
+  .desktop entries already use.
+
+  <id> must match the .desktop file the launcher installs, or a software centre treats the metadata
+  and the installed application as two unrelated things and shows neither properly. jpackage names
+  that file editora-Editora.desktop, hence the <launchable> below.
+
+  One thing this cannot fix: "Potentially Unsafe — Provided by a third party". That label is about
+  PROVENANCE, not metadata — a software centre applies it to anything not from a configured
+  repository, and no file inside a package can assert otherwise about itself.
+-->
+<component type="desktop-application">
+  <id>com.editora.Editora</id>
+  <launchable type="desktop-id">editora-Editora.desktop</launchable>
+
+  <name>Editora</name>
+  <summary>Keyboard-driven programmer's text editor</summary>
+
+  <developer id="dev.editora-project">
+    <name>Adrián Arturo De León Saldivar</name>
+  </developer>
+
+  <metadata_license>CC0-1.0</metadata_license>
+  <project_license>MIT</project_license>
+
+  <description>
+    <p>
+      Editora is a keyboard-driven, cross-platform programmer's text editor. Every action is a
+      command you can reach from the palette or bind to a key, with Emacs, CUA, Sublime, VS Code and
+      IntelliJ keymaps included.
+    </p>
+    <p>Among its features:</p>
+    <ul>
+      <li>Syntax highlighting via TextMate grammars, with folding and structure outlines</li>
+      <li>Language Server Protocol support for over twenty languages</li>
+      <li>Debugging through the Debug Adapter Protocol for Java, Python and JavaScript</li>
+      <li>Git integration, including a commit tool window, inline blame, history and diffs</li>
+      <li>Live previews for Markdown, CSV, diagrams, Typst and structured data</li>
+      <li>Snippets, templates, macros, multiple cursors and project-wide search</li>
+    </ul>
+  </description>
+
+  <categories>
+    <category>Development</category>
+    <category>TextEditor</category>
+    <category>IDE</category>
+  </categories>
+
+  <keywords>
+    <keyword>editor</keyword>
+    <keyword>text</keyword>
+    <keyword>code</keyword>
+    <keyword>programming</keyword>
+    <keyword>ide</keyword>
+  </keywords>
+
+  <!-- Named rather than an absolute path: a software centre resolves a stock icon through the icon
+       theme, which the postinst populates under /usr/share/icons/hicolor. The .desktop entry keeps
+       its own absolute Icon= line, which is what the application menu already uses successfully. -->
+  <icon type="stock">editora</icon>
+
+  <url type="homepage">https://editora-project.dev</url>
+  <url type="bugtracker">https://github.com/adriandeleon/Editora/issues</url>
+  <url type="help">https://github.com/adriandeleon/Editora/blob/master/README.md</url>
+
+  <!-- Required by GNOME Software; an application with nothing to declare still states so explicitly,
+       and its absence is itself shown as a warning. -->
+  <content_rating type="oars-1.1"/>
+
+  <!-- Substituted by scripts/aot_build.java at package time (@VERSION@ / @DATE@ / @YEAR@).
+       Hand-maintaining this block is what makes a software centre say "No details for this release":
+       it would have to be edited on every release, in a file nobody touches, and the one time it is
+       forgotten the app page silently reverts to that message. Deriving it from the version being
+       built cannot drift. The notes themselves stay a link rather than a copy of the changelog —
+       duplicating release notes into a second file is the same rot in slower motion. -->
+  <releases>
+    <release version="@VERSION@" date="@DATE@">
+      <url>https://github.com/adriandeleon/Editora/releases/tag/v@VERSION@</url>
+      <description>
+        <p>Release notes for this version are published on the project's releases page.</p>
+      </description>
+    </release>
+  </releases>
+
+  <provides>
+    <binary>editora</binary>
+  </provides>
+</component>

--- a/packaging/linux/postinst
+++ b/packaging/linux/postinst
@@ -46,6 +46,38 @@ case "$1" in
             break
         done
 
+        # 2b) AppStream metadata + themed icons, for the software centre.
+        #
+        # A software centre (GNOME Software, KDE Discover) describes an installed app from AppStream,
+        # NOT from the .desktop entry. With none present it falls back to the dpkg control fields that
+        # jpackage generates, and the app page reads "editora / Editora", "Unknown License" and "No
+        # details for this release" beside a generic gear. Both files ride in the .deb payload under
+        # /opt (staged into the app image by scripts/aot_build.java) because jpackage's resource dir
+        # can only override template files, not add payload; installing them from here is the same
+        # route the .desktop entries above already take.
+        #
+        # The icons are ADDITIVE: the .desktop keeps its own absolute Icon= line, which is what the
+        # application menu already resolves. These exist so the software centre, which resolves the
+        # metainfo's stock icon name through the theme, has something better than a generic glyph.
+        for src in /opt/*/lib/com.editora.Editora.metainfo.xml; do
+            [ -f "$src" ] || continue
+            mkdir -p /usr/share/metainfo
+            cp -f "$src" /usr/share/metainfo/com.editora.Editora.metainfo.xml
+            chmod 0644 /usr/share/metainfo/com.editora.Editora.metainfo.xml
+            break
+        done
+        for src in /opt/*/lib/icons/editora-*.png; do
+            [ -f "$src" ] || continue
+            size=$(basename "$src" .png | sed 's/^editora-//')
+            case "$size" in
+                ''|*[!0-9]*) continue ;;   # not a size-suffixed icon; skip rather than guess
+            esac
+            dir=/usr/share/icons/hicolor/${size}x${size}/apps
+            mkdir -p "$dir"
+            cp -f "$src" "$dir/editora.png"
+            chmod 0644 "$dir/editora.png"
+        done
+
         # 3) Second menu entry: "Editora Expert Mode" — the same app launched with
         #    --expert --single-window. Derived from the just-registered primary entry so it always
         #    tracks the real launcher path/icon. StartupWMClass is dropped: both entries launch the
@@ -119,6 +151,12 @@ esac
 # Refresh the desktop database so the launcher + icon show up without a re-login.
 if command -v update-desktop-database >/dev/null 2>&1; then
     update-desktop-database -q /usr/share/applications 2>/dev/null || true
+fi
+
+# Without this the freshly-installed hicolor icons are not picked up until something else rebuilds
+# the cache, so the software centre keeps showing the generic glyph for a while after installing.
+if command -v gtk-update-icon-cache >/dev/null 2>&1; then
+    gtk-update-icon-cache -q -t -f /usr/share/icons/hicolor 2>/dev/null || true
 fi
 
 exit 0

--- a/packaging/linux/postrm
+++ b/packaging/linux/postrm
@@ -30,11 +30,23 @@ case "$1" in
                 rm -f "$mimeapps" "$tmp"
             fi
         fi
+        # The AppStream metadata + themed icons the postinst installed. Like the .desktop entries they
+        # live outside the dpkg manifest (installed by the maintainer script, not unpacked), so nothing
+        # else will remove them — a left-behind metainfo file would keep advertising an application
+        # that is no longer installed.
+        rm -f /usr/share/metainfo/com.editora.Editora.metainfo.xml
+        for dir in /usr/share/icons/hicolor/*/apps; do
+            rm -f "$dir/editora.png"
+        done
         ;;
 esac
 
 if command -v update-desktop-database >/dev/null 2>&1; then
     update-desktop-database -q /usr/share/applications 2>/dev/null || true
+fi
+
+if command -v gtk-update-icon-cache >/dev/null 2>&1; then
+    gtk-update-icon-cache -q -t -f /usr/share/icons/hicolor 2>/dev/null || true
 fi
 
 exit 0

--- a/scripts/aot_build.java
+++ b/scripts/aot_build.java
@@ -128,6 +128,13 @@ public class aot_build {
             }
         }
 
+        // Stage the AppStream metadata + themed icons INTO the image, so they travel in the .deb payload
+        // (jpackage's resource dir only substitutes template files it knows about — it cannot add arbitrary
+        // payload). The postinst then installs them to /usr/share/metainfo and /usr/share/icons/hicolor.
+        if (linux) {
+            stageLinuxAppStream(imageRoot, publicVer);
+        }
+
         if ("APP_IMAGE".equalsIgnoreCase(type.trim())) {
             Path out = destDir.resolve(imageRoot.getFileName());
             deleteRecursive(out);
@@ -279,6 +286,63 @@ public class aot_build {
         }
     }
 
+    /**
+     * Copies the AppStream metainfo (version/date substituted) and the themed icon set into the app image,
+     * where the .deb payload will carry them for the postinst to install.
+     *
+     * <p><b>Why this exists:</b> a software centre describes an installed application from AppStream, not
+     * from the .desktop entry. With none shipped, GNOME Software falls back to the dpkg control fields —
+     * which jpackage fills with defaults — and the page reads "editora / Editora", "Unknown License" and
+     * "No details for this release" beside a generic icon.
+     *
+     * <p>The version and date are substituted rather than hand-written: a {@code <releases>} block that has
+     * to be edited on every release is one that eventually is not, and the failure mode is precisely the
+     * "No details for this release" being fixed here.
+     *
+     * <p>Best-effort throughout. Missing metadata makes for a poorly-described package, which is a far
+     * better outcome than a failed build — and it can never affect the application itself.
+     */
+    private static void stageLinuxAppStream(Path imageRoot, String version) {
+        Path lib = imageRoot.resolve("lib");
+        if (!Files.isDirectory(lib)) {
+            return;
+        }
+        Path pkg = Path.of(System.getProperty("user.dir"), "packaging", "linux");
+        try {
+            Path metaSrc = pkg.resolve("com.editora.Editora.metainfo.xml");
+            if (Files.isRegularFile(metaSrc)) {
+                String xml = Files.readString(metaSrc)
+                        .replace("@VERSION@", version)
+                        .replace("@DATE@", java.time.LocalDate.now(java.time.ZoneOffset.UTC).toString())
+                        .replace("@YEAR@", String.valueOf(java.time.Year.now(java.time.ZoneOffset.UTC).getValue()));
+                Files.writeString(lib.resolve("com.editora.Editora.metainfo.xml"), xml);
+                System.out.println("[aot] staged AppStream metainfo (version " + version + ")");
+            }
+            // The themed icon set. The .desktop entry deliberately keeps its absolute Icon= line — that is
+            // what the application menu already resolves correctly — so these are purely additive, for the
+            // software centre, which resolves a stock icon name through the theme instead.
+            Path iconsSrc = Path.of(System.getProperty("user.dir"),
+                    "src", "main", "resources", "com", "editora", "icons");
+            if (Files.isDirectory(iconsSrc)) {
+                Path iconsDst = lib.resolve("icons");
+                Files.createDirectories(iconsDst);
+                int staged = 0;
+                for (String size : new String[] {"16", "32", "48", "128", "256", "512"}) {
+                    Path src = iconsSrc.resolve("icon-" + size + ".png");
+                    if (Files.isRegularFile(src)) {
+                        Files.copy(src, iconsDst.resolve("editora-" + size + ".png"),
+                                StandardCopyOption.REPLACE_EXISTING);
+                        staged++;
+                    }
+                }
+                System.out.println("[aot] staged " + staged + " themed icons");
+            }
+        } catch (IOException e) {
+            System.err.println("[aot] could not stage AppStream metadata (" + e + ") — package will be "
+                    + "described from the dpkg control fields only");
+        }
+    }
+
     /** jpackage --app-image <image> --type <installer> ... (build JDK's jpackage). Returns true on
      *  success; the caller decides whether a failure is fatal (it is for a single-type platform). */
     private static boolean wrapInstaller(Path imageRoot, String appName, String appVer, String type,
@@ -293,16 +357,27 @@ public class aot_build {
                 "--vendor", "Editora",
                 "--app-image", imageRoot.toString(),
                 "--dest", destDir.toString()));
+        String t0 = type.toUpperCase(Locale.ROOT);
         if (icon != null && !icon.isBlank() && !"-".equals(icon) && Files.exists(Path.of(icon))) {
             cmd.add("--icon");
             cmd.add(icon);
+        }
+        // Without these, jpackage defaults the package's own description to the application NAME, so a
+        // software centre (and `apt show`) reads "Description: Editora" — the app describing itself as
+        // itself — with no homepage and a maintainer of "Editora <Unknown>". They cost nothing and are
+        // the only source for those dpkg control fields.
+        cmd.addAll(List.of(
+                "--description", "A keyboard-driven, cross-platform programmer's text editor",
+                "--about-url", "https://editora-project.dev"));
+        if (t0.equals("DEB")) {
+            cmd.addAll(List.of("--linux-deb-maintainer", "editora@editora-project.dev"));
         }
         // Without these, a Windows MSI installs to Program Files but creates NO Start Menu entry,
         // NO desktop shortcut, and NO install wizard — so it looks like "nothing installed". Add a
         // real wizard (dir chooser) + a Start Menu group + a desktop shortcut. Linux .deb/.rpm
         // likewise need --linux-shortcut for an application-menu entry. macOS DMG needs nothing
         // (drag-to-Applications).
-        String t = type.toUpperCase(Locale.ROOT);
+        String t = t0;
         if (t.equals("MSI") || t.equals("EXE")) {
             cmd.addAll(List.of("--win-menu", "--win-menu-group", appName,
                     "--win-shortcut", "--win-dir-chooser"));

--- a/src/test/java/com/editora/packaging/LinuxAppStreamMetadataTest.java
+++ b/src/test/java/com/editora/packaging/LinuxAppStreamMetadataTest.java
@@ -1,0 +1,99 @@
+package com.editora.packaging;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import javax.xml.parsers.DocumentBuilderFactory;
+
+import com.editora.AppInfo;
+import org.junit.jupiter.api.Test;
+import org.w3c.dom.Document;
+import org.w3c.dom.NodeList;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Guards {@code packaging/linux/com.editora.Editora.metainfo.xml} — the AppStream metadata a software
+ * centre describes the installed .deb from.
+ *
+ * <p>Without it, GNOME Software falls back to the dpkg control fields and the app page reads
+ * "editora / Editora", "Unknown License" and "No details for this release". The failure mode this pins is
+ * subtler than the file being absent: the metadata is only *connected* to the installed application when
+ * its {@code <launchable>} names the .desktop file the postinst actually writes, and those two live in
+ * different files with nothing linking them. Get that wrong and everything still installs, validates and
+ * looks correct — the software centre simply goes on showing the fallback, which is exactly the symptom
+ * being fixed here.
+ *
+ * <p>The licence and homepage are pinned to {@link AppInfo} for the same reason: a software centre showing
+ * a licence that contradicts the About dialog is worse than showing none.
+ */
+class LinuxAppStreamMetadataTest {
+
+    private static final Path METAINFO = Path.of("packaging", "linux", "com.editora.Editora.metainfo.xml");
+    private static final Path POSTINST = Path.of("packaging", "linux", "postinst");
+
+    private static Document parse() throws Exception {
+        var factory = DocumentBuilderFactory.newInstance();
+        // Same hardening as maven/PomParser — this is build input, but the habit is cheap.
+        factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+        factory.setExpandEntityReferences(false);
+        return factory.newDocumentBuilder().parse(METAINFO.toFile());
+    }
+
+    private static String text(Document doc, String tag) {
+        NodeList nodes = doc.getElementsByTagName(tag);
+        return nodes.getLength() == 0 ? "" : nodes.item(0).getTextContent().trim();
+    }
+
+    @Test
+    void theMetadataDeclaresWhatTheSoftwareCentreShows() throws Exception {
+        assertTrue(Files.isRegularFile(METAINFO), METAINFO + " is missing — the .deb would be undescribed");
+        Document doc = parse();
+        assertEquals("com.editora.Editora", text(doc, "id"));
+        assertEquals(AppInfo.NAME, text(doc, "name"));
+        assertTrue(text(doc, "summary").length() > 10, "a summary is what replaces the bare package name");
+        // "Unknown License" on the app page is precisely this element being absent.
+        assertEquals("MIT", text(doc, "project_license"));
+        assertTrue(text(doc, "metadata_license").length() > 2, "AppStream requires the metadata's own licence");
+    }
+
+    @Test
+    void theLaunchableNamesTheDesktopFileThePostinstActuallyInstalls() throws Exception {
+        String declared = text(parse(), "launchable");
+        String postinst = Files.readString(POSTINST);
+        assertTrue(
+                postinst.contains("/usr/share/applications/" + declared),
+                "the metainfo points at '" + declared + "' but the postinst installs no such .desktop file — "
+                        + "the software centre would silently keep showing the dpkg fallback");
+    }
+
+    @Test
+    void theHomepageAndLicenceMatchWhatTheApplicationItselfReports() throws Exception {
+        Document doc = parse();
+        NodeList urls = doc.getElementsByTagName("url");
+        String homepage = "";
+        for (int i = 0; i < urls.getLength(); i++) {
+            var node = urls.item(i);
+            var type = node.getAttributes().getNamedItem("type");
+            if (type != null && "homepage".equals(type.getNodeValue())) {
+                homepage = node.getTextContent().trim();
+            }
+        }
+        assertEquals(AppInfo.HOMEPAGE, homepage, "the advertised homepage must match AppInfo.HOMEPAGE");
+        assertTrue(
+                AppInfo.LICENSE.startsWith("MIT"),
+                "project_license is pinned to MIT above; AppInfo says " + AppInfo.LICENSE);
+    }
+
+    @Test
+    void theReleaseBlockIsBuildSubstitutedRatherThanHandMaintained() throws Exception {
+        String raw = Files.readString(METAINFO);
+        // A hand-edited <releases> is the thing that rots back into "No details for this release"; the
+        // build fills these in from the version actually being packaged.
+        assertTrue(raw.contains("@VERSION@"), "the release version must be substituted at build time");
+        assertTrue(raw.contains("@DATE@"), "the release date must be substituted at build time");
+        assertTrue(
+                Files.readString(Path.of("scripts", "aot_build.java")).contains("@VERSION@"),
+                "nothing substitutes @VERSION@ — the shipped metadata would carry the literal placeholder");
+    }
+}


### PR DESCRIPTION
GNOME Software showed the installed `.deb` as **"editora / Editora"**, **"Unknown License"**, **"No details for this release"** and a generic gear icon.

None of that came from the desktop entry, which was already correct. A software centre describes an installed application from **AppStream** metadata, and the package shipped none — so it fell back to the dpkg control fields, which jpackage fills with defaults:

```
Description: Editora              ← the title and summary
Maintainer: Editora <Unknown>
(no Homepage)
```

## What changed

An AppStream metainfo file (name, summary, description, MIT licence, homepage, categories, keywords, content rating, release entry) plus a themed icon set. Both ride in the payload under `/opt` — jpackage's resource dir can only override *template* files, not add payload — and the maintainer scripts install them to `/usr/share/metainfo` and `/usr/share/icons/hicolor`, the same route the `.desktop` entries already take. `postrm` removes them, since nothing else would: they sit outside the dpkg manifest.

The control fields jpackage *does* emit are filled in too, via `--description`, `--about-url` and `--linux-deb-maintainer`.

## Verified, not assumed

Built the `.deb` and ran the **real postinst** against it in a sandbox with every absolute path rebased, so the globs and size-parsing were exercised as written rather than re-typed:

| | before | after |
|---|---|---|
| `Description:` | `Editora` | `A keyboard-driven, cross-platform programmer's text editor` |
| `Maintainer:` | `Editora <Unknown>` | `Editora <editora@editora-project.dev>` |
| `Homepage:` | *(absent)* | `https://editora-project.dev` |
| metainfo | *(none)* | installed; **`appstreamcli validate` passes** |
| icons | *(none)* | 6 sizes under `hicolor` |
| release entry | *(none)* | `version="0.12.4" date="2026-08-18"`, substituted from the build |

`postrm` then left **zero** files behind.

## Two judgement calls

- **Icons are additive, by request.** The desktop entry keeps the absolute `Icon=` path it already resolves correctly, so the application menu cannot regress; the themed copies exist for the software centre, which resolves the metainfo's stock icon name through the theme.
- **The `<releases>` entry is generated, not written.** A block that must be hand-edited on every release is one that eventually is not — and that failure looks exactly like the "No details for this release" this fixes.

## Tests

4010 green. `LinuxAppStreamMetadataTest` pins the part that fails *silently*: the metadata is only connected to the installed app when its `<launchable>` names the `.desktop` the postinst actually writes, and those live in two files with nothing linking them. Get it wrong and everything still installs and validates while the page goes on showing the fallback. Mutation-checked. Licence and homepage are pinned to `AppInfo` so a software centre can't contradict the About dialog.

## Not fixed

- **"Potentially Unsafe — Provided by a third party"** is about *provenance*, not metadata: applied to anything not installed from a configured repository. No file inside a `.deb` can assert otherwise. Fixing it means an APT repo or a Flatpak.
- The **`.rpm`** still has no metadata — it uses jpackage's generated desktop entry and ignores the maintainer-script overrides.

🤖 Generated with [Claude Code](https://claude.com/claude-code)