### PR TITLE
perf(startup): build UpdateService's HttpClient and ObjectMapper lazily

### DIFF
--- a/src/main/java/com/editora/update/UpdateService.java
+++ b/src/main/java/com/editora/update/UpdateService.java
@@ -47,12 +47,34 @@ public final class UpdateService {
         return t;
     });
 
-    private final HttpClient client = HttpClient.newBuilder()
-            .connectTimeout(CONNECT_TIMEOUT)
-            .followRedirects(HttpClient.Redirect.NORMAL)
-            .build();
+    /** Built on first use, never at construction: {@code HttpClient.newBuilder().build()} drags in the whole
+     *  {@code java.net.http} + TLS stack, and this service is constructed as a {@code MainController} field
+     *  initializer — i.e. inside {@code FXMLLoader.load()}, on the FX thread, during startup. Measured at ~30 ms
+     *  there, for a check that is throttled to once a day and runs after {@code init}. Both fields are touched
+     *  only from {@link #fetchSync}, which runs solely on the single-threaded {@link #exec}, so the lazy init is
+     *  confined to that one thread and needs no synchronization. */
+    private HttpClient client;
 
-    private final ObjectMapper mapper = new ObjectMapper();
+    private ObjectMapper mapper;
+
+    /** Executor-thread-confined; see the field comment. */
+    private HttpClient client() {
+        if (client == null) {
+            client = HttpClient.newBuilder()
+                    .connectTimeout(CONNECT_TIMEOUT)
+                    .followRedirects(HttpClient.Redirect.NORMAL)
+                    .build();
+        }
+        return client;
+    }
+
+    /** Executor-thread-confined; see the field comment. */
+    private ObjectMapper mapper() {
+        if (mapper == null) {
+            mapper = new ObjectMapper();
+        }
+        return mapper;
+    }
 
     /** Checks off-thread whether a release newer than {@code currentVersion} exists; {@code onResult} runs on the
      *  FX thread. */
@@ -76,7 +98,7 @@ public final class UpdateService {
                     .header("User-Agent", "Editora/" + AppInfo.VERSION) // GitHub rejects a missing UA with 403
                     .GET()
                     .build();
-            HttpResponse<InputStream> resp = client.send(req, HttpResponse.BodyHandlers.ofInputStream());
+            HttpResponse<InputStream> resp = client().send(req, HttpResponse.BodyHandlers.ofInputStream());
             if (resp.statusCode() / 100 != 2) {
                 resp.body().close();
                 return new Outcome(false, null, "HTTP " + resp.statusCode());
@@ -85,7 +107,7 @@ public final class UpdateService {
             try (InputStream in = resp.body()) {
                 body = PluginRegistry.readCapped(in, MAX_RELEASE_BYTES);
             }
-            ReleaseInfo latest = UpdateCheck.parseLatest(mapper, body);
+            ReleaseInfo latest = UpdateCheck.parseLatest(mapper(), body);
             if (latest == null) {
                 return new Outcome(false, null, "no usable release in response");
             }


### PR DESCRIPTION
`UpdateService` is a `MainController` field initializer, so it was constructed inside `FXMLLoader.load()` — on the FX thread, during window construction — and its own field initializer built a `java.net.http.HttpClient`, dragging in the HTTP + TLS stack there. The update check it serves is throttled to once a day and runs off-thread after `init`, so none of that belonged on the startup path.

Both fields are touched only from `fetchSync`, which runs solely on the single-threaded `update-check` executor, so the lazy init is confined to that one thread and needs no synchronization.

## Measurement

Not measurable at first paint on its own — the surrounding phase moves more than this does. It is here because an HTTP client built during window construction is misplaced regardless of what the clock says.

This is the surviving half of a larger startup experiment. The other half — deferring the console tool-window panels out of `FXMLLoader.load()` — was **measured and dropped**: the FXML phase fell 125 → 105 ms and the saving reappeared in `controller-init`/`window-shown`, because that class loading is shared with the editor, so whichever surface touches it first pays. It is recorded in CLAUDE.md so nobody re-derives it.

## Verification

Full suite (4010 tests) green, including spotless and the JaCoCo gates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)